### PR TITLE
add local pre-commit hook for `cargo fmt`

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,8 @@
+To use the hooks under this folder, either set the git config for this repo:
+```
+git config core.hooksPath .githooks
+```
+
+or
+manually copy the hook files to .git/hooks/ and double check the files are exectuable.
+

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@ files=$((git diff --cached --name-only --diff-filter=ACMR | grep -Ei "\.rs$") ||
 if [ ! -z "$files" ]; then
   echo "[cargo fmt] and [git add] the following files:"
   echo "$files"
-  cargo fmt --all
+  make fmt
   git add $(echo "$files" | paste -s -d " " -)
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ROOTDIR=$(git rev-parse --show-toplevel)
+cd "$ROOTDIR"
+
+files=$((git diff --cached --name-only --diff-filter=ACMR | grep -Ei "\.rs$") || true)
+if [ ! -z "$files" ]; then
+  echo "[cargo fmt] and [git add] the following files:"
+  echo "$files"
+  cargo fmt --all
+  git add $(echo "$files" | paste -s -d " " -)
+fi
+


### PR DESCRIPTION
Resolves #234 

This PR adds a local pre-commit hook for `cargo fmt`.

Note:
it **doesn't** work out of box, see `.githooks/README.md` about how to use it.
