### PR TITLE
Select type to release in the release CI 

### DIFF
--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -3,13 +3,16 @@ name: Create release draft
 on:
   workflow_dispatch:
     inputs:
-      release_type:
-        type: choice
-        description: Which release type
-        options:
-          - both
-          - client
-          - runtime
+      release_client:
+        type: boolean
+        description: release client
+        required: true
+        default: true
+      release_runtime:
+        type: boolean
+        description: release runtime
+        required: true
+        default: true
       release_tag:
         description: an existing tag for creating release (e.g. v1.2.3)
         required: true
@@ -28,15 +31,35 @@ on:
           - moonbase
 
 env:
-  RELEASE_TYPE: ${{ github.event.inputs.release_type }}
   RELEASE_TAG: ${{ github.event.inputs.release_tag }}
   DIFF_TAG: ${{ github.event.inputs.diff_tag }}
   GENESIS_RELEASE: ${{ github.event.inputs.genesis_release }}
 
 jobs:
+  set-release-type:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set release_type
+        id: vars
+        run: |
+          release_type=""
+          if [ "${{ github.event.inputs.release_client }}" = "true" ] && [ "${{ github.event.inputs.release_runtime }}" = "true" ]; then
+            release_type="both"
+          elif [ "${{ github.event.inputs.release_client }}" = "true" ]; then
+            release_type="client"
+          elif [ "${{ github.event.inputs.release_runtime }}" = "true" ]; then
+            release_type="runtime"
+          else
+            echo "::error::Please select at least one release type."
+            exit 1
+          fi
+          echo "::set-output name=release_type::${release_type}"
+    outputs:
+      release_type: ${{ steps.vars.outputs.release_type }}
+
   ## build runtime wasm ##
   build-wasm:
-    if: github.event.inputs.release_type != 'client'
+    if: ${{ github.event.inputs.release_runtime == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -76,7 +99,7 @@ jobs:
 
   ## build docker image of client binary ##
   build-docker:
-    if: github.event.inputs.release_type != 'runtime'
+    if: ${{ github.event.inputs.release_client == 'true' }}
     runs-on: self-hosted
     steps:
       - name: Checkout codes on ${{ env.RELEASE_TAG }}
@@ -166,6 +189,7 @@ jobs:
     needs:
       - build-wasm
       - run-ts-tests
+      - set-release-type
     if: |
       !failure() && !cancelled() &&
       (success('build-wasm') || success('run-ts-tests'))
@@ -181,7 +205,7 @@ jobs:
 
       - name: Generate release notes
         run: |
-          ./scripts/generate-release-notes.sh ${{ github.workspace }}/.github/release_notes.md ${{ env.RELEASE_TYPE }} ${{ env.DIFF_TAG }}
+          ./scripts/generate-release-notes.sh ${{ github.workspace }}/.github/release_notes.md ${{ needs.set-release-type.outputs.release_type }} ${{ env.DIFF_TAG }}
 
       - name: Create release draft
         id: create-release-draft


### PR DESCRIPTION
I'm not sure if these changes will make the code better than before, it seems a bit verbose. Would  `choice-input` be better if release_type had only 3 types(both/client/runtime)?