### PR TITLE
switch to dtolnay/rust-toolchain@stable

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,11 +29,9 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: nightly
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
 
       - name: Install additional dependencies
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly

--- a/.github/workflows/parachain-ci.yml
+++ b/.github/workflows/parachain-ci.yml
@@ -69,11 +69,9 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: nightly
           components: rustfmt
           target: wasm32-unknown-unknown
-          default: true
 
       - name: Run cargo fmt check
         run: make fmtcheck
@@ -102,11 +100,9 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: nightly
           components: clippy
           target: wasm32-unknown-unknown
-          default: true
 
       - name: Install dependencies
         run: |
@@ -234,10 +230,8 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: nightly
           target: wasm32-unknown-unknown
-          default: true
 
       - name: Run unittests
         run: cargo test --features=skip-ias-check --locked --release -p pallet-* --lib
@@ -258,10 +252,8 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: nightly
           target: wasm32-unknown-unknown
-          default: true
 
       - name: Run benchmarks
         run: cargo test --features=skip-ias-check --locked --release -p pallet-* --lib --features runtime-benchmarks
@@ -294,10 +286,8 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: nightly
           target: wasm32-unknown-unknown
-          default: true
 
       # use sccache to accelerate binary compilation
       # see https://www.infinyon.com/blog/2021/04/github-actions-best-practices/

--- a/.github/workflows/parachain-ci.yml
+++ b/.github/workflows/parachain-ci.yml
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly
@@ -100,7 +100,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly
@@ -232,7 +232,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly
@@ -256,7 +256,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly
@@ -292,7 +292,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly


### PR DESCRIPTION
Resolved #1196 
As the title switch action-rs/toolchain to dtolnay/rust-toolchain@stable.

Perhaps can choice dtolnay/rust-toolchain@master.
 
Since these two inputs are not supported in this repo,`profile, default` is removed.