### PR TITLE
Remove filter, and enable tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ test-node:
 test-ci-docker: launch-local-docker
 	@./scripts/run-ci-test.sh
 
+.PHONY: test-release-ci--docker ## Run CI tests with docker without clean-up
+test-release-ci-docker: launch-local-docker
+	@./scripts/run-ci-test.sh -release
+
 .PHONY: test-ci-binary ## Run CI tests with binary without clean-up
 test-ci-binary: launch-local-binary
 	@./scripts/run-ci-test.sh

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -53,7 +53,7 @@ use sp_version::RuntimeVersion;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, match_type, parameter_types,
-	traits::{Contains, Everything, InstanceFilter},
+	traits::{Everything, InstanceFilter},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
 		DispatchClass, IdentityFee, Weight,
@@ -238,7 +238,7 @@ impl frame_system::Config for Runtime {
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = BaseCallFilter;
+	type BaseCallFilter = Everything;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
 	/// Block & extrinsics weights: base values and limits.
@@ -894,18 +894,6 @@ construct_runtime! {
 
 		// TMP
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 255,
-	}
-}
-
-pub struct BaseCallFilter;
-impl Contains<Call> for BaseCallFilter {
-	fn contains(call: &Call) -> bool {
-		matches!(
-			call,
-			Call::Sudo(_) |
-            // System
-            Call::System(_) | Call::Timestamp(_) | Call::ParachainSystem(_)
-		)
 	}
 }
 

--- a/scripts/run-ci-test.sh
+++ b/scripts/run-ci-test.sh
@@ -8,6 +8,8 @@ cd "$ROOTDIR/ts-tests"
 TMPDIR=/tmp/parachain_dev
 [ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
 
+TEST_TYPE=${1:-}
+
 [ -f .env ] || echo "NODE_ENV=ci" > .env
 yarn
-yarn test 2>&1 | tee "$TMPDIR/parachain_ci_test.log"
+yarn test${TEST_TYPE} 2>&1 | tee "$TMPDIR/parachain_ci_test.log"

--- a/ts-tests/package.json
+++ b/ts-tests/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "register-parachain": "ts-node tests/register-parachain.ts",
-    "test": "mocha --exit --sort -r ts-node/register 'tests/base-filter.test.ts'",
-    "test-all": "mocha --exit --sort -r ts-node/register 'tests/**/*.test.ts'"
+    "test": "mocha --exit --sort -r ts-node/register 'tests/**/*.test.ts'",
+    "test-release": "mocha --exit --sort -r ts-node/register 'tests/base-filter.test.ts'"
   },
   "author": "Han Zhao",
   "license": "ISC",


### PR DESCRIPTION
This PR solves issue #243 . 

The runtime filter has been removed on the dev branch. At the same time, previous functional ts tests are activated. A new test type "release test" has been added for filter tests. 

For the later release, we shall add the runtime filter back before each release, and run `make test-release-ci-docker ` to verify if the filter has been correctly added. See [here](https://github.com/litentry/litentry-parachain/commit/e97461a4d2d30e3c1a7adb10d88c24254599b8f8#diff-0ec06ea58bd455f09ce6b3bb4c2c1c0d37bda51c1e1be2151c560c9c973959ec) for details how filter can be added.