### PR TITLE
Switch to local dependencies

### DIFF
--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -322,12 +322,12 @@ jobs:
           name: logs-${{ matrix.test }}-${{ matrix.flavor_id }}
           path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/${{ env.LOG_DIR }}
 
-  # Only push docker image when tests are passed on dev branch
+  # Only push docker image when tests are passed and it's a push event
   push-docker-image:
     runs-on: ubuntu-latest
     needs:
       - integration-tests
-    if: ${{ success() && (github.event_name == 'push') && (github.ref == 'refs/heads/dev') }}
+    if: ${{ success() && (github.event_name == 'push') }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -107,19 +107,19 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: >
-          docker build -t integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }}
+          cd .. && docker build -t integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }}
           --target deployed-worker
           --build-arg WORKER_MODE_ARG=${{ matrix.mode }} --build-arg ADDITIONAL_FEATURES_ARG=${{ matrix.additional_features }}
-          -f build.Dockerfile .
+          -f tee-worker/build.Dockerfile .
 
       - name: Build CLI client
         env:
           DOCKER_BUILDKIT: 1
         run: >
-          docker build -t integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}
+          cd .. && docker build -t integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}
           --target deployed-client
           --build-arg WORKER_MODE_ARG=${{ matrix.mode }} --build-arg ADDITIONAL_FEATURES_ARG=${{ matrix.additional_features }}
-          -f build.Dockerfile .
+          -f tee-worker/build.Dockerfile .
 
       - run: docker images --all
 

--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -4287,7 +4287,7 @@ dependencies = [
  "pallet-balances",
  "pallet-evm",
  "pallet-grandpa",
- "pallet-identity-management 0.1.0",
+ "pallet-identity-management-tee",
  "pallet-parentchain",
  "pallet-randomness-collective-flip",
  "pallet-sudo",
@@ -4462,7 +4462,7 @@ dependencies = [
  "itp-types",
  "litentry-primitives",
  "log 0.4.17",
- "pallet-identity-management 0.1.0 (git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev)",
+ "pallet-identity-management",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -7120,7 +7120,6 @@ dependencies = [
 [[package]]
 name = "mock-tee-primitives"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "parity-scale-codec",
  "primitives",
@@ -7959,7 +7958,6 @@ dependencies = [
 [[package]]
 name = "pallet-asset-manager"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8137,7 +8135,6 @@ dependencies = [
 [[package]]
 name = "pallet-bridge"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "blake2-rfc",
  "frame-benchmarking",
@@ -8155,7 +8152,6 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-transfer"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8226,7 +8222,6 @@ dependencies = [
 [[package]]
 name = "pallet-drop3"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8305,7 +8300,6 @@ dependencies = [
 [[package]]
 name = "pallet-extrinsic-filter"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8363,29 +8357,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
- "litentry-primitives",
- "log 0.4.17",
- "pallet-balances",
- "parity-scale-codec",
- "scale-info",
- "serde 1.0.147",
- "serde_derive 1.0.147",
- "serde_json 1.0.89",
- "sp-core",
- "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29)",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-identity-management"
-version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "hex 0.4.3",
  "log 0.4.17",
  "parity-scale-codec",
  "primitives",
@@ -8399,7 +8370,6 @@ dependencies = [
 [[package]]
 name = "pallet-identity-management-mock"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "aes-gcm 0.10.1",
  "frame-benchmarking",
@@ -8409,13 +8379,35 @@ dependencies = [
  "hex-literal",
  "log 0.4.17",
  "mock-tee-primitives",
- "pallet-identity-management 0.1.0 (git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev)",
+ "pallet-identity-management",
  "parity-scale-codec",
  "primitives",
  "rsa",
  "scale-info",
  "sha2 0.10.6",
  "sp-arithmetic",
+ "sp-core",
+ "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29)",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-identity-management-tee"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "hex 0.4.3",
+ "litentry-primitives",
+ "log 0.4.17",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.147",
+ "serde_derive 1.0.147",
+ "serde_json 1.0.89",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29)",
  "sp-runtime",
@@ -8568,7 +8560,6 @@ dependencies = [
 [[package]]
 name = "pallet-parachain-staking"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8903,7 +8894,6 @@ dependencies = [
 [[package]]
 name = "pallet-vc-management"
 version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10543,7 +10533,6 @@ dependencies = [
 [[package]]
 name = "primitives"
 version = "0.9.11"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11207,7 +11196,6 @@ dependencies = [
 [[package]]
 name = "rococo-parachain-runtime"
 version = "0.9.11"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -11239,7 +11227,7 @@ dependencies = [
  "pallet-democracy",
  "pallet-drop3",
  "pallet-extrinsic-filter",
- "pallet-identity-management 0.1.0 (git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev)",
+ "pallet-identity-management",
  "pallet-identity-management-mock",
  "pallet-membership",
  "pallet-multisig",
@@ -11336,7 +11324,6 @@ dependencies = [
 [[package]]
 name = "runtime-common"
 version = "0.9.11"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",

--- a/tee-worker/app-libs/sgx-runtime/Cargo.toml
+++ b/tee-worker/app-libs/sgx-runtime/Cargo.toml
@@ -50,7 +50,7 @@ pallet-parentchain = { default-features = false, git = "https://github.com/integ
 
 # Litentry
 litentry-primitives = { path = "../../litentry/primitives", default-features = false }
-pallet-identity-management = { path = "../../litentry/pallets/identity-management", default-features = false }
+pallet-imt = { package = "pallet-identity-management-tee", path = "../../litentry/pallets/identity-management", default-features = false }
 
 [features]
 default = ["std"]
@@ -85,7 +85,7 @@ std = [
     "pallet-timestamp/std",
     "pallet-transaction-payment/std",
     "pallet-parentchain/std",
-    "pallet-identity-management/std",
+    "pallet-imt/std",
     "pallet-grandpa/std",
     "sp-api/std",
     "sp-core/std",

--- a/tee-worker/app-libs/sgx-runtime/src/lib.rs
+++ b/tee-worker/app-libs/sgx-runtime/src/lib.rs
@@ -77,7 +77,7 @@ pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
 
 // litentry
-pub use pallet_identity_management::{self, Call as IdentityManagementCall};
+pub use pallet_imt::{self, Call as IdentityManagementCall};
 
 /// Block type as expected by this sgx-runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
@@ -260,7 +260,7 @@ impl pallet_parentchain::Config for Runtime {
 	type WeightInfo = ();
 }
 
-impl pallet_identity_management::Config for Runtime {
+impl pallet_imt::Config for Runtime {
 	type Event = Event;
 	type ManageOrigin = EnsureRoot<AccountId>;
 	type MaxMetadataLength = ConstU32<128>;
@@ -281,7 +281,7 @@ construct_runtime!(
 		TransactionPayment: pallet_transaction_payment::{Pallet, Storage, Event<T>},
 		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>},
 		Parentchain: pallet_parentchain::{Pallet, Call, Storage},
-		IdentityManagement: pallet_identity_management,
+		IdentityManagement: pallet_imt,
 	}
 );
 
@@ -302,7 +302,7 @@ construct_runtime!(
 		TransactionPayment: pallet_transaction_payment::{Pallet, Storage, Event<T>},
 		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>},
 		Parentchain: pallet_parentchain::{Pallet, Call, Storage},
-		IdentityManagement: pallet_identity_management,
+		IdentityManagement: pallet_imt,
 
 		Evm: pallet_evm::{Pallet, Call, Storage, Config, Event<T>},
 	}

--- a/tee-worker/app-libs/stf/Cargo.toml
+++ b/tee-worker/app-libs/stf/Cargo.toml
@@ -41,7 +41,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 lc-stf-task-sender = { path = "../../litentry/core/stf-task/sender", default-features = false }
 litentry-primitives = { path = "../../litentry/primitives", default-features = false }
 pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
-parentchain-primitives = { package = "primitives", git = "https://github.com/litentry/litentry-parachain.git", branch = "tee-dev", default-features = false, optional = true }
+parentchain-primitives = { package = "primitives", path = "../../../primitives", default-features = false, optional = true }
 rand = { version = "0.7", optional = true }
 rand-sgx = { package = "rand", git = "https://github.com/mesalock-linux/rand-sgx", tag = "sgx_1.1.3", features = ["sgx_tstd"], optional = true }
 ring = { version = "0.16.20", default-features = false }

--- a/tee-worker/app-libs/stf/src/lib.rs
+++ b/tee-worker/app-libs/stf/src/lib.rs
@@ -33,9 +33,7 @@ pub use parentchain_primitives::{Balance, BlockNumber, Index};
 
 use codec::{Compact, Decode, Encode};
 use derive_more::Display;
-use ita_sgx_runtime::{
-	pallet_identity_management::MetadataOf, IdentityManagement, Runtime, System,
-};
+use ita_sgx_runtime::{pallet_imt::MetadataOf, IdentityManagement, Runtime, System};
 use itp_node_api_metadata::Error as MetadataError;
 use itp_node_api_metadata_provider::Error as MetadataProviderError;
 use sp_core::{crypto::AccountId32, ed25519, sr25519, Pair, H256};

--- a/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
@@ -187,7 +187,7 @@ impl TrustedCallSigned {
 		assertion: Assertion,
 	) -> StfResult<()> {
 		let v_identity_context =
-		ita_sgx_runtime::pallet_identity_management::Pallet::<Runtime>::get_identity_and_identity_context(&who);
+			ita_sgx_runtime::pallet_imt::Pallet::<Runtime>::get_identity_and_identity_context(&who);
 
 		let mut vec_identity: BoundedVec<Identity, MaxIdentityLength> = vec![].try_into().unwrap();
 

--- a/tee-worker/build.Dockerfile
+++ b/tee-worker/build.Dockerfile
@@ -36,8 +36,8 @@ ENV WORKER_MODE=$WORKER_MODE_ARG
 ARG ADDITIONAL_FEATURES_ARG
 ENV ADDITIONAL_FEATURES=$ADDITIONAL_FEATURES_ARG
 
-WORKDIR $HOME/worker
-COPY . .
+WORKDIR $HOME/tee-worker
+COPY . $HOME
 
 RUN make
 
@@ -71,8 +71,8 @@ ENV RUSTC_WRAPPER="/usr/local/cargo/bin/sccache"
 ARG WORKER_MODE_ARG
 ENV WORKER_MODE=$WORKER_MODE_ARG
 
-WORKDIR $HOME/worker
-COPY . .
+WORKDIR $HOME/tee-worker
+COPY . $HOME
 
 RUN --mount=type=cache,id=cargo,target=/root/work/.cache/sccache make && sccache --show-stats
 
@@ -99,8 +99,8 @@ ARG LOG_DIR=/usr/local/log
 ENV SCRIPT_DIR ${SCRIPT_DIR}
 ENV LOG_DIR ${LOG_DIR}
 
-COPY --from=builder /root/work/worker/bin/integritee-cli /usr/local/bin
-COPY ./cli/*.sh /usr/local/worker-cli/
+COPY --from=builder /root/work/tee-worker/bin/integritee-cli /usr/local/bin
+COPY ./tee-worker/cli/*.sh /usr/local/worker-cli/
 
 RUN chmod +x /usr/local/bin/integritee-cli ${SCRIPT_DIR}/*.sh
 RUN mkdir ${LOG_DIR}
@@ -128,7 +128,7 @@ ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${SGX_SDK}/lib64"
 WORKDIR /usr/local/bin
 
 COPY --from=builder /opt/sgxsdk/lib64 /opt/sgxsdk/lib64
-COPY --from=builder /root/work/worker/bin/* ./
+COPY --from=builder /root/work/tee-worker/bin/* ./
 
 RUN touch spid.txt key.txt
 RUN chmod +x /usr/local/bin/integritee-service

--- a/tee-worker/cli/Cargo.toml
+++ b/tee-worker/cli/Cargo.toml
@@ -23,7 +23,7 @@ sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teacla
 ws = { version = "0.9.1", features = ["ssl"] }
 
 # scs / integritee
-my-node-runtime = { package = "rococo-parachain-runtime", git = "https://github.com/litentry/litentry-parachain.git", branch = "tee-dev" }
+my-node-runtime = { package = "rococo-parachain-runtime", path = "../../runtime/rococo" }
 pallet-evm = { optional = true, git = "https://github.com/integritee-network/frontier.git", branch = "polkadot-v0.9.29" }
 substrate-api-client = { features = ["ws-client"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.29" }
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.29" }

--- a/tee-worker/core/parentchain/indirect-calls-executor/Cargo.toml
+++ b/tee-worker/core/parentchain/indirect-calls-executor/Cargo.toml
@@ -42,7 +42,7 @@ substrate-api-client = { git = "https://github.com/scs/substrate-api-client.git"
 # litentry
 ita-sgx-runtime = { path = "../../../app-libs/sgx-runtime", default-features = false }
 litentry-primitives = { path = "../../../litentry/primitives", default-features = false }
-pallet-imp = { package = "pallet-identity-management", git = "https://github.com/litentry/litentry-parachain.git", branch = "tee-dev", default-features = false }
+pallet-imp = { package = "pallet-identity-management", path = "../../../../pallets/identity-management", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/tee-worker/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/tee-worker/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -24,7 +24,7 @@ use crate::error::Result;
 use beefy_merkle_tree::{merkle_root, Keccak256};
 use codec::{Decode, Encode};
 use futures::executor;
-use ita_sgx_runtime::{pallet_identity_management::MetadataOf, Runtime};
+use ita_sgx_runtime::{pallet_imt::MetadataOf, Runtime};
 use ita_stf::{AccountId, TrustedCall, TrustedOperation};
 use itp_node_api::{
 	api_client::ParentchainUncheckedExtrinsic,

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -1492,7 +1492,7 @@ dependencies = [
  "pallet-balances",
  "pallet-evm",
  "pallet-grandpa",
- "pallet-identity-management 0.1.0",
+ "pallet-identity-management-tee",
  "pallet-parentchain",
  "pallet-randomness-collective-flip",
  "pallet-sudo",
@@ -1649,7 +1649,7 @@ dependencies = [
  "itp-types",
  "litentry-primitives",
  "log",
- "pallet-identity-management 0.1.0 (git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev)",
+ "pallet-identity-management",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3012,6 +3012,23 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
+ "log",
+ "parity-scale-codec",
+ "primitives",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-identity-management-tee"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "hex 0.4.3",
  "litentry-primitives",
  "log",
  "parity-scale-codec",
@@ -3021,24 +3038,6 @@ dependencies = [
  "serde_json 1.0.89",
  "sp-core",
  "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-identity-management"
-version = "0.1.0"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
-dependencies = [
- "frame-support",
- "frame-system",
- "hex 0.4.3",
- "log",
- "parity-scale-codec",
- "primitives",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
  "sp-runtime",
  "sp-std",
 ]
@@ -3273,7 +3272,6 @@ dependencies = [
 [[package]]
 name = "primitives"
 version = "0.9.11"
-source = "git+https://github.com/litentry/litentry-parachain.git?branch=tee-dev#469f769c725ee058a9be22c055ebe5f359800493"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/tee-worker/litentry/pallets/identity-management/Cargo.toml
+++ b/tee-worker/litentry/pallets/identity-management/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['Litentry Dev']
 edition = '2021'
 homepage = 'https://litentry.com'
-name = 'pallet-identity-management'
+name = 'pallet-identity-management-tee'
 repository = 'https://github.com/litentry/litentry-parachain'
 version = '0.1.0'
 

--- a/tee-worker/litentry/primitives/Cargo.toml
+++ b/tee-worker/litentry/primitives/Cargo.toml
@@ -17,7 +17,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 # sgx dependencies
 sgx_tstd = { git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "master", optional = true, features = ["net", "thread"] }
 
-parentchain-primitives = { package = "primitives", git = "https://github.com/litentry/litentry-parachain.git", branch = "tee-dev", default-features = false }
+parentchain-primitives = { package = "primitives", path = "../../../primitives", default-features = false }
 
 [features]
 default = ["std"]

--- a/tee-worker/scripts/litentry/build_parachain_docker.sh
+++ b/tee-worker/scripts/litentry/build_parachain_docker.sh
@@ -2,17 +2,5 @@
 set -euo pipefail
 
 ROOTDIR=$(git rev-parse --show-toplevel)
-ROOTDIR="$ROOTDIR/tee-worker"
-
 cd "$ROOTDIR"
-# with '#' so that it filters out the pallet dependency
-SHA=$(grep -F 'https://github.com/litentry/litentry-parachain.git?branch=tee-dev#' Cargo.lock | head -n1 | sed 's/.*#//;s/"$//')
-
-PARACHAIN_DIR=/tmp/litentry-parachain
-[ -d "$PARACHAIN_DIR" ] && rm -rf "$PARACHAIN_DIR"
-git clone https://github.com/litentry/litentry-parachain "$PARACHAIN_DIR"
-cd "$PARACHAIN_DIR"
-git checkout tee-dev
-git checkout "$SHA"
-
 ./scripts/build-docker.sh release tee-dev --features=tee-dev

--- a/tee-worker/service/Cargo.toml
+++ b/tee-worker/service/Cargo.toml
@@ -55,7 +55,7 @@ its-rpc-handler = { path = "../sidechain/rpc-handler" }
 its-storage = { path = "../sidechain/storage" }
 
 # scs / integritee
-my-node-runtime = { package = "rococo-parachain-runtime", git = "https://github.com/litentry/litentry-parachain.git", branch = "tee-dev" }
+my-node-runtime = { package = "rococo-parachain-runtime", path = "../../runtime/rococo" }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.29" }
 teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "master" }
 


### PR DESCRIPTION
resolves #992 

This PR:
- switches to local path dependencies
- renames the pallet-identity-management with `-tee` suffix to differentiate it with pallets in parachain
- minor adjustment to CI