### PR TITLE
Use release and production consistently

### DIFF
--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build docker image
         run: |
-          ./scripts/build-docker.sh prod runtime-benchmarks --features=runtime-benchmarks
+          ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
 
       - name: Push docker image
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,7 +103,7 @@ jobs:
         timeout-minutes: 60
         if: needs.check-file-change.outputs.src == 'true'
         run: |
-          ./scripts/build-docker.sh dev
+          ./scripts/build-docker.sh release
           echo "============================="
           docker images
 

--- a/.github/workflows/build-docker-with-args.yml
+++ b/.github/workflows/build-docker-with-args.yml
@@ -7,12 +7,12 @@ on:
         description: The commit SHA or tag for checking out code
         default: ''
         required: false
-      dockerfile_type:
+      cargo_profile:
         type: choice
-        description: The type of Dockerfile to use
+        description: which profile to use in cargo
         options:
-        - dev
-        - prod
+        - release
+        - production
       docker_tag:
         description: The tag for the built docker image
         required: true
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build docker image
         run: |
-          ./scripts/build-docker.sh ${{ github.event.inputs.dockerfile_type }} ${{ github.event.inputs.docker_tag }} "${{ github.event.inputs.args }}"
+          ./scripts/build-docker.sh ${{ github.event.inputs.cargo_profile }} ${{ github.event.inputs.docker_tag }} "${{ github.event.inputs.args }}"
           echo "============================="
           docker images
 

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Build docker image
         run: |
-          ./scripts/build-docker.sh prod ${{ env.RELEASE_TAG }}
+          ./scripts/build-docker.sh production ${{ env.RELEASE_TAG }}
           echo "============================="
           docker images
 

--- a/Makefile
+++ b/Makefile
@@ -65,13 +65,13 @@ srtool-build-wasm-rococo:
 srtool-build-wasm-moonbase:
 	@./scripts/build-wasm.sh moonbase
 
-.PHONY: build-docker-dev ## Build docker image using dev setting (--profile release)
-build-docker-dev:
-	@./scripts/build-docker.sh dev
+.PHONY: build-docker-release ## Build docker image using cargo profile `release`
+build-docker-release:
+	@./scripts/build-docker.sh release
 
-.PHONY: build-docker-prod ## Build docker image using prod setting (--profile production)
-build-docker-prod:
-	@./scripts/build-docker.sh prod
+.PHONY: build-docker-production ## Build docker image using cargo profile `production`
+build-docker-production:
+	@./scripts/build-docker.sh production
 
 .PHONY: build-node-benchmarks ## Build release node with `runtime-benchmarks` feature
 build-node-benchmarks:
@@ -81,21 +81,21 @@ build-node-benchmarks:
 build-node-tryruntime:
 	cargo build --locked --features try-runtime --release
 	
-# launching local dev networks
+# launch a local network
 
-.PHONY: launch-docker-litentry ## Launch litentry-parachain dev network with docker locally
+.PHONY: launch-docker-litentry ## Launch a local litentry-parachain network with docker
 launch-docker-litentry: generate-docker-compose-litentry
 	@./scripts/launch-local-docker.sh litentry
 
-.PHONY: launch-docker-litmus ## Launch litmus-parachain dev network with docker locally
+.PHONY: launch-docker-litmus ## Launch a local litmus-parachain network with docker
 launch-docker-litmus: generate-docker-compose-litmus
 	@./scripts/launch-local-docker.sh litmus
 
-.PHONY: launch-binary-litentry ## Launch litentry-parachain dev network with binaries locally
+.PHONY: launch-binary-litentry ## Launch a local litentry-parachain network with binaries
 launch-binary-litentry:
 	@./scripts/launch-local-binary.sh litentry
 
-.PHONY: launch-binary-litmus ## Launch litmus-parachain dev network with binaries locally
+.PHONY: launch-binary-litmus ## Launch a local litmus-parachain network with binaries
 launch-binary-litmus:
 	@./scripts/launch-local-binary.sh litmus
 
@@ -137,11 +137,11 @@ clean-binary:
 
 # generate docker-compose files
 
-.PHONY: generate-docker-compose-litentry ## Generate docker-compose files for litentry dev
+.PHONY: generate-docker-compose-litentry ## Generate docker-compose files for litentry local network
 generate-docker-compose-litentry:
 	@./scripts/generate-docker-files.sh litentry
 
-.PHONY: generate-docker-compose-litmus ## Generate docker-compose files for litmus dev
+.PHONY: generate-docker-compose-litmus ## Generate docker-compose files for litmus local network
 generate-docker-compose-litmus:
 	@./scripts/generate-docker-files.sh litmus
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ make build-node
 
 To build the `litentry/litentry-parachain` docker image locally:
 ```
-make build-docker-dev
+make build-docker-release
 or
-make build-docker-prod
+make build-docker-production
 ```
 they will use `release` or `production` cargo profile, respectively.
 
@@ -41,9 +41,9 @@ The wasms should be located under `target/release/wbuild/litentry-parachain-runt
 
 Similarly, use `make build-runtime-litmus` to build the litmus-parachain-runtime.
 
-## launch of local dev network
+## launch of local network
 
-To start a local dev network with 2 relaychain nodes and 1 parachain node, there're two ways:
+To start a local network with 2 relaychain nodes and 1 parachain node, there're two ways:
 
 ### 1. use docker images for both polkadot and litentry-parachain (preferred)
 Take the litentry-parachain for example:
@@ -54,7 +54,7 @@ make launch-docker-litentry
 
 The generated files will be under `docker/generated-litentry/`.
 
-When finished with the dev network, run
+When finished with the network, run
 ```
 make clean-docker-litentry
 ```
@@ -64,7 +64,7 @@ to stop the processes and tidy things up.
 
 Only when option 1 doesn't work and you suspect the docker-image went wrong.
 
-In this case we could try to launch the dev network with raw binaries.
+In this case we could try to launch the network with raw binaries.
 
 **On Linux host:**
 
@@ -76,7 +76,7 @@ In this case we could try to launch the dev network with raw binaries.
 - you should have locally compiled binaries, for both `polkadot` and `litentry-collator`
 - run `./scripts/launch-local-binary.sh litentry path-to-polkadot-bin path-to-litentry-parachain-bin`
 
-When finished with the dev network, run
+When finished with the network, run
 ```
 make clean-binary
 ```

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 function usage() {
-  echo "Usage:   $0 dev|prod [docker-tag] [build-args]"
+  echo "Usage:   $0 release|production [docker-tag] [build-args]"
 }
 
 [ $# -lt 1 ] && (usage; exit 1)
@@ -10,17 +10,16 @@ function usage() {
 ROOTDIR=$(git rev-parse --show-toplevel)
 cd "$ROOTDIR"
 
-TYPE="$1"
+PROFILE="$1"
 TAG="$2"
 ARGS="$3"
 
 NOCACHE_FLAG=
 
-case "$TYPE" in
-    dev)
-        PROFILE=release ;;
-    prod)
-        PROFILE=production
+case "$PROFILE" in
+    release)
+        ;;
+    production)
         NOCACHE_FLAG="--no-cache" ;;
     *)
         usage; exit 1 ;;
@@ -39,7 +38,7 @@ if [ -z "$TAG" ]; then
     fi
 fi
 
-echo "TYPE: $TYPE"
+echo "PROFILE: $PROFILE"
 echo "TAG: $TAG"
 echo "ARGS: $ARGS"
 


### PR DESCRIPTION
This PR tries to use `release` and `production` as cargo profiles across multiple files consistently:
before: dev & prod
now: release & production