### PR TITLE
Bump ts dep version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ generate-docker-compose-litmus:
 
 .PHONY: update-ts-dep ## update ts-tests dependencies
 update-ts-dep:
-	@cd ts-tests && npx npm-check-updates && yarn
+	@cd ts-tests && npx npm-check-updates -u && yarn
 
 # format
 

--- a/scripts/generate-docker-files.sh
+++ b/scripts/generate-docker-files.sh
@@ -23,7 +23,7 @@ OUTDIR=generated-$CHAIN
 print_divider
 
 echo "installing parachain-launch ..."
-yarn add @open-web3/parachain-launch
+yarn add -s @open-web3/parachain-launch
 print_divider
 
 # pull the polkadot image to make sure we are using the latest

--- a/scripts/launch-local-docker.sh
+++ b/scripts/launch-local-docker.sh
@@ -41,7 +41,7 @@ print_divider
 function check_block() {
   for i in $(seq 1 $WAIT_ROUNDS); do
     sleep $WAIT_INTERVAL_SECONDS
-    if docker-compose logs "$parachain_service" | grep -F '[Parachain]' | grep -Fq "best: #1" 2>/dev/null; then
+    if docker-compose logs "$parachain_service" | grep -F '[Parachain]' 2>/dev/null | grep -Fq "best: #1" 2>/dev/null; then
       echo "parachain produced #1, all good. Quit now"
       exit 0
     fi
@@ -51,7 +51,7 @@ function check_block() {
 echo "waiting for parachain to import blocks ..."
 
 while : ; do
-  if docker-compose logs "$parachain_service" | grep -F '[Parachain]' | grep -Fq "Imported #" 2>/dev/null; then
+  if docker-compose logs "$parachain_service" | grep -F '[Parachain]' 2>/dev/null | grep -Fq "Imported #" 2>/dev/null; then
     echo "parachain imported blocks"
     break
   else

--- a/scripts/launch-local-docker.sh
+++ b/scripts/launch-local-docker.sh
@@ -41,7 +41,7 @@ print_divider
 function check_block() {
   for i in $(seq 1 $WAIT_ROUNDS); do
     sleep $WAIT_INTERVAL_SECONDS
-    if docker-compose logs "$parachain_service" | grep -F '[Parachain]' | grep -Fq "best: #1"; then
+    if docker-compose logs "$parachain_service" | grep -F '[Parachain]' | grep -Fq "best: #1" 2>/dev/null; then
       echo "parachain produced #1, all good. Quit now"
       exit 0
     fi
@@ -51,7 +51,7 @@ function check_block() {
 echo "waiting for parachain to import blocks ..."
 
 while : ; do
-  if docker-compose logs "$parachain_service" | grep -F '[Parachain]' | grep -Fq "Imported #"; then
+  if docker-compose logs "$parachain_service" | grep -F '[Parachain]' | grep -Fq "Imported #" 2>/dev/null; then
     echo "parachain imported blocks"
     break
   else

--- a/ts-tests/package.json
+++ b/ts-tests/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@polkadot/api": "^8.6.2",
-    "@polkadot/types": "^8.5.1",
+    "@polkadot/types": "^8.6.2",
     "dotenv": "^16.0.1",
     "web3": "^1.7.3"
   },

--- a/ts-tests/yarn.lock
+++ b/ts-tests/yarn.lock
@@ -484,7 +484,7 @@
     "@babel/runtime" "^7.18.3"
     "@polkadot/util" "^9.3.1"
 
-"@polkadot/types@8.6.2", "@polkadot/types@^8.5.1":
+"@polkadot/types@8.6.2", "@polkadot/types@^8.6.2":
   version "8.6.2"
   resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-8.6.2.tgz#4a0aad232a21b2c7465d4825e52b0565f0cc3b1d"
   integrity sha512-T35bTk0HojZPJGiJw5t1GFZhg+LU1S1xkZ4EmhxlxjK31dVJVVzwgafdp/fMaSWUKmr32X9mvxVIErtUtUUQ+A==


### PR DESCRIPTION
This PR:
- bumps polkadot/types version
- add more silent flags to reduce logging
- try to suppress 'broken pipe' errors in CI