### PR TITLE
Add standalone `mock-tee-primitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,7 +4604,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-service",
- "primitives 0.9.10",
+ "primitives",
  "rococo-parachain-runtime",
  "sc-basic-authorship",
  "sc-chain-spec",
@@ -4701,7 +4701,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-runtime-parachains",
- "primitives 0.9.10",
+ "primitives",
  "runtime-common",
  "scale-info",
  "serde",
@@ -4724,22 +4724,6 @@ dependencies = [
  "xcm-builder",
  "xcm-executor",
  "xcm-simulator",
-]
-
-[[package]]
-name = "litentry-primitives"
-version = "0.1.0"
-source = "git+https://github.com/litentry/tee-worker#500b7f132cf808160bb90c6081b714f51fd12435"
-dependencies = [
- "pallet-identity-management 0.1.0 (git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev)",
- "parity-scale-codec 3.2.1",
- "primitives 0.9.10 (git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev)",
- "scale-info",
- "serde",
- "serde_json",
- "sp-core",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -4780,7 +4764,7 @@ dependencies = [
  "pallet-democracy",
  "pallet-drop3",
  "pallet-extrinsic-filter",
- "pallet-identity-management 0.1.0",
+ "pallet-identity-management",
  "pallet-identity-management-mock",
  "pallet-membership",
  "pallet-multisig",
@@ -4804,7 +4788,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-runtime-parachains",
- "primitives 0.9.10",
+ "primitives",
  "runtime-common",
  "scale-info",
  "serde",
@@ -5042,6 +5026,21 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "mock-tee-primitives"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "parity-scale-codec 3.2.1",
+ "primitives",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -6015,28 +6014,11 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec 3.2.1",
- "primitives 0.9.10",
+ "primitives",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-identity-management"
-version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#a8a24758c94210780c12bf2a0c7101920f53ce4e"
-dependencies = [
- "frame-support",
- "frame-system",
- "hex",
- "log",
- "parity-scale-codec 3.2.1",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
  "sp-runtime",
  "sp-std",
 ]
@@ -6051,14 +6033,14 @@ dependencies = [
  "frame-system",
  "hex",
  "hex-literal",
- "litentry-primitives",
  "log",
+ "mock-tee-primitives",
  "pallet-balances",
- "pallet-identity-management 0.1.0",
+ "pallet-identity-management",
  "pallet-timestamp",
  "parity-crypto",
  "parity-scale-codec 3.2.1",
- "primitives 0.9.10",
+ "primitives",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rsa",
@@ -6272,7 +6254,7 @@ dependencies = [
  "pallet-balances",
  "pallet-session",
  "parity-scale-codec 3.2.1",
- "primitives 0.9.10",
+ "primitives",
  "scale-info",
  "serde",
  "similar-asserts",
@@ -6627,7 +6609,7 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec 3.2.1",
- "primitives 0.9.10",
+ "primitives",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -8314,15 +8296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primitives"
-version = "0.9.10"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#a8a24758c94210780c12bf2a0c7101920f53ce4e"
-dependencies = [
- "sp-core",
- "sp-runtime",
-]
-
-[[package]]
 name = "prioritized-metered-channel"
 version = "0.2.0"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.28#314298c32ac6df996ea8f3fe23fa5d3768340066"
@@ -9024,7 +8997,7 @@ dependencies = [
  "pallet-democracy",
  "pallet-drop3",
  "pallet-extrinsic-filter",
- "pallet-identity-management 0.1.0",
+ "pallet-identity-management",
  "pallet-identity-management-mock",
  "pallet-membership",
  "pallet-multisig",
@@ -9050,7 +9023,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-runtime-parachains",
- "primitives 0.9.10",
+ "primitives",
  "runtime-common",
  "scale-info",
  "serde",
@@ -9231,7 +9204,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-runtime-parachains",
- "primitives 0.9.10",
+ "primitives",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/mock-tee-primitives/Cargo.toml
+++ b/mock-tee-primitives/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+authors = ["Litentry Dev"]
+edition = "2021"
+name = "mock-tee-primitives"
+version = "0.1.0"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+hex = { version = "0.4.3", default-features = false, optional = true }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
+
+parentchain-primitives = { package = "primitives", path = "../primitives", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+  "hex/std",
+  "serde/std",
+  "serde_json/std",
+  "sp-core/std",
+  "sp-std/std",
+  "sp-runtime/std",
+  "parentchain-primitives/std",
+]

--- a/mock-tee-primitives/src/ethereum_signature.rs
+++ b/mock-tee-primitives/src/ethereum_signature.rs
@@ -1,0 +1,72 @@
+// Copyright 2020-2022 Litentry Technologies GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+#[cfg(feature = "std")]
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq, Clone, Debug)]
+pub struct EthereumSignature(pub [u8; 65]);
+
+impl TryFrom<&[u8]> for EthereumSignature {
+	type Error = ();
+
+	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+		if data.len() == 65 {
+			let mut inner = [0u8; 65];
+			inner.copy_from_slice(data);
+			Ok(EthereumSignature(inner))
+		} else {
+			Err(())
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+impl Serialize for EthereumSignature {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_str(&hex::encode(self))
+	}
+}
+
+#[cfg(feature = "std")]
+impl<'de> Deserialize<'de> for EthereumSignature {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let signature_hex = hex::decode(&String::deserialize(deserializer)?)
+			.map_err(|e| de::Error::custom(format!("{:?}", e)))?;
+		EthereumSignature::try_from(signature_hex.as_ref())
+			.map_err(|e| de::Error::custom(format!("{:?}", e)))
+	}
+}
+
+impl AsRef<[u8; 65]> for EthereumSignature {
+	fn as_ref(&self) -> &[u8; 65] {
+		&self.0
+	}
+}
+
+impl AsRef<[u8]> for EthereumSignature {
+	fn as_ref(&self) -> &[u8] {
+		&self.0[..]
+	}
+}

--- a/mock-tee-primitives/src/identity.rs
+++ b/mock-tee-primitives/src/identity.rs
@@ -1,0 +1,163 @@
+// Copyright 2020-2022 Litentry Technologies GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+#[cfg(any(feature = "std", feature = "sgx"))]
+use std::format;
+
+#[cfg(all(not(feature = "sgx"), feature = "std"))]
+use serde::{Deserialize, Serialize};
+#[cfg(any(feature = "std", feature = "sgx"))]
+use sp_core::hexdisplay::HexDisplay;
+#[cfg(any(feature = "std", feature = "sgx"))]
+use std::vec::Vec;
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_runtime::{traits::ConstU32, BoundedVec};
+
+pub type MaxStringLength = ConstU32<64>;
+pub type IdentityString = BoundedVec<u8, MaxStringLength>;
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum SubstrateNetwork {
+	Polkadot,
+	Kusama,
+	Litentry,
+	Litmus,
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum EvmNetwork {
+	Ethereum,
+	BSC,
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum Web3Network {
+	Substrate(SubstrateNetwork),
+	Evm(EvmNetwork),
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum Web2Network {
+	Twitter,
+	Discord,
+	Github,
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum IdentityWebType {
+	Web2(Web2Network),
+	Web3(Web3Network),
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum IdentityHandle {
+	Address32([u8; 32]),
+	/// Its a 20 byte representation.
+	Address20([u8; 20]),
+	String(IdentityString),
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct Identity {
+	pub web_type: IdentityWebType,
+	pub handle: IdentityHandle,
+}
+
+impl Identity {
+	#[cfg(any(feature = "std", feature = "sgx"))]
+	pub fn flat(&self) -> Vec<u8> {
+		let mut display = match &self.web_type {
+			IdentityWebType::Web3(Web3Network::Substrate(sub)) =>
+				format!("did:{:?}:web3:substrate:", sub)
+					.to_ascii_lowercase()
+					.as_bytes()
+					.to_vec(),
+			IdentityWebType::Web3(Web3Network::Evm(evm)) =>
+				format!("did:{:?}:web3:evm:", evm).to_ascii_lowercase().as_bytes().to_vec(),
+			IdentityWebType::Web2(web2) =>
+				format!("did:{:?}:web2:_:", web2).to_ascii_lowercase().as_bytes().to_vec(),
+		};
+		let mut suffix: Vec<u8> = match &self.handle {
+			IdentityHandle::String(inner) => inner.to_vec(),
+			IdentityHandle::Address32(inner) =>
+				format!("0x{}", HexDisplay::from(inner)).as_bytes().to_vec(),
+			IdentityHandle::Address20(inner) =>
+				format!("0x{}", HexDisplay::from(inner)).as_bytes().to_vec(),
+		};
+		display.append(&mut suffix);
+		display
+	}
+
+	pub fn is_web2(&self) -> bool {
+		match &self.web_type {
+			IdentityWebType::Web2(_) => true,
+			IdentityWebType::Web3(_) => false,
+		}
+	}
+
+	pub fn is_web3(&self) -> bool {
+		match &self.web_type {
+			IdentityWebType::Web2(_) => false,
+			IdentityWebType::Web3(_) => true,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		Identity, IdentityHandle, IdentityString, IdentityWebType, SubstrateNetwork, Web2Network,
+		Web3Network,
+	};
+	use sp_core::Pair;
+	use std::string;
+
+	#[test]
+	fn identity() {
+		let sub_pair = sp_core::sr25519::Pair::from_string("//Alice", None).unwrap();
+		// let eth_pair = sp_core::ed25519::Pair::from_string("//Alice", None).unwrap();
+		let polkadot_identity = Identity {
+			web_type: IdentityWebType::Web3(Web3Network::Substrate(SubstrateNetwork::Polkadot)),
+			handle: IdentityHandle::Address32(sub_pair.public().0),
+		};
+		let twitter_identity = Identity {
+			web_type: IdentityWebType::Web2(Web2Network::Twitter),
+			handle: IdentityHandle::String(
+				IdentityString::try_from("litentry".as_bytes().to_vec()).unwrap(),
+			),
+		};
+		assert_eq!(
+			"did:polkadot:web3:substrate:0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+			string::String::from_utf8(polkadot_identity.flat()).unwrap()
+		);
+		assert_eq!(
+			"did:twitter:web2:_:litentry",
+			string::String::from_utf8(twitter_identity.flat()).unwrap()
+		);
+	}
+}

--- a/mock-tee-primitives/src/lib.rs
+++ b/mock-tee-primitives/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright 2020-2022 Litentry Technologies GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+mod ethereum_signature;
+mod identity;
+mod validation_data;
+pub use ethereum_signature::*;
+pub use identity::*;
+pub use parentchain_primitives::{
+	AesOutput, BlockNumber as ParentchainBlockNumber, UserShieldingKeyType, USER_SHIELDING_KEY_LEN,
+	USER_SHIELDING_KEY_NONCE_LEN, USER_SHIELDING_KEY_TAG_LEN,
+};
+pub use validation_data::*;

--- a/mock-tee-primitives/src/validation_data.rs
+++ b/mock-tee-primitives/src/validation_data.rs
@@ -1,0 +1,84 @@
+// Copyright 2020-2022 Litentry Technologies GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
+use crate::ethereum_signature::EthereumSignature;
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_core::{ecdsa, ed25519, sr25519};
+use sp_runtime::{traits::ConstU32, BoundedVec};
+
+pub type MaxStringLength = ConstU32<64>;
+pub type ValidationString = BoundedVec<u8, MaxStringLength>;
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum IdentityMultiSignature {
+	/// An Ed25519 signature.
+	Ed25519(ed25519::Signature),
+	/// An Sr25519 signature.
+	Sr25519(sr25519::Signature),
+	/// An ECDSA/SECP256k1 signature.
+	Ecdsa(ecdsa::Signature),
+	/// An ECDSA/keccak256 signature. An Ethereum signature. hash message with keccak256
+	Ethereum(EthereumSignature),
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct TwitterValidationData {
+	pub tweet_id: ValidationString,
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct DiscordValidationData {
+	pub channel_id: ValidationString,
+	pub message_id: ValidationString,
+	pub guild_id: ValidationString,
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct Web3CommonValidationData {
+	pub message: ValidationString, // or String if under std
+	pub signature: IdentityMultiSignature,
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[allow(non_camel_case_types)]
+pub enum Web2ValidationData {
+	Twitter(TwitterValidationData),
+	Discord(DiscordValidationData),
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[allow(non_camel_case_types)]
+pub enum Web3ValidationData {
+	Substrate(Web3CommonValidationData),
+	Evm(Web3CommonValidationData),
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum ValidationData {
+	Web2(Web2ValidationData),
+	Web3(Web3ValidationData),
+}

--- a/pallets/identity-management-mock/Cargo.toml
+++ b/pallets/identity-management-mock/Cargo.toml
@@ -21,6 +21,7 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 
+mock-tee-primitives = { path = "../../mock-tee-primitives", default-features = false }
 pallet-identity-management = { path = "../../pallets/identity-management", default-features = false }
 primitives = { path = "../../primitives", default-features = false }
 
@@ -29,7 +30,6 @@ hex = { version = "0.4", default-features = false }
 hex-literal = { version = "0.3.2" }
 rsa = { git = "https://github.com/litentry/RustCrypto-RSA", default-features = false, features = ["serde", "pem"] }
 sha2 = { version = "0.10.2", default-features = false }
-tee-primitives = { git = "https://github.com/litentry/tee-worker", package = "litentry-primitives", default-features = false }
 
 [dev-dependencies]
 aes-gcm = { git = "https://github.com/RustCrypto/AEADs" }

--- a/pallets/identity-management-mock/src/lib.rs
+++ b/pallets/identity-management-mock/src/lib.rs
@@ -39,6 +39,10 @@ mod tests;
 
 use codec::alloc::string::ToString;
 use frame_support::{pallet_prelude::*, traits::ConstU32};
+use mock_tee_primitives::{
+	Identity, IdentityHandle, IdentityMultiSignature, IdentityWebType, ValidationData,
+	Web3CommonValidationData, Web3Network, Web3ValidationData,
+};
 pub use pallet::*;
 use primitives::{ShardIdentifier, UserShieldingKeyType};
 use sha2::Sha256;
@@ -51,10 +55,6 @@ use sp_io::{
 };
 use sp_runtime::DispatchError;
 use sp_std::prelude::*;
-use tee_primitives::{
-	Identity, IdentityHandle, IdentityMultiSignature, IdentityWebType, ValidationData,
-	Web3CommonValidationData, Web3Network, Web3ValidationData,
-};
 
 mod identity_context;
 use identity_context::IdentityContext;

--- a/pallets/identity-management-mock/src/mock.rs
+++ b/pallets/identity-management-mock/src/mock.rs
@@ -32,6 +32,11 @@ use frame_support::{
 	traits::{ConstU128, ConstU16, ConstU32, ConstU64, Everything},
 };
 use frame_system as system;
+use mock_tee_primitives::{
+	EthereumSignature, EvmNetwork, Identity, IdentityHandle, IdentityMultiSignature,
+	IdentityWebType, SubstrateNetwork, TwitterValidationData, UserShieldingKeyType, ValidationData,
+	Web2Network, Web2ValidationData, Web3CommonValidationData, Web3Network, Web3ValidationData,
+};
 pub use parity_crypto::publickey::{sign, Generator, KeyPair as EvmPair, Message, Random};
 use sp_core::sr25519::Pair as SubstratePair; // TODO: maybe use more generic struct
 use sp_core::{blake2_128, Pair, H256};
@@ -40,11 +45,6 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 use system::{EnsureRoot, EnsureSignedBy};
-use tee_primitives::{
-	EthereumSignature, EvmNetwork, Identity, IdentityHandle, IdentityMultiSignature,
-	IdentityWebType, SubstrateNetwork, TwitterValidationData, UserShieldingKeyType, ValidationData,
-	Web2Network, Web2ValidationData, Web3CommonValidationData, Web3Network, Web3ValidationData,
-};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;


### PR DESCRIPTION
This is to break the cyclic dependency of the `parachain` repo and the `tee-worker` repo.

This primitive should only be used by mock pallet.

In this way we make sure we don't have blockers when updating the polkadot dependencies.