### PR TITLE
Add start & stop script for aws instance

### DIFF
--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -54,17 +54,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build docker image
-        run: |
-          ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
+      # - name: Build docker image
+      #   run: |
+      #     ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
 
-      - name: Push docker image
-        run: |
-          docker push litentry/litentry-parachain:runtime-benchmarks
+      # - name: Push docker image
+      #   run: |
+      #     docker push litentry/litentry-parachain:runtime-benchmarks
 
-      - name: Remove dangling images if any
-        run: |
-          [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
+      # - name: Remove dangling images if any
+      #   run: |
+      #     [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
 
       - name: Start remote instance
         id: start_instance

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -71,7 +71,11 @@ jobs:
           sleep 1
           ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`
           cnt=0
-          while [ "$ret" != "running" || "$cnt" < "5" ]; do ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`; cnt=$((cnt + 1)); sleep 1; done
+          while [[ "$ret" != "running" || $cnt -gt 5 ]]; do
+            ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`
+            cnt=$((cnt + 1))
+            sleep 1
+          done
           echo "Remote instance running state: $ret, retry count: $cnt"
           ip=`aws ec2 describe-instances --filters 'Name=instance-state-name,Values=running' 'Name=instance-id,Values=i-0a3bdc24e56b4b457' --query 'Reservations[*].Instances[*].[PublicIpAddress]' | jq '.[0][0][0]'`
           echo "Running instances ip address: $ip"

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -54,17 +54,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Build docker image
-      #   run: |
-      #     ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
+      - name: Build docker image
+        run: |
+          ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
 
-      # - name: Push docker image
-      #   run: |
-      #     docker push litentry/litentry-parachain:runtime-benchmarks
+      - name: Push docker image
+        run: |
+          docker push litentry/litentry-parachain:runtime-benchmarks
 
-      # - name: Remove dangling images if any
-      #   run: |
-      #     [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
+      - name: Remove dangling images if any
+        run: |
+          [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
+
       - name: Start remote instance
         id: start_instance
         run: |
@@ -88,18 +89,18 @@ jobs:
         run: |
           # prepend the asterisk with \ to go through ssh
           echo "Running instances ip address: ${{ steps.start_instance.outputs.remote_ip }}"
-          # arg="${{ github.event.inputs.pallets }}"
-          # chain="${{ env.CHAIN }}"
-          # if [ "$arg" = "*" ]; then
-          #   arg="\\$arg";
-          # fi
-          # for c in $chain; do
-          #   ssh -x "${{ env.REMOTE_HOST }}" 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
-          #   echo "copy generated weights files back ..."
-          #   scp "${{ env.REMOTE_HOST }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
-          # done
-          # echo "======================"
-          # git status
+          arg="${{ github.event.inputs.pallets }}"
+          chain="${{ env.CHAIN }}"
+          if [ "$arg" = "*" ]; then
+            arg="\\$arg";
+          fi
+          for c in $chain; do
+            ssh -x "${{ steps.start_instance.outputs.remote_ip }}" 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
+            echo "copy generated weights files back ..."
+            scp "${{ env.REMOTE_HOST }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
+          done
+          echo "======================"
+          git status
 
       - name: Stop remote instance
         if: always()
@@ -109,25 +110,25 @@ jobs:
           ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'`
           echo "Remote instance running state: $ret"
 
-      # - name: Create auto PR
-      #   uses: peter-evans/create-pull-request@v3
-      #   with:
-      #     commit-message: "[benchmarking bot] Auto commit generated weights files"
-      #     committer: benchmarking bot <noreply@github.com>
-      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-      #     signoff: false
-      #     branch: benchmarking-bot-${{ github.run_id }}
-      #     delete-branch: true
-      #     title: "[benchmarking bot] Update generated weights files"
-      #     body: |
-      #       This is an automatically created PR.
-      #       It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.REMOTE_HOST }}
+      - name: Create auto PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "[benchmarking bot] Auto commit generated weights files"
+          committer: benchmarking bot <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: benchmarking-bot-${{ github.run_id }}
+          delete-branch: true
+          title: "[benchmarking bot] Update generated weights files"
+          body: |
+            This is an automatically created PR.
+            It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.REMOTE_HOST }}
 
-      #       Pallets: "${{ github.event.inputs.pallets }}"
-      #       Chain: "${{ env.CHAIN }}"
-      #       Github action run: https://github.com/litentry/litentry-parachain/actions/runs/${{ github.run_id }}
-      #     labels: |
-      #       automated-pr
-      #     assignees: ${{ github.actor }}
-      #     reviewers: ${{ github.actor }}
-      #     draft: false
+            Pallets: "${{ github.event.inputs.pallets }}"
+            Chain: "${{ env.CHAIN }}"
+            Github action run: https://github.com/litentry/litentry-parachain/actions/runs/${{ github.run_id }}
+          labels: |
+            automated-pr
+          assignees: ${{ github.actor }}
+          reviewers: ${{ github.actor }}
+          draft: false

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -69,11 +69,11 @@ jobs:
         run: |
           aws ec2 start-instances --instance-ids i-0a3bdc24e56b4b457
           sleep 1
-          ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'`
+          ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`
           cnt=0
-          while [ "$ret" != "running" || "$cnt" < "5" ]; do ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'; cnt=$((cnt + 1)); sleep 1; done
+          while [ "$ret" != "running" || "$cnt" < "5" ]; do ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`; cnt=$((cnt + 1)); sleep 1; done
           echo "Remote instance running state: $ret, retry count: $cnt"
-          ip=`aws ec2 describe-instances --filters "Name=instance-state-name,Values=running" "Name=instance-id,Values=i-0a3bdc24e56b4b457" --query 'Reservations[*].Instances[*].[PublicIpAddress]' | jq '.[0][0][0]'`
+          ip=`aws ec2 describe-instances --filters 'Name=instance-state-name,Values=running' 'Name=instance-id,Values=i-0a3bdc24e56b4b457' --query 'Reservations[*].Instances[*].[PublicIpAddress]' | jq '.[0][0][0]'`
           echo "Running instances ip address: $ip"
 
       # # exit status should propagate through ssh

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -54,66 +54,72 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build docker image
-        run: |
-          ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
+      # - name: Build docker image
+      #   run: |
+      #     ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
 
-      - name: Push docker image
-        run: |
-          docker push litentry/litentry-parachain:runtime-benchmarks
+      # - name: Push docker image
+      #   run: |
+      #     docker push litentry/litentry-parachain:runtime-benchmarks
 
-      - name: Remove dangling images if any
-        run: |
-          [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
+      # - name: Remove dangling images if any
+      #   run: |
+      #     [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
       - name: Start remote instance
         run: |
           aws ec2 start-instances --instance-ids i-0a3bdc24e56b4b457
-          sleep 10
+          sleep 1
           ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'`
-          echo "Remote instance running state: $ret"
-      # exit status should propagate through ssh
-      - name: Remotely benchmark pallets ${{ github.event.inputs.pallets }} for ${{ env.CHAIN }}
-        timeout-minutes: 240
-        run: |
-          # prepend the asterisk with \ to go through ssh
-          arg="${{ github.event.inputs.pallets }}"
-          chain="${{ env.CHAIN }}"
-          if [ "$arg" = "*" ]; then
-            arg="\\$arg";
-          fi
-          for c in $chain; do
-            ssh -x "${{ env.REMOTE_HOST }}" 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
-            echo "copy generated weights files back ..."
-            scp "${{ env.REMOTE_HOST }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
-          done
-          echo "======================"
-          git status
+          cnt=0
+          while [ "$ret" != "running" || "$cnt" < "5" ]; do ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'; cnt=$((cnt + 1)); sleep 1; done
+          echo "Remote instance running state: $ret, retry count: $cnt"
+          ip=`aws ec2 describe-instances --filters "Name=instance-state-name,Values=running" "Name=instance-id,Values=i-0a3bdc24e56b4b457" --query 'Reservations[*].Instances[*].[PublicIpAddress]' | jq '.[0][0][0]'`
+          echo "Running instances ip address: $ip"
+
+      # # exit status should propagate through ssh
+      # - name: Remotely benchmark pallets ${{ github.event.inputs.pallets }} for ${{ env.CHAIN }}
+      #   timeout-minutes: 240
+      #   run: |
+      #     # prepend the asterisk with \ to go through ssh
+      #     arg="${{ github.event.inputs.pallets }}"
+      #     chain="${{ env.CHAIN }}"
+      #     if [ "$arg" = "*" ]; then
+      #       arg="\\$arg";
+      #     fi
+      #     for c in $chain; do
+      #       ssh -x "${{ env.REMOTE_HOST }}" 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
+      #       echo "copy generated weights files back ..."
+      #       scp "${{ env.REMOTE_HOST }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
+      #     done
+      #     echo "======================"
+      #     git status
       - name: Stop remote instance
+        if: always()
         run: |
           aws ec2 stop-instances --instance-ids i-0a3bdc24e56b4b457
-          sleep 10
+          sleep 5
           ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'`
           echo "Remote instance running state: $ret"
 
-      - name: Create auto PR
-        uses: peter-evans/create-pull-request@v3
-        with:
-          commit-message: "[benchmarking bot] Auto commit generated weights files"
-          committer: benchmarking bot <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          signoff: false
-          branch: benchmarking-bot-${{ github.run_id }}
-          delete-branch: true
-          title: "[benchmarking bot] Update generated weights files"
-          body: |
-            This is an automatically created PR.
-            It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.REMOTE_HOST }}
+      # - name: Create auto PR
+      #   uses: peter-evans/create-pull-request@v3
+      #   with:
+      #     commit-message: "[benchmarking bot] Auto commit generated weights files"
+      #     committer: benchmarking bot <noreply@github.com>
+      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+      #     signoff: false
+      #     branch: benchmarking-bot-${{ github.run_id }}
+      #     delete-branch: true
+      #     title: "[benchmarking bot] Update generated weights files"
+      #     body: |
+      #       This is an automatically created PR.
+      #       It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.REMOTE_HOST }}
 
-            Pallets: "${{ github.event.inputs.pallets }}"
-            Chain: "${{ env.CHAIN }}"
-            Github action run: https://github.com/litentry/litentry-parachain/actions/runs/${{ github.run_id }}
-          labels: |
-            automated-pr
-          assignees: ${{ github.actor }}
-          reviewers: ${{ github.actor }}
-          draft: false
+      #       Pallets: "${{ github.event.inputs.pallets }}"
+      #       Chain: "${{ env.CHAIN }}"
+      #       Github action run: https://github.com/litentry/litentry-parachain/actions/runs/${{ github.run_id }}
+      #     labels: |
+      #       automated-pr
+      #     assignees: ${{ github.actor }}
+      #     reviewers: ${{ github.actor }}
+      #     draft: false

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -65,7 +65,12 @@ jobs:
       - name: Remove dangling images if any
         run: |
           [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
-
+      - name: Start remote instance
+        run: |
+          aws ec2 start-instances --instance-ids i-0a3bdc24e56b4b457
+          sleep 10
+          ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'`
+          echo "Remote instance running state: $ret"
       # exit status should propagate through ssh
       - name: Remotely benchmark pallets ${{ github.event.inputs.pallets }} for ${{ env.CHAIN }}
         timeout-minutes: 240
@@ -83,6 +88,12 @@ jobs:
           done
           echo "======================"
           git status
+      - name: Stop remote instance
+        run: |
+          aws ec2 stop-instances --instance-ids i-0a3bdc24e56b4b457
+          sleep 10
+          ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'`
+          echo "Remote instance running state: $ret"
 
       - name: Create auto PR
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -24,8 +24,7 @@ on:
         required: true
 
 env:
-  REMOTE_HOST: parachain-benchmark # remote host to run benchmarking upon, must be reachable per ssh
-
+  INSTANCE_ID: ${{ secrets.BENCHMARK_INSTANCE_ID }} # remote host to run benchmarking upon, must be reachable per ssh
 jobs:
   ## build docker image with runtime-benchmarks feature, and then run the benchmarking remotely
   build-and-benchmark:
@@ -69,17 +68,17 @@ jobs:
       - name: Start remote instance
         id: start_instance
         run: |
-          aws ec2 start-instances --instance-ids i-0a3bdc24e56b4b457
+          aws ec2 start-instances --instance-ids ${{ env.INSTANCE_ID }}
           sleep 3
-          ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 --query 'InstanceStatuses[0].InstanceState.Name' --output text`
+          ret=`aws ec2 describe-instance-status --instance-ids ${{ env.INSTANCE_ID }} --query 'InstanceStatuses[0].InstanceState.Name' --output text`
           cnt=0
           while [[ "$ret" != "running" && $cnt -lt 5 ]]; do
-            ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 --query 'InstanceStatuses[0].InstanceState.Name' --output text`
+            ret=`aws ec2 describe-instance-status --instance-ids ${{ env.INSTANCE_ID }} --query 'InstanceStatuses[0].InstanceState.Name' --output text`
             cnt=$((cnt + 1))
             sleep 2
           done
           echo "Remote instance running state: $ret, retry count: $cnt"
-          remote_ip=`aws ec2 describe-instances --filters 'Name=instance-state-name,Values=running' 'Name=instance-id,Values=i-0a3bdc24e56b4b457' --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text`
+          remote_ip=`aws ec2 describe-instances --filters 'Name=instance-state-name,Values=running' 'Name=instance-id,Values=${{ env.INSTANCE_ID }}' --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text`
           echo "Running instances ip address: $remote_ip"
           echo "::set-output name=remote_ip::$remote_ip"
 
@@ -105,9 +104,9 @@ jobs:
       - name: Stop remote instance
         if: always()
         run: |
-          aws ec2 stop-instances --instance-ids i-0a3bdc24e56b4b457
+          aws ec2 stop-instances --instance-ids ${{ env.INSTANCE_ID }}
           sleep 5
-          ret=`aws ec2  describe-instance-status --instance-ids i-0a3bdc24e56b4b457 |jq '.InstanceStatuses[0].InstanceState.Name'`
+          ret=`aws ec2 describe-instance-status --instance-ids ${{ env.INSTANCE_ID }} | jq '.InstanceStatuses[0].InstanceState.Name'`
           echo "Remote instance running state: $ret"
 
       - name: Create auto PR
@@ -122,7 +121,7 @@ jobs:
           title: "[benchmarking bot] Update generated weights files"
           body: |
             This is an automatically created PR.
-            It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.REMOTE_HOST }}
+            It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.INSTANCE_ID }}
 
             Pallets: "${{ github.event.inputs.pallets }}"
             Chain: "${{ env.CHAIN }}"

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -25,6 +25,8 @@ on:
 
 env:
   INSTANCE_ID: ${{ secrets.BENCHMARK_INSTANCE_ID }} # remote host to run benchmarking upon, must be reachable per ssh
+  BENCHMARK_SSH_USER: ${{ secrets.BENCHMARK_SSH_USER }}
+  BENCHMARK_SSH_KEYPATH: ${{ secrets.BENCHMARK_SSH_KEYPATH }}
 jobs:
   ## build docker image with runtime-benchmarks feature, and then run the benchmarking remotely
   build-and-benchmark:
@@ -53,17 +55,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build docker image
-        run: |
-          ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
+      # - name: Build docker image
+      #   run: |
+      #     ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
 
-      - name: Push docker image
-        run: |
-          docker push litentry/litentry-parachain:runtime-benchmarks
+      # - name: Push docker image
+      #   run: |
+      #     docker push litentry/litentry-parachain:runtime-benchmarks
 
-      - name: Remove dangling images if any
-        run: |
-          [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
+      # - name: Remove dangling images if any
+      #   run: |
+      #     [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
 
       - name: Start remote instance
         id: start_instance
@@ -94,9 +96,9 @@ jobs:
             arg="\\$arg";
           fi
           for c in $chain; do
-            ssh -x -o StrictHostKeychecking=no "${{ steps.start_instance.outputs.remote_ip }}" -l ${{ secrets.BENCHMARK_SSH_USER }} -i ${{ secrets.BENCHMARK_SSH_KEYPATH }} 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
+            ssh -x -o StrictHostKeychecking=no "${{ steps.start_instance.outputs.remote_ip }}" -l ${{ env.BENCHMARK_SSH_USER }} -i ${{ env.BENCHMARK_SSH_KEYPATH }} 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
             echo "copy generated weights files back ..."
-            scp -o StrictHostKeychecking=no -i ${{ secrets.BENCHMARK_SSH_KEYPATH }} "${{ secrets.BENCHMARK_SSH_USER }}@${{ steps.start_instance.outputs.remote_ip }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
+            scp -o StrictHostKeychecking=no -i ${{ env.BENCHMARK_SSH_KEYPATH }} "${{ env.BENCHMARK_SSH_USER }}@${{ steps.start_instance.outputs.remote_ip }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
           done
           echo "======================"
           git status
@@ -109,25 +111,25 @@ jobs:
           ret=`aws ec2 describe-instance-status --instance-ids ${{ env.INSTANCE_ID }} | jq '.InstanceStatuses[0].InstanceState.Name'`
           echo "Remote instance running state: $ret"
 
-      - name: Create auto PR
-        uses: peter-evans/create-pull-request@v3
-        with:
-          commit-message: "[benchmarking bot] Auto commit generated weights files"
-          committer: benchmarking bot <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          signoff: false
-          branch: benchmarking-bot-${{ github.run_id }}
-          delete-branch: true
-          title: "[benchmarking bot] Update generated weights files"
-          body: |
-            This is an automatically created PR.
-            It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.INSTANCE_ID }}
+      # - name: Create auto PR
+      #   uses: peter-evans/create-pull-request@v3
+      #   with:
+      #     commit-message: "[benchmarking bot] Auto commit generated weights files"
+      #     committer: benchmarking bot <noreply@github.com>
+      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+      #     signoff: false
+      #     branch: benchmarking-bot-${{ github.run_id }}
+      #     delete-branch: true
+      #     title: "[benchmarking bot] Update generated weights files"
+      #     body: |
+      #       This is an automatically created PR.
+      #       It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.INSTANCE_ID }}
 
-            Pallets: "${{ github.event.inputs.pallets }}"
-            Chain: "${{ env.CHAIN }}"
-            Github action run: https://github.com/litentry/litentry-parachain/actions/runs/${{ github.run_id }}
-          labels: |
-            automated-pr
-          assignees: ${{ github.actor }}
-          reviewers: ${{ github.actor }}
-          draft: false
+      #       Pallets: "${{ github.event.inputs.pallets }}"
+      #       Chain: "${{ env.CHAIN }}"
+      #       Github action run: https://github.com/litentry/litentry-parachain/actions/runs/${{ github.run_id }}
+      #     labels: |
+      #       automated-pr
+      #     assignees: ${{ github.actor }}
+      #     reviewers: ${{ github.actor }}
+      #     draft: false

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -95,9 +95,9 @@ jobs:
             arg="\\$arg";
           fi
           for c in $chain; do
-            ssh -x "${{ steps.start_instance.outputs.remote_ip }}" 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
+            ssh -x -o StrictHostKeychecking=no "${{ steps.start_instance.outputs.remote_ip }}" -l ${{ secrets.BENCHMARK_SSH_USER }} -i ${{ secrets.BENCHMARK_SSH_KEYPATH }} 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
             echo "copy generated weights files back ..."
-            scp "${{ env.REMOTE_HOST }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
+            scp -o StrictHostKeychecking=no -i ${{ secrets.BENCHMARK_SSH_KEYPATH }} "${{ secrets.BENCHMARK_SSH_USER }}@${{ steps.start_instance.outputs.remote_ip }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
           done
           echo "======================"
           git status

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -71,7 +71,7 @@ jobs:
           sleep 1
           ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`
           cnt=0
-          while [[ "$ret" != "running" || $cnt -gt 5 ]]; do
+          while [[ "$ret" != "running" && $cnt -lt 5 ]]; do
             ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`
             cnt=$((cnt + 1))
             sleep 1

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -55,17 +55,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Build docker image
-      #   run: |
-      #     ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
+      - name: Build docker image
+        run: |
+          ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
 
-      # - name: Push docker image
-      #   run: |
-      #     docker push litentry/litentry-parachain:runtime-benchmarks
+      - name: Push docker image
+        run: |
+          docker push litentry/litentry-parachain:runtime-benchmarks
 
-      # - name: Remove dangling images if any
-      #   run: |
-      #     [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
+      - name: Remove dangling images if any
+        run: |
+          [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
 
       - name: Start remote instance
         id: start_instance
@@ -111,25 +111,25 @@ jobs:
           ret=`aws ec2 describe-instance-status --instance-ids ${{ env.INSTANCE_ID }} | jq '.InstanceStatuses[0].InstanceState.Name'`
           echo "Remote instance running state: $ret"
 
-      # - name: Create auto PR
-      #   uses: peter-evans/create-pull-request@v3
-      #   with:
-      #     commit-message: "[benchmarking bot] Auto commit generated weights files"
-      #     committer: benchmarking bot <noreply@github.com>
-      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-      #     signoff: false
-      #     branch: benchmarking-bot-${{ github.run_id }}
-      #     delete-branch: true
-      #     title: "[benchmarking bot] Update generated weights files"
-      #     body: |
-      #       This is an automatically created PR.
-      #       It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.INSTANCE_ID }}
+      - name: Create auto PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "[benchmarking bot] Auto commit generated weights files"
+          committer: benchmarking bot <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: benchmarking-bot-${{ github.run_id }}
+          delete-branch: true
+          title: "[benchmarking bot] Update generated weights files"
+          body: |
+            This is an automatically created PR.
+            It updates the weights files under `runtime/*/src/weights/*.rs` after running benchmarks on the remote machine: ${{ env.INSTANCE_ID }}
 
-      #       Pallets: "${{ github.event.inputs.pallets }}"
-      #       Chain: "${{ env.CHAIN }}"
-      #       Github action run: https://github.com/litentry/litentry-parachain/actions/runs/${{ github.run_id }}
-      #     labels: |
-      #       automated-pr
-      #     assignees: ${{ github.actor }}
-      #     reviewers: ${{ github.actor }}
-      #     draft: false
+            Pallets: "${{ github.event.inputs.pallets }}"
+            Chain: "${{ env.CHAIN }}"
+            Github action run: https://github.com/litentry/litentry-parachain/actions/runs/${{ github.run_id }}
+          labels: |
+            automated-pr
+          assignees: ${{ github.actor }}
+          reviewers: ${{ github.actor }}
+          draft: false

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -66,37 +66,41 @@ jobs:
       #   run: |
       #     [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
       - name: Start remote instance
+        id: start_instance
         run: |
           aws ec2 start-instances --instance-ids i-0a3bdc24e56b4b457
-          sleep 1
-          ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`
+          sleep 3
+          ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 --query 'InstanceStatuses[0].InstanceState.Name' --output text`
           cnt=0
           while [[ "$ret" != "running" && $cnt -lt 5 ]]; do
-            ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 | jq '.InstanceStatuses[0].InstanceState.Name'`
+            ret=`aws ec2 describe-instance-status --instance-ids i-0a3bdc24e56b4b457 --query 'InstanceStatuses[0].InstanceState.Name' --output text`
             cnt=$((cnt + 1))
-            sleep 1
+            sleep 2
           done
           echo "Remote instance running state: $ret, retry count: $cnt"
-          ip=`aws ec2 describe-instances --filters 'Name=instance-state-name,Values=running' 'Name=instance-id,Values=i-0a3bdc24e56b4b457' --query 'Reservations[*].Instances[*].[PublicIpAddress]' | jq '.[0][0][0]'`
-          echo "Running instances ip address: $ip"
+          remote_ip=`aws ec2 describe-instances --filters 'Name=instance-state-name,Values=running' 'Name=instance-id,Values=i-0a3bdc24e56b4b457' --query 'Reservations[*].Instances[*].[PublicIpAddress]' --output text`
+          echo "Running instances ip address: $remote_ip"
+          echo "::set-output name=remote_ip::$remote_ip"
 
-      # # exit status should propagate through ssh
-      # - name: Remotely benchmark pallets ${{ github.event.inputs.pallets }} for ${{ env.CHAIN }}
-      #   timeout-minutes: 240
-      #   run: |
-      #     # prepend the asterisk with \ to go through ssh
-      #     arg="${{ github.event.inputs.pallets }}"
-      #     chain="${{ env.CHAIN }}"
-      #     if [ "$arg" = "*" ]; then
-      #       arg="\\$arg";
-      #     fi
-      #     for c in $chain; do
-      #       ssh -x "${{ env.REMOTE_HOST }}" 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
-      #       echo "copy generated weights files back ..."
-      #       scp "${{ env.REMOTE_HOST }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
-      #     done
-      #     echo "======================"
-      #     git status
+      # exit status should propagate through ssh
+      - name: Remotely benchmark pallets ${{ github.event.inputs.pallets }} for ${{ env.CHAIN }}
+        timeout-minutes: 240
+        run: |
+          # prepend the asterisk with \ to go through ssh
+          echo "Running instances ip address: ${{ steps.start_instance.outputs.remote_ip }}"
+          # arg="${{ github.event.inputs.pallets }}"
+          # chain="${{ env.CHAIN }}"
+          # if [ "$arg" = "*" ]; then
+          #   arg="\\$arg";
+          # fi
+          # for c in $chain; do
+          #   ssh -x "${{ env.REMOTE_HOST }}" 'bash -s' < scripts/benchmark-weight-remote.sh "$c" "${GITHUB_REF#refs/heads/}" "$arg"
+          #   echo "copy generated weights files back ..."
+          #   scp "${{ env.REMOTE_HOST }}":/tmp/litentry-parachain/runtime/$c/src/weights/*.rs runtime/$c/src/weights/
+          # done
+          # echo "======================"
+          # git status
+
       - name: Stop remote instance
         if: always()
         run: |

--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -54,17 +54,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Build docker image
-      #   run: |
-      #     ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
+      - name: Build docker image
+        run: |
+          ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
 
-      # - name: Push docker image
-      #   run: |
-      #     docker push litentry/litentry-parachain:runtime-benchmarks
+      - name: Push docker image
+        run: |
+          docker push litentry/litentry-parachain:runtime-benchmarks
 
-      # - name: Remove dangling images if any
-      #   run: |
-      #     [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
+      - name: Remove dangling images if any
+        run: |
+          [ -z "$(docker images --filter=dangling=true -q)" ] || docker rmi -f $(docker images --filter=dangling=true -q)
 
       - name: Start remote instance
         id: start_instance


### PR DESCRIPTION
I think this script isn't perfect enough. it doesn't consider

- [x]  the edge of network connections between ci server and remote server. 
- [x] the case of `start-instances` succeeds, however, `stop-instances` fails.
- [x] fetch dynamic ip from restarted instance

I think the second case should included in this case. 
I will refactor the script.