### PR TITLE
Versioning of runtime wasm and toml in first release

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://substrate.dev'
 license = 'Unlicense'
 name = 'litentry-collator'
 repository = 'https://github.com/substrate-developer-hub/substrate-parachain-template'
-version = '0.1.0'
+version = '0.9.0'
 
 [[bin]]
 name = 'litentry-collator'

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'primitives'
-version = '0.1.0'
+version = '0.9.0'
 authors = ["Litentry Dev"]
 edition = '2018'
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'litentry-parachain-runtime'
-version = '0.1.0'
+version = '0.9.0'
 authors = ["Litentry Dev"]
 edition = '2018'
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -131,13 +131,13 @@ impl_opaque_keys! {
 /// This runtime version.
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("litentry-parachain"),
-	impl_name: create_runtime_str!("litentry-parachain"),
+	spec_name: create_runtime_str!("litentry"),
+	impl_name: create_runtime_str!("litentry"),
 	authoring_version: 1,
-	// same versioning-mechanism as polkadot, corresponds to 0.1.0 package version/client version.
+	// same versioning-mechanism as polkadot, corresponds to 0.9.0 TOML version
 	// last digit is used for minor updates, like 9110 -> 9111 in polkadot
-	spec_version: 1000,
-	impl_version: 1,
+	spec_version: 9000,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };


### PR DESCRIPTION
resolves #207 

This PR adjusts the runtime and TOML versions as specified in #207 