### PR TITLE
restart relaychain for ci if parachain doesn't produce blocks

### DIFF
--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -30,12 +30,14 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build docker image
+      timeout-minutes: 40
       run: |
         ./scripts/build-docker.sh
         echo "============================="
         docker images
 
     - name: Start docker containers and run CI
+      timeout-minutes: 30
       run: |
         make test-ci
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ format:
 # launch a local dev network using docker
 .PHONY: launch-local-docker ## Launch dev parachain by docker locally
 launch-local-docker: generate-docker-compose-dev
-	@cd docker/generated-dev; docker-compose up -d --build
+	@./scripts/launch-local-docker.sh
 
 # stop the local dev containers and cleanup images
 # for the most part used when done with launch-local-docker

--- a/scripts/launch-local-docker.sh
+++ b/scripts/launch-local-docker.sh
@@ -28,8 +28,8 @@ if [ "$WITH_RESTART" != "true" ]; then
   exit 0
 fi
 
-parachain_service=$(docker-compose ps --services --filter "status=running" | grep -F "parachain-")
-relaychain_service="$(docker-compose ps --services --filter "status=running" | grep -F "relaychain-")"
+parachain_service=$(docker-compose ps --services --filter 'status=running' | grep -F 'parachain-')
+relaychain_service="$(docker-compose ps --services --filter 'status=running' | grep -F 'relaychain-')"
 
 print_divider
 

--- a/scripts/launch-local-docker.sh
+++ b/scripts/launch-local-docker.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-set -eo pipefail
 
 # whether to restart the relaychains if parachain doesn't produce blocks
 WITH_RESTART=${1:-true}
 
-# wait intervail in seconds to check the block import and production of parachain
+# wait interval in seconds to check the block import and production of parachain
 WAIT_INTERVAL_SECONDS=10
 
+# rounds to wait in `check_block`, in total it's 12 * 10 = 2min
 WAIT_ROUNDS=12
 
 # restart interval in seconds for restarting relaychains sequentially
@@ -27,6 +27,10 @@ docker-compose up -d --build
 if [ "$WITH_RESTART" != "true" ]; then
   exit 0
 fi
+
+# sleep for a while to make sure `docker-compose` is ready
+# otherwise `docker-compose logs` could print empty output
+sleep 10
 
 parachain_service=$(docker-compose ps --services --filter 'status=running' | grep -F 'parachain-')
 relaychain_service="$(docker-compose ps --services --filter 'status=running' | grep -F 'relaychain-')"

--- a/scripts/launch-local-docker.sh
+++ b/scripts/launch-local-docker.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# whether to restart the relaychains if parachain doesn't produce blocks
+WITH_RESTART=${1:-true}
+
+# wait intervail in seconds to check the block import and production of parachain
+WAIT_INTERVAL_SECONDS=10
+
+WAIT_ROUNDS=12
+
+# restart interval in seconds for restarting relaychains sequentially
+RESTART_INTERVAL_SECONDS=20
+
+# if the parachain ever produces the first block
+HAS_BLOCK=false
+
+function print_divider() {
+  echo "------------------------------------------------------------"
+}
+
+ROOTDIR=$(git rev-parse --show-toplevel)
+cd "$ROOTDIR/docker/generated-dev/"
+
+docker-compose up -d --build
+
+if [ "$WITH_RESTART" != "true" ]; then
+  exit 0
+fi
+
+parachain_service=$(docker-compose ps --services --filter "status=running" | grep -F "parachain-")
+relaychain_service="$(docker-compose ps --services --filter "status=running" | grep -F "relaychain-")"
+
+print_divider
+
+function check_block() {
+  for i in $(seq 1 $WAIT_ROUNDS); do
+    sleep $WAIT_INTERVAL_SECONDS
+    if docker-compose logs "$parachain_service" | grep -F '[Parachain]' | grep -Fq "best: #1"; then
+      echo "parachain produced #1, all good. Quite now"
+      exit 0
+    fi
+  done
+}
+
+echo "waiting for parachain to import blocks ..."
+
+while : ; do
+  if docker-compose logs "$parachain_service" | grep -F '[Parachain]' | grep -Fq "Imported #1"; then
+    echo "parachain imported #1"
+    break
+  else
+    sleep $WAIT_INTERVAL_SECONDS
+  fi
+done
+
+print_divider
+echo "checking parachain block production ..."
+check_block
+
+echo "no parachain blocks detected, restart relaychains ..."
+for i in $relaychain_service; do
+  sleep $RESTART_INTERVAL_SECONDS
+  docker-compose restart $i
+done
+
+print_divider
+echo "relaychain restarted"
+echo "checking parachain block production again ..."
+
+check_block
+echo "still no blocks detected, you might want to check it manually. Quit now"


### PR DESCRIPTION
resolves #187 

This PR:
- adds a script to restart the relaychain services if no blocks are produced by parachain.
- adds a timeout for docker-build and ci-test

Tested multiple times locally.