### PR TITLE
Support standalone node for parachain

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -7,7 +7,7 @@ jobs:
   release-bot:
     runs-on: ubuntu-latest
     # this means the release contains a new docker image (thus a new client)
-    if: contains(github.event.release.body, 'docker')
+    if: contains(github.event.release.body, 'litentry/litentry-parachain:v')
     steps:
       - name: Post discord message
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4579,6 +4579,7 @@ dependencies = [
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
+ "sc-consensus-aura",
  "sc-executor",
  "sc-network",
  "sc-network-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2020,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2035,15 +2035,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "environmental"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "errno"
@@ -4066,9 +4066,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libloading"
@@ -5248,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -7086,9 +7086,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -7096,9 +7096,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423c2ba011d6e27b02b482a3707c773d19aec65cc024637aec44e19652e66f63"
+checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
 dependencies = [
  "pest",
  "pest_generator",
@@ -7106,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e64e6c2c85031c02fdbd9e5c72845445ca0a724d419aa0bc068ac620c9935c1"
+checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -7119,9 +7119,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57959b91f0a133f89a68be874a5c88ed689c19cd729ecdb5d762ebf16c64d662"
+checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
 dependencies = [
  "once_cell",
  "pest",
@@ -8409,9 +8409,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
+checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -12138,9 +12138,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12409,9 +12409,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13711,9 +13711,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4541,7 +4541,7 @@ checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "litentry-collator"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "clap",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "litentry-parachain-runtime"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "litmus-parachain-runtime"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -5337,9 +5337,9 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec 0.7.2",
  "itoa",
@@ -9141,7 +9141,7 @@ dependencies = [
 
 [[package]]
 name = "rococo-parachain-runtime"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -9385,7 +9385,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -10834,18 +10834,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ build-node-tryruntime:
 	cargo build --locked --features try-runtime --release
 
 # launch a local network
+
+.PHONY: launch-standalone ## Launch a local standalone node without relaychain network
+launch-standalone:
+	@./scripts/launch-standalone.sh
+
 .PHONY: launch-docker-bridge
 launch-docker-bridge:
 	@./scripts/launch-local-bridge-docker.sh

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ In this case we could try to launch the network with raw binaries.
 - you should have locally compiled binaries, for both `polkadot` and `litentry-collator`
 - run `./scripts/launch-local-binary.sh rococo path-to-polkadot-bin path-to-litentry-parachain-bin`
 
+After launching, the parachain node is reachable via ws 9944 port and the relaychain nodes are reachable via ws 9946/9947 ports.
+
 When finished with the network, run
 ```
 make clean-binary

--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ The wasms should be located under `target/release/wbuild/litentry-parachain-runt
 
 Similarly, use `make build-runtime-litmus` and `make build-runtime-rococo` to build the litmus-parachain-runtime and rococo-parachain-runtime, respectively.
 
-## launch of local network
+## launch a standalone node
+
+Simply run
+```
+make launch-standalone
+```
+A standalone node will be launched without relaychain, where blocks are finalised immediately. The node is accessible via ws 9944 port.
+
+## launch a local network with relaychain + parachain
 
 The following steps take rococo-parachain for example, because `sudo` will be removed for litentry-parachain and [was removed](https://github.com/litentry/litentry-parachain/issues/775) for litmus-parachain. But generally speaking, lauching a local network works with either of the three chain-settings.
 

--- a/docker/litentry-parachain-launch-config.yml
+++ b/docker/litentry-parachain-launch-config.yml
@@ -13,7 +13,13 @@ relaychain:
     - --execution=wasm
   nodes:
     - name: alice
+      wsPort: 9946
+      rpcPort: 9936
+      port: 30336
     - name: bob
+      wsPort: 9947
+      rpcPort: 9937
+      port: 30337
 
 # Parachain Configuration
 parachains:
@@ -34,3 +40,6 @@ parachains:
   nodes:
   - flags:
     - --alice
+    wsPort: 9944
+    rpcPort: 9933
+    port: 30333

--- a/docker/litmus-parachain-launch-config.yml
+++ b/docker/litmus-parachain-launch-config.yml
@@ -13,7 +13,13 @@ relaychain:
     - --execution=wasm
   nodes:
     - name: alice
+      wsPort: 9946
+      rpcPort: 9936
+      port: 30336
     - name: bob
+      wsPort: 9947
+      rpcPort: 9937
+      port: 30337
 
 # Parachain Configuration
 parachains:
@@ -33,3 +39,6 @@ parachains:
   nodes:
   - flags:
     - --alice
+    wsPort: 9944
+    rpcPort: 9933
+    port: 30333

--- a/docker/rococo-parachain-launch-config.yml
+++ b/docker/rococo-parachain-launch-config.yml
@@ -23,7 +23,7 @@ relaychain:
 
 # Parachain Configuration
 parachains:
-- image: litentry/litentry-parachain:tmp
+- image: litentry/litentry-parachain:latest
   chain: rococo-dev
   id: 2106
   parachain: true

--- a/docker/rococo-parachain-launch-config.yml
+++ b/docker/rococo-parachain-launch-config.yml
@@ -13,11 +13,17 @@ relaychain:
     - --execution=wasm
   nodes:
     - name: alice
+      wsPort: 9946
+      rpcPort: 9936
+      port: 30336
     - name: bob
+      wsPort: 9947
+      rpcPort: 9937
+      port: 30337
 
 # Parachain Configuration
 parachains:
-- image: litentry/litentry-parachain:latest
+- image: litentry/litentry-parachain:tmp
   chain: rococo-dev
   id: 2106
   parachain: true
@@ -33,3 +39,6 @@ parachains:
   nodes:
   - flags:
     - --alice
+    wsPort: 9944
+    rpcPort: 9933
+    port: 30333

--- a/mock-tee-primitives/Cargo.toml
+++ b/mock-tee-primitives/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, optional = true }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://litentry.com/'
 license = 'GPL-3.0'
 name = 'litentry-collator'
 repository = 'https://github.com/litentry/litentry-parachain'
-version = '0.9.12'
+version = '0.9.13'
 
 [[bin]]
 name = 'litentry-collator'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -31,6 +31,7 @@ sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "pol
 sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", features = ["wasmtime"] }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
+sc-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", features = ["wasmtime"] }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
 sc-network-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }

--- a/node/src/chain_specs/rococo.rs
+++ b/node/src/chain_specs/rococo.rs
@@ -55,10 +55,11 @@ struct GenesisInfo {
 	telemetry_endpoints: Vec<String>,
 }
 
-pub fn get_chain_spec_dev() -> ChainSpec {
+pub fn get_chain_spec_dev(is_standalone: bool) -> ChainSpec {
+	let id = if is_standalone { "standalone" } else { "litentry-rococo-dev" };
 	ChainSpec::from_genesis(
 		"Litentry-rococo-dev",
-		"litentry-rococo-dev",
+		id,
 		ChainType::Development,
 		move || {
 			generate_genesis(

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -63,7 +63,7 @@ pub enum Subcommand {
 	TryRuntime(try_runtime_cli::TryRuntimeCmd),
 }
 
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, Parser)]
 #[command(
 	propagate_version = true,
 	args_conflicts_with_subcommands = true,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -91,8 +91,8 @@ impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	Ok(match id {
-		// `--chain=standalone or --chain=dev` to start a standalone node using rococo-dev chain
-		// spec mainly based on Acala's `dev` implementation
+		// `--chain=standalone or --chain=dev` to start a standalone node with rococo-dev chain spec
+		// mainly based on Acala's `dev` implementation
 		"dev" | "standalone" => Box::new(chain_specs::rococo::get_chain_spec_dev(true)),
 		// Litentry
 		"litentry-dev" => Box::new(chain_specs::litentry::get_chain_spec_dev()),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -84,6 +84,8 @@ impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	Ok(match id {
+		// `--dev` to start a standalone node in dev network, using rococo-dev
+		"dev" => Box::new(chain_specs::rococo::get_chain_spec_dev()),
 		// Litentry
 		"litentry-dev" => Box::new(chain_specs::litentry::get_chain_spec_dev()),
 		"litentry-staging" => Box::new(chain_specs::litentry::get_chain_spec_staging()),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -67,7 +67,7 @@ impl IdentifyChain for dyn sc_service::ChainSpec {
 		self.id().ends_with("dev")
 	}
 	fn is_standalone(&self) -> bool {
-		self.id().eq("standalone")
+		self.id().eq("standalone") || self.id().eq("dev")
 	}
 }
 
@@ -91,9 +91,9 @@ impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	Ok(match id {
-		// `--standalone` to start a standalone node in dev network, using rococo-dev
-		// mainly based on Acala's `dev` implementation
-		"standalone" => Box::new(chain_specs::rococo::get_chain_spec_dev()),
+		// `--chain=standalone or --chain=dev` to start a standalone node using rococo-dev chain
+		// spec mainly based on Acala's `dev` implementation
+		"dev" | "standalone" => Box::new(chain_specs::rococo::get_chain_spec_dev(true)),
 		// Litentry
 		"litentry-dev" => Box::new(chain_specs::litentry::get_chain_spec_dev()),
 		"litentry-staging" => Box::new(chain_specs::litentry::get_chain_spec_staging()),
@@ -107,7 +107,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, St
 			&include_bytes!("../res/chain_specs/litmus.json")[..],
 		)?),
 		// Rococo
-		"rococo-dev" => Box::new(chain_specs::rococo::get_chain_spec_dev()),
+		"rococo-dev" => Box::new(chain_specs::rococo::get_chain_spec_dev(false)),
 		"rococo-staging" => Box::new(chain_specs::rococo::get_chain_spec_staging()),
 		"rococo" => Box::new(chain_specs::rococo::ChainSpec::from_json_bytes(
 			&include_bytes!("../res/chain_specs/rococo-170000.json")[..],

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -47,6 +47,7 @@ trait IdentifyChain {
 	fn is_litmus(&self) -> bool;
 	fn is_rococo(&self) -> bool;
 	fn is_dev(&self) -> bool;
+	fn is_standalone(&self) -> bool;
 }
 
 impl IdentifyChain for dyn sc_service::ChainSpec {
@@ -65,6 +66,9 @@ impl IdentifyChain for dyn sc_service::ChainSpec {
 	fn is_dev(&self) -> bool {
 		self.id().ends_with("dev")
 	}
+	fn is_standalone(&self) -> bool {
+		self.id().eq("standalone")
+	}
 }
 
 impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
@@ -80,12 +84,16 @@ impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
 	fn is_dev(&self) -> bool {
 		<dyn sc_service::ChainSpec>::is_dev(self)
 	}
+	fn is_standalone(&self) -> bool {
+		<dyn sc_service::ChainSpec>::is_standalone(self)
+	}
 }
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	Ok(match id {
-		// `--dev` to start a standalone node in dev network, using rococo-dev
-		"dev" => Box::new(chain_specs::rococo::get_chain_spec_dev()),
+		// `--standalone` to start a standalone node in dev network, using rococo-dev
+		// mainly based on Acala's `dev` implementation
+		"standalone" => Box::new(chain_specs::rococo::get_chain_spec_dev()),
 		// Litentry
 		"litentry-dev" => Box::new(chain_specs::litentry::get_chain_spec_dev()),
 		"litentry-staging" => Box::new(chain_specs::litentry::get_chain_spec_staging()),
@@ -215,18 +223,21 @@ macro_rules! construct_benchmark_partials {
 		if $config.chain_spec.is_litmus() {
 			let $partials = new_partial::<litmus_parachain_runtime::RuntimeApi, _>(
 				&$config,
+				false,
 				crate::service::build_import_queue::<litmus_parachain_runtime::RuntimeApi>,
 			)?;
 			$code
 		} else if $config.chain_spec.is_litentry() {
 			let $partials = new_partial::<litentry_parachain_runtime::RuntimeApi, _>(
 				&$config,
+				false,
 				crate::service::build_import_queue::<litentry_parachain_runtime::RuntimeApi>,
 			)?;
 			$code
 		} else if $config.chain_spec.is_rococo() {
 			let $partials = new_partial::<rococo_parachain_runtime::RuntimeApi, _>(
 				&$config,
+				false,
 				crate::service::build_import_queue::<rococo_parachain_runtime::RuntimeApi>,
 			)?;
 			$code
@@ -247,6 +258,7 @@ macro_rules! construct_async_run {
 					_
 				>(
 					&$config,
+					false,
 					crate::service::build_import_queue::<litmus_parachain_runtime::RuntimeApi>,
 				)?;
 				let task_manager = $components.task_manager;
@@ -259,6 +271,7 @@ macro_rules! construct_async_run {
 					_
 				>(
 					&$config,
+					false,
 					crate::service::build_import_queue::<litentry_parachain_runtime::RuntimeApi>,
 				)?;
 				let task_manager = $components.task_manager;
@@ -271,6 +284,7 @@ macro_rules! construct_async_run {
 					_
 				>(
 					&$config,
+					false,
 					crate::service::build_import_queue::<rococo_parachain_runtime::RuntimeApi>,
 				)?;
 				let task_manager = $components.task_manager;
@@ -442,8 +456,17 @@ pub fn run() -> Result<()> {
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;
 			let collator_options = cli.run.collator_options();
+			let is_standalone = runner.config().chain_spec.is_standalone();
 
 			runner.run_node_until_exit(|config| async move {
+				if is_standalone {
+					return crate::service::start_standalone_node::<rococo_parachain_runtime::RuntimeApi>(
+						config
+					)
+					.await
+					.map_err(Into::into)
+				}
+
 				let hwbench = if !cli.no_hardware_benchmarks {
 					config.database.path().map(|database_path| {
 						let _ = std::fs::create_dir_all(database_path);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -22,6 +22,7 @@ mod service;
 mod cli;
 mod command;
 mod rpc;
+mod standalone_block_import;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -567,7 +567,7 @@ where
 			sc_consensus_aura::ImportQueueParams {
 				block_import: client.clone(),
 				justification_import: None,
-				client: client.clone(),
+				client,
 				create_inherent_data_providers: move |block: Hash, ()| {
 					let current_para_block = client_for_cidp
 						.number(block)

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -17,9 +17,6 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 
-// rpc
-use jsonrpsee::RpcModule;
-
 use cumulus_client_cli::CollatorOptions;
 use cumulus_client_consensus_aura::{AuraConsensus, BuildAuraConsensusParams, SlotProportion};
 use cumulus_client_consensus_common::ParachainConsensus;
@@ -34,6 +31,7 @@ use cumulus_primitives_parachain_inherent::{
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
 use cumulus_relay_chain_minimal_node::build_minimal_relay_chain_node;
+use jsonrpsee::RpcModule;
 use polkadot_service::CollatorPair;
 
 use crate::{rpc, standalone_block_import::StandaloneBlockImport};
@@ -60,6 +58,7 @@ type HostFunctions = sp_io::SubstrateHostFunctions;
 #[cfg(feature = "runtime-benchmarks")]
 type HostFunctions =
 	(sp_io::SubstrateHostFunctions, frame_benchmarking::benchmarking::HostFunctions);
+
 // Native executor instance.
 pub struct LitentryParachainRuntimeExecutor;
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -36,7 +36,7 @@ use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayC
 use cumulus_relay_chain_minimal_node::build_minimal_relay_chain_node;
 use polkadot_service::CollatorPair;
 
-use crate::rpc;
+use crate::{rpc, standalone_block_import::StandaloneBlockImport};
 pub use primitives::{AccountId, Balance, Block, Hash, Header, Index as Nonce};
 
 use sc_consensus::LongestChain;
@@ -718,8 +718,7 @@ where
 			slot_duration: sc_consensus_aura::slot_duration(&*client)?,
 			client: client.clone(),
 			select_chain,
-			// block_import: instant_finalize::InstantFinalizeBlockImport::new(client.clone()),
-			block_import: client.clone(),
+			block_import: StandaloneBlockImport::new(client.clone()),
 			proposer_factory,
 			create_inherent_data_providers: move |block: Hash, ()| {
 				let current_para_block = client_for_cidp

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -28,6 +28,9 @@ use cumulus_client_service::{
 	prepare_node_config, start_collator, start_full_node, StartCollatorParams, StartFullNodeParams,
 };
 use cumulus_primitives_core::ParaId;
+use cumulus_primitives_parachain_inherent::{
+	MockValidationDataInherentDataProvider, MockXcmConfig,
+};
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
 use cumulus_relay_chain_minimal_node::build_minimal_relay_chain_node;
@@ -36,12 +39,15 @@ use polkadot_service::CollatorPair;
 use crate::rpc;
 pub use primitives::{AccountId, Balance, Block, Hash, Header, Index as Nonce};
 
+use sc_consensus::LongestChain;
+use sc_consensus_aura::StartAuraParams;
 use sc_executor::WasmExecutor;
 use sc_network::NetworkService;
 use sc_network_common::service::NetworkBlock;
 use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
 use sp_api::ConstructRuntimeApi;
+use sp_blockchain::HeaderBackend;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::traits::BlakeTwo256;
@@ -103,18 +109,21 @@ type ParachainClient<RuntimeApi> = TFullClient<Block, RuntimeApi, WasmExecutor<H
 
 type ParachainBackend = TFullBackend<Block>;
 
+type MaybeSelectChain = Option<LongestChain<ParachainBackend, Block>>;
+
 /// Starts a `ServiceBuilder` for a full service.
 ///
 /// Use this macro if you don't actually need the full service, but just the builder in order to
 /// be able to perform chain operations.
 pub fn new_partial<RuntimeApi, BIQ>(
 	config: &Configuration,
+	is_standalone: bool,
 	build_import_queue: BIQ,
 ) -> Result<
 	PartialComponents<
 		ParachainClient<RuntimeApi>,
 		ParachainBackend,
-		(),
+		MaybeSelectChain,
 		sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
 		sc_transaction_pool::FullPool<Block, ParachainClient<RuntimeApi>>,
 		(Option<Telemetry>, Option<TelemetryWorkerHandle>),
@@ -137,6 +146,7 @@ where
 		&Configuration,
 		Option<TelemetryHandle>,
 		&TaskManager,
+		bool,
 	) -> Result<
 		sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
 		sc_service::Error,
@@ -184,11 +194,14 @@ where
 		client.clone(),
 	);
 
+	let select_chain = if is_standalone { Some(LongestChain::new(backend.clone())) } else { None };
+
 	let import_queue = build_import_queue(
 		client.clone(),
 		config,
 		telemetry.as_ref().map(|telemetry| telemetry.handle()),
 		&task_manager,
+		is_standalone,
 	)?;
 
 	let params = PartialComponents {
@@ -198,7 +211,7 @@ where
 		keystore_container,
 		task_manager,
 		transaction_pool,
-		select_chain: (),
+		select_chain,
 		other: (telemetry, telemetry_worker_handle),
 	};
 
@@ -262,6 +275,7 @@ where
 			&Configuration,
 			Option<TelemetryHandle>,
 			&TaskManager,
+			bool,
 		) -> Result<
 			sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
 			sc_service::Error,
@@ -280,7 +294,7 @@ where
 {
 	let parachain_config = prepare_node_config(parachain_config);
 
-	let params = new_partial::<RuntimeApi, BIQ>(&parachain_config, build_import_queue)?;
+	let params = new_partial::<RuntimeApi, BIQ>(&parachain_config, false, build_import_queue)?;
 	let (mut telemetry, telemetry_worker_handle) = params.other;
 
 	let client = params.client.clone();
@@ -526,6 +540,7 @@ pub fn build_import_queue<RuntimeApi>(
 	config: &Configuration,
 	telemetry: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
+	is_standalone: bool,
 ) -> Result<sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>, sc_service::Error>
 where
 	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
@@ -543,32 +558,252 @@ where
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
 {
-	let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
+	if is_standalone {
+		// aura import queue
+		let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
+		let client_for_cidp = client.clone();
 
-	cumulus_client_consensus_aura::import_queue::<
-		sp_consensus_aura::sr25519::AuthorityPair,
-		_,
-		_,
-		_,
-		_,
-		_,
-	>(cumulus_client_consensus_aura::ImportQueueParams {
-		block_import: client.clone(),
+		sc_consensus_aura::import_queue::<sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _>(
+			sc_consensus_aura::ImportQueueParams {
+				block_import: client.clone(),
+				justification_import: None,
+				client: client.clone(),
+				create_inherent_data_providers: move |block: Hash, ()| {
+					let current_para_block = client_for_cidp
+						.number(block)
+						.expect("Header lookup should succeed")
+						.expect("Header passed in as parent should be present in backend.");
+					let client_for_xcm = client_for_cidp.clone();
+
+					async move {
+						let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+
+						let slot = sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+								*timestamp,
+								slot_duration,
+							);
+
+						let mocked_parachain = MockValidationDataInherentDataProvider {
+							current_para_block,
+							relay_offset: 1000,
+							relay_blocks_per_para_block: 2,
+							para_blocks_per_relay_epoch: 0,
+							relay_randomness_config: (),
+							xcm_config: MockXcmConfig::new(
+								&*client_for_xcm,
+								block,
+								Default::default(),
+								Default::default(),
+							),
+							raw_downward_messages: vec![],
+							raw_horizontal_messages: vec![],
+						};
+
+						Ok((slot, timestamp, mocked_parachain))
+					}
+				},
+				spawner: &task_manager.spawn_essential_handle(),
+				registry: config.prometheus_registry(),
+				check_for_equivocation: Default::default(),
+				telemetry,
+			},
+		)
+		.map_err(Into::into)
+	} else {
+		let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
+
+		cumulus_client_consensus_aura::import_queue::<
+			sp_consensus_aura::sr25519::AuthorityPair,
+			_,
+			_,
+			_,
+			_,
+			_,
+		>(cumulus_client_consensus_aura::ImportQueueParams {
+			block_import: client.clone(),
+			client,
+			create_inherent_data_providers: move |_, _| async move {
+				let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+
+				let slot =
+					sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+						*timestamp,
+						slot_duration,
+					);
+
+				Ok((slot, timestamp))
+			},
+			registry: config.prometheus_registry(),
+			spawner: &task_manager.spawn_essential_handle(),
+			telemetry,
+		})
+		.map_err(Into::into)
+	}
+}
+
+// start a standalone node which doesn't need to connect to relaychain
+pub async fn start_standalone_node<RuntimeApi>(
+	config: Configuration,
+) -> Result<TaskManager, sc_service::Error>
+where
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
+	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
+		+ sp_api::Metadata<Block>
+		+ sp_session::SessionKeys<Block>
+		+ sp_api::ApiExt<
+			Block,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
+		> + sp_offchain::OffchainWorkerApi<Block>
+		+ sp_block_builder::BlockBuilder<Block>
+		+ cumulus_primitives_core::CollectCollationInfo<Block>
+		+ sp_consensus_aura::AuraApi<Block, AuraId>
+		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
+		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
+{
+	let sc_service::PartialComponents {
 		client,
-		create_inherent_data_providers: move |_, _| async move {
-			let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+		backend,
+		mut task_manager,
+		import_queue,
+		keystore_container,
+		select_chain: maybe_select_chain,
+		transaction_pool,
+		other: (_, _),
+	} = new_partial::<RuntimeApi, _>(&config, true, build_import_queue::<RuntimeApi>)?;
 
-			let slot =
-				sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
-					*timestamp,
-					slot_duration,
-				);
+	let (network, system_rpc_tx, tx_handler_controller, start_network) =
+		sc_service::build_network(sc_service::BuildNetworkParams {
+			config: &config,
+			client: client.clone(),
+			transaction_pool: transaction_pool.clone(),
+			spawn_handle: task_manager.spawn_handle(),
+			import_queue,
+			block_announce_validator_builder: None,
+			warp_sync: None,
+		})?;
 
-			Ok((slot, timestamp))
-		},
-		registry: config.prometheus_registry(),
-		spawner: &task_manager.spawn_essential_handle(),
-		telemetry,
-	})
-	.map_err(Into::into)
+	let role = config.role.clone();
+	let force_authoring = config.force_authoring;
+	let backoff_authoring_blocks: Option<()> = None;
+
+	let select_chain = maybe_select_chain
+		.expect("In `standalone` mode, `new_partial` will return some `select_chain`; qed");
+
+	if role.is_authority() {
+		let proposer_factory = sc_basic_authorship::ProposerFactory::new(
+			task_manager.spawn_handle(),
+			client.clone(),
+			transaction_pool.clone(),
+			None,
+			None,
+		);
+		// aura
+		let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
+		let client_for_cidp = client.clone();
+
+		let aura = sc_consensus_aura::start_aura::<
+			sp_consensus_aura::sr25519::AuthorityPair,
+			_,
+			_,
+			_,
+			_,
+			_,
+			_,
+			_,
+			_,
+			_,
+			_,
+		>(StartAuraParams {
+			slot_duration: sc_consensus_aura::slot_duration(&*client)?,
+			client: client.clone(),
+			select_chain,
+			// block_import: instant_finalize::InstantFinalizeBlockImport::new(client.clone()),
+			block_import: client.clone(),
+			proposer_factory,
+			create_inherent_data_providers: move |block: Hash, ()| {
+				let current_para_block = client_for_cidp
+					.number(block)
+					.expect("Header lookup should succeed")
+					.expect("Header passed in as parent should be present in backend.");
+				let client_for_xcm = client_for_cidp.clone();
+
+				async move {
+					let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+
+					let slot = sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+							*timestamp,
+							slot_duration,
+						);
+
+					let mocked_parachain = MockValidationDataInherentDataProvider {
+						current_para_block,
+						relay_offset: 1000,
+						relay_blocks_per_para_block: 2,
+						para_blocks_per_relay_epoch: 0,
+						relay_randomness_config: (),
+						xcm_config: MockXcmConfig::new(
+							&*client_for_xcm,
+							block,
+							Default::default(),
+							Default::default(),
+						),
+						raw_downward_messages: vec![],
+						raw_horizontal_messages: vec![],
+					};
+
+					Ok((slot, timestamp, mocked_parachain))
+				}
+			},
+			force_authoring,
+			backoff_authoring_blocks,
+			keystore: keystore_container.sync_keystore(),
+			sync_oracle: network.clone(),
+			justification_sync_link: network.clone(),
+			// We got around 500ms for proposing
+			block_proposal_slot_portion: SlotProportion::new(1f32 / 24f32),
+			// And a maximum of 750ms if slots are skipped
+			max_block_proposal_slot_portion: Some(SlotProportion::new(1f32 / 16f32)),
+			telemetry: None,
+		})?;
+
+		// the AURA authoring task is considered essential, i.e. if it
+		// fails we take down the service with it.
+		task_manager
+			.spawn_essential_handle()
+			.spawn_blocking("aura", Some("block-authoring"), aura);
+	}
+
+	let rpc_builder = {
+		let client = client.clone();
+		let transaction_pool = transaction_pool.clone();
+
+		Box::new(move |deny_unsafe, _| {
+			let deps = rpc::FullDeps {
+				client: client.clone(),
+				pool: transaction_pool.clone(),
+				deny_unsafe,
+			};
+
+			crate::rpc::create_full(deps).map_err(Into::into)
+		})
+	};
+
+	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+		rpc_builder,
+		client,
+		transaction_pool,
+		task_manager: &mut task_manager,
+		config,
+		keystore: keystore_container.sync_keystore(),
+		backend,
+		network,
+		system_rpc_tx,
+		tx_handler_controller,
+		telemetry: None,
+	})?;
+
+	start_network.start_network();
+
+	Ok(task_manager)
 }

--- a/node/src/standalone_block_import.rs
+++ b/node/src/standalone_block_import.rs
@@ -1,0 +1,58 @@
+// Copyright 2020-2022 Litentry Technologies GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+// based on Acala's instant_finalize implementation
+// used in standalone mode to help to immediately finalize the block
+
+use sc_consensus::BlockImport;
+use sp_runtime::traits::Block as BlockT;
+
+pub struct StandaloneBlockImport<I> {
+	inner: I,
+}
+
+impl<I> StandaloneBlockImport<I> {
+	pub fn new(inner: I) -> Self {
+		Self { inner }
+	}
+}
+
+#[async_trait::async_trait]
+impl<Block, I> BlockImport<Block> for StandaloneBlockImport<I>
+where
+	Block: BlockT,
+	I: BlockImport<Block> + Send,
+{
+	type Error = I::Error;
+	type Transaction = I::Transaction;
+
+	async fn check_block(
+		&mut self,
+		block: sc_consensus::BlockCheckParams<Block>,
+	) -> Result<sc_consensus::ImportResult, Self::Error> {
+		self.inner.check_block(block).await
+	}
+
+	async fn import_block(
+		&mut self,
+		mut block_import_params: sc_consensus::BlockImportParams<Block, Self::Transaction>,
+		cache: std::collections::HashMap<sp_consensus::CacheKeyId, Vec<u8>>,
+	) -> Result<sc_consensus::ImportResult, Self::Error> {
+		// immediately finalize the block
+		block_import_params.finalized = true;
+		self.inner.import_block(block_import_params, cache).await
+	}
+}

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -15,14 +15,14 @@ serde = { version = "1.0", optional = true }
 primitives = { path = "../../primitives", default-features = false }
 
 # Substrate
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", optional = true, default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
 pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
 pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
-parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
 sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
@@ -44,7 +44,7 @@ std = [
   "pallet-authorship/std",
   "pallet-balances/std",
   "pallet-session/std",
-  "parity-scale-codec/std",
+  "codec/std",
   "primitives/std",
   "scale-info/std",
   "serde",

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -27,13 +27,13 @@ use crate::{
 	},
 	Delegator,
 };
+use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
 	ensure,
 	traits::{Get, ReservableCurrency},
 	RuntimeDebug,
 };
-use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::traits::Saturating;
 use sp_std::{vec, vec::Vec};

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -23,8 +23,8 @@ use crate::{
 	pallet::{BalanceOf, Config, Pallet},
 	traits::IssuanceAdapter,
 };
+use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::traits::Currency;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -19,7 +19,7 @@
 //! implementations.
 
 /* TODO: use orml_utilities::OrderedSet without leaking substrate v2.0 dependencies */
-use parity_scale_codec::{Decode, Encode};
+use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -24,8 +24,8 @@ use crate::{
 	set::OrderedSet, BalanceOf, BottomDelegations, CandidateInfo, Config, DelegatorState, Error,
 	Event, Pallet, Round, RoundIndex, TopDelegations, Total,
 };
+use codec::{Decode, Encode};
 use frame_support::{pallet_prelude::*, traits::ReservableCurrency};
-use parity_scale_codec::{Decode, Encode};
 use sp_runtime::{
 	traits::{Saturating, Zero},
 	Perbill, Percent, RuntimeDebug,

--- a/pallets/xcm-asset-manager/Cargo.toml
+++ b/pallets/xcm-asset-manager/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = '0.3.4' }
 log = { version = "0.4", default-features = false }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = "1.8.0"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -6,7 +6,7 @@ version = '0.9.12'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Litentry Dev"]
 edition = '2021'
 name = 'runtime-common'
-version = '0.9.12'
+version = '0.9.13'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/runtime/litentry/Cargo.toml
+++ b/runtime/litentry/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Litentry Dev"]
 edition = '2021'
 name = 'litentry-parachain-runtime'
-version = '0.9.12'
+version = '0.9.13'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/runtime/litentry/src/lib.rs
+++ b/runtime/litentry/src/lib.rs
@@ -140,7 +140,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot:
 	// last digit is used for minor updates, like 9110 -> 9111 in polkadot
-	spec_version: 9120,
+	spec_version: 9130,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/litmus/Cargo.toml
+++ b/runtime/litmus/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Litentry Dev"]
 edition = '2021'
 name = 'litmus-parachain-runtime'
-version = '0.9.12'
+version = '0.9.13'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litmus-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9120,
+	spec_version: 9130,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/rococo/Cargo.toml
+++ b/runtime/rococo/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Litentry Dev"]
 edition = '2021'
 name = 'rococo-parachain-runtime'
-version = '0.9.12'
+version = '0.9.13'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot:
 	// last digit is used for minor updates, like 9110 -> 9111 in polkadot
-	spec_version: 9120,
+	spec_version: 9130,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/scripts/launch-local-binary.sh
+++ b/scripts/launch-local-binary.sh
@@ -85,21 +85,21 @@ $PARACHAIN_BIN export-genesis-state --chain $CHAIN-dev > genesis-state
 $PARACHAIN_BIN export-genesis-wasm --chain $CHAIN-dev > genesis-wasm
 
 # run alice and bob as relay nodes
-$POLKADOT_BIN --chain $ROCOCO_CHAINSPEC --alice --tmp --port 30333 --ws-port 9944 --rpc-port 9933 &> "relay.alice.log" &
+$POLKADOT_BIN --chain $ROCOCO_CHAINSPEC --alice --tmp --port 30336 --ws-port 9946 --rpc-port 9936 &> "relay.alice.log" &
 sleep 10
 
 RELAY_ALICE_IDENTITY=$(grep 'Local node identity' relay.alice.log | sed 's/^.*: //')
 
-$POLKADOT_BIN --chain $ROCOCO_CHAINSPEC --bob --tmp --port 30334 --ws-port 9945  --rpc-port 9934 \
+$POLKADOT_BIN --chain $ROCOCO_CHAINSPEC --bob --tmp --port 30337 --ws-port 9947  --rpc-port 9937 \
   --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/$RELAY_ALICE_IDENTITY &> "relay.bob.log" &
 sleep 10
 
 # run a litentry-collator instance
 $PARACHAIN_BIN --alice --collator --force-authoring --tmp --chain $CHAIN-dev \
-  --port 30335 --ws-port 9946 --rpc-port 9935 --execution wasm \
+  --port 30333 --ws-port 9944 --rpc-port 9933 --execution wasm \
   -- \
   --execution wasm --chain $ROCOCO_CHAINSPEC --port 30332 --ws-port 9943 --rpc-port 9932 \
-  --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/$RELAY_ALICE_IDENTITY &> "para.alice.log" &
+  --bootnodes /ip4/127.0.0.1/tcp/30336/p2p/$RELAY_ALICE_IDENTITY &> "para.alice.log" &
 sleep 10
 
 echo "register parachain now ..."

--- a/scripts/launch-standalone.sh
+++ b/scripts/launch-standalone.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# This scripts starts a standalone node without relaychain network locally, with the parachain runtime
+
+ROOTDIR=$(git rev-parse --show-toplevel)
+PARACHAIN_BIN="$ROOTDIR/target/release/litentry-collator"
+
+cd "$ROOTDIR"
+
+if [ ! -f "$PARACHAIN_BIN" ]; then
+  echo "no litentry-collator found, build it now ..."
+  make build-node
+fi
+
+if ! "$PARACHAIN_BIN" --version &> /dev/null; then
+  echo "Cannot execute $PARACHAIN_BIN, wrong executable?"
+  exit 1
+fi
+
+echo "Starting litentry-collator in standalone mode ..."
+
+$PARACHAIN_BIN --dev --unsafe-ws-external --unsafe-rpc-external

--- a/ts-tests/config.ci.json
+++ b/ts-tests/config.ci.json
@@ -5,7 +5,7 @@
     "ocw_account": "5FEYX9NES9mAJt1Xg4WebmHWywxyeGQK8G3oEBXtyfZrRePX",
     "genesis_state_path": "/tmp/parachain_dev/genesis-state",
     "genesis_wasm_path": "/tmp/parachain_dev/genesis-wasm",
-    "parachain_ws": "ws://127.0.0.1:9946",
-    "relaynode_ws": "ws://127.0.0.1:9944",
+    "parachain_ws": "ws://127.0.0.1:9944",
+    "relaynode_ws": "ws://127.0.0.1:9946",
     "bridge_path": "/tmp/parachain_dev/chainbridge"
 }

--- a/ts-tests/config.ci.json
+++ b/ts-tests/config.ci.json
@@ -6,6 +6,6 @@
     "genesis_state_path": "/tmp/parachain_dev/genesis-state",
     "genesis_wasm_path": "/tmp/parachain_dev/genesis-wasm",
     "parachain_ws": "ws://127.0.0.1:9944",
-    "relaynode_ws": "ws://127.0.0.1:9946",
+    "relaychain_ws": "ws://127.0.0.1:9946",
     "bridge_path": "/tmp/parachain_dev/chainbridge"
 }

--- a/ts-tests/config.example.json
+++ b/ts-tests/config.example.json
@@ -3,5 +3,5 @@
     "private_key": "0xe82c0c4259710bb0d6cf9f9e8d0ad73419c1278a14d375e5ca691e7618103011",
     "ocw_account": "5FEYX9NES9mAJt1Xg4WebmHWywxyeGQK8G3oEBXtyfZrRePX",
     "parachain_ws": "ws://localhost:9844",
-    "relaynode_ws": "ws://localhost:9944"
+    "relaychain_ws": "ws://localhost:9944"
 }

--- a/ts-tests/config.staging.json
+++ b/ts-tests/config.staging.json
@@ -3,5 +3,5 @@
     "private_key": "0xe82c0c4259710bb0d6cf9f9e8d0ad73419c1278a14d375e5ca691e7618103011",
     "ocw_account": "5FEYX9NES9mAJt1Xg4WebmHWywxyeGQK8G3oEBXtyfZrRePX",
     "parachain_ws": "wss://parachain.staging.litentry.io",
-    "relaynode_ws": "wss://relayer-sg-1.staging.litentry.io"
+    "relaychain_ws": "wss://relayer-sg-1.staging.litentry.io"
 }

--- a/ts-tests/tests/register-parachain.ts
+++ b/ts-tests/tests/register-parachain.ts
@@ -32,7 +32,7 @@ async function registerParachain(api: ApiPromise, config: any) {
     console.log('Register parachain ...');
     const config = loadConfig();
 
-    const provider = new WsProvider(config.relaynode_ws);
+    const provider = new WsProvider(config.relaychain_ws);
     const api = await ApiPromise.create({
         provider: provider,
     });

--- a/ts-tests/tests/setup-bridge.ts
+++ b/ts-tests/tests/setup-bridge.ts
@@ -210,7 +210,7 @@ function generateBridgeConfig(
                 name: 'sub',
                 type: 'substrate',
                 id: parachainChainID.toString(),
-                endpoint: 'ws://127.0.0.1:9946',
+                endpoint: 'ws://127.0.0.1:9944',
                 from: parachainRelayer,
                 opts: {
                     useExtendedCall: 'true',


### PR DESCRIPTION
resolves #984 

This PR:
- adds support to start parachain node without launching relaychain
- use unified ws port for parachain node: `9944` in all cases
- bump version for release preparation
- adjust README
- `cargo update`