### PR TITLE
Use dev chain for tryruntime and benchmark

### DIFF
--- a/scripts/benchmark-weight-local.sh
+++ b/scripts/benchmark-weight-local.sh
@@ -29,7 +29,7 @@ case "$3" in
     runtime)
         OUTPUT="--output=./runtime/$1/src/weights/$PALLET.rs"
         TEMPLATE=
-        CHAIN="--chain=generate-$1"
+        CHAIN="--chain=$1-dev"
         ;;
     pallet)
         OUTPUT="$(cargo pkgid -q $2 | sed 's/.*litentry-parachain/\./;s/#.*/\/src\/weights.rs/')"

--- a/scripts/benchmark-weight-remote.sh
+++ b/scripts/benchmark-weight-remote.sh
@@ -48,11 +48,8 @@ for p in $PALLETS; do
   # filter out the flooding warnings from pallet_scheduler:
   # Warning: There are more items queued in the Scheduler than expected from the runtime configuration.
   #          An update might be needed
-  #
-  # TODO: which chain-spec type in `--chain=` should be used? prod or dev?
-  #       It shouldn't matter too much though
   RUST_LOG=runtime::scheduler=error ./litentry-collator benchmark \
-      --chain=generate-$1 \
+      --chain=$1-dev \
       --execution=wasm  \
       --db-cache=20 \
       --wasm-execution=compiled \


### PR DESCRIPTION
resolves #310 

This PR forcibly uses dev chain for `try-runtime` and `benchmark` command.