### PR TITLE
Allow external connection when launching binary network

### DIFF
--- a/scripts/launch-local-binary.sh
+++ b/scripts/launch-local-binary.sh
@@ -98,6 +98,7 @@ sleep 10
 
 # run a litentry-collator instance
 $PARACHAIN_BIN --alice --collator --force-authoring --tmp --chain $CHAIN-dev \
+  --unsafe-ws-external --unsafe-rpc-external --rpc-cors=all \
   --port 30333 --ws-port 9944 --rpc-port 9933 --execution wasm \
   -- \
   --execution wasm --chain $ROCOCO_CHAINSPEC --port 30332 --ws-port 9943 --rpc-port 9932 \


### PR DESCRIPTION
A minor change.

When launching the dev network with binaries, it should allow remote connections. Usecase is e.g. when IDHub colleagues want to debug F/E connecting to tee-dev host.

cc @jonalvarezz 