### PR TITLE
Fix MakeFile syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash
 all:
 	@make help
 

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ launch-binary-rococo:
 test-cargo-all:
 	@cargo test --release --all
 
-.PHONY: test-cargo-all-benchmarks
+.PHONY: test-cargo-all-benchmarks ## cargo test --all --features runtime-benchmarks
 test-cargo-all-benchmarks:
 	@cargo test --release --all --features runtime-benchmarks
 

--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,11 @@ launch-binary-rococo:
 
 .PHONY: test-cargo-all ## cargo test --all
 test-cargo-all:
-	@cargo test --release --all
+	@cargo test --release --all --features=skip-ias-check
 
 .PHONY: test-cargo-all-benchmarks ## cargo test --all --features runtime-benchmarks
 test-cargo-all-benchmarks:
-	@cargo test --release --all --features runtime-benchmarks
+	@cargo test --release --all --features runtime-benchmarks --features=skip-ias-check
 
 .PHONY: test-ts-docker-litentry ## Run litentry ts tests with docker without clean-up
 test-ts-docker-litentry: launch-docker-litentry launch-docker-bridge


### PR DESCRIPTION
reloves #1134 

- MakeFile is `bin/sh` by default, so should set the `SHELL=/bin/bash` on ubuntu OS.  The image below is the result of my test.

- `make test-cargo-all`  add `--features=skip-ias-check`  this is the configuration in the adaptation CI.  https://github.com/litentry/litentry-parachain/commit/a2c921ae0c2d909e465ee8bd2f6c57f8607b9beb#diff-b8d2f0de9b16a7e11499d628e1c7487b6f24733466b4036e2598828f0f490aedR243

Fixed the `make help` syntax error, which didn't affect the execution of other make commands. 

reference link https://makefiletutorial.com/

<img width="517" alt="image" src="https://user-images.githubusercontent.com/87012234/210032401-350d7d29-72f5-46d5-9997-92dcaf2cd06e.png">


<img width="502" alt="image" src="https://user-images.githubusercontent.com/87012234/210032432-b61a8907-7a9b-4c27-93b6-c63a8a3e3587.png">



