### PR TITLE
Enable vest() function call for reward claiming

### DIFF
--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -864,6 +864,7 @@ impl Contains<Call> for SafeModeFilter {
 pub struct NormalModeFilter;
 impl Contains<Call> for NormalModeFilter {
 	fn contains(call: &Call) -> bool {
+		// Calls that fulfill either matches or match below can pass the filter
 		matches!(
 			call,
 			Call::Sudo(_) |
@@ -871,7 +872,14 @@ impl Contains<Call> for NormalModeFilter {
 			Call::System(_) | Call::Timestamp(_) | Call::ParachainSystem(_) |
 			// ExtrinsicFilter
 			Call::ExtrinsicFilter(_)
-		)
+		) || match call {
+			// Only enable vest() call function in vesting
+			Call::Vesting(method) => match method {
+				pallet_vesting::Call::vest { .. } => true,
+				_ => false,
+			},
+			_ => false,
+		}
 	}
 }
 

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -864,7 +864,6 @@ impl Contains<Call> for SafeModeFilter {
 pub struct NormalModeFilter;
 impl Contains<Call> for NormalModeFilter {
 	fn contains(call: &Call) -> bool {
-		// Calls that fulfill either matches or match below can pass the filter
 		matches!(
 			call,
 			Call::Sudo(_) |

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -871,15 +871,10 @@ impl Contains<Call> for NormalModeFilter {
 			// System
 			Call::System(_) | Call::Timestamp(_) | Call::ParachainSystem(_) |
 			// ExtrinsicFilter
-			Call::ExtrinsicFilter(_)
-		) || match call {
-			// Only enable vest() call function in vesting
-			Call::Vesting(method) => match method {
-				pallet_vesting::Call::vest { .. } => true,
-				_ => false,
-			},
-			_ => false,
-		}
+			Call::ExtrinsicFilter(_) | 
+			// Vesting - only enable vest() call function
+			Call::Vesting(pallet_vesting::Call::vest { .. })
+		) 
 	}
 }
 

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -870,10 +870,10 @@ impl Contains<Call> for NormalModeFilter {
 			// System
 			Call::System(_) | Call::Timestamp(_) | Call::ParachainSystem(_) |
 			// ExtrinsicFilter
-			Call::ExtrinsicFilter(_) | 
+			Call::ExtrinsicFilter(_) |
 			// Vesting - only enable vest() call function
 			Call::Vesting(pallet_vesting::Call::vest { .. })
-		) 
+		)
 	}
 }
 


### PR DESCRIPTION
This PR resolves #430 

The reason of enabling vest() function only is, that the vesting pallets contains other functions like vestedTransfer() which does not require sudo for calling. So we just enable vest() for users to claim their own vested rewards.