### PR TITLE
Enclave update [2] - adjust key provisioning(fix #1178)

### DIFF
--- a/pallets/teerex/src/lib.rs
+++ b/pallets/teerex/src/lib.rs
@@ -403,8 +403,6 @@ pub mod pallet {
 		EmptyEnclaveRegistry,
 		/// Can not found the desired scheduled enclave.
 		ScheduledEnclaveNotExist,
-		/// Enclave already stored in scheduled list
-		ScheduledEnclaveAlreadyExist,
 		/// Enclave not in the scheduled list, therefore unexpected.
 		EnclaveNotInSchedule,
 	}

--- a/pallets/teerex/src/lib.rs
+++ b/pallets/teerex/src/lib.rs
@@ -377,7 +377,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			T::EnclaveAdminOrigin::ensure_origin(origin)?;
 			ensure!(
-				!ScheduledEnclaveIndex::<T>::contains_key(&mr_enclave),
+				!ScheduledEnclaveIndex::<T>::contains_key(mr_enclave),
 				Error::<T>::ScheduledEnclaveAlreadyExist
 			);
 			ScheduledEnclave::<T>::insert(sidechain_block_number, mr_enclave);

--- a/pallets/teerex/src/lib.rs
+++ b/pallets/teerex/src/lib.rs
@@ -127,14 +127,14 @@ pub mod pallet {
 	#[pallet::getter(fn scheduled_enclave)]
 	pub type ScheduledEnclave<T: Config> = StorageMap<_, Blake2_128Concat, u32, MREnclave>;
 
-	/// store the last MrEnclave Index, the biggest one
+	/// store the last MrEnclave Index
 	/// Watch out: we start indexing with 1 instead of zero in order to
 	/// avoid ambiguity between Null and 0.
 	#[pallet::storage]
 	#[pallet::getter(fn scheduled_enclave_count)]
 	pub type ScheduledEnclaveCount<T: Config> = StorageValue<_, u64, ValueQuery>;
 
-	/// storage map of the enclave_index <-> MrEnclave, starts from 1
+	/// Storage map of the mrenclave_index <-> MrEnclave, starts from 1
 	/// Watch out: we start indexing with 1 instead of zero in order to
 	/// avoid ambiguity between Null and 0.
 	#[pallet::storage]

--- a/pallets/teerex/src/lib.rs
+++ b/pallets/teerex/src/lib.rs
@@ -138,9 +138,15 @@ pub mod pallet {
 	/// Watch out: we start indexing with 1 instead of zero in order to
 	/// avoid ambiguity between Null and 0.
 	#[pallet::storage]
-	#[pallet::getter(fn scheduled_enclave_index)]
+	#[pallet::getter(fn scheduled_enclave_registry)]
 	pub type ScheduledEnclaveRegistry<T: Config> =
 		StorageMap<_, Blake2_128Concat, u64, MREnclave, ValueQuery>;
+
+	/// Restore the index of MrEnclave
+	#[pallet::storage]
+	#[pallet::getter(fn scheduled_enclave_index)]
+	pub type ScheduledEnclaveIndex<T: Config> =
+		StorageMap<_, Blake2_128Concat, MREnclave, u64, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn heartbeat_timeout)]
@@ -370,13 +376,18 @@ pub mod pallet {
 			mr_enclave: MREnclave,
 		) -> DispatchResultWithPostInfo {
 			T::EnclaveAdminOrigin::ensure_origin(origin)?;
-			// TODO: check if the mr_enclave already inserted
+			ensure!(
+				!ScheduledEnclaveIndex::<T>::contains_key(&mr_enclave),
+				Error::<T>::ScheduledEnclaveAlreadyExist
+			);
 			ScheduledEnclave::<T>::insert(sidechain_block_number, mr_enclave);
 			Self::deposit_event(Event::UpdatedScheduledEnclave(sidechain_block_number, mr_enclave));
 			let enclave_idx = Self::scheduled_enclave_count()
 				.checked_add(1)
 				.ok_or("[Teerex]: Overflow adding new MrEnclave to registry")?;
 			<ScheduledEnclaveRegistry<T>>::insert(enclave_idx, mr_enclave);
+			<ScheduledEnclaveIndex<T>>::insert(mr_enclave, enclave_idx);
+			<ScheduledEnclaveCount<T>>::put(enclave_idx);
 			Ok(().into())
 		}
 
@@ -391,7 +402,12 @@ pub mod pallet {
 				ScheduledEnclave::<T>::contains_key(sidechain_block_number),
 				Error::<T>::ScheduledEnclaveNotExist
 			);
+			let mr_enclave = <ScheduledEnclave<T>>::get(sidechain_block_number)
+				.ok_or(Error::<T>::ScheduledEnclaveNotExist)?;
+			let removed_index = <ScheduledEnclaveIndex<T>>::get(mr_enclave);
+			// remove
 			ScheduledEnclave::<T>::remove(sidechain_block_number);
+			ScheduledEnclaveRegistry::<T>::remove(removed_index);
 			Self::deposit_event(Event::RemovedScheduledEnclave(sidechain_block_number));
 			Ok(().into())
 		}
@@ -422,6 +438,8 @@ pub mod pallet {
 		EmptyEnclaveRegistry,
 		/// Can not found the desired scheduled enclave.
 		ScheduledEnclaveNotExist,
+		/// Enclave already stored in scheduled list
+		ScheduledEnclaveAlreadyExist,
 		/// Enclave not in the scheduled list, therefore unexpected.
 		EnclaveNotInSchedule,
 	}

--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -4540,6 +4540,7 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 name = "itp-api-client-extensions"
 version = "0.9.0"
 dependencies = [
+ "hex 0.4.3",
  "itp-types",
  "parity-scale-codec",
  "sp-core",

--- a/tee-worker/core-primitives/node-api/api-client-extensions/Cargo.toml
+++ b/tee-worker/core-primitives/node-api/api-client-extensions/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.9.0"
 [dependencies]
 # crates.io
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
+hex = "0.4"
 thiserror = { version = "1.0" }
 
 # substrate

--- a/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex.rs
+++ b/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex.rs
@@ -71,7 +71,7 @@ where
 			.map(|key| {
 				let key = key.strip_prefix("0x").unwrap_or(key);
 				let raw_key = hex::decode(key).unwrap();
-				self.get_storage_by_key_hash::<MrEnclave>(StorageKey(raw_key.clone()), at_block)
+				self.get_storage_by_key_hash::<MrEnclave>(StorageKey(raw_key), at_block)
 			})
 			.filter(|enclave| matches!(enclave, Ok(Some(_))))
 			.map(|enclave| enclave.unwrap().unwrap())

--- a/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex.rs
+++ b/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex.rs
@@ -32,6 +32,7 @@ pub trait PalletTeerexApi {
 	fn schedule_enclave(&self, index: u64, at_block: Option<Hash>) -> ApiResult<Option<MrEnclave>>;
 	fn schedule_enclaves_count(&self, at_block: Option<Hash>) -> ApiResult<u64>;
 	fn all_schedule_mr_enclaves(&self, at_block: Option<Hash>) -> ApiResult<Vec<MrEnclave>>;
+	fn all_schedule_height(&self, at_block: Option<Hash>) -> ApiResult<Vec<u64>>;
 	fn worker_for_shard(
 		&self,
 		shard: &ShardIdentifier,

--- a/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex.rs
+++ b/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex.rs
@@ -32,7 +32,6 @@ pub trait PalletTeerexApi {
 	fn schedule_enclave(&self, index: u64, at_block: Option<Hash>) -> ApiResult<Option<MrEnclave>>;
 	fn schedule_enclaves_count(&self, at_block: Option<Hash>) -> ApiResult<u64>;
 	fn all_schedule_mr_enclaves(&self, at_block: Option<Hash>) -> ApiResult<Vec<MrEnclave>>;
-	fn all_schedule_height(&self, at_block: Option<Hash>) -> ApiResult<Vec<u64>>;
 	fn worker_for_shard(
 		&self,
 		shard: &ShardIdentifier,

--- a/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex_api_mock.rs
+++ b/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex_api_mock.rs
@@ -50,20 +50,6 @@ impl PalletTeerexApi for PalletTeerexApiMock {
 		Ok(self.registered_enclaves.clone())
 	}
 
-	fn schedule_enclave(
-		&self,
-		index: u64,
-		_at_block: Option<Hash>,
-	) -> ApiResult<Option<MrEnclave>> {
-		let mr_enclave = self.scheduled_mr_enclaves.get(&index).copied();
-		Ok(mr_enclave)
-	}
-
-	fn schedule_enclaves_count(&self, _at_block: Option<Hash>) -> ApiResult<u64> {
-		let count = self.scheduled_mr_enclaves.len();
-		Ok(count as u64)
-	}
-
 	fn all_schedule_mr_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<MrEnclave>> {
 		let mr_enclaves = self.scheduled_mr_enclaves.values().copied().collect();
 		Ok(mr_enclaves)

--- a/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex_api_mock.rs
+++ b/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex_api_mock.rs
@@ -55,7 +55,7 @@ impl PalletTeerexApi for PalletTeerexApiMock {
 		index: u64,
 		_at_block: Option<Hash>,
 	) -> ApiResult<Option<MrEnclave>> {
-		let mr_enclave = self.scheduled_mr_enclaves.get(&index).map(|m| *m);
+		let mr_enclave = self.scheduled_mr_enclaves.get(&index).copied();
 		Ok(mr_enclave)
 	}
 
@@ -65,7 +65,7 @@ impl PalletTeerexApi for PalletTeerexApiMock {
 	}
 
 	fn all_schedule_mr_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<MrEnclave>> {
-		let mr_enclaves = self.scheduled_mr_enclaves.values().map(|m| *m).collect();
+		let mr_enclaves = self.scheduled_mr_enclaves.values().copied().collect();
 		Ok(mr_enclaves)
 	}
 

--- a/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex_api_mock.rs
+++ b/tee-worker/core-primitives/node-api/api-client-extensions/src/pallet_teerex_api_mock.rs
@@ -16,15 +16,22 @@
 */
 
 use crate::{pallet_teerex::PalletTeerexApi, ApiResult};
-use itp_types::{Enclave, IpfsHash, ShardIdentifier, H256 as Hash};
+use itp_types::{Enclave, IpfsHash, MrEnclave, ShardIdentifier, H256 as Hash};
+use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct PalletTeerexApiMock {
 	registered_enclaves: Vec<Enclave>,
+	scheduled_mr_enclaves: HashMap<u64, MrEnclave>,
 }
 
 impl PalletTeerexApiMock {
 	pub fn with_enclaves(mut self, enclaves: Vec<Enclave>) -> Self {
+		self.scheduled_mr_enclaves = enclaves
+			.iter()
+			.enumerate()
+			.map(|(index, e)| (index as u64, e.mr_enclave))
+			.collect();
 		self.registered_enclaves.extend(enclaves);
 		self
 	}
@@ -41,6 +48,25 @@ impl PalletTeerexApi for PalletTeerexApiMock {
 
 	fn all_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<Enclave>> {
 		Ok(self.registered_enclaves.clone())
+	}
+
+	fn schedule_enclave(
+		&self,
+		index: u64,
+		_at_block: Option<Hash>,
+	) -> ApiResult<Option<MrEnclave>> {
+		let mr_enclave = self.scheduled_mr_enclaves.get(&index).map(|m| *m);
+		Ok(mr_enclave)
+	}
+
+	fn schedule_enclaves_count(&self, _at_block: Option<Hash>) -> ApiResult<u64> {
+		let count = self.scheduled_mr_enclaves.len();
+		Ok(count as u64)
+	}
+
+	fn all_schedule_mr_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<MrEnclave>> {
+		let mr_enclaves = self.scheduled_mr_enclaves.values().map(|m| *m).collect();
+		Ok(mr_enclaves)
 	}
 
 	fn worker_for_shard(

--- a/tee-worker/service/src/error.rs
+++ b/tee-worker/service/src/error.rs
@@ -52,6 +52,8 @@ pub enum Error {
 	MissingLastFinalizedBlock,
 	#[error("Current enclave is not included in the parentchain")]
 	InvalidMrEnclave,
+	#[error("Parachain scheduled mrenclaves is empty")]
+	NoParachainScheduledMrEnclaves,
 	#[error("{0}")]
 	Custom(Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/tee-worker/service/src/error.rs
+++ b/tee-worker/service/src/error.rs
@@ -50,6 +50,8 @@ pub enum Error {
 	MissingGenesisHeader,
 	#[error("Could not find last finalized block of the parentchain")]
 	MissingLastFinalizedBlock,
+	#[error("Current enclave is not included in the parentchain")]
+	InvalidMrEnclave,
 	#[error("{0}")]
 	Custom(Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/tee-worker/service/src/sync_state.rs
+++ b/tee-worker/service/src/sync_state.rs
@@ -87,6 +87,9 @@ async fn get_enclave_url_of_first_registered<NodeApi: PalletTeerexApi, EnclaveAp
 ) -> Result<String> {
 	let self_mr_enclave = enclave_api.get_mrenclave()?;
 	let all_scheduled_mr_enclaves = node_api.all_schedule_mr_enclaves(None)?;
+	if all_scheduled_mr_enclaves.is_empty() {
+		return Err(Error::NoParachainScheduledMrEnclaves)
+	}
 	if !all_scheduled_mr_enclaves.contains(&self_mr_enclave) {
 		return Err(Error::InvalidMrEnclave)
 	}

--- a/tee-worker/service/src/sync_state.rs
+++ b/tee-worker/service/src/sync_state.rs
@@ -86,10 +86,14 @@ async fn get_enclave_url_of_first_registered<NodeApi: PalletTeerexApi, EnclaveAp
 	enclave_api: &EnclaveApi,
 ) -> Result<String> {
 	let self_mr_enclave = enclave_api.get_mrenclave()?;
+	let all_scheduled_mr_enclaves = node_api.all_schedule_mr_enclaves(None)?;
+	if !all_scheduled_mr_enclaves.contains(&self_mr_enclave) {
+		return Err(Error::InvalidMrEnclave)
+	}
 	let first_enclave = node_api
 		.all_enclaves(None)?
 		.into_iter()
-		.find(|e| e.mr_enclave == self_mr_enclave)
+		.find(|e| all_scheduled_mr_enclaves.contains(&e.mr_enclave))
 		.ok_or(Error::NoPeerWorkerFound)?;
 	let worker_api_direct = DirectWorkerApi::new(first_enclave.url);
 	Ok(worker_api_direct.get_mu_ra_url()?)

--- a/tee-worker/service/src/tests/mock.rs
+++ b/tee-worker/service/src/tests/mock.rs
@@ -15,9 +15,9 @@
 
 */
 
-use std::collections::HashSet;
 use itp_node_api::api_client::{ApiResult, PalletTeerexApi};
 use itp_types::{Enclave, MrEnclave, ShardIdentifier, H256 as Hash};
+use std::collections::HashSet;
 
 pub struct TestNodeApi;
 

--- a/tee-worker/service/src/tests/mock.rs
+++ b/tee-worker/service/src/tests/mock.rs
@@ -15,6 +15,7 @@
 
 */
 
+use std::collections::HashSet;
 use itp_node_api::api_client::{ApiResult, PalletTeerexApi};
 use itp_types::{Enclave, MrEnclave, ShardIdentifier, H256 as Hash};
 
@@ -45,8 +46,8 @@ impl PalletTeerexApi for TestNodeApi {
 
 	fn all_schedule_mr_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<MrEnclave>> {
 		let enclaves = enclaves();
-		let mr_enclaves = enclaves.into_iter().map(|e| e.mr_enclave).collect();
-		Ok(mr_enclaves)
+		let mr_enclaves: HashSet<_> = enclaves.into_iter().map(|e| e.mr_enclave).collect();
+		Ok(mr_enclaves.into_iter().collect())
 	}
 
 	fn worker_for_shard(

--- a/tee-worker/service/src/tests/mock.rs
+++ b/tee-worker/service/src/tests/mock.rs
@@ -43,23 +43,6 @@ impl PalletTeerexApi for TestNodeApi {
 		Ok(enclaves())
 	}
 
-	fn schedule_enclave(
-		&self,
-		index: u64,
-		_at_block: Option<Hash>,
-	) -> ApiResult<Option<MrEnclave>> {
-		let enclaves = enclaves();
-		if index == 1 {
-			Ok(Some(enclaves[0].mr_enclave))
-		} else {
-			Ok(Some(enclaves[1].mr_enclave))
-		}
-	}
-
-	fn schedule_enclaves_count(&self, _at_block: Option<Hash>) -> ApiResult<u64> {
-		Ok(2)
-	}
-
 	fn all_schedule_mr_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<MrEnclave>> {
 		let enclaves = enclaves();
 		let mr_enclaves = enclaves.into_iter().map(|e| e.mr_enclave).collect();

--- a/tee-worker/service/src/tests/mock.rs
+++ b/tee-worker/service/src/tests/mock.rs
@@ -16,7 +16,7 @@
 */
 
 use itp_node_api::api_client::{ApiResult, PalletTeerexApi};
-use itp_types::{Enclave, ShardIdentifier, H256 as Hash};
+use itp_types::{Enclave, MrEnclave, ShardIdentifier, H256 as Hash};
 
 pub struct TestNodeApi;
 
@@ -34,12 +34,36 @@ impl PalletTeerexApi for TestNodeApi {
 	fn enclave(&self, index: u64, _at_block: Option<Hash>) -> ApiResult<Option<Enclave>> {
 		Ok(Some(enclaves().remove(index as usize)))
 	}
+
 	fn enclave_count(&self, _at_block: Option<Hash>) -> ApiResult<u64> {
 		unreachable!()
 	}
 
 	fn all_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<Enclave>> {
 		Ok(enclaves())
+	}
+
+	fn schedule_enclave(
+		&self,
+		index: u64,
+		_at_block: Option<Hash>,
+	) -> ApiResult<Option<MrEnclave>> {
+		let enclaves = enclaves();
+		if index == 1 {
+			Ok(Some(enclaves[0].mr_enclave))
+		} else {
+			Ok(Some(enclaves[1].mr_enclave))
+		}
+	}
+
+	fn schedule_enclaves_count(&self, _at_block: Option<Hash>) -> ApiResult<u64> {
+		Ok(2)
+	}
+
+	fn all_schedule_mr_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<MrEnclave>> {
+		let enclaves = enclaves();
+		let mr_enclaves = enclaves.into_iter().map(|e| e.mr_enclave).collect();
+		Ok(mr_enclaves)
 	}
 
 	fn worker_for_shard(
@@ -49,6 +73,7 @@ impl PalletTeerexApi for TestNodeApi {
 	) -> ApiResult<Option<Enclave>> {
 		unreachable!()
 	}
+
 	fn latest_ipfs_hash(
 		&self,
 		_: &ShardIdentifier,


### PR DESCRIPTION
Before syncing the state key, check the current MrEnclave matches the scheduled enclaves.