### PR TITLE
Revert to use of raw binaries in CI

### DIFF
--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -24,19 +24,17 @@ jobs:
     concurrency:
       group: ${{ github.ref }}
       cancel-in-progress: true
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout codes
       uses: actions/checkout@v2
 
-    - name: Build docker image
-      timeout-minutes: 40
+    - name: install packages
       run: |
-        ./scripts/build-docker.sh
-        echo "============================="
-        docker images
+        sudo apt install jq wget
+        sudo snap install node --classic --channel=15
 
-    - name: Start docker containers and run CI
+    - name: run CI
       timeout-minutes: 30
       run: |
         make test-ci-binary

--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -29,14 +29,7 @@ jobs:
     - name: Checkout codes
       uses: actions/checkout@v2
 
-    - name: Build docker image
-      timeout-minutes: 40
-      run: |
-        ./scripts/build-docker.sh
-        echo "============================="
-        docker images
-
-    - name: Start docker containers and run CI
+    - name: Build binary and run CI
       timeout-minutes: 30
       run: |
         make test-ci-binary
@@ -48,11 +41,6 @@ jobs:
         name: ci-artifacts
         path: /tmp/parachain_dev/
         retention-days: 7
-
-    - name: Push docker image on dev branch if test passes
-      if: ${{ success() && (github.event_name == 'push') && (github.ref == 'refs/heads/dev') }}
-      run:
-        docker push litentry/litentry-parachain:latest
 
     - name: Clean up
       if: ${{ always() }}

--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -24,17 +24,19 @@ jobs:
     concurrency:
       group: ${{ github.ref }}
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - name: Checkout codes
       uses: actions/checkout@v2
 
-    - name: install packages
+    - name: Build docker image
+      timeout-minutes: 40
       run: |
-        sudo apt install jq wget
-        sudo snap install node --classic --channel=15
+        ./scripts/build-docker.sh
+        echo "============================="
+        docker images
 
-    - name: run CI
+    - name: Start docker containers and run CI
       timeout-minutes: 30
       run: |
         make test-ci-binary

--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -32,9 +32,11 @@ jobs:
     - name: Install toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        profile: minimal
+        toolchain: nightly
+        components: rustfmt
         target: wasm32-unknown-unknown
-        override: true
+        default: true
 
     - name: Build binary and run CI
       timeout-minutes: 50

--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -29,8 +29,15 @@ jobs:
     - name: Checkout codes
       uses: actions/checkout@v2
 
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-unknown-unknown
+        override: true
+
     - name: Build binary and run CI
-      timeout-minutes: 30
+      timeout-minutes: 50
       run: |
         make test-ci-binary
 

--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -39,14 +39,14 @@ jobs:
     - name: Start docker containers and run CI
       timeout-minutes: 30
       run: |
-        make test-ci
+        make test-ci-binary
 
     - name: Archive logs if test fails
       uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
-        name: ci-log
-        path: /tmp/parachain_ci_test.log
+        name: ci-artifacts
+        path: /tmp/parachain_dev/
         retention-days: 7
 
     - name: Push docker image on dev branch if test passes
@@ -57,5 +57,4 @@ jobs:
     - name: Clean up
       if: ${{ always() }}
       run: |
-        rm -f /tmp/parachain_ci_test.log
-        make clean-local-docker
+        make clean-local-binary

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all:
 NODE_BIN=litentry-collator
 RUNTIME=litentry-parachain-runtime
 
-.PHONY: help ## Display help commands.
+.PHONY: help ## Display help commands
 help:
 	@printf 'Usage:\n'
 	@printf '  make <tagert>\n'
@@ -25,88 +25,99 @@ help:
 
 # build release
 
-.PHONY: build-all ## Build release version.
+.PHONY: build-all ## Build release version
 build-all:
 	cargo build --release
 
-.PHONY: build-node ## Build release node only.
+.PHONY: build-node ## Build release node only
 build-node:
 	cargo build -p $(call pkgid, $(NODE_BIN)) --release
 
-.PHONY: build-runtime ## Build release runtime only.
+.PHONY: build-runtime ## Build release runtime only
 build-runtime:
 	cargo build -p $(call pkgid, $(RUNTIME)) --release
 
-# use srtool to build wasm locally
-# in github actions srtool-actions is used
-.PHONY: srtool-build-wasm
+.PHONY: srtool-build-wasm ## Build wasm locally with srtools
 srtool-build-wasm:
 	@./scripts/build-wasm.sh
 
-.PHONY: build-docker ## Build docker image.
+.PHONY: build-docker ## Build docker image
 build-docker:
 	@./scripts/build-docker.sh
 
-.PHONY: build-spec-dev ## Build specifiction without bootnodes.
+.PHONY: build-spec-dev ## Build specifiction without bootnodes
 build-spec-dev:
 	./target/release/$(NODE_BIN) build-spec --chain dev --disable-default-bootnode > ./source/local.json
 
 .PHONY: build-benchmark ## Build release version with `runtime-benchmarks`
 build-benchmark:
 	cargo build --features runtime-benchmarks --release
+	
+# launching local dev networks
 
-# test
+.PHONY: launch-local-docker ## Launch dev parachain network with docker locally
+launch-local-docker: generate-docker-compose-dev
+	@./scripts/launch-local-docker.sh
+
+.PHONY: launch-local-binary ## Launch dev parachain network with binaries locally
+launch-local-binary:
+	@./scripts/launch-local-binary.sh
+
+# run tests
 
 .PHONY: test-node
 test-node:
 	cargo test --package $(call pkgid, $(NODE_BIN))
 
-.PHONY: test-ci
-test-ci: launch-local-docker
+.PHONY: test-ci-docker ## Run CI tests with docker without clean-up
+test-ci-docker: launch-local-docker
+	@./scripts/run-ci-test.sh docker
+
+.PHONY: test-ci-binary ## Run CI tests with binary without clean-up
+test-ci-binary: launch-local-binary
 	@./scripts/run-ci-test.sh
 
-# format
+# clean up
 
-.PHONY: format ## Format source code by `cargo fmt`.
-format:
-	cargo fmt --all -- --check
-
-# launch a local dev network using docker
-.PHONY: launch-local-docker ## Launch dev parachain by docker locally
-launch-local-docker: generate-docker-compose-dev
-	@./scripts/launch-local-docker.sh
-
-# stop the local dev containers and cleanup images
-# for the most part used when done with launch-local-docker
-.PHONY: clean-local-docker ## Clean up docker images, containers, volumes, etc.
+.PHONY: clean-local-docker ## Clean up docker images, containers, volumes, etc
 clean-local-docker:
 	@./scripts/clean-local-docker.sh
 
+.PHONY: clean-local-binary ## Clean up (kill) started relaychain and parachain binaries
+clean-local-binary:
+	@./scripts/clean-local-binary.sh
+
 # generate docker-compose files
 
-.PHONY: generate-docker-compose-dev ## Generate dev docker-compose files.
+.PHONY: generate-docker-compose-dev ## Generate dev docker-compose files
 generate-docker-compose-dev:
 	@./scripts/generate-docker-files.sh dev
 
-.PHONY: generate-docker-compose-staging ## Generate staging docker-compose files.
+.PHONY: generate-docker-compose-staging ## Generate staging docker-compose files
 generate-docker-compose-staging:
 	@./scripts/generate-docker-files.sh staging
 
+# format
+
+.PHONY: format ## Format source code by `cargo fmt`
+format:
+	cargo fmt --all -- --check
+
 # benchmark for pallets
 
-.PHONY: benchmark-frame-system ## Benchmark pallet `frame-system`.
+.PHONY: benchmark-frame-system ## Benchmark pallet `frame-system`
 benchmark-frame-system:
 	@./scripts/run-benchmark-pallet.sh frame_system
 
-.PHONY: benchmark-account-linker  ## Benchmark pallet `account-linker`.
+.PHONY: benchmark-account-linker  ## Benchmark pallet `account-linker`
 benchmark-account-linker:
 	@./scripts/run-benchmark-pallet.sh account-linker
 
-.PHONY: benchmark-offchain-worker ## Benchmark pallet `offchain-worker`.
+.PHONY: benchmark-offchain-worker ## Benchmark pallet `offchain-worker`
 benchmark-offchain-worker:
 	@./scripts/run-benchmark-pallet.sh pallet-offchain-worker
 
-.PHONY: benchmark-nft ## Benchmark pallet `nft`.
+.PHONY: benchmark-nft ## Benchmark pallet `nft`
 benchmark-nft:
 	@./scripts/run-benchmark-pallet.sh pallet-nft
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,35 @@
 [![Build & Test](https://github.com/litentry/litentry-parachain/actions/workflows/build_and_run_test.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/build_and_run_test.yml)
 [![Build wasm](https://github.com/litentry/litentry-parachain/actions/workflows/build_wasm.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/build_wasm.yml)
 [![Update Pallets](https://github.com/litentry/litentry-parachain/actions/workflows/update_pallets.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/update_pallets.yml)
-[![Build docker with features](https://github.com/litentry/litentry-parachain/actions/workflows/build_docker_with_features.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/build_docker_with_features.yml)
 [![Create release draft](https://github.com/litentry/litentry-parachain/actions/workflows/create_release_draft.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/create_release_draft.yml)
 
 The Litentry parachain.
 
-
 ## launch of local dev network
 
-To start a dev network locally with 2 relaychain nodes and 1 parachain node:
+To start a dev network locally with 2 relaychain nodes and 1 parachain node, there're 2 ways:
+
+### 1. use docker images for both polkadot and litentry-parachain (preferred)
+
 ```
 make launch-local-docker
 ```
 During this a few files will be generated under `docker/generated-dev/`.
+
+### 2. use raw binaries for both polkadot and litentry-parachain
+
+Only when option 1 doesn't work.
+Due to a [known issue](https://github.com/litentry/litentry-parachain/issues/187) it's possible that after launching the parachain is not producing any blocks. In this case we could try to launch the dev network with raw binaries.
+
+prequisite:
+- you have the `./target/release/litentry-collator` binary, locally compiled.
+- if you have on non-Linux host, you need to have polkadot binary locally compiled.
+
+To start the network:
+If you are on linux host, run `make launch-local-binary`
+If you are on other OS, run `./scripts/launch-local-binary.sh path-to-polkadot-bin path-to-litentry-parachain-bin`
+
+**Build and push of docker images are disabled** until we find a robust solution for [issue #192](https://github.com/litentry/litentry-parachain/issues/192).
 
 ## manual builds
 
@@ -52,11 +68,15 @@ The default leasing duration for parachain is 1 day, in case you want to extend 
 
 ## run CI tests locally
 
-To run the CI tests locally, dev network must be launched first as above, then:
+To run the CI tests locally, similar to launching the networks, it's possible to run them in either docker or binary mode:
 ```
-make test-ci
+make test-ci-docker
 ```
-You may want to run `make clean-local-docker` to stop the containers and tidy them.
+or
+```
+make test-ci-binary
+```
+You may want to run `make clean-local-docker` or `make clean-local-binary` to stop the containers and tidy them afterwards.
 Please note that this command also removes all local `litentry/litentry-parachain` images except the one with `latest` tag.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -6,31 +6,12 @@
 
 The Litentry parachain.
 
-## launch of local dev network
-
-To start a dev network locally with 2 relaychain nodes and 1 parachain node, there're 2 ways:
-
-### 1. use docker images for both polkadot and litentry-parachain (preferred)
-
+## Lists of make targets
+Simply run
 ```
-make launch-local-docker
+make help
 ```
-During this a few files will be generated under `docker/generated-dev/`.
-
-### 2. use raw binaries for both polkadot and litentry-parachain
-
-Only when option 1 doesn't work.
-Due to a [known issue](https://github.com/litentry/litentry-parachain/issues/187) it's possible that after launching the parachain is not producing any blocks. In this case we could try to launch the dev network with raw binaries.
-
-prequisite:
-- you have the `./target/release/litentry-collator` binary, locally compiled.
-- if you have on non-Linux host, you need to have polkadot binary locally compiled.
-
-To start the network:
-If you are on linux host, run `make launch-local-binary`
-If you are on other OS, run `./scripts/launch-local-binary.sh path-to-polkadot-bin path-to-litentry-parachain-bin`
-
-**Build and push of docker images are disabled** until we find a robust solution for [issue #192](https://github.com/litentry/litentry-parachain/issues/192).
+to see the full lists of market targets and their short descriptions.
 
 ## manual builds
 
@@ -50,21 +31,49 @@ To build the `litentry/litentry-parachain` docker image locally:
 make build-docker
 ```
 
-To build staging env chain-specs:
-```
-make generate-docker-compose-staging
-```
-Staging env doesn't really run the service inside docker container, but the generated chain specs are useful.
+## launch of local dev network
 
-For a full list of make targets, run:
+To start a local dev network with 2 relaychain nodes and 1 parachain node, there're two ways:
+
+### 1. use docker images for both polkadot and litentry-parachain (preferred)
+
 ```
-make help
+make launch-local-docker
 ```
+[parachain-launch](https://github.com/open-web3-stack/parachain-launch) will be installed and used to generate chain-specs and docker-compose files.
 
-The default leasing duration for parachain is 1 day, in case you want to extend it (even after it's downgraded to parathread), simply do a `forceLease` via sudo, it should be upgraded to parachain soon again and start to produce blocks.
+The generated files will be under `docker/generated-dev/`.
 
-![image](https://user-images.githubusercontent.com/7630809/135689832-1f57cd5c-7f83-4fce-9bb0-832b77a38dcc.png)
+When finished with the dev network, run
+```
+make clean-local-docker
+```
+to stop the processes and tidy things up.
 
+### 2. use raw binaries for both polkadot and litentry-parachain
+
+Only when option 1 doesn't work.
+Due to a [known issue](https://github.com/litentry/litentry-parachain/issues/187) it's possible that after launching the parachain is not producing any blocks.
+
+In this case we could try to launch the dev network with raw binaries.
+
+**On Linux host:**
+
+- you should have the locally compiled `./target/release/litentry-collator` binary.
+- run `make launch-local-binary`
+
+**On Non-Linux host:**
+
+- you should have locally compiled binaries, for both `polkadot` and `litentry-collator`
+- run `./scripts/launch-local-binary.sh path-to-polkadot-bin path-to-litentry-parachain-bin`
+
+When finished with the dev network, run
+```
+make clean-local-binary
+```
+to stop the processes and tidy things up.
+
+**Build and push of docker images are disabled** until we find a robust solution for [issue #192](https://github.com/litentry/litentry-parachain/issues/192).
 
 ## run CI tests locally
 
@@ -74,10 +83,20 @@ make test-ci-docker
 ```
 or
 ```
+# if on Linux
 make test-ci-binary
+
+# otherwise
+./scripts/launch-local-binary.sh path-to-polkadot-bin path-to-litentry-parachain-bin
+./scripts/run-ci-test.sh
 ```
-You may want to run `make clean-local-docker` or `make clean-local-binary` to stop the containers and tidy them afterwards.
-Please note that this command also removes all local `litentry/litentry-parachain` images except the one with `latest` tag.
+Remember to run the clean-up afterwards.
+
+## extend the leasing period
+
+The default leasing duration for parachain is 1 day, in case you want to extend it (even after it's downgraded to parathread), simply do a `forceLease` via sudo, it should be upgraded to parachain soon again and start to produce blocks.
+
+![image](https://user-images.githubusercontent.com/7630809/135689832-1f57cd5c-7f83-4fce-9bb0-832b77a38dcc.png)
 
 ## License
 Apache-2.0

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -132,6 +132,11 @@ pub fn get_chain_spec_dev(id: ParaId) -> ChainSpec {
 }
 
 pub fn get_chain_spec_staging(id: ParaId) -> ChainSpec {
+	// Staging keys are derivative keys based on a single master secret phrase:
+	//
+	// root: 	$SECRET
+	// account:	$SECRET//collator//<id>
+	// aura: 	$SECRET//collator//<id>//aura
 	get_chain_spec_from_genesis_info(
 		include_bytes!("../res/genesis_info/staging.json"),
 		"Litentry-staging",

--- a/scripts/clean-local-binary.sh
+++ b/scripts/clean-local-binary.sh
@@ -4,10 +4,15 @@
 
 TMPDIR=/tmp/parachain_dev
 
-for f in $(ls $TMPDIR/*.pid 2>/dev/null); do
-  echo "Killing $f ..."
-  kill -9 $(cat "$f")
-done
+# for f in $(ls $TMPDIR/*.pid 2>/dev/null); do
+#   echo "Killing $f ..."
+#   kill -9 $(cat "$f")
+# done
+
+# use killall here:
+# the previously written PID could change if any process restarted
+killall polkadot
+killall litentry-collator
 
 rm -rf "$TMPDIR"
 

--- a/scripts/clean-local-binary.sh
+++ b/scripts/clean-local-binary.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# no `set -e` here as we allow commands to fail in this script
+
+TMPDIR=/tmp/parachain_dev
+
+for f in $(ls $TMPDIR/*.pid 2>/dev/null); do
+  echo "Killing $f ..."
+  kill -9 $(cat "$f")
+done
+
+rm -rf "$TMPDIR"
+
+echo "cleaned up."

--- a/scripts/launch-local-binary.sh
+++ b/scripts/launch-local-binary.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# This scripts starts a local network with 2 relaychain nodes + 1 parachain node.
+# The binaries are passed as arguments for this script.
+#
+# mainly used on CI-runner, where:
+# - The `polkadot` binary will be downloaded directly from official release.
+# - The `litentry-collator` binary will be copied out from the litentry/litentry-parachain:latest image.
+#
+# To use this script locally, you might have to first compile the binaries that can run on your OS.
+
+function usage() {
+  echo
+  echo "Usage:   $0 [path-to-polkadot-bin] [path-to-litentry-collator]"
+  echo "Default: polkadot bin from the latest official release"
+  echo "         litentry-collator bin from litentry/litentry-parachain:latest image"
+  echo "         both are of Linux verion"
+}
+
+if [ "$#" -gt 2 ] ; then
+  usage
+  exit 1
+fi
+
+POLKADOT_BIN="$1"
+PARACHAIN_BIN="$2"
+PARACHAIN_ID=2022
+
+TMPDIR=/tmp/parachain_dev
+[ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
+
+cd "$TMPDIR"
+
+function print_divider() {
+  echo "------------------------------------------------------------"
+}
+
+print_divider
+
+if [ -z "$POLKADOT_BIN" ]; then
+  echo "no polkadot binary provided, download now ..."
+  # download from latest official release
+  url=$(wget -q -O - https://api.github.com/repos/paritytech/polkadot/releases/latest | grep browser_download_url | grep "polkadot\"$" | sed 's/.*https/https/;s/"//')
+  wget -O polkadot -q "$url"
+  chmod a+x polkadot
+  POLKADOT_BIN="$TMPDIR/polkadot"
+fi
+
+if ! "$POLKADOT_BIN" --version &> /dev/null; then
+  echo "Cannot execute $POLKADOT_BIN, wrong executable?"
+  usage
+  exit 1
+fi
+
+if [ -z "$PARACHAIN_BIN" ]; then
+  echo "no litentry-collator binary provided, download now ..."
+  # copy the binary from docker image
+  docker cp $(docker create --rm litentry/litentry-parachain:latest):/usr/local/bin/litentry-collator .
+  chmod a+x litentry-collator
+  PARACHAIN_BIN="$TMPDIR/litentry-collator"
+fi
+
+if ! "$PARACHAIN_BIN" --version &> /dev/null; then
+  echo "Cannot execute $PARACHAIN_BIN, wrong executable?"
+  usage
+  exit 1
+fi
+
+echo "starting dev network with binaries ..."
+
+# generate chain spec
+ROCOCO_CHAINSPEC=rococo-local-chain-spec.json
+$POLKADOT_BIN build-spec --chain rococo-local --disable-default-bootnode --raw > $ROCOCO_CHAINSPEC
+
+# generate genesis state and wasm for registration
+$PARACHAIN_BIN export-genesis-state --parachain-id $PARACHAIN_ID --chain dev > para-$PARACHAIN_ID-genesis
+$PARACHAIN_BIN export-genesis-wasm --chain dev > para-$PARACHAIN_ID-wasm
+
+# run alice and bob as relay nodes
+$POLKADOT_BIN --chain $ROCOCO_CHAINSPEC --alice --tmp --port 30333 --ws-port 9944 &> "relay.alice.log" &
+echo $! > "relay.alice.pid"
+sleep 5
+
+$POLKADOT_BIN --chain $ROCOCO_CHAINSPEC --bob --tmp --port 30334 --ws-port 9945  &> "relay.bob.log" &
+echo $! > "relay.bob.pid"
+sleep 5
+
+# run a litentry-collator instance
+$PARACHAIN_BIN --alice --collator --force-authoring --tmp --chain dev --parachain-id $PARACHAIN_ID --port 40333 --ws-port 9946 --execution wasm \
+  -- \
+  --execution wasm --chain $ROCOCO_CHAINSPEC --port 30332 --ws-port 9943 &> "para.alice.log" &
+echo $! > "para.alice.pid"
+sleep 5
+
+echo "done. please check $TMPDIR for generated files if need"
+print_divider

--- a/scripts/launch-local-binary.sh
+++ b/scripts/launch-local-binary.sh
@@ -40,7 +40,8 @@ print_divider
 if [ -z "$POLKADOT_BIN" ]; then
   echo "no polkadot binary provided, download now ..."
   # download from latest official release
-  url=$(wget -q -O - https://api.github.com/repos/paritytech/polkadot/releases/latest | grep browser_download_url | grep "polkadot\"$" | sed 's/.*https/https/;s/"//')
+  wget -q -O download.log https://api.github.com/repos/paritytech/polkadot/releases/latest
+  url=$(cat download.log | jq | grep browser_download_url | grep "polkadot\"$" | sed 's/.*https/https/;s/"//')
   wget -O polkadot -q "$url"
   chmod a+x polkadot
   POLKADOT_BIN="$TMPDIR/polkadot"

--- a/scripts/launch-local-binary.sh
+++ b/scripts/launch-local-binary.sh
@@ -55,7 +55,7 @@ fi
 if [ -z "$PARACHAIN_BIN" ]; then
   echo "no litentry-collator binary provided, download now ..."
   # copy the binary from docker image
-  docker cp $(docker create --rm litentry/litentry-parachain:latest):/usr/local/bin/litentry-collator .
+  docker cp $(docker create --rm litentry/litentry-parachain:collective):/usr/local/bin/litentry-collator .
   chmod a+x litentry-collator
   PARACHAIN_BIN="$TMPDIR/litentry-collator"
 fi

--- a/scripts/run-ci-test.sh
+++ b/scripts/run-ci-test.sh
@@ -5,5 +5,12 @@ set -eo pipefail
 ROOTDIR=$(git rev-parse --show-toplevel)
 cd "$ROOTDIR/ts-tests"
 
+TMPDIR=/tmp/parachain_dev
+[ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
+
 echo "NODE_ENV=ci" > .env
-yarn && yarn test 2>&1 | tee "/tmp/parachain_ci_test.log"
+yarn
+if [ "$1" != "docker" ]; then
+  yarn register-parachain 2>&1 | tee "$TMPDIR/register-parachain.log"
+fi
+yarn test 2>&1 | tee "$TMPDIR/parachain_ci_test.log"

--- a/ts-tests/config.ci.json
+++ b/ts-tests/config.ci.json
@@ -2,6 +2,8 @@
     "eth_address" : "[0x4d88dc5d528a33e4b8be579e9476715f60060582]",
     "private_key" : "0xe82c0c4259710bb0d6cf9f9e8d0ad73419c1278a14d375e5ca691e7618103011",
     "ocw_account" : "5FEYX9NES9mAJt1Xg4WebmHWywxyeGQK8G3oEBXtyfZrRePX",
+    "parachain_genesis_path": "/tmp/parachain_dev/para-2022-genesis",
+    "parachain_wasm_path": "/tmp/parachain_dev/para-2022-wasm",
     "parachain_ws" : "ws://localhost:9946",
     "relaynode_ws" : "ws://localhost:9944"
 }


### PR DESCRIPTION
resolves #190 

This PR:
- builds and uses the raw binaries in CI
  - polkadot: downloaded latest release
  - litentry-parachain: locally compiled raw binary
- disables building and pushing of docker image for now
- adds comments to how staging keys were generated.
