### PR TITLE
Creating the same identity as main litentry address should be disallowed(fix #1132)

### DIFF
--- a/mock-tee-primitives/src/identity.rs
+++ b/mock-tee-primitives/src/identity.rs
@@ -66,6 +66,18 @@ pub enum SubstrateNetwork {
 	Litmus,
 }
 
+impl SubstrateNetwork {
+	/// get the ss58 prefix, see https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
+	pub fn ss58_prefix(&self) -> u16 {
+		match self {
+			Self::Polkadot => 0,
+			Self::Kusama => 2,
+			Self::Litentry => 31,
+			Self::Litmus => 131,
+		}
+	}
+}
+
 #[derive(Encode, Decode, Copy, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum EvmNetwork {

--- a/pallets/identity-management-mock/src/lib.rs
+++ b/pallets/identity-management-mock/src/lib.rs
@@ -322,7 +322,12 @@ pub mod pallet {
 			let identity = Identity::decode(&mut decrypted_identitty.as_slice())
 				.map_err(|_| Error::<T>::WrongDecodedType)?;
 			if let Identity::Substrate { network, address } = identity {
-				if network == SubstrateNetwork::Litentry {
+				// see all the address prefix:
+				// https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
+				let ss58_prefix = T::SS58Prefix::get();
+				if (network == SubstrateNetwork::Litentry && ss58_prefix == 31) ||
+					(network == SubstrateNetwork::Litmus && ss58_prefix == 131)
+				{
 					let address_raw: [u8; 32] = who
 						.encode()
 						.try_into()

--- a/pallets/identity-management-mock/src/lib.rs
+++ b/pallets/identity-management-mock/src/lib.rs
@@ -322,15 +322,14 @@ pub mod pallet {
 			let identity = Identity::decode(&mut decrypted_identitty.as_slice())
 				.map_err(|_| Error::<T>::WrongDecodedType)?;
 			if let Identity::Substrate { network, address } = identity {
-				let address_raw: [u8; 32] = who
-					.encode()
-					.try_into()
-					.map_err(|_| DispatchError::Other("invalid account id"))?;
-				let user_address: Address32 = address_raw.into();
-				ensure!(
-					!(network == SubstrateNetwork::Litentry && user_address == address),
-					Error::<T>::IdentityShouldBeDisallowed
-				);
+				if network == SubstrateNetwork::Litentry {
+					let address_raw: [u8; 32] = who
+						.encode()
+						.try_into()
+						.map_err(|_| DispatchError::Other("invalid account id"))?;
+					let user_address: Address32 = address_raw.into();
+					ensure!(user_address != address, Error::<T>::IdentityShouldBeDisallowed);
+				}
 			}
 			let metadata = match encrypted_metadata {
 				None => None,

--- a/pallets/identity-management-mock/src/lib.rs
+++ b/pallets/identity-management-mock/src/lib.rs
@@ -69,7 +69,7 @@ pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
 pub mod pallet {
 	use super::*;
 	use frame_system::pallet_prelude::*;
-	use mock_tee_primitives::{Address32, SubstrateNetwork};
+	use mock_tee_primitives::Address32;
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
@@ -325,9 +325,7 @@ pub mod pallet {
 				// see all the address prefix:
 				// https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
 				let ss58_prefix = T::SS58Prefix::get();
-				if (network == SubstrateNetwork::Litentry && ss58_prefix == 31) ||
-					(network == SubstrateNetwork::Litmus && ss58_prefix == 131)
-				{
+				if network.ss58_prefix() == ss58_prefix {
 					let address_raw: [u8; 32] = who
 						.encode()
 						.try_into()

--- a/pallets/identity-management/src/tests.rs
+++ b/pallets/identity-management/src/tests.rs
@@ -59,12 +59,14 @@ fn create_identity_without_delegatee_works() {
 fn create_identity_with_authorised_delegatee_works() {
 	new_test_ext().execute_with(|| {
 		let shard: ShardIdentifier = H256::from_slice(&TEST_MRENCLAVE);
+		let ss58_prefix = 131_u16;
 		assert_ok!(IdentityManagement::create_identity(
 			RuntimeOrigin::signed(5), // authorised delegatee set in initialisation
 			shard,
 			1,
 			vec![1u8; 2048],
-			Some(vec![1u8; 2048])
+			Some(vec![1u8; 2048]),
+			ss58_prefix,
 		));
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
 			crate::Event::CreateIdentityRequested { shard },
@@ -76,13 +78,15 @@ fn create_identity_with_authorised_delegatee_works() {
 fn create_identity_with_unauthorised_delegatee_fails() {
 	new_test_ext().execute_with(|| {
 		let shard: ShardIdentifier = H256::from_slice(&TEST_MRENCLAVE);
+		let ss58_prefix = 131_u16;
 		assert_noop!(
 			IdentityManagement::create_identity(
 				RuntimeOrigin::signed(3),
 				shard,
 				1,
 				vec![1u8; 2048],
-				Some(vec![1u8; 2048])
+				Some(vec![1u8; 2048]),
+				ss58_prefix,
 			),
 			Error::<Test>::UnauthorisedUser
 		);

--- a/pallets/identity-management/src/tests.rs
+++ b/pallets/identity-management/src/tests.rs
@@ -59,14 +59,12 @@ fn create_identity_without_delegatee_works() {
 fn create_identity_with_authorised_delegatee_works() {
 	new_test_ext().execute_with(|| {
 		let shard: ShardIdentifier = H256::from_slice(&TEST_MRENCLAVE);
-		let ss58_prefix = 131_u16;
 		assert_ok!(IdentityManagement::create_identity(
 			RuntimeOrigin::signed(5), // authorised delegatee set in initialisation
 			shard,
 			1,
 			vec![1u8; 2048],
 			Some(vec![1u8; 2048]),
-			ss58_prefix,
 		));
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
 			crate::Event::CreateIdentityRequested { shard },
@@ -78,7 +76,6 @@ fn create_identity_with_authorised_delegatee_works() {
 fn create_identity_with_unauthorised_delegatee_fails() {
 	new_test_ext().execute_with(|| {
 		let shard: ShardIdentifier = H256::from_slice(&TEST_MRENCLAVE);
-		let ss58_prefix = 131_u16;
 		assert_noop!(
 			IdentityManagement::create_identity(
 				RuntimeOrigin::signed(3),
@@ -86,7 +83,6 @@ fn create_identity_with_unauthorised_delegatee_fails() {
 				1,
 				vec![1u8; 2048],
 				Some(vec![1u8; 2048]),
-				ss58_prefix,
 			),
 			Error::<Test>::UnauthorisedUser
 		);

--- a/tee-worker/app-libs/stf/src/trusted_call.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call.rs
@@ -46,6 +46,7 @@ use std::{format, prelude::v1::*, sync::Arc};
 
 #[cfg(feature = "evm")]
 use ita_sgx_runtime::{AddressMapping, HashedAddressMapping};
+use itp_node_api_metadata::pallet_system::SystemSs58Prefix;
 
 #[cfg(feature = "evm")]
 use crate::evm_helpers::{create_code_hash, evm_create2_address, evm_create_address};
@@ -207,7 +208,7 @@ impl TrustedReturnValue
 impl<NodeMetadataRepository> ExecuteCall<NodeMetadataRepository> for TrustedCallSigned
 where
 	NodeMetadataRepository: AccessNodeMetadata,
-	NodeMetadataRepository::MetadataType: TeerexCallIndexes + IMPCallIndexes,
+	NodeMetadataRepository::MetadataType: TeerexCallIndexes + IMPCallIndexes + SystemSs58Prefix,
 {
 	type Error = StfError;
 
@@ -439,7 +440,15 @@ where
 					identity,
 					metadata
 				);
-				match Self::create_identity_runtime(who.clone(), identity.clone(), metadata, bn) {
+				let parent_ss58_prefix =
+					node_metadata_repo.get_from_metadata(|m| m.system_ss58_prefix())??;
+				match Self::create_identity_runtime(
+					who.clone(),
+					identity.clone(),
+					metadata,
+					bn,
+					parent_ss58_prefix,
+				) {
 					Ok(code) => {
 						debug!("create_identity {} OK", account_id_to_string(&who));
 						if let Some(key) = IdentityManagement::user_shielding_keys(&who) {

--- a/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
@@ -69,13 +69,15 @@ impl TrustedCallSigned {
 		identity: Identity,
 		metadata: Option<MetadataOf<Runtime>>,
 		bn: ParentchainBlockNumber,
+		parent_ss58_prefix: u16,
 	) -> StfResult<ChallengeCode> {
 		debug!(
-			"who.str = {:?}, identity = {:?}, metadata = {:?}, bn = {:?}",
+			"who.str = {:?}, identity = {:?}, metadata = {:?}, bn = {:?}, parent_ss58_prefix = {}",
 			account_id_to_string(&who),
 			identity,
 			metadata,
-			bn
+			bn,
+			parent_ss58_prefix,
 		);
 
 		ita_sgx_runtime::IdentityManagementCall::<Runtime>::create_identity {
@@ -83,6 +85,7 @@ impl TrustedCallSigned {
 			identity: identity.clone(),
 			metadata,
 			creation_request_block: bn,
+			parent_ss58_prefix,
 		}
 		.dispatch_bypass_filter(ita_sgx_runtime::RuntimeOrigin::root())
 		.map_err(|e| StfError::Dispatch(format!("{:?}", e.error)))?;

--- a/tee-worker/core-primitives/node-api/metadata-provider/src/lib.rs
+++ b/tee-worker/core-primitives/node-api/metadata-provider/src/lib.rs
@@ -72,7 +72,7 @@ where
 
 impl<NodeMetadata> AccessNodeMetadata for NodeMetadataRepository<NodeMetadata>
 where
-	NodeMetadata:,
+	NodeMetadata: Default,
 {
 	type MetadataType = NodeMetadata;
 

--- a/tee-worker/core-primitives/node-api/metadata/src/error.rs
+++ b/tee-worker/core-primitives/node-api/metadata/src/error.rs
@@ -20,6 +20,8 @@ use derive_more::From;
 pub enum Error {
 	/// Metadata has not been set
 	MetadataNotSet,
+	/// Invalid Metadata
+	InvalidMetadata,
 	/// Api-client metadata error
 	NodeMetadata(substrate_api_client::MetadataError),
 }

--- a/tee-worker/core-primitives/node-api/metadata/src/metadata_mocks.rs
+++ b/tee-worker/core-primitives/node-api/metadata/src/metadata_mocks.rs
@@ -17,8 +17,8 @@
 
 use crate::{
 	error::Result, pallet_imp::IMPCallIndexes, pallet_imp_mock::IMPMockCallIndexes,
-	pallet_sidechain::SidechainCallIndexes, pallet_teerex::TeerexCallIndexes,
-	pallet_vcmp::VCMPCallIndexes,
+	pallet_sidechain::SidechainCallIndexes, pallet_system::SystemSs58Prefix,
+	pallet_teerex::TeerexCallIndexes, pallet_vcmp::VCMPCallIndexes,
 };
 use codec::{Decode, Encode};
 
@@ -237,5 +237,11 @@ impl VCMPCallIndexes for NodeMetadataMock {
 
 	fn some_error_call_indexes(&self) -> Result<[u8; 2]> {
 		Ok([self.vcmp_module, self.vcmp_some_error])
+	}
+}
+
+impl SystemSs58Prefix for NodeMetadataMock {
+	fn system_ss58_prefix(&self) -> Result<u16> {
+		Ok(131)
 	}
 }

--- a/tee-worker/core-primitives/stf-executor/src/executor.rs
+++ b/tee-worker/core-primitives/stf-executor/src/executor.rs
@@ -27,7 +27,8 @@ use ita_stf::{
 	ParentchainHeader, StfError, TrustedCallSigned, TrustedOperation,
 };
 use itp_node_api::metadata::{
-	pallet_imp::IMPCallIndexes, pallet_teerex::TeerexCallIndexes, provider::AccessNodeMetadata,
+	pallet_imp::IMPCallIndexes, pallet_system::SystemSs58Prefix, pallet_teerex::TeerexCallIndexes,
+	provider::AccessNodeMetadata,
 };
 use itp_ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi};
 use itp_sgx_externalities::{SgxExternalitiesTrait, StateHash};
@@ -60,6 +61,7 @@ where
 	StateHandler::StateT: SgxExternalitiesTrait + Encode,
 	NodeMetadataRepository: AccessNodeMetadata,
 	NodeMetadataRepository::MetadataType: TeerexCallIndexes + IMPCallIndexes,
+	<NodeMetadataRepository as AccessNodeMetadata>::MetadataType: SystemSs58Prefix,
 	Stf: UpdateState<
 			StateHandler::StateT,
 			<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType,
@@ -239,6 +241,7 @@ where
 	<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesType: Encode,
 	NodeMetadataRepository: AccessNodeMetadata,
 	NodeMetadataRepository::MetadataType: TeerexCallIndexes + IMPCallIndexes,
+	<NodeMetadataRepository as AccessNodeMetadata>::MetadataType: SystemSs58Prefix,
 	Stf: UpdateState<
 			StateHandler::StateT,
 			<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType,
@@ -261,7 +264,7 @@ where
 	) -> Result<BatchExecutionResult<Self::Externalities>>
 	where
 		PH: HeaderTrait<Hash = H256>,
-		F: FnOnce(Self::Externalities) -> Self::Externalities,
+		F: FnOnce(Self::Externalities) -> Self::Externalities
 	{
 		let ends_at = duration_now() + max_exec_duration;
 

--- a/tee-worker/core-primitives/stf-executor/src/executor.rs
+++ b/tee-worker/core-primitives/stf-executor/src/executor.rs
@@ -240,8 +240,7 @@ where
 	StateHandler::StateT: SgxExternalitiesTrait + Encode + StateHash,
 	<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesType: Encode,
 	NodeMetadataRepository: AccessNodeMetadata,
-	NodeMetadataRepository::MetadataType: TeerexCallIndexes + IMPCallIndexes,
-	<NodeMetadataRepository as AccessNodeMetadata>::MetadataType: SystemSs58Prefix,
+	NodeMetadataRepository::MetadataType: TeerexCallIndexes + IMPCallIndexes + SystemSs58Prefix,
 	Stf: UpdateState<
 			StateHandler::StateT,
 			<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType,

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -48,8 +48,8 @@ use sp_std::vec::Vec;
 
 #[frame_support::pallet]
 pub mod pallet {
-
 	use super::*;
+	use litentry_primitives::SubstrateNetwork;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
@@ -97,6 +97,8 @@ pub mod pallet {
 		IdentityNotExist,
 		/// the identity was not created before verification
 		IdentityNotCreated,
+		/// the identity should be disallowed
+		IdentityShouldBeDisallowed,
 		/// a verification reqeust comes too early
 		VerificationRequestTooEarly,
 		/// a verification reqeust comes too late
@@ -195,6 +197,12 @@ pub mod pallet {
 			T::ManageOrigin::ensure_origin(origin)?;
 			if let Some(c) = IDGraphs::<T>::get(&who, &identity) {
 				ensure!(!c.is_verified, Error::<T>::IdentityAlreadyVerified);
+			}
+			if let Identity::Substrate { network, .. } = identity {
+				ensure!(
+					network != SubstrateNetwork::Litentry,
+					Error::<T>::IdentityShouldBeDisallowed
+				);
 			}
 			let context = IdentityContext {
 				metadata,

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -49,7 +49,7 @@ use sp_std::vec::Vec;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use litentry_primitives::SubstrateNetwork;
+	use litentry_primitives::{Address32, SubstrateNetwork};
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
@@ -198,9 +198,14 @@ pub mod pallet {
 			if let Some(c) = IDGraphs::<T>::get(&who, &identity) {
 				ensure!(!c.is_verified, Error::<T>::IdentityAlreadyVerified);
 			}
-			if let Identity::Substrate { network, .. } = identity {
+			if let Identity::Substrate { network, address } = identity {
+				let address_raw: [u8; 32] = who
+					.encode()
+					.try_into()
+					.map_err(|_| DispatchError::Other("invalid account id"))?;
+				let user_address: Address32 = address_raw.into();
 				ensure!(
-					network != SubstrateNetwork::Litentry,
+					!(network == SubstrateNetwork::Litentry && user_address == address),
 					Error::<T>::IdentityShouldBeDisallowed
 				);
 			}

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -49,7 +49,7 @@ use sp_std::vec::Vec;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use litentry_primitives::{Address32, SubstrateNetwork};
+	use litentry_primitives::Address32;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
@@ -193,18 +193,14 @@ pub mod pallet {
 			identity: Identity,
 			metadata: Option<MetadataOf<T>>,
 			creation_request_block: ParentchainBlockNumber,
+			parent_ss58_prefix: u16,
 		) -> DispatchResult {
 			T::ManageOrigin::ensure_origin(origin)?;
 			if let Some(c) = IDGraphs::<T>::get(&who, &identity) {
 				ensure!(!c.is_verified, Error::<T>::IdentityAlreadyVerified);
 			}
 			if let Identity::Substrate { network, address } = identity {
-				// see all the address prefix:
-				// https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
-				let ss58_prefix = T::SS58Prefix::get();
-				if (network == SubstrateNetwork::Litentry && ss58_prefix == 31)
-					|| (network == SubstrateNetwork::Litmus && ss58_prefix == 131)
-				{
+				if network.ss58_prefix() == parent_ss58_prefix {
 					let address_raw: [u8; 32] = who
 						.encode()
 						.try_into()

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -199,15 +199,14 @@ pub mod pallet {
 				ensure!(!c.is_verified, Error::<T>::IdentityAlreadyVerified);
 			}
 			if let Identity::Substrate { network, address } = identity {
-				let address_raw: [u8; 32] = who
-					.encode()
-					.try_into()
-					.map_err(|_| DispatchError::Other("invalid account id"))?;
-				let user_address: Address32 = address_raw.into();
-				ensure!(
-					!(network == SubstrateNetwork::Litentry && user_address == address),
-					Error::<T>::IdentityShouldBeDisallowed
-				);
+				if network == SubstrateNetwork::Litentry {
+					let address_raw: [u8; 32] = who
+						.encode()
+						.try_into()
+						.map_err(|_| DispatchError::Other("invalid account id"))?;
+					let user_address: Address32 = address_raw.into();
+					ensure!(user_address != address, Error::<T>::IdentityShouldBeDisallowed);
+				}
 			}
 			let context = IdentityContext {
 				metadata,

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -199,7 +199,12 @@ pub mod pallet {
 				ensure!(!c.is_verified, Error::<T>::IdentityAlreadyVerified);
 			}
 			if let Identity::Substrate { network, address } = identity {
-				if network == SubstrateNetwork::Litentry {
+				// see all the address prefix:
+				// https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
+				let ss58_prefix = T::SS58Prefix::get();
+				if (network == SubstrateNetwork::Litentry && ss58_prefix == 31)
+					|| (network == SubstrateNetwork::Litmus && ss58_prefix == 131)
+				{
 					let address_raw: [u8; 32] = who
 						.encode()
 						.try_into()

--- a/tee-worker/litentry/pallets/identity-management/src/tests.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/tests.rs
@@ -37,13 +37,15 @@ fn set_user_shielding_key_works() {
 #[test]
 fn create_identity_works() {
 	new_test_ext().execute_with(|| {
+		let ss58_prefix = 131_u16;
 		let metadata: MetadataOf<Test> = vec![0u8; 16].try_into().unwrap();
 		assert_ok!(IMT::create_identity(
 			RuntimeOrigin::signed(1),
 			2,
 			alice_web3_identity(),
 			Some(metadata.clone()),
-			1
+			1,
+			ss58_prefix,
 		));
 		assert_eq!(
 			IMT::id_graphs(2, alice_web3_identity()).unwrap(),
@@ -61,6 +63,7 @@ fn create_identity_works() {
 fn remove_identity_works() {
 	new_test_ext().execute_with(|| {
 		let metadata: MetadataOf<Test> = vec![0u8; 16].try_into().unwrap();
+		let ss58_prefix = 131_u16;
 		assert_noop!(
 			IMT::remove_identity(RuntimeOrigin::signed(1), 2, alice_web3_identity()),
 			Error::<Test>::IdentityNotExist
@@ -70,7 +73,8 @@ fn remove_identity_works() {
 			2,
 			alice_web3_identity(),
 			Some(metadata.clone()),
-			1
+			1,
+			ss58_prefix,
 		));
 		assert_eq!(
 			IMT::id_graphs(2, alice_web3_identity()).unwrap(),
@@ -90,12 +94,14 @@ fn remove_identity_works() {
 fn verify_identity_works() {
 	new_test_ext().execute_with(|| {
 		let metadata: MetadataOf<Test> = vec![0u8; 16].try_into().unwrap();
+		let ss58_prefix = 131_u16;
 		assert_ok!(IMT::create_identity(
 			RuntimeOrigin::signed(1),
 			2,
 			alice_web3_identity(),
 			Some(metadata.clone()),
-			1
+			1,
+			ss58_prefix,
 		));
 		assert_ok!(IMT::verify_identity(RuntimeOrigin::signed(1), 2, alice_web3_identity(), 1));
 		assert_eq!(
@@ -114,12 +120,14 @@ fn verify_identity_works() {
 fn get_id_graph_works() {
 	new_test_ext().execute_with(|| {
 		let metadata3: MetadataOf<Test> = vec![0u8; 16].try_into().unwrap();
+		let ss58_prefix = 131_u16;
 		assert_ok!(IMT::create_identity(
 			RuntimeOrigin::signed(1),
 			2,
 			alice_web3_identity(),
 			Some(metadata3.clone()),
-			3
+			3,
+			ss58_prefix,
 		));
 		assert_ok!(IMT::verify_identity(RuntimeOrigin::signed(1), 2, alice_web3_identity(), 3));
 
@@ -133,7 +141,8 @@ fn get_id_graph_works() {
 			2,
 			alice_web2_identity.clone(),
 			Some(metadata2.clone()),
-			2
+			2,
+			ss58_prefix,
 		));
 		assert_ok!(IMT::verify_identity(
 			RuntimeOrigin::signed(1),
@@ -154,12 +163,14 @@ fn verify_identity_fails_when_too_early() {
 		const VERIFICATION_REQUEST_BLOCK: ParentchainBlockNumber = 1;
 
 		let metadata: MetadataOf<Test> = vec![0u8; 16].try_into().unwrap();
+		let ss58_prefix = 131_u16;
 		assert_ok!(IMT::create_identity(
 			RuntimeOrigin::signed(1),
 			2,
 			alice_web3_identity(),
 			Some(metadata.clone()),
-			CREATION_REQUEST_BLOCK
+			CREATION_REQUEST_BLOCK,
+			ss58_prefix,
 		));
 		assert_noop!(
 			IMT::verify_identity(
@@ -189,12 +200,14 @@ fn verify_identity_fails_when_too_late() {
 		const VERIFICATION_REQUEST_BLOCK: ParentchainBlockNumber = 5;
 
 		let metadata: MetadataOf<Test> = vec![0u8; 16].try_into().unwrap();
+		let ss58_prefix = 131_u16;
 		assert_ok!(IMT::create_identity(
 			RuntimeOrigin::signed(1),
 			2,
 			alice_web3_identity(),
 			Some(metadata.clone()),
-			CREATION_REQUEST_BLOCK
+			CREATION_REQUEST_BLOCK,
+			ss58_prefix,
 		));
 		assert_noop!(
 			IMT::verify_identity(

--- a/tee-worker/litentry/primitives/src/identity.rs
+++ b/tee-worker/litentry/primitives/src/identity.rs
@@ -74,6 +74,18 @@ pub enum SubstrateNetwork {
 	Litmus,
 }
 
+impl SubstrateNetwork {
+	/// get the ss58 prefix, see https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
+	pub fn ss58_prefix(&self) -> u16 {
+		match self {
+			Self::Polkadot => 0,
+			Self::Kusama => 2,
+			Self::Litentry => 31,
+			Self::Litmus => 131,
+		}
+	}
+}
+
 #[derive(Encode, Decode, Copy, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum EvmNetwork {


### PR DESCRIPTION
ignore the Litentry network when create identity