### PR TITLE
Further refine the benchmark code

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -210,6 +210,31 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.2
 
+  run-cargo-benchmarks:
+    runs-on: ubuntu-latest
+    needs: [check-cargo-fmt, check-file-change]
+    if: needs.check-file-change.outputs.src == 'true'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: wasm32-unknown-unknown
+          default: true
+
+      - name: Run benchmarks
+        run: cargo test --release -p pallet-* --lib --features runtime-benchmarks
+
+      - name: Fail-fast; cancel other jobs
+        if: failure()
+        uses: andymckay/cancel-action@0.2
+
+
   # The reason why not to put the if-check on the job level is to make sure the
   # *matrix* job is run, although it can be skipped in the end.
   #
@@ -303,6 +328,7 @@ jobs:
       [
         "check-cargo-clippy",
         "run-cargo-unit-tests",
+        "run-cargo-benchmarks",
         "run-cargo-runtime-tests",
         "run-ts-tests",
       ]

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,10 @@ launch-binary-rococo:
 test-cargo-all:
 	@cargo test --release --all
 
+.PHONY: test-cargo-all-benchmarks
+test-cargo-all-benchmarks:
+	@cargo test --release --all --features runtime-benchmarks
+
 .PHONY: test-ts-docker-litentry ## Run litentry ts tests with docker without clean-up
 test-ts-docker-litentry: launch-docker-litentry launch-docker-bridge
 	@./scripts/run-ts-test.sh litentry bridge

--- a/pallets/bridge-transfer/Cargo.toml
+++ b/pallets/bridge-transfer/Cargo.toml
@@ -36,9 +36,9 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "
 [features]
 default = ["std"]
 runtime-benchmarks = [
-  'frame-benchmarking',
-  'frame-support/runtime-benchmarks',
-  'frame-system/runtime-benchmarks',
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
 ]
 std = [
   "codec/std",

--- a/pallets/bridge-transfer/src/mock.rs
+++ b/pallets/bridge-transfer/src/mock.rs
@@ -134,6 +134,7 @@ impl SortedMembers<u64> for MembersProvider {
 		MembersProviderTestvalue::get()
 	}
 
+	#[cfg(not(feature = "runtime-benchmarks"))]
 	fn contains(who: &u64) -> bool {
 		Self::sorted_members().contains(who)
 	}
@@ -141,6 +142,11 @@ impl SortedMembers<u64> for MembersProvider {
 	#[cfg(feature = "runtime-benchmarks")]
 	fn add(_: &u64) {
 		unimplemented!()
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn contains(_who: &u64) -> bool {
+		true
 	}
 }
 

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -28,9 +28,9 @@ pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "p
 [features]
 default = ["std"]
 runtime-benchmarks = [
-  'frame-benchmarking',
-  'frame-support/runtime-benchmarks',
-  'frame-system/runtime-benchmarks',
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
 ]
 std = [
   "codec/std",

--- a/pallets/bridge/src/benchmarking.rs
+++ b/pallets/bridge/src/benchmarking.rs
@@ -20,7 +20,7 @@
 #![allow(clippy::type_complexity)]
 
 use super::*;
-use crate::{Call, Event, Pallet as bridge};
+use crate::{BridgeChainId, Call, Event, Pallet as bridge};
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_system::{Call as SystemCall, RawOrigin};
 use sp_std::{boxed::Box, vec, vec::Vec};
@@ -36,7 +36,6 @@ fn make_proposal<T: Config>(remark: Vec<u8>) -> T::Proposal {
 }
 
 benchmarks! {
-	// This will measure the execution time of `set_threshold` for b in [1..1000] range.
 	set_threshold{
 		let i = 100u32;
 	}:_(RawOrigin::Root,i)
@@ -67,7 +66,7 @@ benchmarks! {
 	}
 
 	whitelist_chain{
-		let bridgechain_id:BridgeChainId = 5;
+		let bridgechain_id = T::BridgeChainId::get().saturating_add(1);
 	}:_(RawOrigin::Root,bridgechain_id)
 	verify{
 		assert!(ChainNonces::<T>::contains_key(bridgechain_id));
@@ -102,7 +101,7 @@ benchmarks! {
 	acknowledge_proposal{
 		let relayer_id: T::AccountId = account("TEST_A", 0u32, USER_SEED);
 		let prop_id:DepositNonce = 1;
-		let src_id:BridgeChainId = 5;
+		let src_id:BridgeChainId = T::BridgeChainId::get().saturating_add(1);
 		let r_id:ResourceId = derive_resource_id(src_id, b"remark");
 
 		let proposal = make_proposal::<T>(vec![]);
@@ -129,9 +128,9 @@ benchmarks! {
 	}
 
 	reject_proposal{
-		let relayer_id: T::AccountId = account("TEST_B", 0u32, USER_SEED);
+		let relayer_id: T::AccountId = account("TEST_B", 1u32, USER_SEED+1);
 		let prop_id:DepositNonce = 1;
-		let src_id:BridgeChainId = 5;
+		let src_id:BridgeChainId = T::BridgeChainId::get().saturating_add(1);
 		let r_id:ResourceId = derive_resource_id(src_id, b"remark");
 
 		let proposal = make_proposal::<T>(vec![]);
@@ -165,7 +164,7 @@ benchmarks! {
 		let relayer_id_b: T::AccountId = account("TEST_B", 1u32, USER_SEED+1);
 		let relayer_id_c: T::AccountId = account("TEST_C", 2u32, USER_SEED-1);
 		let prop_id:DepositNonce = 1;
-		let src_id:BridgeChainId = 5;
+		let src_id:BridgeChainId = T::BridgeChainId::get().saturating_add(1);
 		let r_id:ResourceId = derive_resource_id(src_id, b"remark");
 
 		let proposal = make_proposal::<T>(vec![]);

--- a/pallets/drop3/src/benchmarking.rs
+++ b/pallets/drop3/src/benchmarking.rs
@@ -111,10 +111,17 @@ fn setup<T: Config>(should_start: bool) -> (T::AccountId, T::PoolId, Vec<u8>) {
 benchmarks! {
 	set_admin {
 		let origin = T::SetAdminOrigin::successful_origin();
+		/*
+		If the setup function is used here then old_admin uses the configuration in setup func, i.e whitelisted_caller()
+		But here we are not using setup, so when using the `cargo test -p pallet-drop3 --features runtime-benchmarks`  command,
+		go back to using the environment configured by the pallet mock.rs
+		i.e let _ = Drop3::set_admin(Origin::signed(1), 1);  mock.rs 147
+		*/
+		let old_admin= <Admin<T>>::get();
 		let admin: T::AccountId = account("admin", 0, SEED);
 	}: _<T::Origin>(origin, admin)
 	verify {
-		assert_last_event::<T>(Event::AdminChanged { old_admin: None }.into());
+		assert_last_event::<T>(Event::AdminChanged { old_admin }.into());
 	}
 
 	approve_reward_pool {

--- a/pallets/xcm-asset-manager/Cargo.toml
+++ b/pallets/xcm-asset-manager/Cargo.toml
@@ -48,6 +48,7 @@ std = [
   "sp-runtime/std",
   "sp-std/std",
   "xcm/std",
+  "frame-benchmarking/std",
 ]
 
 runtime-benchmarks = [

--- a/pallets/xcm-asset-manager/Cargo.toml
+++ b/pallets/xcm-asset-manager/Cargo.toml
@@ -29,7 +29,7 @@ xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.2
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.28" }
 
 # Benchmarks
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false, optional = true }
 
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28" }
@@ -51,6 +51,8 @@ std = [
 ]
 
 runtime-benchmarks = [
-  "frame-benchmarking",
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]


### PR DESCRIPTION
All our pallets can successfully execute the `cargo test --package pallet-pallet_name -features runtime-benchmarks` command. And these changes do not affect the generation of the weight file. Also, a command to run all benchmark code has been added to the Makefile.
The link to [issue](https://github.com/litentry/litentry-parachain/issues/851).