### PR TITLE
use mint for bridge token import

### DIFF
--- a/pallets/bridge-transfer/src/lib.rs
+++ b/pallets/bridge-transfer/src/lib.rs
@@ -100,7 +100,7 @@ pub mod pallet {
 			T::BridgeOrigin::ensure_origin(origin)?;
 
 			let total_issuance = <T as Config>::Currency::total_issuance();
-			if total_issuance + amount > T::MaximumIssuance::get() {
+			if amount > T::MaximumIssuance::get() || total_issuance + amount > T::MaximumIssuance::get() {
 				return Err(Error::<T>::ReachMaximumSupply.into())
 			}
 			if rid == T::NativeTokenResourceId::get() {

--- a/pallets/bridge-transfer/src/lib.rs
+++ b/pallets/bridge-transfer/src/lib.rs
@@ -100,7 +100,9 @@ pub mod pallet {
 			T::BridgeOrigin::ensure_origin(origin)?;
 
 			let total_issuance = <T as Config>::Currency::total_issuance();
-			if amount > T::MaximumIssuance::get() || total_issuance + amount > T::MaximumIssuance::get() {
+			if amount > T::MaximumIssuance::get() ||
+				total_issuance + amount > T::MaximumIssuance::get()
+			{
 				return Err(Error::<T>::ReachMaximumSupply.into())
 			}
 			if rid == T::NativeTokenResourceId::get() {

--- a/pallets/bridge-transfer/src/mock.rs
+++ b/pallets/bridge-transfer/src/mock.rs
@@ -32,6 +32,7 @@ use pallet_bridge as bridge;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
+pub const MAXIMUM_ISSURANCE: u64 = 20_000_000_000_000;
 
 frame_support::construct_runtime!(
 	pub enum Test where
@@ -117,6 +118,7 @@ impl bridge::Config for Test {
 }
 
 parameter_types! {
+	pub const MaximumIssuance: u64 = MAXIMUM_ISSURANCE;
 	// bridge::derive_resource_id(1, &bridge::hashing::blake2_128(b"LIT"));
 	pub const NativeTokenResourceId: [u8; 32] = hex!("0000000000000000000000000000000a21dfe87028f214dd976be8479f5af001");
 }
@@ -126,6 +128,7 @@ impl Config for Test {
 	type BridgeOrigin = bridge::EnsureBridge<Test>;
 	type Currency = Balances;
 	type NativeTokenResourceId = NativeTokenResourceId;
+	type MaximumIssuance = MaximumIssuance;
 }
 
 parameter_types! {

--- a/pallets/bridge-transfer/src/tests.rs
+++ b/pallets/bridge-transfer/src/tests.rs
@@ -20,8 +20,8 @@ use super::{
 	bridge,
 	mock::{
 		assert_events, balances, new_test_ext, Balances, Bridge, BridgeTransfer, Call, Event,
-		NativeTokenResourceId, Origin, ProposalLifetime, Test, ENDOWED_BALANCE, RELAYER_A,
-		RELAYER_B, RELAYER_C,
+		NativeTokenResourceId, Origin, ProposalLifetime, Test, ENDOWED_BALANCE, MAXIMUM_ISSURANCE,
+		RELAYER_A, RELAYER_B, RELAYER_C,
 	},
 	*,
 };
@@ -65,6 +65,25 @@ fn transfer() {
 			who: RELAYER_A,
 			amount: 10,
 		})]);
+	})
+}
+
+#[test]
+fn exceed_max_supply() {
+	new_test_ext().execute_with(|| {
+		let bridge_id: u64 = Bridge::account_id();
+		let resource_id = NativeTokenResourceId::get();
+		assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE);
+
+		assert_noop!(
+			BridgeTransfer::transfer(
+				Origin::signed(Bridge::account_id()),
+				RELAYER_A,
+				MAXIMUM_ISSURANCE + 1,
+				resource_id,
+			),
+			Error::<Test>::ReachMaximumSupply
+		);
 	})
 }
 

--- a/pallets/bridge-transfer/src/tests.rs
+++ b/pallets/bridge-transfer/src/tests.rs
@@ -88,6 +88,33 @@ fn exceed_max_supply() {
 }
 
 #[test]
+fn exceed_max_supply() {
+	new_test_ext().execute_with(|| {
+		let bridge_id: u64 = Bridge::account_id();
+		let resource_id = NativeTokenResourceId::get();
+		assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE);
+
+		assert_ok!(BridgeTransfer::transfer(
+			Origin::signed(Bridge::account_id()),
+				RELAYER_A,
+				MAXIMUM_ISSURANCE,
+				resource_id,
+		));
+
+		assert_noop!(
+			BridgeTransfer::transfer(
+				Origin::signed(Bridge::account_id()),
+				RELAYER_A,
+				10,
+				resource_id,
+			),
+			Error::<Test>::ReachMaximumSupply
+		);
+	})
+}
+
+
+#[test]
 fn transfer_to_regular_account() {
 	new_test_ext().execute_with(|| {
 		let dest_chain = 0;

--- a/pallets/bridge-transfer/src/tests.rs
+++ b/pallets/bridge-transfer/src/tests.rs
@@ -88,7 +88,7 @@ fn exceed_max_supply() {
 }
 
 #[test]
-fn exceed_max_supply() {
+fn exceed_max_supply_second() {
 	new_test_ext().execute_with(|| {
 		let bridge_id: u64 = Bridge::account_id();
 		let resource_id = NativeTokenResourceId::get();

--- a/pallets/bridge-transfer/src/tests.rs
+++ b/pallets/bridge-transfer/src/tests.rs
@@ -96,9 +96,9 @@ fn exceed_max_supply() {
 
 		assert_ok!(BridgeTransfer::transfer(
 			Origin::signed(Bridge::account_id()),
-				RELAYER_A,
-				MAXIMUM_ISSURANCE,
-				resource_id,
+			RELAYER_A,
+			MAXIMUM_ISSURANCE,
+			resource_id,
 		));
 
 		assert_noop!(
@@ -112,7 +112,6 @@ fn exceed_max_supply() {
 		);
 	})
 }
-
 
 #[test]
 fn transfer_to_regular_account() {

--- a/pallets/bridge-transfer/src/tests.rs
+++ b/pallets/bridge-transfer/src/tests.rs
@@ -69,6 +69,25 @@ fn transfer() {
 }
 
 #[test]
+fn mint_overflow() {
+	new_test_ext().execute_with(|| {
+		let bridge_id: u64 = Bridge::account_id();
+		let resource_id = NativeTokenResourceId::get();
+		assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE);
+
+		assert_noop!(
+			BridgeTransfer::transfer(
+				Origin::signed(Bridge::account_id()),
+				RELAYER_A,
+				u64::MAX,
+				resource_id,
+			),
+			Error::<Test>::OverFlow
+		);
+	})
+}
+
+#[test]
 fn exceed_max_supply() {
 	new_test_ext().execute_with(|| {
 		let bridge_id: u64 = Bridge::account_id();
@@ -97,7 +116,7 @@ fn exceed_max_supply_second() {
 		assert_ok!(BridgeTransfer::transfer(
 			Origin::signed(Bridge::account_id()),
 			RELAYER_A,
-			MAXIMUM_ISSURANCE,
+			MAXIMUM_ISSURANCE - Balances::total_issuance(),
 			resource_id,
 		));
 

--- a/runtime/litentry/src/lib.rs
+++ b/runtime/litentry/src/lib.rs
@@ -902,6 +902,7 @@ impl pallet_bridge::Config for Runtime {
 }
 
 parameter_types! {
+	pub const MaximumIssuance: Balance = 80_000_000 * DOLLARS;
 	// bridge::derive_resource_id(1, &bridge::hashing::blake2_128(b"LIT"));
 	pub const NativeTokenResourceId: [u8; 32] = hex_literal::hex!("00000000000000000000000000000063a7e2be78898ba83824b0c0cc8dfb6001");
 }
@@ -911,6 +912,7 @@ impl pallet_bridge_transfer::Config for Runtime {
 	type BridgeOrigin = pallet_bridge::EnsureBridge<Runtime>;
 	type Currency = Balances;
 	type NativeTokenResourceId = NativeTokenResourceId;
+	type MaximumIssuance = MaximumIssuance;
 }
 
 parameter_types! {

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -892,6 +892,7 @@ impl pallet_bridge::Config for Runtime {
 }
 
 parameter_types! {
+	pub const MaximumIssuance: Balance = 20_000_000 * DOLLARS;
 	// bridge::derive_resource_id(1, &bridge::hashing::blake2_128(b"LIT"));
 	pub const NativeTokenResourceId: [u8; 32] = hex_literal::hex!("00000000000000000000000000000063a7e2be78898ba83824b0c0cc8dfb6001");
 }
@@ -901,6 +902,7 @@ impl pallet_bridge_transfer::Config for Runtime {
 	type BridgeOrigin = pallet_bridge::EnsureBridge<Runtime>;
 	type Currency = Balances;
 	type NativeTokenResourceId = NativeTokenResourceId;
+	type MaximumIssuance = MaximumIssuance;
 }
 
 parameter_types! {


### PR DESCRIPTION
The PR resolves #358, the bridge will use mint for the imported token.