### PR TITLE
add generate_weights.yml template

### DIFF
--- a/.github/workflows/generate_weights.yml
+++ b/.github/workflows/generate_weights.yml
@@ -1,0 +1,18 @@
+name: Generate weights files
+
+on:
+  workflow_dispatch:
+    inputs:
+      pallets:
+        description: pallets to calculate weights, * for all, or comma listed (e.g. frame-system,pallet-proxy)
+        default: '*'
+        required: true
+
+jobs:
+  build-and-run-benchmark:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout codes on ${{ github.ref }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0


### PR DESCRIPTION

According to [this doc](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#:~:text=To%20trigger%20the%20workflow_dispatch%20event%2C%20your%20workflow%20must%20be%20in%20the%20default%20branch), `workflow_dispatch` even can only take effect when it was once-off checked in into default branch.

This PR merely adds the yml template file so that it can be triggered/tested from feature-branch.