### PR TITLE
Use !failure() to cover skipped jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Archive logs if test fails
         uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
+        if: failure()
         with:
           name: ${{ matrix.chain }}-ts-tests-artifacts
           path: /tmp/parachain_dev/
@@ -496,12 +496,14 @@ jobs:
   #
   # We don't have to depend on jobs like `parachain-unit-test` as those jobs have the same file-filter dependencies as
   # docker image build: `parachain_src` changed, so there must be no new image if `parachain-unit-test` is skipped.
+  #
+  # `!failure()` needs to be used to cover skipped jobs
   push-docker:
     runs-on: ubuntu-latest
     needs:
       - parachain-ts-test-hook
       - tee-test-hook
-    if: ${{ success() && (github.event_name == 'push') && (github.ref == 'refs/heads/dev') }}
+    if: ${{ !failure() && (github.event_name == 'push') && (github.ref == 'refs/heads/dev') }}
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
as title.

After I found the [latest dev run](https://github.com/litentry/litentry-parachain/actions/runs/4173415293) still didn't push the images, I realised `success()` is evaluated as `false` whenever there're skipped jobs.