### PR TITLE
Fix ss58prefix in system pallet for litmus

### DIFF
--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -210,7 +210,7 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	pub const SS58Prefix: u8 = 31;
+	pub const SS58Prefix: u8 = 131;
 }
 
 impl frame_system::Config for Runtime {


### PR DESCRIPTION
resolves #343 

we might have to consider if we need any GA for releasing runtime only, while the client doesn't change.