### PR TITLE
without pipefail the exit status won't go through

### DIFF
--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -46,6 +46,7 @@ jobs:
       run: |
         tmpdir=${{ steps.set-tmpdir.outputs.tmpdir }}
         ts-tests/scripts/run-test.sh $tmpdir
+      shell: bash {0}
 
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}

--- a/ts-tests/scripts/run-test.sh
+++ b/ts-tests/scripts/run-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 basedir=$(dirname "$0")
 cd "$basedir"
 


### PR DESCRIPTION
resolves #101 :
without pipefail the exit status won't go through, which causes CI to succeed wrongly