### PR TITLE
Run runtime upgrade simulation conditionally

### DIFF
--- a/.github/workflows/simulate-runtime-upgrade.yml
+++ b/.github/workflows/simulate-runtime-upgrade.yml
@@ -11,6 +11,7 @@ on:
         required: true
 
 env:
+  SUBWASM_VERSION: 0.18.0
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.release.tag_name }}
 
 jobs:
@@ -33,6 +34,12 @@ jobs:
         timeout-minutes: 10
         run: |
           ./scripts/fork-parachain-and-launch.sh ${{ matrix.chain }}
+
+      - name: Install subwasm ${{ env.SUBWASM_VERSION }}
+        run: |
+          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          subwasm --version
 
       - name: Test runtime upgrade
         timeout-minutes: 10


### PR DESCRIPTION
resolves #1167 

Only do it when there's an existing wasm and the released runtime version > on-chain runtime version.