### PR TITLE
Add releasing checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,36 @@
+---
+name: Release issue template
+about: Tracking issue for new releases
+title: Litentry-parachain {{ env.VERSION }} Release checklist
+---
+## Release Checklist
+
+Here is a release checklist for Litentry-parachain {{ env.VERSION }}.
+
+The current release candidate can be checked out with `git checkout release-{{ env.VERSION }}`
+
+### before forking to a release branch
+
+These checks should be performed prior to forking to a release branch, that is, on `dev` branch.
+
+- [ ] Verify **`spec_version`** has been bumped since the last release in case of runtime change.
+- [ ] Verify previously **`completed migrations`** are removed (or at least guarded with if-check if they shouldn't be removed for some reason)
+- [ ] Verify pallet and extrinsic ordering has stayed the same. Bump **`transaction_version`** if not.
+- [ ] Verify new extrinsics have been correctly whitelisted/blacklisted for **`baseCallFilter`**.
+- [ ] Verify **`benchmarks`** have been updated for any modified runtime logic.
+
+### after forking to a release branch
+
+These checks should be performed after forking to a release branch, that is, on the `release-{{ env.VERSION }}` branch.
+
+- [ ] Verify **`new migrations`** complete successfully, ideally tested with both unittests and `try-runtime` on a current state.
+- [ ] Verify **`all tests`** pass for release codebase, including cargo tests and ts tests.
+- [ ] Verify the new release (including runtime upgrade) can be run on **`staging`** env.
+- [ ] Verify the new release (including runtime upgrade) can be run on **`public network`** env, like westend/rococo, if applicable.
+
+### publish the release
+
+These are the general checks for the releasing process.
+
+- [ ] Verify a **`tag`** has been correctly acquired on `release-{{ env.VERSION }}` branch.
+- [ ] Verify **`release-draft`** has been created by [create_release_draft.yml](https://github.com/litentry/litentry-parachain/blob/dev/.github/workflows/create_release_draft.yml) and is ready to publish.

--- a/.github/workflows/create_release_issue.yml
+++ b/.github/workflows/create_release_issue.yml
@@ -1,0 +1,24 @@
+name: Create release issue
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  create-release-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codes on ${{ github.ref }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - id: create-issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${GITHUB_REF#refs/*/}
+        with:
+          filename: .github/ISSUE_TEMPLATE/release.md
+          update_existing: false


### PR DESCRIPTION
Resolves #238 

This PR adds a releasing checklist template which will be included in a auto-generated tracking issues upon push for any release tag.

The template is inspired by https://github.com/paritytech/polkadot/blob/master/.github/ISSUE_TEMPLATE/release.md