### PR TITLE
Skip GHA steps conditionally

### DIFF
--- a/.github/file-filter.yml
+++ b/.github/file-filter.yml
@@ -8,17 +8,23 @@ parachain_src: &parachain_src
   - 'runtime/**'
   - 'mock-tee-primitives/**'
   - 'docker/Dockerfile'
-  - 'docker/bridge.Dockerfile'
+  - 'docker/bridge.dockerfile'
   - 'Cargo.lock'
   - 'Cargo.toml'
   - 'rust-toolchain.toml'
 
-parachain_ts_tests: &parachain_ts_tests
+parachain_test: &parachain_test
   - 'ts-tests/**'
 
 tee_src: &tee_src
-  - '!(tee-worker)/ts-tests/**'
-  - 'tee-worker/**'
+  - 'tee-worker/**/*.rs'
+  - 'tee-worker/**/Cargo.toml'
+  - 'tee-worker/**/Cargo.lock'
+  - 'tee-worker/**/rust-toolchain.toml'
+  - 'tee-worker/build.Dockerfile'
+  - 'tee-worker/enclave-runtime/**'
 
-tee_ts_tests: &tee_ts_tests
+tee_test: &tee_test
   - 'tee-worker/ts-tests/**'
+  - 'tee-worker/docker/*.yml'
+  - 'tee-worker/cli/*.sh'

--- a/.github/file-filter.yml
+++ b/.github/file-filter.yml
@@ -1,0 +1,24 @@
+# This is used by the action https://github.com/dorny/paths-filter to run jobs conditionally
+# Put all defined set of files here, similar to https://github.com/getsentry/sentry/blob/master/.github/workflows/getsentry-dispatch.yml
+
+parachain_src: &parachain_src
+  - 'node/**'
+  - 'pallets/**'
+  - 'primitives/**'
+  - 'runtime/**'
+  - 'mock-tee-primitives/**'
+  - 'docker/Dockerfile'
+  - 'docker/bridge.Dockerfile'
+  - 'Cargo.lock'
+  - 'Cargo.toml'
+  - 'rust-toolchain.toml'
+
+parachain_ts_tests: &parachain_ts_tests
+  - 'ts-tests/**'
+
+tee_src: &tee_src
+  - '!(tee-worker)/ts-tests/**'
+  - 'tee-worker/**'
+
+tee_ts_tests: &tee_ts_tests
+  - 'tee-worker/ts-tests/**'

--- a/.github/workflows/parachain-ci.yml
+++ b/.github/workflows/parachain-ci.yml
@@ -34,7 +34,8 @@ jobs:
     # see https://github.com/orgs/community/discussions/25722
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      parachain_src: ${{ steps.filter.outputs.parachain_src }}
+      parachain_ts_tests: ${{ steps.filter.outputs.parachain_ts_tests }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,17 +46,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
-          filters: |
-            src:
-              - 'node/**'
-              - 'pallets/**'
-              - 'primitives/**'
-              - 'runtime/**'
-              - 'mock-tee-primitives/**'
-              - 'docker/Dockerfile'
-              - 'Cargo.lock'
-              - 'Cargo.toml'
-              - 'rust-toolchain.toml'
+          filters: .github/file-filter.yml
 
   check-cargo-fmt:
     runs-on: ubuntu-latest
@@ -91,7 +82,7 @@ jobs:
   check-cargo-clippy:
     runs-on: ubuntu-latest
     needs: [check-cargo-fmt, check-file-change]
-    if: needs.check-file-change.outputs.src == 'true'
+    if: needs.check-file-change.outputs.parachain_src == 'true'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -132,14 +123,14 @@ jobs:
 
       - name: Build docker image
         timeout-minutes: 60
-        if: needs.check-file-change.outputs.src == 'true'
+        if: needs.check-file-change.outputs.parachain_src == 'true'
         run: |
           make build-docker-release
           echo "============================="
           docker images
 
       - name: Pull docker image optinally
-        if: needs.check-file-change.outputs.src == 'false'
+        if: needs.check-file-change.outputs.parachain_src == 'false'
         run: |
           docker pull litentry/litentry-parachain:latest
 
@@ -163,7 +154,8 @@ jobs:
 
   run-ts-tests:
     runs-on: ubuntu-latest
-    needs: build-docker
+    needs: [check-file-change, build-docker]
+    if: needs.check-file-change.outputs.parachain_src == 'true' || needs.check-file-change.outputs.parachain_ts_tests == 'true'
     strategy:
       matrix:
         chain:
@@ -221,7 +213,7 @@ jobs:
   run-cargo-unit-tests:
     runs-on: ubuntu-latest
     needs: [check-cargo-fmt, check-file-change]
-    if: needs.check-file-change.outputs.src == 'true'
+    if: needs.check-file-change.outputs.parachain_src == 'true'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -243,7 +235,7 @@ jobs:
   run-cargo-benchmarks:
     runs-on: ubuntu-latest
     needs: [check-cargo-fmt, check-file-change]
-    if: needs.check-file-change.outputs.src == 'true'
+    if: needs.check-file-change.outputs.parachain_src == 'true'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -266,7 +258,7 @@ jobs:
   run-cargo-runtime-tests:
     runs-on: ubuntu-latest
     needs: [check-cargo-fmt, check-file-change]
-    if: needs.check-file-change.outputs.src == 'true'
+    if: needs.check-file-change.outputs.parachain_src == 'true'
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G

--- a/.github/workflows/parachain-ci.yml
+++ b/.github/workflows/parachain-ci.yml
@@ -50,8 +50,8 @@ jobs:
 
   check-cargo-fmt:
     runs-on: ubuntu-latest
-    # so that the if condition on `check-file-change` propagates here
     needs: check-file-change
+    if: needs.check-file-change.outputs.parachain_src == 'true'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/parachain-ci.yml
+++ b/.github/workflows/parachain-ci.yml
@@ -35,7 +35,7 @@ jobs:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     outputs:
       parachain_src: ${{ steps.filter.outputs.parachain_src }}
-      parachain_ts_tests: ${{ steps.filter.outputs.parachain_ts_tests }}
+      parachain_test: ${{ steps.filter.outputs.parachain_test }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -47,6 +47,7 @@ jobs:
         id: filter
         with:
           filters: .github/file-filter.yml
+          list-files: shell
 
   check-cargo-fmt:
     runs-on: ubuntu-latest
@@ -155,7 +156,7 @@ jobs:
   run-ts-tests:
     runs-on: ubuntu-latest
     needs: [check-file-change, build-docker]
-    if: needs.check-file-change.outputs.parachain_src == 'true' || needs.check-file-change.outputs.parachain_ts_tests == 'true'
+    if: needs.check-file-change.outputs.parachain_src == 'true' || needs.check-file-change.outputs.parachain_test == 'true'
     strategy:
       matrix:
         chain:

--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -95,7 +95,6 @@ jobs:
   build-test:
     runs-on: ubuntu-20.04
     needs: check-file-change
-    if: needs.check-file-change.outputs.tee_src == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -49,7 +49,7 @@ jobs:
     outputs:
       parachain_src: ${{ steps.filter.outputs.parachain_src }}
       tee_src: ${{ steps.filter.outputs.tee_src }}
-      tee_ts_tests: ${{ steps.filter.outputs.tee_ts_tests }}
+      tee_test: ${{ steps.filter.outputs.tee_test }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -61,6 +61,7 @@ jobs:
         id: filter
         with:
           filters: .github/file-filter.yml
+          list-files: shell
 
   build-parachain-docker:
     runs-on: ubuntu-latest
@@ -233,7 +234,7 @@ jobs:
     if: >
       needs.check-file-change.outputs.parachain_src == 'true' ||
       needs.check-file-change.outputs.tee_src == 'true' ||
-      needs.check-file-change.outputs.tee_ts_tests == 'true'
+      needs.check-file-change.outputs.tee_test == 'true'
     env:
       WORKER_IMAGE_TAG: integritee-worker:dev
       CLIENT_IMAGE_TAG: integritee-cli:dev

--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -116,7 +116,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: >
-          cd .. && docker build -t integritee-worker-${{ matrix.flavor_id }}
+          cd .. && docker build -t litentry/integritee-worker-${{ matrix.flavor_id }}
           --target deployed-worker
           --build-arg WORKER_MODE_ARG=${{ matrix.mode }} --build-arg ADDITIONAL_FEATURES_ARG=${{ matrix.additional_features }}
           -f tee-worker/build.Dockerfile .
@@ -126,7 +126,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: >
-          cd .. && docker build -t integritee-cli-${{ matrix.flavor_id }}
+          cd .. && docker build -t litentry/integritee-cli-${{ matrix.flavor_id }}
           --target deployed-client
           --build-arg WORKER_MODE_ARG=${{ matrix.mode }} --build-arg ADDITIONAL_FEATURES_ARG=${{ matrix.additional_features }}
           -f tee-worker/build.Dockerfile .
@@ -140,11 +140,11 @@ jobs:
       - run: docker images --all
 
       - name: Test Enclave # cargo test is not supported in the enclave, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
-        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-${{ matrix.flavor_id }} test --all
+        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} litentry/integritee-worker-${{ matrix.flavor_id }} test --all
 
       - name: Save docker images
         run: >
-          docker save integritee-worker-${{ matrix.flavor_id }} integritee-cli-${{ matrix.flavor_id }}
+          docker save litentry/integritee-worker-${{ matrix.flavor_id }} litentry/integritee-cli-${{ matrix.flavor_id }}
           -o ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-${{ matrix.flavor_id }}.tar
 
       - name: Upload docker images
@@ -294,8 +294,8 @@ jobs:
 
       - name: Re-name Image Tags
         run: |
-          docker tag integritee-worker-${{ matrix.flavor_id }} ${{ env.WORKER_IMAGE_TAG }}
-          docker tag integritee-cli-${{ matrix.flavor_id }} ${{ env.CLIENT_IMAGE_TAG }}
+          docker tag litentry/integritee-worker-${{ matrix.flavor_id }} ${{ env.WORKER_IMAGE_TAG }}
+          docker tag litentry/integritee-cli-${{ matrix.flavor_id }} ${{ env.CLIENT_IMAGE_TAG }}
           docker images --all
 
       - name: Generate parachain artefacts

--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -126,7 +126,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: >
-          cd .. && docker build -t integritee-cli-{{ matrix.flavor_id }}
+          cd .. && docker build -t integritee-cli-${{ matrix.flavor_id }}
           --target deployed-client
           --build-arg WORKER_MODE_ARG=${{ matrix.mode }} --build-arg ADDITIONAL_FEATURES_ARG=${{ matrix.additional_features }}
           -f tee-worker/build.Dockerfile .
@@ -134,24 +134,24 @@ jobs:
       - name: Pull and tag worker and cli image optionally
         if: needs.check-file-change.outputs.tee_src == 'false'
         run: |
-          docker pull litentry/integritee-worker-{{ matrix.flavor_id }}
-          docker pull litentry/integritee-cli-{{ matrix.flavor_id }}
+          docker pull litentry/integritee-worker-${{ matrix.flavor_id }}
+          docker pull litentry/integritee-cli-${{ matrix.flavor_id }}
 
       - run: docker images --all
 
       - name: Test Enclave # cargo test is not supported in the enclave, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
-        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-{{ matrix.flavor_id }} test --all
+        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-${{ matrix.flavor_id }} test --all
 
       - name: Save docker images
         run: >
-          docker image save integritee-worker-{{ matrix.flavor_id }} integritee-cli-{{ matrix.flavor_id }}
-          -o ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-{{ matrix.flavor_id }}.tar
+          docker save integritee-worker-${{ matrix.flavor_id }} integritee-cli-${{ matrix.flavor_id }}
+          -o ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-${{ matrix.flavor_id }}.tar
 
       - name: Upload docker images
         uses: actions/upload-artifact@v3
         with:
-          name: tee-{{ matrix.flavor_id }}-artifact
-          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-{{ matrix.flavor_id }}.tar
+          name: tee-${{ matrix.flavor_id }}-artifact
+          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-${{ matrix.flavor_id }}.tar
 
   build-test-status-check:
     if: ${{ always() }}
@@ -284,13 +284,13 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: tee-{{ matrix.flavor_id }}-artifact
+          name: tee-${{ matrix.flavor_id }}-artifact
           path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}
 
       - name: Load docker image
         run: |
           docker load -i ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-parachain.tar
-          docker load -i ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-{{ matrix.flavor_id }}.tar
+          docker load -i ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-${{ matrix.flavor_id }}.tar
 
       - name: Re-name Image Tags
         run: |
@@ -351,8 +351,8 @@ jobs:
         if: ${{ success() && (github.event_name == 'push') && (github.ref == 'refs/heads/dev') }}
         run: |
           docker push litentry/litentry-parachain
-          docker push litentry/integritee-worker-{{ matrix.flavor_id }}
-          docker push litentry/integritee-cli-{{ matrix.flavor_id }}
+          docker push litentry/integritee-worker-${{ matrix.flavor_id }}
+          docker push litentry/integritee-cli-${{ matrix.flavor_id }}
 
   integration-tests-status-check:
     if: ${{ always() }}

--- a/.github/workflows/tee-worker-ci.yml
+++ b/.github/workflows/tee-worker-ci.yml
@@ -47,7 +47,9 @@ jobs:
     # see https://github.com/orgs/community/discussions/25722
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      parachain_src: ${{ steps.filter.outputs.parachain_src }}
+      tee_src: ${{ steps.filter.outputs.tee_src }}
+      tee_ts_tests: ${{ steps.filter.outputs.tee_ts_tests }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -58,24 +60,26 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
-          filters: |
-            src:
-              - 'tee-worker/**'
-              - '.github/workflows/tee-worker-ci.yml'
+          filters: .github/file-filter.yml
 
   build-parachain-docker:
     runs-on: ubuntu-latest
     needs: check-file-change
-    if: needs.check-file-change.outputs.src == 'true'
     steps:
       - uses: actions/checkout@v3
 
       - name: Build docker image
+        if: needs.check-file-change.outputs.parachain_src == 'true'
         run: |
           cd ..
           make build-docker-release
           echo "============================="
           docker images
+
+      - name: Pull docker image optinally
+        if: needs.check-file-change.outputs.parachain_src == 'false'
+        run: |
+          docker pull litentry/litentry-parachain:latest
 
       - name: Save docker image
         run: |
@@ -90,7 +94,7 @@ jobs:
   build-test:
     runs-on: ubuntu-20.04
     needs: check-file-change
-    if: needs.check-file-change.outputs.src == 'true'
+    if: needs.check-file-change.outputs.tee_src == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -108,44 +112,46 @@ jobs:
           driver: docker-container
 
       - name: Build Worker & Run Cargo Test
+        if: needs.check-file-change.outputs.tee_src == 'true'
         env:
           DOCKER_BUILDKIT: 1
         run: >
-          cd .. && docker build -t integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }}
+          cd .. && docker build -t integritee-worker-${{ matrix.flavor_id }}
           --target deployed-worker
           --build-arg WORKER_MODE_ARG=${{ matrix.mode }} --build-arg ADDITIONAL_FEATURES_ARG=${{ matrix.additional_features }}
           -f tee-worker/build.Dockerfile .
 
       - name: Build CLI client
+        if: needs.check-file-change.outputs.tee_src == 'true'
         env:
           DOCKER_BUILDKIT: 1
         run: >
-          cd .. && docker build -t integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}
+          cd .. && docker build -t integritee-cli-{{ matrix.flavor_id }}
           --target deployed-client
           --build-arg WORKER_MODE_ARG=${{ matrix.mode }} --build-arg ADDITIONAL_FEATURES_ARG=${{ matrix.additional_features }}
           -f tee-worker/build.Dockerfile .
 
+      - name: Pull and tag worker and cli image optionally
+        if: needs.check-file-change.outputs.tee_src == 'false'
+        run: |
+          docker pull litentry/integritee-worker-{{ matrix.flavor_id }}
+          docker pull litentry/integritee-cli-{{ matrix.flavor_id }}
+
       - run: docker images --all
 
       - name: Test Enclave # cargo test is not supported in the enclave, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
-        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }} test --all
+        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-{{ matrix.flavor_id }} test --all
 
-      - name: Export worker image(s)
-        run: |
-          docker image save integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }} | gzip > ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
-          docker image save integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }} | gzip > ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
+      - name: Save docker images
+        run: >
+          docker image save integritee-worker-{{ matrix.flavor_id }} integritee-cli-{{ matrix.flavor_id }}
+          -o ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-{{ matrix.flavor_id }}.tar
 
-      - name: Upload worker image
+      - name: Upload docker images
         uses: actions/upload-artifact@v3
         with:
-          name: integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
-          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
-
-      - name: Upload CLI client image
-        uses: actions/upload-artifact@v3
-        with:
-          name: integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
-          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
+          name: tee-{{ matrix.flavor_id }}-artifact
+          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-{{ matrix.flavor_id }}.tar
 
   build-test-status-check:
     if: ${{ always() }}
@@ -162,7 +168,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     needs: check-file-change
-    if: needs.check-file-change.outputs.src == 'true'
+    if: needs.check-file-change.outputs.tee_src == 'true'
     container: "integritee/integritee-dev:0.1.10"
     steps:
       - uses: actions/checkout@v3
@@ -198,7 +204,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     needs: check-file-change
-    if: needs.check-file-change.outputs.src == 'true'
+    if: needs.check-file-change.outputs.tee_src == 'true'
     steps:
       - uses: actions/checkout@v3
       - name: init rust
@@ -223,6 +229,11 @@ jobs:
     needs:
       - build-parachain-docker
       - build-test
+      - check-file-change
+    if: >
+      needs.check-file-change.outputs.parachain_src == 'true' ||
+      needs.check-file-change.outputs.tee_src == 'true' ||
+      needs.check-file-change.outputs.tee_ts_tests == 'true'
     env:
       WORKER_IMAGE_TAG: integritee-worker:dev
       CLIENT_IMAGE_TAG: integritee-cli:dev
@@ -271,34 +282,20 @@ jobs:
           name: parachain-artifact
           path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: tee-{{ matrix.flavor_id }}-artifact
+          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}
+
       - name: Load docker image
         run: |
           docker load -i ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-parachain.tar
-
-      - name: Download Worker Image
-        uses: actions/download-artifact@v3
-        with:
-          name: integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
-          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}
-
-      - name: Download CLI client Image
-        uses: actions/download-artifact@v3
-        with:
-          name: integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
-          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}
-
-      - name: Load Worker & Client Images
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker image load --input ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
-          docker image load --input ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
-          docker images --all
+          docker load -i ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-tee-{{ matrix.flavor_id }}.tar
 
       - name: Re-name Image Tags
         run: |
-          docker tag integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }} ${{ env.WORKER_IMAGE_TAG }}
-          docker tag integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }} ${{ env.CLIENT_IMAGE_TAG }}
+          docker tag integritee-worker-${{ matrix.flavor_id }} ${{ env.WORKER_IMAGE_TAG }}
+          docker tag integritee-cli-${{ matrix.flavor_id }} ${{ env.CLIENT_IMAGE_TAG }}
           docker images --all
 
       - name: Generate parachain artefacts
@@ -334,7 +331,6 @@ jobs:
         if: always()
         uses: jwalton/gh-docker-logs@v2
         with:
-          #images: '${{ env.WORKER_IMAGE_TAG }},${{ env.CLIENT_IMAGE_TAG }}'
           tail: all
           dest: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/${{ env.LOG_DIR }}
 
@@ -344,6 +340,19 @@ jobs:
         with:
           name: logs-${{ matrix.test }}-${{ matrix.flavor_id }}
           path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/${{ env.LOG_DIR }}
+
+      - name: Dockerhub login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Push docker images
+        if: ${{ success() && (github.event_name == 'push') && (github.ref == 'refs/heads/dev') }}
+        run: |
+          docker push litentry/litentry-parachain
+          docker push litentry/integritee-worker-{{ matrix.flavor_id }}
+          docker push litentry/integritee-cli-{{ matrix.flavor_id }}
 
   integration-tests-status-check:
     if: ${{ always() }}
@@ -357,33 +366,7 @@ jobs:
             *) exit 1 ;;
           esac
 
-  # Only push docker image when tests are passed and pushing to `dev` branch
-  push-docker-image:
-    runs-on: ubuntu-latest
-    needs:
-      - integration-tests
-    if: ${{ success() && (github.event_name == 'push') && (github.ref == 'refs/heads/dev') }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: parachain-artifact
-          path: ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}
-
-      - name: Load docker image
-        run: |
-          docker load -i ${{ env.UPLOAD_DOWNLOAD_DIR_PREFIX }}/litentry-parachain.tar
-
-      - name: Dockerhub login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Push docker image
-        run: docker push litentry/litentry-parachain:latest
-
+  # TODO: this "release" section is from the original yml -- unmaintained
   release:
     name: Draft Release
     if: startsWith(github.ref, 'refs/tags/')

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -114,7 +114,7 @@ describeLitentry('Test Identity', (context) => {
     });
 
     step('create identity', async function () {
-        // create twitter identity
+        //create twitter identity
         const resp_twitter = await createIdentity(context, context.defaultSigner[0], aesKey, true, twitterIdentity);
         assertIdentityCreated(context.defaultSigner[0], resp_twitter);
 
@@ -129,7 +129,7 @@ describeLitentry('Test Identity', (context) => {
             console.log('post verification msg to twitter: ', msg);
             assert.isNotEmpty(resp_twitter.challengeCode, 'challengeCode empty');
         }
-        // create ethereum identity
+        //create ethereum identity
         const resp_ethereum = await createIdentity(context, context.defaultSigner[0], aesKey, true, ethereumIdentity);
         assertIdentityCreated(context.defaultSigner[0], resp_ethereum);
 

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -114,7 +114,7 @@ describeLitentry('Test Identity', (context) => {
     });
 
     step('create identity', async function () {
-        //create twitter identity
+        // create twitter identity
         const resp_twitter = await createIdentity(context, context.defaultSigner[0], aesKey, true, twitterIdentity);
         assertIdentityCreated(context.defaultSigner[0], resp_twitter);
 
@@ -129,7 +129,7 @@ describeLitentry('Test Identity', (context) => {
             console.log('post verification msg to twitter: ', msg);
             assert.isNotEmpty(resp_twitter.challengeCode, 'challengeCode empty');
         }
-        //create ethereum identity
+        // create ethereum identity
         const resp_ethereum = await createIdentity(context, context.defaultSigner[0], aesKey, true, ethereumIdentity);
         assertIdentityCreated(context.defaultSigner[0], resp_ethereum);
 


### PR DESCRIPTION
resolves #1101, based on the files changed.

Now CI will also upload the `integirtee-worker` and `integritee-cli` image to the docker hub.

If you later find a case where a CI should have been triggered but isn't triggered, please let me know (that probably means `./github/file-filter.yml` needs to be adjusted)