### PR TITLE
Improve CI status check

### DIFF
--- a/.github/workflows/parachain-ci.yml
+++ b/.github/workflows/parachain-ci.yml
@@ -53,9 +53,9 @@ jobs:
               - 'runtime/**'
               - 'mock-tee-primitives/**'
               - 'docker/Dockerfile'
-              - '**/Cargo.lock'
-              - '**/Cargo.toml'
-              - '**/rust-toolchain.toml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'rust-toolchain.toml'
 
   check-cargo-fmt:
     runs-on: ubuntu-latest
@@ -206,6 +206,24 @@ jobs:
         run: |
           make clean-docker-${{ matrix.chain }}
 
+  # This is used to set github merge rules to protected branch, it's useful for
+  # checking the matrix status, where we need to cover
+  # - "successful" status (e.g. run-ts-tests(litmus)), and
+  # - "skipped" status (run-ts-tests).
+  # see https://github.com/orgs/community/discussions/26822
+  run-ts-tests-status-check:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: run-ts-tests
+    steps:
+      - run: |
+        result="${{ needs.run-ts-tests.result }}"
+        if [[ $result == "success" || $result == "skipped" ]]; then
+          exit 0
+        else
+          exit 1
+        fi
+
   run-cargo-unit-tests:
     runs-on: ubuntu-latest
     needs: [check-cargo-fmt, check-file-change]
@@ -254,18 +272,11 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.2
 
-
-  # The reason why not to put the if-check on the job level is to make sure the
-  # *matrix* job is run, although it can be skipped in the end.
-  #
-  # This is required when setting github merge rules to protected branch,
-  # where you can only select one of `run-cargo-runtime-tests` and `run-cargo-runtime-tests(litmus)`.
-  # If you put if-check on the job level, it can't fit every possible case.
-  #
   # Tried https://github.com/Swatinem/rust-cache too but it didn't work so well
   run-cargo-runtime-tests:
     runs-on: ubuntu-latest
     needs: [check-cargo-fmt, check-file-change]
+    if: needs.check-file-change.outputs.src == 'true'
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
@@ -283,7 +294,6 @@ jobs:
           fetch-depth: 0
 
       - name: Install toolchain
-        if: needs.check-file-change.outputs.src == 'true'
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -311,9 +321,7 @@ jobs:
          sudo apt-get install -yq openssl clang libclang-dev cmake protobuf-compiler
 
       - name: Cache cargo registry
-        if: needs.check-file-change.outputs.src == 'true'
         uses: actions/cache@v3
-        continue-on-error: false
         with:
           path: |
             ~/.cargo/registry
@@ -324,9 +332,7 @@ jobs:
             cargo-
 
       - name: Cache sccache
-        if: needs.check-file-change.outputs.src == 'true'
         uses: actions/cache@v3
-        continue-on-error: false
         with:
           path: /home/runner/.cache/sccache
           key: sccache-${{ env.REF_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
@@ -335,16 +341,27 @@ jobs:
             sccache-
 
       - name: Run runtime integration tests
-        if: needs.check-file-change.outputs.src == 'true'
         run: cargo test --locked --release -p ${{ matrix.chain }}-parachain-runtime --lib
 
       - name: Print sccache stats
-        if: needs.check-file-change.outputs.src == 'true'
         run: sccache --show-stats
 
       - name: Fail-fast; cancel other jobs
         if: failure()
         uses: andymckay/cancel-action@0.2
+
+  run-cargo-runtime-tests-status-check:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: run-cargo-runtime-tests
+    steps:
+      - run: |
+        result="${{ needs.run-cargo-runtime-tests.result }}"
+        if [[ $result == "success" || $result == "skipped" ]]; then
+          exit 0
+        else
+          exit 1
+        fi
 
   # Secrets are not passed to the runner when a workflow is triggered from a forked repository,
   # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

--- a/.github/workflows/parachain-ci.yml
+++ b/.github/workflows/parachain-ci.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           sudo apt-get update && \
           sudo apt-get install -yq openssl clang libclang-dev cmake protobuf-compiler
-          
+
       - name: Run cargo clippy check
         run: make clippy
 
@@ -217,12 +217,10 @@ jobs:
     needs: run-ts-tests
     steps:
       - run: |
-        result="${{ needs.run-ts-tests.result }}"
-        if [[ $result == "success" || $result == "skipped" ]]; then
-          exit 0
-        else
-          exit 1
-        fi
+          case "${{ needs.run-ts-tests.result }}" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac
 
   run-cargo-unit-tests:
     runs-on: ubuntu-latest
@@ -356,12 +354,10 @@ jobs:
     needs: run-cargo-runtime-tests
     steps:
       - run: |
-        result="${{ needs.run-cargo-runtime-tests.result }}"
-        if [[ $result == "success" || $result == "skipped" ]]; then
-          exit 0
-        else
-          exit 1
-        fi
+          case "${{ needs.run-cargo-runtime-tests.result }}" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac
 
   # Secrets are not passed to the runner when a workflow is triggered from a forked repository,
   # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -152,6 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     steps:
+      - uses: actions/checkout@v3
       - run: |
           case "${{ needs.build-test.result }}" in
             success|skipped) exit 0 ;;
@@ -335,6 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-tests
     steps:
+      - uses: actions/checkout@v3
       - run: |
           case "${{ needs.integration-tests.result }}" in
             success|skipped) exit 0 ;;

--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -147,6 +147,17 @@ jobs:
           name: integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
           path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
 
+  build-test-status-check:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - run: |
+          case "${{ needs.build-test.result }}" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac
+
   clippy:
     runs-on: ubuntu-latest
     needs: check-file-change
@@ -318,6 +329,17 @@ jobs:
         with:
           name: logs-${{ matrix.test }}-${{ matrix.flavor_id }}
           path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/${{ env.LOG_DIR }}
+
+  integration-tests-status-check:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: integration-tests
+    steps:
+      - run: |
+          case "${{ needs.integration-tests.result }}" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac
 
   # Only push docker image when tests are passed and it's a push event
   push-docker-image:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # litentry-parachain
-[![Build & Test](https://github.com/litentry/litentry-parachain/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/build-and-test.yml)
-[![Build wasm](https://github.com/litentry/litentry-parachain/actions/workflows/build-wasm.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/build-wasm.yml)
-[![Benchmark runtime weights](https://github.com/litentry/litentry-parachain/actions/workflows/benchmark-runtime-weights.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/benchmark-runtime-weights.yml)
-[![Release](https://github.com/litentry/litentry-parachain/actions/workflows/create-release-draft.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/create-release-draft.yml)
+[![parachain](https://github.com/litentry/litentry-parachain/actions/workflows/parachain-ci.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/parachain-ci.yml)
+[![tee-worker](https://github.com/litentry/litentry-parachain/actions/workflows/tee-worker-ci.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/tee-worker-ci.yml)
+[![release](https://github.com/litentry/litentry-parachain/actions/workflows/create-release-draft.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/create-release-draft.yml)
+[![runtime upgrade](https://github.com/litentry/litentry-parachain/actions/workflows/runtime-upgrade-simulation.yml/badge.svg)](https://github.com/litentry/litentry-parachain/actions/workflows/runtime-upgrade-simulation.yml)
 
 The Litentry parachain.
 


### PR DESCRIPTION
This PR does a few improvements to CI:
- file patch detector correction for parachain CI
- add status-check for matrix based jobs (for branch protection rules)
- adjust badges in README