### PR TITLE
Add `NativeTokenMinted` event

### DIFF
--- a/pallets/bridge-transfer/src/lib.rs
+++ b/pallets/bridge-transfer/src/lib.rs
@@ -90,6 +90,8 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// MaximumIssuance was changed
 		MaximumIssuanceChanged { old_value: BalanceOf<T> },
+		/// A certain amount of native tokens was minted
+		NativeTokenMinted { to: T::AccountId, amount: BalanceOf<T> },
 	}
 
 	#[pallet::error]
@@ -176,6 +178,9 @@ pub mod pallet {
 					.ok_or(Error::<T>::OverFlow)?;
 				// ERC20 LIT mint
 				<T as bridge::Config>::Currency::mint_into(&to, amount)?;
+				// There is a Balances.Deposit event but many other extrinsics can
+				// trigger that event, use `NativeTokenMinted` for easier tracking
+				Self::deposit_event(Event::NativeTokenMinted { to, amount });
 				<ExternalBalances<T>>::put(external_balances);
 			} else {
 				return Err(Error::<T>::InvalidResourceId.into())

--- a/pallets/bridge-transfer/src/tests.rs
+++ b/pallets/bridge-transfer/src/tests.rs
@@ -61,10 +61,13 @@ fn transfer() {
 		));
 		assert_eq!(Balances::free_balance(RELAYER_A), ENDOWED_BALANCE + 10);
 
-		assert_events(vec![RuntimeEvent::Balances(balances::Event::Deposit {
-			who: RELAYER_A,
-			amount: 10,
-		})]);
+		assert_events(vec![
+			RuntimeEvent::Balances(balances::Event::Deposit { who: RELAYER_A, amount: 10 }),
+			RuntimeEvent::BridgeTransfer(crate::Event::NativeTokenMinted {
+				to: RELAYER_A,
+				amount: 10,
+			}),
+		]);
 	})
 }
 
@@ -272,6 +275,10 @@ fn create_successful_transfer_proposal() {
 			RuntimeEvent::Bridge(bridge::Event::VoteFor(src_id, prop_id, RELAYER_C)),
 			RuntimeEvent::Bridge(bridge::Event::ProposalApproved(src_id, prop_id)),
 			RuntimeEvent::Balances(balances::Event::Deposit { who: RELAYER_A, amount: 10 }),
+			RuntimeEvent::BridgeTransfer(crate::Event::NativeTokenMinted {
+				to: RELAYER_A,
+				amount: 10,
+			}),
 			RuntimeEvent::Bridge(bridge::Event::ProposalSucceeded(src_id, prop_id)),
 		]);
 	})
@@ -311,10 +318,13 @@ fn test_external_balances_adjusted() {
 		// Check the external_balances
 		assert_eq!(ExternalBalances::<Test>::get(), MaximumIssuance::<Test>::get() / 2 - 10);
 
-		assert_events(vec![RuntimeEvent::Balances(balances::Event::Deposit {
-			who: RELAYER_A,
-			amount: 10,
-		})]);
+		assert_events(vec![
+			RuntimeEvent::Balances(balances::Event::Deposit { who: RELAYER_A, amount: 10 }),
+			RuntimeEvent::BridgeTransfer(crate::Event::NativeTokenMinted {
+				to: RELAYER_A,
+				amount: 10,
+			}),
+		]);
 
 		// Token cross out of parachain
 		// Whitelist setup


### PR DESCRIPTION
resolves #1373 

A minor PR to add a `NativeTokenMinted` event for easier tracking of successful token transfer from ETH => parachain.