### PR TITLE
set-up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    labels: ["I1-low", "F7-devop"]
+    # Handle updates for crates from github.com/paritytech/substrate manually.
+    ignore:
+      - dependency-name: "substrate-*"
+      - dependency-name: "polkadot-*"
+      - dependency-name: "sc-*"
+      - dependency-name: "sp-*"
+      - dependency-name: "frame-*"
+      - dependency-name: "cumulus-*"
+      - dependency-name: "pallet-*"
+      - dependency-name: "xcm*"
+      - dependency-name: "parachain-runtime"
+      - dependency-name: "litentry-*"
+      - dependency-name: "fork-tree"
+      - dependency-name: "remote-externalities"
+      - dependency-name: "beefy-*"
+      - dependency-name: "try-runtime-*"
+      - dependency-name: "test-runner"
+      - dependency-name: "generate-bags"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,4 +22,4 @@ updates:
       - dependency-name: "test-runner"
       - dependency-name: "generate-bags"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -6,11 +6,13 @@ on:
       - dev
     paths-ignore:
       - '**/dependabot.yml'
+      - '**/README.md'
   pull_request:
     branches:
       - dev
     paths-ignore:
       - '**/dependabot.yml'
+      - '**/README.md'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -2,9 +2,15 @@ name: Build & Test
 
 on:
   push:
-    branches: [ dev ]
+    branches:
+      - dev
+    paths-ignore:
+      - '**/dependabot.yml'
   pull_request:
-    branches: [ dev ]
+    branches:
+      - dev
+    paths-ignore:
+      - '**/dependabot.yml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
resolves #91 

Similar to polkadot, a dependabot is set to weekly track the rust package changes.
Note: polka/substrate/cumulus related versions are pinned, see `ignore` part in _dependabot.yml_