### PR TITLE
rework release process

### DIFF
--- a/.github/workflows/build_and_run_test.yml
+++ b/.github/workflows/build_and_run_test.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Install toolchain
       uses: actions-rs/toolchain@v1
@@ -46,6 +48,8 @@ jobs:
     steps:
     - name: Checkout codes
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Build docker image
       timeout-minutes: 40

--- a/.github/workflows/build_docker_with_args.yml
+++ b/.github/workflows/build_docker_with_args.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout codes on ${{ github.ref }}
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Build docker image
         run: |

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+          fetch-depth: 0
 
       - name: Build with srtool
         id: srtool_build

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -3,16 +3,21 @@ name: Create release draft
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: an existing tag (e.g. v1.2.3)
+      release_tag:
+        description: an existing tag for creating release (e.g. v1.2.3)
         required: true
+      diff_tag:
+        description: an existing tag to run diff against (e.g. v1.2.0)
+        default: ''
+        required: false
       is_geneis_release:
         description: if it's genesis release [true|false]
         default: 'false'
         required: false
 
 env:
-  RELEASE_TAG: ${{ github.event.inputs.ref }}
+  RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+  DIFF_TAG: ${{ github.event.inputs.diff_tag }}
   GENESIS_RELEASE: ${{ github.event.inputs.is_geneis_release }}
 
 jobs:
@@ -106,7 +111,7 @@ jobs:
 
       - name: Generate release notes
         run: |
-          ./scripts/generate-release-notes.sh ${{ github.workspace }}/.github/release_notes.md
+          ./scripts/generate-release-notes.sh ${{ github.workspace }}/.github/release_notes.md ${{ env.DIFF_TAG }}
 
       - name: Create release draft
         id: create-release-draft

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - name: Build with srtool
         id: srtool_build
@@ -60,6 +61,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - name: Build docker image
         run: |
@@ -105,6 +107,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - name: Download all artefacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -37,7 +37,6 @@ jobs:
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > litentry-parachain-srtool-digest.json
           echo "==============================================="
           cat litentry-parachain-srtool-digest.json
-          cp ${{ steps.srtool_build.outputs.wasm }} litentry-parachain-runtime.compact.wasm
           cp ${{ steps.srtool_build.outputs.wasm_compressed }} litentry-parachain-runtime.compact.compressed.wasm
 
       - name: Upload wasm artefacts
@@ -46,7 +45,6 @@ jobs:
           name: litentry-parachain-runtime
           path: |
             litentry-parachain-srtool-digest.json
-            litentry-parachain-runtime.compact.wasm
             litentry-parachain-runtime.compact.compressed.wasm
 
   ## build docker image of client binary ##
@@ -115,11 +113,10 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          name: Litentry-parachain release ${{ env.RELEASE_TAG }}
+          name: Litentry-parachain ${{ env.RELEASE_TAG }}
           body_path: ${{ github.workspace }}/.github/release_notes.md
           draft: true
           files: |
             litentry-parachain-runtime/litentry-parachain-srtool-digest.json
-            litentry-parachain-runtime/litentry-parachain-runtime.compact.wasm
             litentry-parachain-runtime/litentry-parachain-runtime.compact.compressed.wasm
             litentry-collator/*

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -75,9 +75,9 @@ proposal (authorizeUpgrade)  : $RUNTIME_COMPRESSED_AUTHORIZE_UPGRADE_HASH
 ## Dependencies
 
 <CODEBLOCK>
-Substrate : $SUBSTRATE_DEP
-Polkadot  : $POLKADOT_DEP
-Cumulus   : $CUMULUS_DEP
+Substrate                    : $SUBSTRATE_DEP
+Polkadot                     : $POLKADOT_DEP
+Cumulus                      : $CUMULUS_DEP
 <CODEBLOCK>
 
 EOF
@@ -133,7 +133,7 @@ Details:
 
 EOF
 
-  git log --no-merges --abbrev-commit --pretty="format:%t|%s" $DIFF_TAG..$RELEASE_TAG | while read -r f; do
+  git log --no-merges --abbrev-commit --pretty="format:%h|%s" $DIFF_TAG..$RELEASE_TAG | while read -r f; do
     commit=$(echo "$f" | cut -d'|' -f1)
     desc=$(echo "$f" | cut -d'|' -f2)
     echo -e "- [\`$commit\`]($REPO/commit/$commit) $desc" >> "$1"

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -115,25 +115,27 @@ sed -i.bak 's/<CODEBLOCK>/```/g' "$1"
 rm -f "$1.bak"
 
 # if we have a diff-tag, list the changes inbetween
-OLD_TAG="$2"
+DIFF_TAG="$2"
 
-if [ -z "$OLD_TAG" ]; then
+if [ -z "$DIFF_TAG" ]; then
   echo "Nothing to compare"
   exit 0
-elif [ "$OLD_TAG" = "$RELEASE_TAG" ]; then
+elif [ "$DIFF_TAG" = "$RELEASE_TAG" ]; then
   echo "Skip compare to itself"
   exit 0
 else
   cat << EOF >> "$1"
 ## Changes
 
-Raw diff: [$OLD_TAG...$RELEASE_TAG](https://github.com/litentry/litentry-parachain/compare/$OLD_TAG...$RELEASE_TAG)
+Raw diff: [$DIFF_TAG...$RELEASE_TAG](https://github.com/litentry/litentry-parachain/compare/$DIFF_TAG...$RELEASE_TAG)
+
+Details:
 
 EOF
 
-  git log --no-merges --abbrev-commit --pretty="format:%t|%s" $OLD_TAG...$RELEASE_TAG | while read -r f; do
+  git log --no-merges --abbrev-commit --pretty="format:%t|%s" $DIFF_TAG...$RELEASE_TAG | while read -r f; do
     commit=$(echo "$f" | cut -d'|' -f1)
     desc=$(echo "$f" | cut -d'|' -f2)
-    echo "- [$commit]($REPO/commit/$commit) $desc" >> "$1"
+    echo "- [[$commit]($REPO/commit/$commit)]  $desc" >> "$1"
   done
 fi

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -31,10 +31,6 @@ SRTOOL_DIGEST_FILE=litentry-parachain-runtime/litentry-parachain-srtool-digest.j
 
 RUNTIME_VERSION=$(grep spec_version runtime/src/lib.rs | sed 's/.*version: //;s/,//')
 
-RUNTIME_COMPACT_SHA256=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compact.sha256 | sed 's/"//g')
-RUNTIME_COMPACT_PROPOSAL_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compact.subwasm.proposal_hash | sed 's/"//g')
-RUNTIME_COMPACT_PARACHAIN_UPGRADE_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compact.subwasm.parachain_authorize_upgrade_hash | sed 's/"//g')
-
 RUNTIME_COMPRESSED_SHA256=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.sha256 | sed 's/"//g')
 RUNTIME_COMPRESSED_PROPOSAL_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.subwasm.proposal_hash | sed 's/"//g')
 RUNTIME_COMPRESSED_PARACHAIN_UPGRADE_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.subwasm.parachain_authorize_upgrade_hash | sed 's/"//g')
@@ -44,8 +40,6 @@ RUNTIME_COMPRESSED_PARACHAIN_UPGRADE_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runt
 # use <CODE> to decorate around the stuff and then replace it with `
 # so that it's not executed as commands inside heredoc
 cat << EOF > "$1"
-
-# Release notes for litentry-parachain $RELEASE_TAG
 
 ## Client
 
@@ -63,11 +57,6 @@ version: **$NODE_VERSION**
 ## Runtime
 
 version: **$RUNTIME_VERSION**
-
-### compact
-- sha256: <CODE>$RUNTIME_COMPACT_SHA256<CODE>
-- proposal_hash: <CODE>$RUNTIME_COMPACT_PROPOSAL_HASH<CODE>
-- parachain_authorize_upgrade_hash: <CODE>$RUNTIME_COMPACT_PARACHAIN_UPGRADE_HASH<CODE>
 
 ### compact-compressed
 - sha256: <CODE>$RUNTIME_COMPRESSED_SHA256<CODE>

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -8,34 +8,43 @@ err_report() {
 trap 'err_report $LINENO' ERR
 
 function usage() {
-    echo "Usage: $0 path-to-output"
+    echo "Usage: $0 path-to-output diff-tag"
 }
 
-[ $# -ne 1 ] && (usage; exit 1)
+[ $# -gt 2 ] && (usage; exit 1)
 
 ROOTDIR=$(git rev-parse --show-toplevel)
 cd "$ROOTDIR"
 
+REPO=https://github.com/litentry/litentry-parachain
+
+# base image used to build the node binary
 NODE_BUILD_BASE_IMAGE=$(grep FROM docker/Dockerfile | head -n1 | sed 's/^FROM //;s/ as.*//')
 
 # somehow `docker inspect` doesn't pull our litentry-parachain image sometimes
 docker pull "$NODE_BUILD_BASE_IMAGE"
 docker pull "litentry/litentry-parachain:$RELEASE_TAG"
 
-NODE_HASH=$(sha1sum litentry-collator/litentry-collator | awk '{print $1}')
-NODE_RUSTC_VERSION=$(docker run --rm "$NODE_BUILD_BASE_IMAGE" rustup default nightly 2>&1 | grep " installed" | sed 's/.*installed - //')
-NODE_BINARY_DOCKER_IMAGE_DIGEST=$(docker inspect "litentry/litentry-parachain:$RELEASE_TAG"  | grep litentry/litentry-parachain@sha256 | sed 's/ *"//;s/"//')
 NODE_VERSION=$(grep version node/Cargo.toml | head -n1 | sed "s/'$//;s/.*'//")
+NODE_BIN=litentry-collator
+NODE_SHA1SUM=$(shasum litentry-collator/"$NODE_BIN" | awk '{print $1}')
+NODE_RUSTC_VERSION=$(docker run --rm "$NODE_BUILD_BASE_IMAGE" rustup default nightly 2>&1 | grep " installed" | sed 's/.*installed - //')
 
 SRTOOL_DIGEST_FILE=litentry-parachain-runtime/litentry-parachain-srtool-digest.json
 
 RUNTIME_VERSION=$(grep spec_version runtime/src/lib.rs | sed 's/.*version: //;s/,//')
-
+RUNTIME_COMPRESSED_SIZE=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.size | sed 's/"//g')
+RUNTIME_RUSTC_VERSION=$(cat "$SRTOOL_DIGEST_FILE" | jq .rustc | sed 's/"//g')
 RUNTIME_COMPRESSED_SHA256=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.sha256 | sed 's/"//g')
-RUNTIME_COMPRESSED_PROPOSAL_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.subwasm.proposal_hash | sed 's/"//g')
-RUNTIME_COMPRESSED_PARACHAIN_UPGRADE_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.subwasm.parachain_authorize_upgrade_hash | sed 's/"//g')
+RUNTIME_COMPRESSED_BLAKE2=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.blake2_256 | sed 's/"//g')
+RUNTIME_COMPRESSED_SET_CODE_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.subwasm.proposal_hash | sed 's/"//g')
+RUNTIME_COMPRESSED_AUTHORIZE_UPGRADE_HASH=$(cat "$SRTOOL_DIGEST_FILE" | jq .runtimes.compressed.subwasm.parachain_authorize_upgrade_hash | sed 's/"//g')
 
+SUBSTRATE_DEP=$(grep sp-core node/Cargo.toml | sed 's/.*branch = "//;s/".*//')
+CUMULUS_DEP=$(grep cumulus-client-cli node/Cargo.toml | sed 's/.*branch = "//;s/".*//')
+POLKADOT_DEP=$(grep polkadot-cli node/Cargo.toml | sed 's/.*branch = "//;s/".*//')
 
+TAB="$(printf '\t')"
 
 # use <CODE> to decorate around the stuff and then replace it with `
 # so that it's not executed as commands inside heredoc
@@ -43,31 +52,39 @@ cat << EOF > "$1"
 
 ## Client
 
-version: **$NODE_VERSION**
-
-### binary
-- name: <CODE>litentry-collator<CODE>
-- sha1sum hash: <CODE>$NODE_HASH<CODE>
-- rustc version: <CODE>$NODE_RUSTC_VERSION<CODE>
-
-### docker image
-- name: <CODE>litentry/litentry-parachain:$RELEASE_TAG<CODE>
-- repo digest hash: <CODE>$NODE_BINARY_DOCKER_IMAGE_DIGEST<CODE>
+<CODEBLOCK>
+version                      : $NODE_VERSION
+name                         : $NODE_BIN
+rustc                        : $NODE_RUSTC_VERSION
+sha1sum                      : $NODE_SHA1SUM
+docker image                 : litentry/litentry-parachain:$RELEASE_TAG
+<CODEBLOCK>
 
 ## Runtime
 
-version: **$RUNTIME_VERSION**
+<CODEBLOCK>
+version                      : $RUNTIME_VERSION
+size                         : $RUNTIME_COMPRESSED_SIZE
+rustc                        : $RUNTIME_RUSTC_VERSION
+sha256                       : $RUNTIME_COMPRESSED_SHA256
+blake2-256                   : $RUNTIME_COMPRESSED_BLAKE2
+proposal (setCode)           : $RUNTIME_COMPRESSED_SET_CODE_HASH
+proposal (authorizeUpgrade)  : $RUNTIME_COMPRESSED_AUTHORIZE_UPGRADE_HASH
+<CODEBLOCK>
 
-### compact-compressed
-- sha256: <CODE>$RUNTIME_COMPRESSED_SHA256<CODE>
-- proposal_hash: <CODE>$RUNTIME_COMPRESSED_PROPOSAL_HASH<CODE>
-- parachain_authorize_upgrade_hash: <CODE>$RUNTIME_COMPRESSED_PARACHAIN_UPGRADE_HASH<CODE>
+## Dependencies
+
+<CODEBLOCK>
+Substrate : $SUBSTRATE_DEP
+Polkadot  : $POLKADOT_DEP
+Cumulus   : $CUMULUS_DEP
+<CODEBLOCK>
 
 EOF
 
 if [ "$GENESIS_RELEASE" = "true" ]; then
-  GENESIS_STATE_HASH=$(sha1sum litentry-collator/litentry-genesis-state | awk '{print $1}')
-  GENESIS_WASM_HASH=$(sha1sum litentry-collator/litentry-genesis-wasm | awk '{print $1}')
+  GENESIS_STATE_HASH=$(shasum litentry-collator/litentry-genesis-state | awk '{print $1}')
+  GENESIS_WASM_HASH=$(shasum litentry-collator/litentry-genesis-wasm | awk '{print $1}')
 
   # double check that exported wasm matches what's written in chain-spec
   # intentionally use 'generate-prod' as chain type
@@ -84,10 +101,39 @@ if [ "$GENESIS_RELEASE" = "true" ]; then
   cat << EOF >> "$1"
 ## Genesis artefacts
 
-- genesis-state sha1sum <CODE>$GENESIS_STATE_HASH<CODE>
-- genesis-wasm  sha1sum <CODE>$GENESIS_WASM_HASH<CODE>
+<CODEBLOCK>
+sha1sum of genesis state  : $GENESIS_STATE_HASH
+sha1sum of genesis wasm   : $GENESIS_WASM_HASH
+<CODEBLOCK>
 
 EOF
 fi
 
-sed -i 's/<CODE>/`/g' "$1"
+# restore ``` in markdown doc
+# use -i.bak for compatibility for MacOS and Linux
+sed -i.bak 's/<CODEBLOCK>/```/g' "$1"
+rm -f "$1.bak"
+
+# if we have a diff-tag, list the changes inbetween
+OLD_TAG="$2"
+
+if [ -z "$OLD_TAG" ]; then
+  echo "Nothing to compare"
+  exit 0
+elif [ "$OLD_TAG" = "$RELEASE_TAG" ]; then
+  echo "Skip compare to itself"
+  exit 0
+else
+  cat << EOF >> "$1"
+## Changes
+
+Raw diff: [$OLD_TAG...$RELEASE_TAG](https://github.com/litentry/litentry-parachain/compare/$OLD_TAG...$RELEASE_TAG)
+
+EOF
+
+  git log --no-merges --abbrev-commit --pretty="format:%t|%s" $OLD_TAG...$RELEASE_TAG | while read -r f; do
+    commit=$(echo "$f" | cut -d'|' -f1)
+    desc=$(echo "$f" | cut -d'|' -f2)
+    echo "- [$commit]($REPO/commit/$commit) $desc" >> "$1"
+  done
+fi

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -136,6 +136,6 @@ EOF
   git log --no-merges --abbrev-commit --pretty="format:%t|%s" $DIFF_TAG..$RELEASE_TAG | while read -r f; do
     commit=$(echo "$f" | cut -d'|' -f1)
     desc=$(echo "$f" | cut -d'|' -f2)
-    echo "- [[$commit]($REPO/commit/$commit)]  $desc" >> "$1"
+    echo -e "- [\`$commit\`]($REPO/commit/$commit) $desc" >> "$1"
   done
 fi

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -133,7 +133,7 @@ Details:
 
 EOF
 
-  git log --no-merges --abbrev-commit --pretty="format:%t|%s" $DIFF_TAG...$RELEASE_TAG | while read -r f; do
+  git log --no-merges --abbrev-commit --pretty="format:%t|%s" $DIFF_TAG..$RELEASE_TAG | while read -r f; do
     commit=$(echo "$f" | cut -d'|' -f1)
     desc=$(echo "$f" | cut -d'|' -f2)
     echo "- [[$commit]($REPO/commit/$commit)]  $desc" >> "$1"


### PR DESCRIPTION
Resolves #215 

This PR:
- removed unused runtime format (compact)
- reworked the build info of client and runtime
- add dependency info of substrate/polkadot/cumulus
- use `fetch-depth: 0` to make sure we fetch all the branches and tags
- include changes between tags
- other format and alignment changes

An exemplary release note with these changes can be found here: https://github.com/litentry/litentry-parachain/releases/tag/215-tmp-release
