### PR TITLE
Replace dockerize with healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,6 +46,9 @@ ARG PROFILE
 
 COPY --from=builder /litentry/target/$PROFILE/litentry-collator /usr/local/bin
 
+# install netcat for healthcheck
+RUN apt-get update && apt-get install -yq netcat && cp /usr/bin/nc /usr/local/bin/
+
 RUN useradd -m -u 1000 -U -s /bin/sh -d /litentry litentry && \
 	mkdir -p /data /litentry/.local/share && \
 	chown -R litentry:litentry /data && \
@@ -54,9 +57,6 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /litentry litentry && \
 	rm -rf /usr/bin /usr/sbin && \
 # check if executable works in this container
 	/usr/local/bin/litentry-collator --version
-
-# install netcat for healthcheck
-RUN apt-get install -yq netcat
 
 USER litentry
 EXPOSE 30333 9933 9944 9615

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,9 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /litentry litentry && \
 # check if executable works in this container
 	/usr/local/bin/litentry-collator --version
 
+# install netcat for healthcheck
+RUN apt-get install -yq netcat
+
 USER litentry
 EXPOSE 30333 9933 9944 9615
 VOLUME ["/data"]

--- a/tee-worker/.dockerignore
+++ b/tee-worker/.dockerignore
@@ -2,7 +2,10 @@
 .githooks
 .github
 .idea
-ci/
+bin/*.bin
+bin/key.txt
+bin/spid.txt
+bin/sidechain_db/
 docker/
 docs/
 local-setup/

--- a/tee-worker/.gitignore
+++ b/tee-worker/.gitignore
@@ -69,5 +69,3 @@ bin/light_client_db.bin.1
 
 # generated upstream patch
 upstream.patch
-
-dockerize*

--- a/tee-worker/build.Dockerfile
+++ b/tee-worker/build.Dockerfile
@@ -85,8 +85,6 @@ FROM ubuntu:20.04 AS runner
 
 RUN apt update && apt install -y libssl-dev iproute2
 
-COPY --from=powerman/dockerize /usr/local/bin/dockerize /usr/local/bin/dockerize
-
 
 ### Deployed CLI client
 ##################################################

--- a/tee-worker/build.Dockerfile
+++ b/tee-worker/build.Dockerfile
@@ -140,4 +140,6 @@ RUN ls -al /usr/local/bin
 RUN ldd /usr/local/bin/integritee-service && \
 	/usr/local/bin/integritee-service --version
 
+RUN apt-get install -y curl
+
 ENTRYPOINT ["/usr/local/bin/integritee-service"]

--- a/tee-worker/docker/demo-direct-call.yml
+++ b/tee-worker/docker/demo-direct-call.yml
@@ -6,11 +6,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s    
-      /usr/local/worker-cli/demo_direct_call_2_workers.sh -p 9912 -u ws://integritee-node 
+    entrypoint:
+      "/usr/local/worker-cli/demo_direct_call_2_workers.sh -p 9912 -u ws://integritee-node
       -V wss://integritee-worker-1 -A 2011 -W wss://integritee-worker-2 -B 2012 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/tee-worker/docker/demo-indirect-invocation.yml
+++ b/tee-worker/docker/demo-indirect-invocation.yml
@@ -6,13 +6,19 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,itc_rpc_client=warn
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s    
-      /usr/local/worker-cli/demo_indirect_invocation.sh -p 9912 -u ws://integritee-node 
+    entrypoint:
+      "/usr/local/worker-cli/demo_indirect_invocation.sh -p 9912 -u ws://integritee-node
       -V wss://integritee-worker-1 -A 2011 -W wss://integritee-worker-2 -B 2012 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/tee-worker/docker/demo-sidechain.yml
+++ b/tee-worker/docker/demo-sidechain.yml
@@ -6,11 +6,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s    
-      /usr/local/worker-cli/demo_sidechain.sh -p 9912 -A 2011 -B 2012 -u ws://integritee-node 
+    entrypoint:
+      "/usr/local/worker-cli/demo_sidechain.sh -p 9912 -A 2011 -B 2012 -u ws://integritee-node
       -V wss://integritee-worker-1 -W wss://integritee-worker-2 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/tee-worker/docker/demo-smart-contract.yml
+++ b/tee-worker/docker/demo-smart-contract.yml
@@ -6,13 +6,19 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,itc_rpc_client=warn
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s
-      /usr/local/worker-cli/demo_smart_contract.sh -p 9912 -u ws://integritee-node
+    entrypoint:
+      "/usr/local/worker-cli/demo_smart_contract.sh -p 9912 -u ws://integritee-node
       -V wss://integritee-worker-1 -A 2011 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/tee-worker/docker/demo-teeracle-generic.yml
+++ b/tee-worker/docker/demo-teeracle-generic.yml
@@ -10,13 +10,20 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-worker
-    depends_on: [ 'integritee-node' ]
+    depends_on:
+      integritee-node:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=info,integritee_service::teeracle=debug,ita_stf=warn,ita_oracle=debug
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s
-        /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-teeracle-worker -T wss://integritee-teeracle-worker 
+    healthcheck:
+      test: curl -s -f http://localhost:4645/is_initialized || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    entrypoint:
+        "/usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-teeracle-worker -T wss://integritee-teeracle-worker
         -u ws://integritee-node -U ws://integritee-teeracle-worker -P 2011 -w 2101 -p 9912 -h 4645
         run --dev --skip-ra --teeracle-interval ${TEERACLE_INTERVAL_SECONDS}s"
     restart: always
@@ -27,13 +34,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-teeracle-worker']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-teeracle-worker:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,sp_io=warn,integritee_cli::exchange_oracle=debug
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-teeracle-worker:4645/is_initialized -timeout 250s    
-      /usr/local/worker-cli/demo_teeracle_generic.sh 
+    entrypoint:
+      "/usr/local/worker-cli/demo_teeracle_generic.sh 
       -u ws://integritee-node -p 9912
       -V wss://integritee-teeracle-worker -P 2011
       -d 21 -i ${TEERACLE_INTERVAL_SECONDS}

--- a/tee-worker/docker/demo-teeracle.yml
+++ b/tee-worker/docker/demo-teeracle.yml
@@ -12,14 +12,21 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-worker
-    depends_on: [ 'integritee-node' ]
+    depends_on:
+      integritee-node:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=info,integritee_service::teeracle=debug,ita_stf=warn,ita_oracle=debug
       - COINMARKETCAP_KEY
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 600s
-        /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-teeracle-worker -T wss://integritee-teeracle-worker 
+    healthcheck:
+      test: curl -s -f http://localhost:4645/is_initialized || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    entrypoint:
+        "/usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-teeracle-worker -T wss://integritee-teeracle-worker
         -u ws://integritee-node -U ws://integritee-teeracle-worker -P 2011 -w 2101 -p 9912 -h 4645
         run --dev --skip-ra --teeracle-interval ${TEERACLE_INTERVAL_SECONDS}s"
     restart: always
@@ -30,13 +37,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-teeracle-worker']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-teeracle-worker:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,sp_io=warn,integritee_cli::exchange_oracle=debug
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-teeracle-worker:4645/is_initialized -timeout 600s    
-      /usr/local/worker-cli/demo_teeracle_whitelist.sh 
+    entrypoint:
+      "/usr/local/worker-cli/demo_teeracle_whitelist.sh
       -u ws://integritee-node -p 9912
       -V wss://integritee-teeracle-worker -P 2011
       -d 21 -i ${TEERACLE_INTERVAL_SECONDS}

--- a/tee-worker/docker/docker-compose.yml
+++ b/tee-worker/docker/docker-compose.yml
@@ -116,7 +116,7 @@ services:
     networks:
       - integritee-test-network
     healthcheck:
-      test: curl -f http://localhost:4645/is_initialized || exit 1
+      test: curl -s -f http://localhost:4645/is_initialized || exit 1
       interval: 30s
       timeout: 10s
       retries: 20
@@ -142,7 +142,7 @@ services:
     networks:
       - integritee-test-network
     healthcheck:
-      test: curl -f http://localhost:4646/is_initialized || exit 1
+      test: curl -s -f http://localhost:4646/is_initialized || exit 1
       interval: 30s
       timeout: 10s
       retries: 20

--- a/tee-worker/docker/docker-compose.yml
+++ b/tee-worker/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       dockerfile: parachain-2106.Dockerfile
     depends_on: ['relaychain-alice', 'relaychain-bob']
     healthcheck:
-      test: nc -z localhost 9912 || exit 1
+      test: ["CMD", "nc", "-z", "localhost", "9912"]
       interval: 30s
       timeout: 10s
       retries: 20

--- a/tee-worker/docker/docker-compose.yml
+++ b/tee-worker/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-
-
 services:
   relaychain-alice:
     image: docker_relaychain-alice:latest
@@ -77,6 +75,11 @@ services:
       context: litentry
       dockerfile: parachain-2106.Dockerfile
     depends_on: ['relaychain-alice', 'relaychain-bob']
+    healthcheck:
+      test: nc -z localhost 9912 || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 20
     command:
       - --base-path=/data
       - --chain=/app/rococo-dev-2106.json
@@ -105,13 +108,20 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-worker
-    depends_on: ['integritee-node']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 600s
-      /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-1 -T wss://integritee-worker-1
+    healthcheck:
+      test: curl -f http://localhost:4645/is_initialized || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    entrypoint:
+      "/usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-1 -T wss://integritee-worker-1
       -u ws://integritee-node -U ws://integritee-worker-1 -P 2011 -w 2101 -p 9912 -h 4645
       run --dev --skip-ra"
     restart: "no"
@@ -122,13 +132,22 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-worker
-    depends_on: ['integritee-node', 'integritee-worker-1']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-1:4645/is_initialized -timeout 600s
-      /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-2 -T wss://integritee-worker-2
+    healthcheck:
+      test: curl -f http://localhost:4646/is_initialized || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    entrypoint:
+      "/usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-2 -T wss://integritee-worker-2
       -u ws://integritee-node -U ws://integritee-worker-2 -P 2012 -w 2102 -p 9912 -h 4646
       run --dev --skip-ra --request-state"
     restart: "no"

--- a/tee-worker/docker/fork-inducer.yml
+++ b/tee-worker/docker/fork-inducer.yml
@@ -14,13 +14,19 @@ services:
     build:
       context: .
       dockerfile: fork.Dockerfile
-    depends_on: [ 'integritee-node', 'integritee-worker-1', 'integritee-worker-2' ]
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s
-     pumba --interval 3m netem --interface eth0 --duration 30s delay --time 1000 integritee-worker-2"
+    entrypoint:
+      "pumba --interval 3m netem --interface eth0 --duration 30s delay --time 1000 integritee-worker-2"
 networks:
   integritee-test-network:
     driver: bridge

--- a/tee-worker/docker/set-heartbeat-timeout.yml
+++ b/tee-worker/docker/set-heartbeat-timeout.yml
@@ -6,11 +6,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s
-      /usr/local/worker-cli/set_heartbeat_timeout.sh -p 9912 -u ws://integritee-node
+    entrypoint:
+      "/usr/local/worker-cli/set_heartbeat_timeout.sh -p 9912 -u ws://integritee-node
       -V wss://integritee-worker-1 -A 2011 -W wss://integritee-worker-2 -B 2012 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/tee-worker/docker/sidechain-benchmark.yml
+++ b/tee-worker/docker/sidechain-benchmark.yml
@@ -6,11 +6,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s 
-      /usr/local/worker-cli/benchmark.sh -p 9912 -A 2011 -u ws://integritee-node 
+    entrypoint:
+      "/usr/local/worker-cli/benchmark.sh -p 9912 -A 2011 -u ws://integritee-node
       -V wss://integritee-worker-1 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/tee-worker/docker/ts-tests.yml
+++ b/tee-worker/docker/ts-tests.yml
@@ -8,11 +8,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s    
-      /usr/local/worker-cli/ts_tests.sh 2>&1"
+    entrypoint:
+      "/usr/local/worker-cli/ts_tests.sh 2>&1"
     restart: "no"
 networks:
   integritee-test-network:

--- a/tee-worker/docker/user-shielding-key.yml
+++ b/tee-worker/docker/user-shielding-key.yml
@@ -6,11 +6,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 600s    
-      /usr/local/worker-cli/user_shielding_key.sh -p 9912 -u ws://integritee-node 
+    entrypoint:
+      "/usr/local/worker-cli/user_shielding_key.sh -p 9912 -u ws://integritee-node
       -V wss://integritee-worker-1 -A 2011 -W wss://integritee-worker-2 -B 2012 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:


### PR DESCRIPTION
resolves #1068 

- node uses `nc` to check if the port is open
- workers use `curl` to check if it's initialised

The parachain image doesn't have shell, so we have to quote the test command with `CMD`.