### PR TITLE
Update to codecov v3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,8 +51,8 @@ jobs:
           --exclude-files **/mock.rs **/weights.rs **/benchmarking.rs **/weights/* node/* runtime/*
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
+          fail_ci_if_error: false
+          verbose: true
 


### PR DESCRIPTION
We often get "certificate expired" error when uploading to codecov: https://github.com/litentry/litentry-parachain/actions/runs/2706753348

let's see if things get better with v3: https://github.com/codecov/codecov-action/issues/788
This PR doesn't fail CI if upload fails.