### PR TITLE
Seperate constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,6 +3942,7 @@ dependencies = [
  "parachain-info",
  "parity-scale-codec",
  "polkadot-parachain",
+ "primitives",
  "scale-info",
  "serde",
  "sp-api",
@@ -4399,6 +4400,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "node-primitives"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.11#57346f6b24875f8935280dba51fa8ab0a9ba1e39"
+dependencies = [
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6681,6 +6695,26 @@ dependencies = [
  "impl-serde",
  "scale-info",
  "uint",
+]
+
+[[package]]
+name = "primitives"
+version = "0.1.0"
+dependencies = [
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "node-primitives",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4403,19 +4403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "node-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.11#57346f6b24875f8935280dba51fa8ab0a9ba1e39"
-dependencies = [
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
-]
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6701,20 +6688,8 @@ dependencies = [
 name = "primitives"
 version = "0.1.0"
 dependencies = [
- "frame-executive",
- "frame-support",
- "frame-system",
- "node-primitives",
- "pallet-balances",
- "pallet-collator-selection",
- "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "sp-consensus-aura",
  "sp-core",
- "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -4,45 +4,14 @@ version = '0.1.0'
 authors = ["Litentry Dev"]
 edition = '2018'
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
 [dependencies]
-# External dependencies
-codec = { package = "parity-scale-codec", version = "2.2", default-features = false, features = ["derive", "max-encoded-len"] }
-
 # Substrate dependencies
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
-frame-executive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
-node-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
-
-# Polkadot dependencies
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.11", default-features = false }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.11", default-features = false }
-
-# Local dependencies
-pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.11", default-features = false }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
-	"sp-consensus-aura/std",
-	"sp-std/std",
-	"sp-io/std",
-	"frame-support/std",
-	"frame-executive/std",
-	"frame-system/std",
-	"pallet-collator-selection/std",
-	"pallet-balances/std",
-	"node-primitives/std",
-	"polkadot-runtime-common/std",
-	"polkadot-primitives/std",
+    "sp-core/std",
+    "sp-runtime/std",
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = 'primitives'
+version = '0.1.0'
+authors = ["Litentry Dev"]
+edition = '2018'
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+# External dependencies
+codec = { package = "parity-scale-codec", version = "2.2", default-features = false, features = ["derive", "max-encoded-len"] }
+
+# Substrate dependencies
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+node-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.11", default-features = false }
+
+# Polkadot dependencies
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.11", default-features = false }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.11", default-features = false }
+
+# Local dependencies
+pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.11", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"sp-consensus-aura/std",
+	"sp-std/std",
+	"sp-io/std",
+	"frame-support/std",
+	"frame-executive/std",
+	"frame-system/std",
+	"pallet-collator-selection/std",
+	"pallet-balances/std",
+	"node-primitives/std",
+	"polkadot-runtime-common/std",
+	"polkadot-primitives/std",
+]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,0 +1,72 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#![allow(clippy::identity_op)]
+
+pub use constants::*;
+pub use opaque::*;
+pub use types::*;
+
+/// Common types of parachains.
+mod types {
+    use::sp_runtime::{
+        traits::{IdentifyAccount, Verify},
+        MultiSignature,
+    };
+    /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
+    pub type Signature = MultiSignature;
+
+    /// Some way of identifying an account on the chain. We intentionally make it equivalent
+    /// to the public key of our transaction signing scheme.
+    pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+    /// Balance of an account.
+    pub type Balance = u128;
+
+    /// Index of a transaction in the chain.
+    pub type Index = u32;
+
+    /// A hash of some data used by the chain.
+    pub type Hash = sp_core::H256;
+
+    /// An index to a block.
+    pub type BlockNumber = u32;
+}
+
+/// Common constants of parachains.
+mod constants {
+	use super::types::BlockNumber;
+
+    /// This determines the average expected block time that we are targeting.
+    /// Blocks will be produced at a minimum duration defined by `SLOT_DURATION`.
+    /// `SLOT_DURATION` is picked up by `pallet_timestamp` which is in turn picked
+    /// up by `pallet_aura` to implement `fn slot_duration()`.
+    ///
+    /// Change this to adjust the block time.
+    pub const MILLISECS_PER_BLOCK: u64 = 12000;
+
+    // NOTE: Currently it is not possible to change the slot duration after the chain has started.
+    //       Attempting to do so will brick block production.
+    pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
+
+    // Time is measured by number of blocks.
+    pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
+    pub const HOURS: BlockNumber = MINUTES * 60;
+    pub const DAYS: BlockNumber = HOURS * 24;
+}
+
+/// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
+/// the specifics of the runtime. They can then be made to be agnostic over specific formats
+/// of data like extrinsics, allowing for them to continue syncing the network through upgrades
+/// to even the core data structures.
+pub mod opaque {
+	use super::*;
+	use sp_runtime::{generic, traits::BlakeTwo256};
+
+	pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
+	/// Opaque block header type.
+	pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	/// Opaque block type.
+	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+	/// Opaque block identifier type.
+	pub type BlockId = generic::BlockId<Block>;
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,6 +11,8 @@ log = { version = "0.4.14", default-features = false }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
 
+primitives = { path = "../primitives", default-features = false }
+
 # Substrate Dependencies
 ## Substrate Primitive Dependencies
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.11" }
@@ -116,6 +118,7 @@ std = [
 	"pallet-treasury/std",
 	"pallet-utility/std",
 	"pallet-vesting/std",
+	"primitives/std",
 	"cumulus-pallet-aura-ext/std",
 	"cumulus-pallet-dmp-queue/std",
 	"cumulus-pallet-parachain-system/std",

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -1,0 +1,14 @@
+/// Money matters.
+pub mod currency {
+    use crate::Balance;
+
+    pub const UNIT: Balance = 1_000_000_000_000;
+    pub const DOLLARS: Balance = UNIT;
+    pub const CENTS: Balance = DOLLARS / 100;
+    pub const MILLICENTS: Balance = CENTS / 1_000;
+
+    /// Function used in some fee configurations
+    pub const fn deposit(items: u32, bytes: u32) -> Balance {
+        items as Balance * DOLLARS + (bytes as Balance) * 100 * MILLICENTS
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,6 +9,10 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 pub mod constants;
 pub use constants::{currency::*};
 
+pub use primitives::*;
+pub use primitives::Index as Index;
+pub use primitives::opaque as opaque;
+
 use sp_api::impl_runtime_apis;
 use sp_core::{
 	crypto::KeyTypeId,
@@ -17,9 +21,9 @@ use sp_core::{
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, Verify},
+	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, MultiSignature,
+	ApplyExtrinsicResult,
 };
 
 use sp_std::prelude::*;
@@ -62,30 +66,8 @@ use xcm_builder::{
 };
 use xcm_executor::{Config, XcmExecutor};
 
-/// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
-pub type Signature = MultiSignature;
-
-/// Some way of identifying an account on the chain. We intentionally make it equivalent
-/// to the public key of our transaction signing scheme.
-pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
-
-/// Balance of an account.
-pub type Balance = u128;
-
-/// Index of a transaction in the chain.
-pub type Index = u32;
-
-/// A hash of some data used by the chain.
-pub type Hash = sp_core::H256;
-
-/// An index to a block.
-pub type BlockNumber = u32;
-
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;
-
-/// Block header type as expected by this runtime.
-pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
@@ -123,23 +105,6 @@ pub type Executive = frame_executive::Executive<
 	AllPallets,
 >;
 
-/// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
-/// the specifics of the runtime. They can then be made to be agnostic over specific formats
-/// of data like extrinsics, allowing for them to continue syncing the network through upgrades
-/// to even the core data structures.
-pub mod opaque {
-	use super::*;
-	use sp_runtime::{generic, traits::BlakeTwo256};
-
-	pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
-	/// Opaque block header type.
-	pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-	/// Opaque block type.
-	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-	/// Opaque block identifier type.
-	pub type BlockId = generic::BlockId<Block>;
-}
-
 impl_opaque_keys! {
 	pub struct SessionKeys {
 		pub aura: Aura,
@@ -159,23 +124,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };
-
-/// This determines the average expected block time that we are targeting.
-/// Blocks will be produced at a minimum duration defined by `SLOT_DURATION`.
-/// `SLOT_DURATION` is picked up by `pallet_timestamp` which is in turn picked
-/// up by `pallet_aura` to implement `fn slot_duration()`.
-///
-/// Change this to adjust the block time.
-pub const MILLISECS_PER_BLOCK: u64 = 12000;
-
-// NOTE: Currently it is not possible to change the slot duration after the chain has started.
-//       Attempting to do so will brick block production.
-pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
-
-// Time is measured by number of blocks.
-pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
-pub const HOURS: BlockNumber = MINUTES * 60;
-pub const DAYS: BlockNumber = HOURS * 24;
 
 /// The existential deposit.
 pub const EXISTENTIAL_DEPOSIT: Balance = 10 * CENTS;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,6 +6,9 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+pub mod constants;
+pub use constants::{currency::*};
+
 use sp_api::impl_runtime_apis;
 use sp_core::{
 	crypto::KeyTypeId,
@@ -174,12 +177,6 @@ pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
 
-// Unit or DOLLARS = the base number of indivisible units for balances
-pub const UNIT: Balance = 1_000_000_000_000;
-pub const DOLLARS: Balance = UNIT;
-pub const CENTS: Balance = DOLLARS / 100;
-pub const MILLICENTS: Balance = CENTS / 1000;
-
 /// The existential deposit.
 pub const EXISTENTIAL_DEPOSIT: Balance = 10 * CENTS;
 
@@ -193,11 +190,6 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 /// We allow for 0.5 of a second of compute with a 12 second average block time.
 const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND / 2;
-
-/// Function used in some fee configurations
-pub const fn deposit(items: u32, bytes: u32) -> Balance {
-	items as Balance * DOLLARS + (bytes as Balance) * 100 * MILLICENTS
-}
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -183,9 +183,6 @@ pub const MILLICENTS: Balance = CENTS / 1000;
 /// The existential deposit.
 pub const EXISTENTIAL_DEPOSIT: Balance = 10 * CENTS;
 
-// 1 in 4 blocks (on average, not counting collisions) will be primary babe blocks.
-pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
-
 /// We assume that ~10% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);


### PR DESCRIPTION
Move most of the basic constants and configurable constants into two separate files. Generally nothing should be changed.
Closes #143 

@wangminqi fee related things (ex. WeightToFee) should go to runtime/src/constants.rs