### PR TITLE
add pallet-parentchain 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6333,6 +6333,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-parentchain"
+version = "0.9.0"
+dependencies = [
+ "env_logger 0.9.3",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "parity-scale-codec 3.2.1",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-keyring",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.36#cb4f2491b00af7d7817f3a54209c26b20faa1f51"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   'pallets/sidechain',
   'pallets/teeracle',
   'pallets/teerex',
+  'pallets/parentchain',
   'pallets/test-utils',
   'primitives/common',
   'primitives/core',

--- a/pallets/parentchain/Cargo.toml
+++ b/pallets/parentchain/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+authors = ["Integritee AG <hello@integritee.network>"]
+description = "The remote attestation registry and verification pallet for integritee blockchains and parachains"
+edition = "2021"
+homepage = "https://integritee.network/"
+license = "Apache-2.0"
+name = "pallet-parentchain"
+repository = "https://github.com/integritee-network/pallets/"
+version = "0.9.0"
+
+[dependencies]
+codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
+log = { version = "0.4.14", default-features = false }
+scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+serde = { version = "1.0.13", features = ["derive"], optional = true }
+
+# substrate dependencies
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
+frame-system = { default-features = false, package = "frame-system", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
+
+[dev-dependencies]
+env_logger = "0.9.0"
+pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
+sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "log/std",
+  "scale-info/std",
+  "serde",
+  # substrate dependencies
+  "frame-support/std",
+  "frame-system/std",
+  "sp-core/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "sp-std/std",
+]
+
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/parentchain/src/lib.rs
+++ b/pallets/parentchain/src/lib.rs
@@ -1,0 +1,57 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use crate::weights::WeightInfo;
+	use frame_support::{pallet_prelude::*, sp_runtime::traits::Header};
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	/// Configuration trait.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type WeightInfo: WeightInfo;
+	}
+
+	/// The current block number being processed. Set by `set_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn block_number)]
+	pub(super) type Number<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
+
+	/// Hash of the previous block. Set by `set_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn parent_hash)]
+	pub(super) type ParentHash<T: Config> = StorageValue<_, T::Hash, ValueQuery>;
+
+	/// Hash of the last block. Set by `set_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn block_hash)]
+	pub(super) type BlockHash<T: Config> = StorageValue<_, T::Hash, ValueQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_block())]
+		pub fn set_block(origin: OriginFor<T>, header: T::Header) -> DispatchResult {
+			ensure_root(origin)?;
+			<Number<T>>::put(header.number());
+			<ParentHash<T>>::put(header.parent_hash());
+			<BlockHash<T>>::put(header.hash());
+			Ok(())
+		}
+	}
+}
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+pub mod weights;

--- a/pallets/parentchain/src/mock.rs
+++ b/pallets/parentchain/src/mock.rs
@@ -1,0 +1,124 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use crate as pallet_parentchain;
+use frame_support::parameter_types;
+use frame_system as system;
+use pallet_parentchain::Config;
+use sp_core::H256;
+use sp_keyring::AccountKeyring;
+use sp_runtime::{
+	generic,
+	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
+};
+
+pub type Signature = sp_runtime::MultiSignature;
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
+
+pub type BlockNumber = u32;
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic =
+	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+
+pub type SignedExtra = (
+	frame_system::CheckSpecVersion<Test>,
+	frame_system::CheckTxVersion<Test>,
+	frame_system::CheckGenesis<Test>,
+	frame_system::CheckEra<Test>,
+	frame_system::CheckNonce<Test>,
+	frame_system::CheckWeight<Test>,
+);
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Parentchain: pallet_parentchain::{Pallet, Call, Storage},
+	}
+);
+
+impl Config for Test {
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const BlockHashCount: u32 = 250;
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Index = u64;
+	type RuntimeCall = RuntimeCall;
+	type BlockNumber = BlockNumber;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+pub type Balance = u64;
+
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 1;
+}
+
+impl pallet_balances::Config for Test {
+	type MaxLocks = ();
+	type Balance = u64;
+	type DustRemoval = ();
+	type RuntimeEvent = RuntimeEvent;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = ();
+}
+
+// This function basically just builds a genesis storage key/value store according to
+// our desired mockup. RA from enclave compiled in debug mode is allowed
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	pallet_balances::GenesisConfig::<Test> {
+		balances: vec![(AccountKeyring::Alice.to_account_id(), 1 << 60)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+	let mut ext: sp_io::TestExternalities = t.into();
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/pallets/parentchain/src/tests.rs
+++ b/pallets/parentchain/src/tests.rs
@@ -1,0 +1,65 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use crate::mock::*;
+use frame_support::{assert_err, assert_ok};
+use sp_core::H256;
+use sp_keyring::AccountKeyring;
+use sp_runtime::{
+	generic,
+	traits::{BlakeTwo256, Header as HeaderT},
+	DispatchError::BadOrigin,
+};
+
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+
+#[test]
+fn verify_storage_works() {
+	let block_number = 3;
+	let parent_hash = H256::from_low_u64_be(420);
+
+	let header: Header = HeaderT::new(
+		block_number,
+		Default::default(),
+		Default::default(),
+		parent_hash,
+		Default::default(),
+	);
+	let hash = header.hash();
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Parentchain::set_block(RuntimeOrigin::root(), header));
+		assert_eq!(Parentchain::block_number(), block_number);
+		assert_eq!(Parentchain::parent_hash(), parent_hash);
+		assert_eq!(Parentchain::block_hash(), hash);
+	})
+}
+
+#[test]
+fn non_root_account_errs() {
+	let header = HeaderT::new(
+		1,
+		Default::default(),
+		Default::default(),
+		[69; 32].into(),
+		Default::default(),
+	);
+
+	new_test_ext().execute_with(|| {
+		let root = AccountKeyring::Ferdie.to_account_id();
+		assert_err!(Parentchain::set_block(RuntimeOrigin::signed(root), header), BadOrigin);
+	})
+}

--- a/pallets/parentchain/src/weights.rs
+++ b/pallets/parentchain/src/weights.rs
@@ -1,0 +1,13 @@
+pub use frame_support::weights::{constants::RocksDbWeight, Weight};
+
+/// Weight functions needed for pallet_parentchain.
+pub trait WeightInfo {
+	fn set_block() -> Weight;
+}
+
+/// Weights for pallet_parentchain using the Integritee parachain node and recommended hardware.
+impl WeightInfo for () {
+	fn set_block() -> Weight {
+		Weight::from_ref_time(10_000)
+	}
+}

--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -3934,23 +3934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ias-verify"
-version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#07d17756d7c60fe85b973a75446827961fe55ec4"
-dependencies = [
- "base64 0.13.1",
- "chrono 0.4.23",
- "frame-support",
- "parity-scale-codec",
- "scale-info",
- "serde_json 1.0.91",
- "sp-core",
- "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.36)",
- "sp-std",
- "webpki 0.21.0",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.0"
 source = "git+https://github.com/mesalock-linux/rust-url-sgx?tag=sgx_1.1.3#23832f3191456c2d4a0faab10952e1747be58ca8"
@@ -4133,7 +4116,7 @@ dependencies = [
  "sp-runtime",
  "substrate-api-client",
  "substrate-client-keystore",
- "teerex-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=master)",
+ "teerex-primitives",
  "ws",
 ]
 
@@ -4194,7 +4177,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "substrate-api-client",
- "teerex-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=master)",
+ "teerex-primitives",
  "thiserror 1.0.38",
  "tokio",
  "warp",
@@ -8529,7 +8512,6 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#07d17756d7c60fe85b973a75446827961fe55ec4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8644,7 +8626,7 @@ dependencies = [
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.36)",
  "sp-runtime",
  "sp-std",
- "teerex-primitives 0.1.0",
+ "teerex-primitives",
 ]
 
 [[package]]
@@ -8727,7 +8709,7 @@ version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "ias-verify 0.1.4",
+ "ias-verify",
  "log 0.4.17",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -8737,7 +8719,7 @@ dependencies = [
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.36)",
  "sp-runtime",
  "sp-std",
- "teerex-primitives 0.1.0",
+ "teerex-primitives",
 ]
 
 [[package]]
@@ -14560,21 +14542,7 @@ dependencies = [
 name = "teerex-primitives"
 version = "0.1.0"
 dependencies = [
- "ias-verify 0.1.4",
- "parity-scale-codec",
- "scale-info",
- "serde 1.0.152",
- "sp-core",
- "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.36)",
- "sp-std",
-]
-
-[[package]]
-name = "teerex-primitives"
-version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#07d17756d7c60fe85b973a75446827961fe55ec4"
-dependencies = [
- "ias-verify 0.1.4 (git+https://github.com/integritee-network/pallets.git?branch=master)",
+ "ias-verify",
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.152",

--- a/tee-worker/app-libs/sgx-runtime/Cargo.toml
+++ b/tee-worker/app-libs/sgx-runtime/Cargo.toml
@@ -46,7 +46,7 @@ sp-version = { default-features = false, git = "https://github.com/paritytech/su
 
 # Integritee dependencies
 pallet-evm = { default-features = false, optional = true, git = "https://github.com/integritee-network/frontier.git", branch = "polkadot-v0.9.36" }
-pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
+pallet-parentchain = { path = "../../../pallets/parentchain", default-features = false }
 
 # Litentry
 litentry-primitives = { path = "../../litentry/primitives", default-features = false }

--- a/tee-worker/app-libs/stf/Cargo.toml
+++ b/tee-worker/app-libs/stf/Cargo.toml
@@ -41,7 +41,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 # litentry
 lc-stf-task-sender = { path = "../../litentry/core/stf-task/sender", default-features = false }
 litentry-primitives = { path = "../../litentry/primitives", default-features = false }
-pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
+pallet-parentchain = { path = "../../../pallets/parentchain", default-features = false }
 parentchain-primitives = { package = "core-primitives", path = "../../../primitives/core", default-features = false, optional = true }
 rand = { version = "0.7", optional = true }
 rand-sgx = { package = "rand", git = "https://github.com/mesalock-linux/rand-sgx", tag = "sgx_1.1.3", features = ["sgx_tstd"], optional = true }

--- a/tee-worker/cli/Cargo.toml
+++ b/tee-worker/cli/Cargo.toml
@@ -27,7 +27,7 @@ my-node-runtime = { package = "rococo-parachain-runtime", path = "../../runtime/
 pallet-evm = { optional = true, git = "https://github.com/integritee-network/frontier.git", branch = "polkadot-v0.9.36" }
 substrate-api-client = { features = ["ws-client"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.36" }
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.36" }
-teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "master" }
+teerex-primitives = { path = "../../primitives/teerex", default-features = false }
 
 # substrate dependencies
 frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -3138,7 +3138,6 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#07d17756d7c60fe85b973a75446827961fe55ec4"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/tee-worker/service/Cargo.toml
+++ b/tee-worker/service/Cargo.toml
@@ -58,7 +58,7 @@ its-storage = { path = "../sidechain/storage" }
 # scs / integritee
 my-node-runtime = { package = "rococo-parachain-runtime", path = "../../runtime/rococo" }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.36" }
-teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "master" }
+teerex-primitives = { path = "../../primitives/teerex", default-features = false }
 
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }


### PR DESCRIPTION
In `tee-worker`, it depends on `teerex-primitives` & `pallet-parentchain`.

- [x] replace `teerex-primitives` dependence in Cargo.toml
- [x] add `pallet-parentchain` to `pallets`  & update Cargo.toml 