### PR TITLE
Add extra ref parameter when building docker

### DIFF
--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout codes on ${{ github.ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
   check-cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
     needs: [check-cargo-fmt, check-file-change]
     if: needs.check-file-change.outputs.src == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
     needs: [check-cargo-fmt, check-file-change]
     steps:
       - name: Checkout codes
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -150,7 +150,7 @@ jobs:
           - litentry
     steps:
       - name: Checkout codes
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -185,7 +185,7 @@ jobs:
     needs: [check-cargo-fmt, check-file-change]
     if: needs.check-file-change.outputs.src == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -223,7 +223,7 @@ jobs:
           - rococo
           - moonbase
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-docker-with-args.yml
+++ b/.github/workflows/build-docker-with-args.yml
@@ -3,6 +3,10 @@ name: Build docker with args
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: The commit SHA or tag for checking out code
+        default: ${{ github.ref }}
+        required: false
       dockerfile_type:
         type: choice
         description: The type of Dockerfile to use
@@ -23,9 +27,10 @@ jobs:
   build-docker-with-args:
     runs-on: self-hosted
     steps:
-      - name: Checkout codes on ${{ github.ref }}
-        uses: actions/checkout@v2
+      - name: Checkout codes on ${{ github.event.inputs.ref }}
+        uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
       - name: Build docker image

--- a/.github/workflows/build-docker-with-args.yml
+++ b/.github/workflows/build-docker-with-args.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       ref:
         description: The commit SHA or tag for checking out code
-        default: ${{ github.ref }}
+        default: ''
         required: false
       dockerfile_type:
         type: choice
@@ -27,10 +27,10 @@ jobs:
   build-docker-with-args:
     runs-on: self-hosted
     steps:
-      - name: Checkout codes on ${{ github.event.inputs.ref }}
+      - name: Checkout codes on ${{ github.event.inputs.ref || github.ref }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
           fetch-depth: 0
 
       - name: Build docker image

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -12,7 +12,7 @@ on:
         - rococo
         - moonbase
       ref:
-        description: The ref to be used for the repo
+        description: The commit SHA or tag for checking out code
         default: ''
         required: false
 

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codes on ${{ github.event.inputs.ref || github.ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
           fetch-depth: 0

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -47,7 +47,7 @@ jobs:
           - moonbase
     steps:
       - name: Checkout codes on ${{ env.RELEASE_TAG }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
@@ -80,7 +80,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout codes on ${{ env.RELEASE_TAG }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
@@ -131,7 +131,7 @@ jobs:
           - litentry
     steps:
       - name: Checkout codes
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -171,7 +171,7 @@ jobs:
       (success('build-wasm') || success('run-ts-tests'))
     steps:
       - name: Checkout codes on ${{ env.RELEASE_TAG }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0

--- a/.github/workflows/create-release-issue.yml
+++ b/.github/workflows/create-release-issue.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codes on ${{ github.ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0

--- a/.github/workflows/update-pallets.yml
+++ b/.github/workflows/update-pallets.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: litentry/litentry-parachain
           submodules: true


### PR DESCRIPTION
This PR:

- adds an extra ref parameter when building docker so that different commit SHA/tag can be used for checkout
- update `actions/checkout` to **v3**