### PR TITLE
Improve docker rebuild strategy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,26 @@ name: General CI
 # - unit tests
 # - integration tests
 
-# the tee-worker part is a modified version of tee-worker/.github/workflows/build_and_test.yml
+# Some notes:
+#
+# [1] the tee-worker part is a modified version of tee-worker/.github/workflows/build_and_test.yml
 # with extra triggering control.
 #
-# the original file (`tee-worker/.github/workflows/build_and_test.yml`) is kept to sync
+# [2] the original file (`tee-worker/.github/workflows/build_and_test.yml`) is kept to sync
 # upstream changes, therefore we need to manually apply the changes to this file.
 
-# please beware that if a job in `needs` is skipped, its dependent job will also be skipped,
+# [3] please beware that if a job in `needs` is skipped, its dependent job will also be skipped,
 # see https://github.com/actions/runner/issues/491
 #
 # jobs that will always be executed:
 # - fmt
-# - check-file-change
+# - set-condition
 # - parachain-build
 # - tee-build
+#
+# [4] please note that job-level if `env` is not supported:
+# https://github.com/actions/runner/issues/1189
+# as a workaround, we need to put it in a step-level or use `needs.outputs`
 
 on:
   push:
@@ -70,14 +76,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-file-change:
+  set-condition:
     runs-on: ubuntu-latest
     # see https://github.com/orgs/community/discussions/25722
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     outputs:
-      parachain_src: ${{ steps.filter.outputs.parachain_src }}
+      rebuild_parachain: ${{ steps.env.outputs.rebuild_parachain }}
+      rebuild_tee: ${{ steps.env.outputs.rebuild_tee }}
+      push_docker: ${{ steps.env.outputs.push_docker }}
       parachain_test: ${{ steps.filter.outputs.parachain_test }}
-      tee_src: ${{ steps.filter.outputs.tee_src }}
       tee_test: ${{ steps.filter.outputs.tee_test }}
     steps:
       - uses: actions/checkout@v3
@@ -93,10 +100,13 @@ jobs:
           list-files: shell
 
       - name: Set env
+        id: env
         run: |
           rebuild_parachain=false
           rebuild_tee=false
           push_docker=false
+          run_parachain_test=false
+          run_tee_test=false
           if [ "${{ github.event.inputs.rebuild-parachain-docker }}" = "true" ] || [ "${{ steps.filter.outputs.parachain_src }}" = "true" ]; then
             rebuild_parachain=true
           fi
@@ -108,11 +118,17 @@ jobs:
           elif [ "${{ github.event_name }}" = 'push' ] && [ "${{ github.ref }}" = 'refs/heads/dev' ]; then
             push_docker=true
           fi
-          echo "REBUILD_PARACHAIN=$rebuild_parachain" >> $GITHUB_ENV
-          echo "REBUILD_TEE=$rebuild_tee" >> $GITHUB_ENV
-          echo "PUSH_DOCKER=$push_docker" >> $GITHUB_ENV
-          env
-
+          if [ "${{ steps.filter.outputs.parachain_test }}" = "true" ] || [ "$rebuild_parachain" = "true" ]; then
+            run_parachain_test=true
+          fi
+          if [ "${{ steps.filter.outputs.tee_test }}" = "true" ] || [ "$rebuild_parachain" = "true" ] || [ "$rebuild_tee" = "true" ]; then
+            run_tee_test=true
+          fi
+          echo "rebuild_parachain=$rebuild_parachain" >> $GITHUB_OUTPUT
+          echo "rebuild_tee=$rebuild_tee" >> $GITHUB_OUTPUT
+          echo "push_docker=$push_docker" >> $GITHUB_OUTPUT
+          echo "run_parachain_test=$run_parachain_test" >> $GITHUB_OUTPUT
+          echo "run_tee_test=$run_tee_test" >> $GITHUB_OUTPUT
   fmt:
     runs-on: ubuntu-latest
     steps:
@@ -167,9 +183,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - fmt
-      - check-file-change
+      - set-condition
       - sequentialise
-    if: ${{ env.REBUILD_PARACHAIN == 'true' }}
+    if: needs.set-condition.outputs.rebuild_parachain == 'true'
     steps:
       - uses: actions/checkout@v3
 
@@ -192,10 +208,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - fmt
-      - check-file-change
+      - set-condition
       - sequentialise
+    if: needs.set-condition.outputs.rebuild_tee == 'true'
     container: "integritee/integritee-dev:0.1.12"
-    if: ${{ env.REBUILD_TEE == 'true' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -227,20 +243,20 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - fmt
-      - check-file-change
+      - set-condition
       - sequentialise
     steps:
       - uses: actions/checkout@v3
 
       - name: Build docker image
-        if: ${{ env.REBUILD_PARACHAIN == 'true' }}
+        if: needs.set-condition.outputs.rebuild_parachain == 'true'
         run: |
           make build-docker-release
           echo "============================="
           docker images
 
       - name: Pull docker image optinally
-        if: ${{ env.REBUILD_PARACHAIN != 'true' }}
+        if: needs.set-condition.outputs.rebuild_parachain == 'false'
         run: |
           docker pull litentry/litentry-parachain
 
@@ -262,7 +278,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - fmt
-      - check-file-change
+      - set-condition
       - sequentialise
     steps:
       - uses: actions/checkout@v3
@@ -274,7 +290,7 @@ jobs:
           driver: docker-container
 
       - name: Build worker (sidechain)
-        if: ${{ env.REBUILD_TEE == 'true' }}
+        if: needs.set-condition.outputs.rebuild_tee == 'true'
         env:
           DOCKER_BUILDKIT: 1
         run: >
@@ -284,7 +300,7 @@ jobs:
           -f tee-worker/build.Dockerfile .
 
       - name: Build cli (sidechain)
-        if: ${{ env.REBUILD_TEE == 'true' }}
+        if: needs.set-condition.outputs.rebuild_tee == 'true'
         env:
           DOCKER_BUILDKIT: 1
         run: >
@@ -294,7 +310,7 @@ jobs:
           -f tee-worker/build.Dockerfile .
 
       - name: Pull and tag worker and cli image optionally
-        if: ${{ env.REBUILD_TEE != 'true' }}
+        if: needs.set-condition.outputs.rebuild_tee == 'false'
         run: |
           docker pull litentry/integritee-worker
           docker pull litentry/integritee-cli
@@ -323,10 +339,9 @@ jobs:
   parachain-ts-test:
     runs-on: ubuntu-latest
     needs:
+      - set-condition
       - parachain-build
-    if: >
-      env.REBUILD_PARACHAIN == 'true' ||
-      needs.check-file-change.outputs.parachain_test == 'true'
+    if: needs.set-condition.outputs.run_parachain_test == 'true'
     strategy:
       matrix:
         chain: [litmus, litentry, rococo]
@@ -382,9 +397,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - fmt
-      - check-file-change
+      - set-condition
       - sequentialise
-    if: ${{ env.REBUILD_PARACHAIN == 'true' }}
+    # run_parachain_test is related to ts-tests only
+    if: needs.set-condition.outputs.rebuild_parachain == 'true'
     steps:
       - uses: actions/checkout@v3
 
@@ -402,9 +418,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - fmt
-      - check-file-change
+      - set-condition
       - sequentialise
-    if: ${{ env.REBUILD_PARACHAIN == 'true' }}
+    # run_parachain_test is related to ts-tests only
+    if: needs.set-condition.outputs.rebuild_parachain == 'true'
     steps:
       - uses: actions/checkout@v3
 
@@ -436,13 +453,10 @@ jobs:
   tee-test:
     runs-on: ubuntu-latest
     needs:
-      - check-file-change
+      - set-condition
       - parachain-build
       - tee-build
-    if: >
-      env.REBUILD_PARACHAIN == 'true' ||
-      env.REBUILD_TEE == 'true' ||
-      needs.check-file-change.outputs.tee_test == 'true'
+    if: needs.set-condition.outputs.run_tee_test == 'true'
     env:
       WORKER_IMAGE_TAG: integritee-worker:dev
       CLIENT_IMAGE_TAG: integritee-cli:dev
@@ -561,9 +575,10 @@ jobs:
   push-docker:
     runs-on: ubuntu-latest
     needs:
+      - set-condition
       - parachain-ts-test-hook
       - tee-test-hook
-    if: ${{ !failure() && env.PUSH_DOCKER == 'true' }}
+    if: ${{ !failure() && needs.set-condition.outputs.push-docker == 'true' }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,17 +124,11 @@ jobs:
           if [ "${{ steps.filter.outputs.tee_test }}" = "true" ] || [ "$rebuild_parachain" = "true" ] || [ "$rebuild_tee" = "true" ]; then
             run_tee_test=true
           fi
-          echo "rebuild_parachain=$rebuild_parachain" >> $GITHUB_OUTPUT
-          echo "rebuild_tee=$rebuild_tee" >> $GITHUB_OUTPUT
-          echo "push_docker=$push_docker" >> $GITHUB_OUTPUT
-          echo "run_parachain_test=$run_parachain_test" >> $GITHUB_OUTPUT
-          echo "run_tee_test=$run_tee_test" >> $GITHUB_OUTPUT
-
-      - name: Print GITHUB_OUTPUT
-        run: |
-          echo "::group::Github outputs"
-          cat "$GITHUB_OUTPUT"
-          echo "::endgroup::"
+          echo "rebuild_parachain=$rebuild_parachain" | tee -a $GITHUB_OUTPUT
+          echo "rebuild_tee=$rebuild_tee" | tee -a $GITHUB_OUTPUT
+          echo "push_docker=$push_docker" | tee -a $GITHUB_OUTPUT
+          echo "run_parachain_test=$run_parachain_test" | tee -a $GITHUB_OUTPUT
+          echo "run_tee_test=$run_tee_test" | tee -a $GITHUB_OUTPUT
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Print GITHUB_OUTPUT
         run: |
           echo "::group::Github outputs"
-          echo "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
           echo "::endgroup::"
 
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
       rebuild_parachain: ${{ steps.env.outputs.rebuild_parachain }}
       rebuild_tee: ${{ steps.env.outputs.rebuild_tee }}
       push_docker: ${{ steps.env.outputs.push_docker }}
-      parachain_test: ${{ steps.filter.outputs.parachain_test }}
-      tee_test: ${{ steps.filter.outputs.tee_test }}
+      run_parachain_test: ${{ steps.env.outputs.run_parachain_test }}
+      run_tee_test: ${{ steps.env.outputs.run_tee_test }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ on:
         description: rebuild-tee-docker
         required: true
         default: true
-      force-push-docker:
+      push-docker:
         type: boolean
-        description: force-push-docker
+        description: push-docker
         required: true
         default: fasle
 
@@ -113,7 +113,7 @@ jobs:
           if [ "${{ github.event.inputs.rebuild-tee-docker }}" = "true" ] || [ "${{ steps.filter.outputs.tee_src }}" = "true" ]; then
             rebuild_tee=true
           fi
-          if [ "${{ github.event.inputs.force-push-docker }}" = "true" ]; then
+          if [ "${{ github.event.inputs.push-docker }}" = "true" ]; then
             push_docker=true
           elif [ "${{ github.event_name }}" = 'push' ] && [ "${{ github.ref }}" = 'refs/heads/dev' ]; then
             push_docker=true
@@ -561,15 +561,15 @@ jobs:
   # Secrets are not passed to the runner when a workflow is triggered from a forked repository,
   # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
   #
-  # Only push docker image when
-  #   - tests are passed on dev branch
+  # Only try to push docker image when
   #   - parachain-ts-test-hook passes
   #   - tee-test-hook passes
-  # These hooks will always be executed - even when the image didn't change. It shouldn't do harm
-  # even the image is simply downloaded and re-pushed.
+  #   - set-condition.outputs.push-docker is `true`
+  # Whether the parachain or tee-worker image will actually be pushed still depends on if a new image was built/rebuilt.
+  # This is important not to overwrite any other jobs where a rebuild **was** triggered.
   #
-  # We don't have to depend on jobs like `parachain-unit-test` as those jobs have the same file-filter dependencies as
-  # docker image build: `parachain_src` changed, so there must be no new image if `parachain-unit-test` is skipped.
+  # We don't have to depend on jobs like `parachain-unit-test` as they have the same trigger condition `rebuild_parachain`,
+  # so there must be no new image if `parachain-unit-test` is skipped.
   #
   # `!failure()` needs to be used to cover skipped jobs
   push-docker:
@@ -599,8 +599,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Push docker image
+      # only push the docker image if we rebuilt it
+      - name: Push parachain image
+        if: needs.set-condition.outputs.rebuild-parachain == 'true'
         run: |
           docker push litentry/litentry-parachain
+
+      # only push the docker image if we rebuilt it
+      - name: Push tee-worker image
+        if: needs.set-condition.outputs.rebuild-tee == 'true'
+        run: |
           docker push litentry/integritee-worker
           docker push litentry/integritee-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,22 @@ on:
       - synchronize
       - ready_for_review
   workflow_dispatch:
+    inputs:
+      rebuild-parachain-docker:
+        type: boolean
+        description: rebuild-parachain-docker
+        required: true
+        default: true
+      rebuild-tee-docker:
+        type: boolean
+        description: rebuild-tee-docker
+        required: true
+        default: true
+      force-push-docker:
+        type: boolean
+        description: force-push-docker
+        required: true
+        default: fasle
 
 env:
   CARGO_TERM_COLOR: always
@@ -75,6 +91,27 @@ jobs:
         with:
           filters: .github/file-filter.yml
           list-files: shell
+
+      - name: Set env
+        run: |
+          rebuild_parachain=false
+          rebuild_tee=false
+          push_docker=false
+          if [ "${{ github.event.inputs.rebuild-parachain-docker }}" = "true" ] || [ "${{ steps.filter.outputs.parachain_src }}" = "true" ]; then
+            rebuild_parachain=true
+          fi
+          if [ "${{ github.event.inputs.rebuild-tee-docker }}" = "true" ] || [ "${{ steps.filter.outputs.tee_src }}" = "true" ]; then
+            rebuild_tee=true
+          fi
+          if [ "${{ github.event.inputs.force-push-docker }}" = "true" ]; then
+            push_docker=true
+          elif [ "${{ github.event_name }}" = 'push' ] && [ "${{ github.ref }}" = 'refs/heads/dev' ]; then
+            push_docker=true
+          fi
+          echo "REBUILD_PARACHAIN=$rebuild_parachain" >> $GITHUB_ENV
+          echo "REBUILD_TEE=$rebuild_tee" >> $GITHUB_ENV
+          echo "PUSH_DOCKER=$push_docker" >> $GITHUB_ENV
+          env
 
   fmt:
     runs-on: ubuntu-latest
@@ -132,7 +169,7 @@ jobs:
       - fmt
       - check-file-change
       - sequentialise
-    if: needs.check-file-change.outputs.parachain_src == 'true'
+    if: ${{ env.REBUILD_PARACHAIN == 'true' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -158,7 +195,7 @@ jobs:
       - check-file-change
       - sequentialise
     container: "integritee/integritee-dev:0.1.12"
-    if: needs.check-file-change.outputs.tee_src == 'true'
+    if: ${{ env.REBUILD_TEE == 'true' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -196,14 +233,14 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build docker image
-        if: needs.check-file-change.outputs.parachain_src == 'true'
+        if: ${{ env.REBUILD_PARACHAIN == 'true' }}
         run: |
           make build-docker-release
           echo "============================="
           docker images
 
       - name: Pull docker image optinally
-        if: needs.check-file-change.outputs.parachain_src == 'false'
+        if: ${{ env.REBUILD_PARACHAIN != 'true' }}
         run: |
           docker pull litentry/litentry-parachain
 
@@ -237,7 +274,7 @@ jobs:
           driver: docker-container
 
       - name: Build worker (sidechain)
-        if: needs.check-file-change.outputs.tee_src == 'true'
+        if: ${{ env.REBUILD_TEE == 'true' }}
         env:
           DOCKER_BUILDKIT: 1
         run: >
@@ -247,7 +284,7 @@ jobs:
           -f tee-worker/build.Dockerfile .
 
       - name: Build cli (sidechain)
-        if: needs.check-file-change.outputs.tee_src == 'true'
+        if: ${{ env.REBUILD_TEE == 'true' }}
         env:
           DOCKER_BUILDKIT: 1
         run: >
@@ -257,7 +294,7 @@ jobs:
           -f tee-worker/build.Dockerfile .
 
       - name: Pull and tag worker and cli image optionally
-        if: needs.check-file-change.outputs.tee_src == 'false'
+        if: ${{ env.REBUILD_TEE != 'true' }}
         run: |
           docker pull litentry/integritee-worker
           docker pull litentry/integritee-cli
@@ -286,10 +323,9 @@ jobs:
   parachain-ts-test:
     runs-on: ubuntu-latest
     needs:
-      - check-file-change
       - parachain-build
     if: >
-      needs.check-file-change.outputs.parachain_src == 'true' ||
+      env.REBUILD_PARACHAIN == 'true' ||
       needs.check-file-change.outputs.parachain_test == 'true'
     strategy:
       matrix:
@@ -348,7 +384,7 @@ jobs:
       - fmt
       - check-file-change
       - sequentialise
-    if: needs.check-file-change.outputs.parachain_src == 'true'
+    if: ${{ env.REBUILD_PARACHAIN == 'true' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -368,7 +404,7 @@ jobs:
       - fmt
       - check-file-change
       - sequentialise
-    if: needs.check-file-change.outputs.parachain_src == 'true'
+    if: ${{ env.REBUILD_PARACHAIN == 'true' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -404,8 +440,8 @@ jobs:
       - parachain-build
       - tee-build
     if: >
-      needs.check-file-change.outputs.parachain_src == 'true' ||
-      needs.check-file-change.outputs.tee_src == 'true' ||
+      env.REBUILD_PARACHAIN == 'true' ||
+      env.REBUILD_TEE == 'true' ||
       needs.check-file-change.outputs.tee_test == 'true'
     env:
       WORKER_IMAGE_TAG: integritee-worker:dev
@@ -527,7 +563,7 @@ jobs:
     needs:
       - parachain-ts-test-hook
       - tee-test-hook
-    if: ${{ !failure() && (github.event_name == 'push') && (github.ref == 'refs/heads/dev') }}
+    if: ${{ !failure() && env.PUSH_DOCKER == 'true' }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,7 @@ jobs:
         with:
           name: parachain-artifact
           path: litentry-parachain.tar
+          if-no-files-found: error
 
       - name: Fail early
         if: failure()
@@ -332,6 +333,7 @@ jobs:
         with:
           name: tee-artifact
           path: litentry-tee.tar
+          if-no-files-found: error
 
       - name: Fail early
         if: failure()
@@ -371,6 +373,7 @@ jobs:
         with:
           name: ${{ matrix.chain }}-ts-tests-artifacts
           path: /tmp/parachain_dev/
+          if-no-files-found: ignore
           retention-days: 3
 
       - name: Fail early
@@ -528,6 +531,7 @@ jobs:
         with:
           name: logs-${{ matrix.test_name }}
           path: logs
+          if-no-files-found: ignore
 
   # Secrets are not passed to the runner when a workflow is triggered from a forked repository,
   # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
           echo "push_docker=$push_docker" >> $GITHUB_OUTPUT
           echo "run_parachain_test=$run_parachain_test" >> $GITHUB_OUTPUT
           echo "run_tee_test=$run_tee_test" >> $GITHUB_OUTPUT
+
+      - name: Print GITHUB_OUTPUT
+        run: |
           echo "$GITHUB_OUTPUT"
 
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,10 +342,12 @@ jobs:
     needs:
       - set-condition
       - parachain-build
-    if: needs.set-condition.outputs.run_parachain_test == 'true'
     strategy:
       matrix:
-        chain: [litmus, litentry, rococo]
+        chain:
+          - litmus
+          - litentry
+          - rococo
     steps:
       - uses: actions/checkout@v3
 
@@ -358,6 +360,7 @@ jobs:
           docker load -i litentry-parachain.tar
 
       - name: Run ts tests for ${{ matrix.chain }}
+        if: needs.set-condition.outputs.run_parachain_test == 'true'
         timeout-minutes: 20
         run: |
           make test-ts-docker-${{ matrix.chain }}
@@ -370,29 +373,9 @@ jobs:
           path: /tmp/parachain_dev/
           retention-days: 3
 
-      - name: Clean up for ${{ matrix.chain }}
-        if: ${{ always() }}
-        run: |
-          make clean-docker-${{ matrix.chain }}
-
       - name: Fail early
         if: failure()
         uses: andymckay/cancel-action@0.3
-
-  # This "hook" is used in branch protection rules, where we need to cover the matrix in both
-  #   - "successful" status (e.g. parachain-ts-test(litmus)), and
-  #   - "skipped" status (parachain-ts-test).
-  # see https://github.com/orgs/community/discussions/26822
-  parachain-ts-test-hook:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    needs: parachain-ts-test
-    steps:
-      - run: |
-          case "${{ needs.parachain-ts-test.result }}" in
-            success|skipped) exit 0 ;;
-            *) exit 1 ;;
-          esac
 
   parachain-unit-test:
     runs-on: ubuntu-latest
@@ -457,7 +440,6 @@ jobs:
       - set-condition
       - parachain-build
       - tee-build
-    if: needs.set-condition.outputs.run_tee_test == 'true'
     env:
       WORKER_IMAGE_TAG: integritee-worker:dev
       CLIENT_IMAGE_TAG: integritee-cli:dev
@@ -515,20 +497,19 @@ jobs:
           docker compose -f litentry-parachain.build.yml build
 
       - name: Integration Test ${{ matrix.test_name }}
+        if: needs.set-condition.outputs.run_tee_test == 'true'
         timeout-minutes: 30
-        if: ${{ matrix.test_name != 'lit-resume-worker' }}
         run: |
           cd tee-worker/docker
-          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} -- ${{ matrix.test_name }}
-
-      - name: Integration Test ${{ matrix.test_name }}
-        timeout-minutes: 30
-        if: ${{ matrix.test_name == 'lit-resume-worker' }}
-        run: |
-          cd tee-worker/docker
-          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} --attach ${{ matrix.test_name }} relaychain-alice relaychain-bob integritee-node ${{ matrix.test_name }}
+          if [ "${{ matrix.test_name }}" = "lit-resume-worker" ]; then
+            docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} \
+            --attach ${{ matrix.test_name }} relaychain-alice relaychain-bob integritee-node ${{ matrix.test_name }}
+          else
+            docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} -- ${{ matrix.test_name }}
+          fi
 
       - name: Stop docker containers
+        if: needs.set-condition.outputs.run_tee_test == 'true'
         run: |
           cd tee-worker/docker
           docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
@@ -548,23 +529,12 @@ jobs:
           name: logs-${{ matrix.test_name }}
           path: logs
 
-  tee-test-hook:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    needs: tee-test
-    steps:
-      - run: |
-          case "${{ needs.tee-test.result }}" in
-            success|skipped) exit 0 ;;
-            *) exit 1 ;;
-          esac
-
   # Secrets are not passed to the runner when a workflow is triggered from a forked repository,
   # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
   #
   # Only try to push docker image when
-  #   - parachain-ts-test-hook passes
-  #   - tee-test-hook passes
+  #   - parachain-ts-test passes
+  #   - tee-test passes
   #   - set-condition.outputs.push-docker is `true`
   # Whether the parachain or tee-worker image will actually be pushed still depends on if a new image was built/rebuilt.
   # This is important not to overwrite any other jobs where a rebuild **was** triggered.
@@ -577,8 +547,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - set-condition
-      - parachain-ts-test-hook
-      - tee-test-hook
+      - parachain-ts-test
+      - tee-test
     if: ${{ !failure() && needs.set-condition.outputs.push-docker == 'true' }}
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           filters: .github/file-filter.yml
           list-files: shell
 
-      - name: Set env
+      - name: Set condition
         id: env
         run: |
           rebuild_parachain=false
@@ -576,13 +576,13 @@ jobs:
 
       # only push the docker image if we rebuilt it
       - name: Push parachain image
-        if: needs.set-condition.outputs.rebuild-parachain == 'true'
+        if: needs.set-condition.outputs.rebuild_parachain == 'true'
         run: |
           docker push litentry/litentry-parachain
 
       # only push the docker image if we rebuilt it
       - name: Push tee-worker image
-        if: needs.set-condition.outputs.rebuild-tee == 'true'
+        if: needs.set-condition.outputs.rebuild_tee == 'true'
         run: |
           docker push litentry/integritee-worker
           docker push litentry/integritee-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,7 +539,7 @@ jobs:
   # Only try to push docker image when
   #   - parachain-ts-test passes
   #   - tee-test passes
-  #   - set-condition.outputs.push-docker is `true`
+  #   - set-condition.outputs.push_docker is `true`
   # Whether the parachain or tee-worker image will actually be pushed still depends on if a new image was built/rebuilt.
   # This is important not to overwrite any other jobs where a rebuild **was** triggered.
   #
@@ -553,7 +553,7 @@ jobs:
       - set-condition
       - parachain-ts-test
       - tee-test
-    if: ${{ !failure() && needs.set-condition.outputs.push-docker == 'true' }}
+    if: ${{ !failure() && needs.set-condition.outputs.push_docker == 'true' }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
           echo "push_docker=$push_docker" >> $GITHUB_OUTPUT
           echo "run_parachain_test=$run_parachain_test" >> $GITHUB_OUTPUT
           echo "run_tee_test=$run_tee_test" >> $GITHUB_OUTPUT
+          echo "$GITHUB_OUTPUT"
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,9 @@ jobs:
 
       - name: Print GITHUB_OUTPUT
         run: |
+          echo "::group::Github outputs"
           echo "$GITHUB_OUTPUT"
+          echo "::endgroup::"
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR:

- adds inputs to workflow_dispatch to allow forcibly docker image rebuild
- use `set-condition` to extend the file-filter with the input parameters
- remove hooks - the test **job** will always be executed, but the test **step** will be skipped if needed
- only push the image if it's rebuilt