### PR TITLE
update VC-A1

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/a1.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a1.rs
@@ -49,8 +49,8 @@ pub fn build(
 
 	match Credential::generate_unsigned_credential(&Assertion::A1, who, &shard.clone(), bn) {
 		Ok(mut credential_unsigned) => {
-			credential_unsigned.add_assertion_a1(web2_cnt, web3_cnt);
-			credential_unsigned.credential_subject.set_value(true);
+			let flag = web2_cnt != 0 && web3_cnt != 0;
+			credential_unsigned.credential_subject.set_value(flag);
 			Ok(credential_unsigned)
 		},
 		Err(e) => {

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -408,16 +408,6 @@ impl Credential {
 		}
 	}
 
-	pub fn add_assertion_a1(&mut self, web2_cnt: i32, web3_cnt: i32) {
-		let web2_item =
-			AssertionLogic::new_item("$web2_account_cnt", Op::Equal, &(format!("{}", web2_cnt)));
-		let web3_item =
-			AssertionLogic::new_item("$web3_account_cnt", Op::Equal, &(format!("{}", web3_cnt)));
-
-		let assertion = AssertionLogic::new_or().add_item(web2_item).add_item(web3_item);
-		self.credential_subject.assertions = assertion;
-	}
-
 	pub fn add_assertion_a8(&mut self, min: u64, max: u64) {
 		let min = format!("{}", min);
 		let max = format!("{}", max);

--- a/tee-worker/litentry/core/credentials/src/templates/a1.json
+++ b/tee-worker/litentry/core/credentials/src/templates/a1.json
@@ -25,14 +25,14 @@
         "assertions": {
             "and": [
                 {
-                    "src": "$web2_account_cnt",
+                    "src": "$has_web2_account",
                     "op": "==",
-                    "dsc": ""
+                    "dsc": "true"
                 },
                 {
-                    "src": "$web3_account_cnt",
+                    "src": "$has_web3_account",
                     "op": "==",
-                    "dsc": ""
+                    "dsc": "true"
                 }
             ]
         },


### PR DESCRIPTION
Update VC-A1 assertions.

According to [Build Ruleset 1](the https://github.com/litentry/litentry-parachain/issues/815), 
* Check the IDHub address has linked at least one Web2.0 and at least one Web3 account

no need to show the real web2/web3 account numbers.