### PR TITLE
Quick fix 0.9.12 13 leftover issue

### DIFF
--- a/runtime/litentry/src/transaction_payment.rs
+++ b/runtime/litentry/src/transaction_payment.rs
@@ -33,10 +33,7 @@ where
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
 		let _numeric_amount = amount.peek();
 		let author = <pallet_authorship::Pallet<R>>::author();
-		<pallet_balances::Pallet<R>>::resolve_creating(
-			&author,
-			amount,
-		);
+		<pallet_balances::Pallet<R>>::resolve_creating(&author, amount);
 	}
 }
 

--- a/runtime/litentry/src/transaction_payment.rs
+++ b/runtime/litentry/src/transaction_payment.rs
@@ -31,7 +31,6 @@ where
 	<R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		let _numeric_amount = amount.peek();
 		let author = <pallet_authorship::Pallet<R>>::author();
 		<pallet_balances::Pallet<R>>::resolve_creating(&author, amount);
 	}

--- a/runtime/litentry/src/transaction_payment.rs
+++ b/runtime/litentry/src/transaction_payment.rs
@@ -37,10 +37,6 @@ where
 			&<pallet_authorship::Pallet<R>>::author(),
 			amount,
 		);
-		<frame_system::Pallet<R>>::deposit_event(pallet_balances::Event::Deposit {
-			who: author,
-			amount: numeric_amount,
-		});
 	}
 }
 

--- a/runtime/litentry/src/transaction_payment.rs
+++ b/runtime/litentry/src/transaction_payment.rs
@@ -31,8 +31,8 @@ where
 	<R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		let numeric_amount = amount.peek();
-		let author = <pallet_authorship::Pallet<R>>::author();
+		let _numeric_amount = amount.peek();
+		let _author = <pallet_authorship::Pallet<R>>::author();
 		<pallet_balances::Pallet<R>>::resolve_creating(
 			&<pallet_authorship::Pallet<R>>::author(),
 			amount,

--- a/runtime/litentry/src/transaction_payment.rs
+++ b/runtime/litentry/src/transaction_payment.rs
@@ -32,9 +32,9 @@ where
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
 		let _numeric_amount = amount.peek();
-		let _author = <pallet_authorship::Pallet<R>>::author();
+		let author = <pallet_authorship::Pallet<R>>::author();
 		<pallet_balances::Pallet<R>>::resolve_creating(
-			&<pallet_authorship::Pallet<R>>::author(),
+			&author,
 			amount,
 		);
 	}

--- a/runtime/litmus/src/transaction_payment.rs
+++ b/runtime/litmus/src/transaction_payment.rs
@@ -33,10 +33,7 @@ where
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
 		let _numeric_amount = amount.peek();
 		let author = <pallet_authorship::Pallet<R>>::author();
-		<pallet_balances::Pallet<R>>::resolve_creating(
-			&author,
-			amount,
-		);
+		<pallet_balances::Pallet<R>>::resolve_creating(&author,amount);
 	}
 }
 

--- a/runtime/litmus/src/transaction_payment.rs
+++ b/runtime/litmus/src/transaction_payment.rs
@@ -33,7 +33,7 @@ where
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
 		let _numeric_amount = amount.peek();
 		let author = <pallet_authorship::Pallet<R>>::author();
-		<pallet_balances::Pallet<R>>::resolve_creating(&author,amount);
+		<pallet_balances::Pallet<R>>::resolve_creating(&author, amount);
 	}
 }
 

--- a/runtime/litmus/src/transaction_payment.rs
+++ b/runtime/litmus/src/transaction_payment.rs
@@ -31,7 +31,6 @@ where
 	<R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		let _numeric_amount = amount.peek();
 		let author = <pallet_authorship::Pallet<R>>::author();
 		<pallet_balances::Pallet<R>>::resolve_creating(&author, amount);
 	}

--- a/runtime/litmus/src/transaction_payment.rs
+++ b/runtime/litmus/src/transaction_payment.rs
@@ -37,10 +37,6 @@ where
 			&<pallet_authorship::Pallet<R>>::author(),
 			amount,
 		);
-		<frame_system::Pallet<R>>::deposit_event(pallet_balances::Event::Deposit {
-			who: author,
-			amount: numeric_amount,
-		});
 	}
 }
 

--- a/runtime/litmus/src/transaction_payment.rs
+++ b/runtime/litmus/src/transaction_payment.rs
@@ -31,8 +31,8 @@ where
 	<R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		let numeric_amount = amount.peek();
-		let author = <pallet_authorship::Pallet<R>>::author();
+		let _numeric_amount = amount.peek();
+		let _author = <pallet_authorship::Pallet<R>>::author();
 		<pallet_balances::Pallet<R>>::resolve_creating(
 			&<pallet_authorship::Pallet<R>>::author(),
 			amount,

--- a/runtime/litmus/src/transaction_payment.rs
+++ b/runtime/litmus/src/transaction_payment.rs
@@ -32,9 +32,9 @@ where
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
 		let _numeric_amount = amount.peek();
-		let _author = <pallet_authorship::Pallet<R>>::author();
+		let author = <pallet_authorship::Pallet<R>>::author();
 		<pallet_balances::Pallet<R>>::resolve_creating(
-			&<pallet_authorship::Pallet<R>>::author(),
+			&author,
 			amount,
 		);
 	}


### PR DESCRIPTION
This is a quick fix of event printed. As substrate upgrade from 0.9.12 to 0.9.13, transactionPayment implementation does not need to manual generating pallet_balance deposit event, otherwise a duplicated event will be printed. 