### PR TITLE
Emit new challenge code for each `create_identity`

### DIFF
--- a/pallets/identity-management-mock/Cargo.toml
+++ b/pallets/identity-management-mock/Cargo.toml
@@ -50,6 +50,7 @@ runtime-benchmarks = [
   "frame-system/runtime-benchmarks",
 ]
 std = [
+  "log/std",
   "codec/std",
   "sp-std/std",
   "sp-runtime/std",

--- a/pallets/identity-management-mock/src/identity_context.rs
+++ b/pallets/identity-management-mock/src/identity_context.rs
@@ -27,8 +27,8 @@ use crate::{BlockNumberOf, Config, Metadata};
 pub struct IdentityContext<T: Config> {
 	// the metadata
 	pub metadata: Option<Metadata>,
-	// the block number (of parent chain) where the linking was intially requested
-	pub linking_request_block: Option<BlockNumberOf<T>>,
+	// the block number (of parent chain) where the creation was intially requested
+	pub creation_request_block: Option<BlockNumberOf<T>>,
 	// the block number (of parent chain) where the verification was intially requested
 	pub verification_request_block: Option<BlockNumberOf<T>>,
 	// if this did is verified
@@ -41,7 +41,7 @@ impl<T: Config> Default for IdentityContext<T> {
 	fn default() -> Self {
 		Self {
 			metadata: None,
-			linking_request_block: None,
+			creation_request_block: None,
 			verification_request_block: None,
 			is_verified: false,
 		}
@@ -50,12 +50,12 @@ impl<T: Config> Default for IdentityContext<T> {
 
 impl<T: Config> IdentityContext<T> {
 	pub fn new(
-		linking_request_block: BlockNumberOf<T>,
+		creation_request_block: BlockNumberOf<T>,
 		verification_request_block: BlockNumberOf<T>,
 	) -> Self {
 		Self {
 			metadata: None,
-			linking_request_block: Some(linking_request_block),
+			creation_request_block: Some(creation_request_block),
 			verification_request_block: Some(verification_request_block),
 			is_verified: false,
 		}

--- a/pallets/identity-management-mock/src/lib.rs
+++ b/pallets/identity-management-mock/src/lib.rs
@@ -319,7 +319,7 @@ pub mod pallet {
 			// emit the challenge code event, TODO: use randomness pallet
 			let code = Self::get_mock_challenge_code(
 				<frame_system::Pallet<T>>::block_number(),
-				ChallengeCodes::<T>::get(&who, &identity).clone(),
+				ChallengeCodes::<T>::get(&who, &identity),
 			);
 			ChallengeCodes::<T>::insert(&who, &identity, &code);
 			Self::deposit_event(Event::<T>::ChallengeCodeGeneratedPlain {

--- a/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
@@ -81,7 +81,7 @@ impl TrustedCallSigned {
 			who: who.clone(),
 			identity: identity.clone(),
 			metadata,
-			linking_request_block: bn,
+			creation_request_block: bn,
 		}
 		.dispatch_bypass_filter(ita_sgx_runtime::Origin::root())
 		.map_err(|e| StfError::Dispatch(format!("{:?}", e.error)))?;

--- a/tee-worker/litentry/pallets/identity-management/src/identity_context.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/identity_context.rs
@@ -28,8 +28,8 @@ use litentry_primitives::ParentchainBlockNumber;
 pub struct IdentityContext<T: Config> {
 	// the metadata
 	pub metadata: Option<MetadataOf<T>>,
-	// the block number (of parent chain) where the linking was intially requested
-	pub linking_request_block: Option<ParentchainBlockNumber>,
+	// the block number (of parent chain) where the creation was intially requested
+	pub creation_request_block: Option<ParentchainBlockNumber>,
 	// the block number (of parent chain) where the verification was intially requested
 	pub verification_request_block: Option<ParentchainBlockNumber>,
 	// if this did is verified
@@ -42,7 +42,7 @@ impl<T: Config> Default for IdentityContext<T> {
 	fn default() -> Self {
 		Self {
 			metadata: None,
-			linking_request_block: None,
+			creation_request_block: None,
 			verification_request_block: None,
 			is_verified: false,
 		}
@@ -51,12 +51,12 @@ impl<T: Config> Default for IdentityContext<T> {
 
 impl<T: Config> IdentityContext<T> {
 	pub fn new(
-		linking_request_block: ParentchainBlockNumber,
+		creation_request_block: ParentchainBlockNumber,
 		verification_request_block: ParentchainBlockNumber,
 	) -> Self {
 		Self {
 			metadata: None,
-			linking_request_block: Some(linking_request_block),
+			creation_request_block: Some(creation_request_block),
 			verification_request_block: Some(verification_request_block),
 			is_verified: false,
 		}

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -91,8 +91,8 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// challenge code doesn't exist
 		ChallengeCodeNotExist,
-		/// the pair (litentry-account, identity) already exists
-		IdentityAlreadyExist,
+		/// the pair (litentry-account, identity) already verified when creating an identity
+		IdentityAlreadyVerified,
 		/// the pair (litentry-account, identity) doesn't exist
 		IdentityNotExist,
 		/// the identity was not created before verification
@@ -189,10 +189,9 @@ pub mod pallet {
 			creation_request_block: ParentchainBlockNumber,
 		) -> DispatchResult {
 			T::ManageOrigin::ensure_origin(origin)?;
-			ensure!(
-				!IDGraphs::<T>::contains_key(&who, &identity),
-				Error::<T>::IdentityAlreadyExist
-			);
+			if let Some(c) = IDGraphs::<T>::get(&who, &identity) {
+				ensure!(!c.is_verified, Error::<T>::IdentityAlreadyVerified);
+			}
 			let context = IdentityContext {
 				metadata,
 				creation_request_block: Some(creation_request_block),

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -67,7 +67,7 @@ pub mod pallet {
 		/// maximum metadata length
 		#[pallet::constant]
 		type MaxMetadataLength: Get<u32>;
-		/// maximum delay in block numbers between linking an identity and verifying an identity
+		/// maximum delay in block numbers between creating an identity and verifying an identity
 		#[pallet::constant]
 		type MaxVerificationDelay: Get<ParentchainBlockNumber>;
 	}
@@ -186,7 +186,7 @@ pub mod pallet {
 			who: T::AccountId,
 			identity: Identity,
 			metadata: Option<MetadataOf<T>>,
-			linking_request_block: ParentchainBlockNumber,
+			creation_request_block: ParentchainBlockNumber,
 		) -> DispatchResult {
 			T::ManageOrigin::ensure_origin(origin)?;
 			ensure!(
@@ -195,7 +195,7 @@ pub mod pallet {
 			);
 			let context = IdentityContext {
 				metadata,
-				linking_request_block: Some(linking_request_block),
+				creation_request_block: Some(creation_request_block),
 				..Default::default()
 			};
 			IDGraphs::<T>::insert(&who, &identity, context);
@@ -227,7 +227,7 @@ pub mod pallet {
 			IDGraphs::<T>::try_mutate(&who, &identity, |context| -> DispatchResult {
 				let mut c = context.take().ok_or(Error::<T>::IdentityNotExist)?;
 
-				if let Some(b) = c.linking_request_block {
+				if let Some(b) = c.creation_request_block {
 					ensure!(
 						b <= verification_request_block,
 						Error::<T>::VerificationRequestTooEarly

--- a/tee-worker/litentry/pallets/identity-management/src/tests.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/tests.rs
@@ -51,7 +51,7 @@ fn create_identity_works() {
 			IMT::id_graphs(2, ALICE_WEB3_IDENTITY).unwrap(),
 			IdentityContext {
 				metadata: Some(metadata),
-				linking_request_block: Some(1),
+				creation_request_block: Some(1),
 				verification_request_block: None,
 				is_verified: false,
 			}
@@ -78,7 +78,7 @@ fn remove_identity_works() {
 			IMT::id_graphs(2, ALICE_WEB3_IDENTITY.clone()).unwrap(),
 			IdentityContext {
 				metadata: Some(metadata),
-				linking_request_block: Some(1),
+				creation_request_block: Some(1),
 				verification_request_block: None,
 				is_verified: false,
 			}
@@ -104,7 +104,7 @@ fn verify_identity_works() {
 			IMT::id_graphs(2, ALICE_WEB3_IDENTITY).unwrap(),
 			IdentityContext {
 				metadata: Some(metadata),
-				linking_request_block: Some(1),
+				creation_request_block: Some(1),
 				verification_request_block: Some(1),
 				is_verified: true,
 			}
@@ -149,7 +149,7 @@ fn get_identity_and_identity_context_works() {
 #[test]
 fn verify_identity_fails_when_too_early() {
 	new_test_ext().execute_with(|| {
-		const LINKNIG_REQUEST_BLOCK: ParentchainBlockNumber = 2;
+		const CREATION_REQUEST_BLOCK: ParentchainBlockNumber = 2;
 		const VERIFICATION_REQUEST_BLOCK: ParentchainBlockNumber = 1;
 
 		let metadata: MetadataOf<Test> = vec![0u8; 16].try_into().unwrap();
@@ -158,7 +158,7 @@ fn verify_identity_fails_when_too_early() {
 			2,
 			ALICE_WEB3_IDENTITY.clone(),
 			Some(metadata.clone()),
-			LINKNIG_REQUEST_BLOCK
+			CREATION_REQUEST_BLOCK
 		));
 		assert_noop!(
 			IMT::verify_identity(
@@ -173,7 +173,7 @@ fn verify_identity_fails_when_too_early() {
 			IMT::id_graphs(2, ALICE_WEB3_IDENTITY).unwrap(),
 			IdentityContext {
 				metadata: Some(metadata),
-				linking_request_block: Some(LINKNIG_REQUEST_BLOCK),
+				creation_request_block: Some(CREATION_REQUEST_BLOCK),
 				verification_request_block: None,
 				is_verified: false,
 			}
@@ -184,7 +184,7 @@ fn verify_identity_fails_when_too_early() {
 #[test]
 fn verify_identity_fails_when_too_late() {
 	new_test_ext().execute_with(|| {
-		const LINKNIG_REQUEST_BLOCK: ParentchainBlockNumber = 1;
+		const CREATION_REQUEST_BLOCK: ParentchainBlockNumber = 1;
 		const VERIFICATION_REQUEST_BLOCK: ParentchainBlockNumber = 5;
 
 		let metadata: MetadataOf<Test> = vec![0u8; 16].try_into().unwrap();
@@ -193,7 +193,7 @@ fn verify_identity_fails_when_too_late() {
 			2,
 			ALICE_WEB3_IDENTITY.clone(),
 			Some(metadata.clone()),
-			LINKNIG_REQUEST_BLOCK
+			CREATION_REQUEST_BLOCK
 		));
 		assert_noop!(
 			IMT::verify_identity(
@@ -208,7 +208,7 @@ fn verify_identity_fails_when_too_late() {
 			IMT::id_graphs(2, ALICE_WEB3_IDENTITY).unwrap(),
 			IdentityContext {
 				metadata: Some(metadata),
-				linking_request_block: Some(LINKNIG_REQUEST_BLOCK),
+				creation_request_block: Some(CREATION_REQUEST_BLOCK),
 				verification_request_block: None,
 				is_verified: false,
 			}


### PR DESCRIPTION
resolves #981 

More test cases for IMP mock and adjustment in sgx-runtime pallets.
some leftover renamings too

TODO: #1073 