### PR TITLE
remove unrelated std features from dev-dependencies

### DIFF
--- a/pallets/drop3/Cargo.toml
+++ b/pallets/drop3/Cargo.toml
@@ -22,8 +22,8 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 
 [features]
 default = ["std"]
@@ -36,8 +36,6 @@ std = [
 	"codec/std",
 	"sp-std/std",
 	"sp-runtime/std",
-	"sp-io/std",
-	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 	"frame-benchmarking/std",

--- a/pallets/extrinsic-filter/Cargo.toml
+++ b/pallets/extrinsic-filter/Cargo.toml
@@ -20,10 +20,10 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false, optional = true }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.13" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 
 [features]
 default = ["std"]
@@ -36,11 +36,7 @@ std = [
 	"codec/std",
 	"sp-std/std",
 	"sp-runtime/std",
-	"sp-io/std",
-	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 	"frame-benchmarking/std",
-	"pallet-balances/std",
-	"pallet-timestamp/std",
 ]


### PR DESCRIPTION
This PR removes unrelated std features from dev-dependencies so that wasm can be correctly built.