### PR TITLE
Fix benchmarking pallet-teerex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ help:
 
 # build release
 
-.PHONY: build-all ## Build release version
+.PHONY: build-all ## Build release all with `tee-dev` feature
 build-all:
 	cargo build --locked --release --features=tee-dev
 
-.PHONY: build-node ## Build release node with default features
+.PHONY: build-node ## Build release node with `tee-dev` feature
 build-node:
 	cargo build --locked -p $(call pkgid, $(NODE_BIN)) --release --features=tee-dev
 
@@ -59,8 +59,9 @@ srtool-build-wasm-rococo:
 	@./scripts/build-wasm.sh rococo
 
 .PHONY: build-docker-release ## Build docker image using cargo profile `release`
+# with `tee-dev` feature as we use release profile in dev
 build-docker-release:
-	@./scripts/build-docker.sh release
+	@./scripts/build-docker.sh release latest --features=tee-dev
 
 .PHONY: build-docker-production ## Build docker image using cargo profile `production`
 build-docker-production:

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ help:
 
 .PHONY: build-all ## Build release version
 build-all:
-	cargo build --locked --release
+	cargo build --locked --release --features=tee-dev
 
 .PHONY: build-node ## Build release node with default features
 build-node:
-	cargo build --locked -p $(call pkgid, $(NODE_BIN)) --release
+	cargo build --locked -p $(call pkgid, $(NODE_BIN)) --release --features=tee-dev
 
 .PHONY: build-runtime-litentry ## Build litentry release runtime
 build-runtime-litentry:
@@ -68,7 +68,7 @@ build-docker-production:
 
 .PHONY: build-node-benchmarks ## Build release node with `runtime-benchmarks` feature
 build-node-benchmarks:
-	cargo build --locked --features runtime-benchmarks --release --no-default-features
+	cargo build --locked --features runtime-benchmarks --release
 
 .PHONY: build-node-tryruntime ## Build release node with `try-runtime` feature
 build-node-tryruntime:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,8 @@ ENV RUSTC_WRAPPER=$RUSTC_WRAPPER
 # see https://github.com/docker/build-push-action/issues/716
 #     https://github.com/moby/buildkit/issues/1512
 #     https://github.com/moby/buildkit/issues/1673
-RUN --mount=type=cache,target=/root/.cache/sccache cargo build --locked --profile $PROFILE $BUILD_ARGS && sccache --show-stats
+# TODO: we'll need build two variants, with and without `tee-dev`, someday.
+RUN --mount=type=cache,target=/root/.cache/sccache cargo build --locked --profile $PROFILE $BUILD_ARGS --features=tee-dev && sccache --show-stats
 
 # ==========================
 # stage 2: packaging

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG BUILD_ARGS
 ARG PROFILE
 
 # TODO: we'll need build two variants, with and without `tee-dev`, someday.
-cargo build --locked --profile $PROFILE $BUILD_ARGS --features=tee-dev
+RUN cargo build --locked --profile $PROFILE $BUILD_ARGS --features=tee-dev
 
 # ==========================
 # stage 2: packaging

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,29 +13,11 @@ COPY . /litentry
 
 RUN apt-get update && apt-get install -yq clang libclang-dev cmake protobuf-compiler
 
-# install sccache, must before `ARG RUSTC_WRAPPER`
-# otherwise the wrapper is set but sccache is not installed
-RUN cargo install sccache
-
 ARG BUILD_ARGS
 ARG PROFILE
-ARG RUSTC_WRAPPER
 
-RUN type sccache && sccache --version
-ENV SCCACHE_CACHE_SIZE=10G
-ENV SCCACHE_DIR=/root/.cache/sccache
-ENV RUSTC_WRAPPER=$RUSTC_WRAPPER
-
-# please note this only works for self-hosted runner (i.e. on the same host)
-# CI across different GH-runners won't work well, my understanding is docker only considers
-# image layers as "bulid cache", and mounted cache doesn't belong to it and therefore not
-# exported/imported with build-push-action
-#
-# see https://github.com/docker/build-push-action/issues/716
-#     https://github.com/moby/buildkit/issues/1512
-#     https://github.com/moby/buildkit/issues/1673
 # TODO: we'll need build two variants, with and without `tee-dev`, someday.
-RUN --mount=type=cache,target=/root/.cache/sccache cargo build --locked --profile $PROFILE $BUILD_ARGS --features=tee-dev && sccache --show-stats
+cargo build --locked --profile $PROFILE $BUILD_ARGS --features=tee-dev
 
 # ==========================
 # stage 2: packaging

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,7 @@ RUN apt-get update && apt-get install -yq clang libclang-dev cmake protobuf-comp
 ARG BUILD_ARGS
 ARG PROFILE
 
-# TODO: we'll need build two variants, with and without `tee-dev`, someday.
-RUN cargo build --locked --profile $PROFILE $BUILD_ARGS --features=tee-dev
+RUN cargo build --locked --profile $PROFILE $BUILD_ARGS
 
 # ==========================
 # stage 2: packaging

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -125,6 +125,5 @@ try-runtime = [
 # allow workers to register without remote attestation for dev purposes
 # currently only available on litmus and rococo
 tee-dev = [
-  "litmus-parachain-runtime/tee-dev",
   "rococo-parachain-runtime/tee-dev",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -102,9 +102,7 @@ rococo-parachain-runtime = { path = "../runtime/rococo" }
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 
 [features]
-default = [
-  "tee-dev",
-]
+default = []
 fast-runtime = [
   "litentry-parachain-runtime/fast-runtime",
   "litmus-parachain-runtime/fast-runtime",

--- a/runtime/litmus/Cargo.toml
+++ b/runtime/litmus/Cargo.toml
@@ -227,10 +227,6 @@ std = [
   "pallet-teeracle/std",
   "pallet-vc-management/std",
 ]
-tee-dev = [
-  "pallet-teerex/skip-ias-check",
-  "pallet-teerex/skip-scheduled-enclave-check",
-]
 try-runtime = [
   "cumulus-pallet-aura-ext/try-runtime",
   "cumulus-pallet-dmp-queue/try-runtime",

--- a/scripts/benchmark-weight-local.sh
+++ b/scripts/benchmark-weight-local.sh
@@ -4,16 +4,13 @@ set -eo pipefail
 
 # This script benchmarks the runtime or pallet weight locally.
 #
-# When benchmarking pallet weight, only our own pallets are supported.
-# Therefore substrate (or other github) pallets are not supported:
-# they are benchmarked by the source anyway (e.g. SubstrateWeigt)
-# The `litentry-collator` binary must be compiled with `runtime-benchmarks` feature.
+# Benchmarking pallet weight only works for the local pallets. Substrate (or other github) pallets are not supported:
+# they are already benchmarked anyway (e.g. SubstrateWeigt)
 #
-# When benchmarking runtime weight, a third parameter is needed to
-# define the runtime: litentry or litmus.
+# The `litentry-collator` binary must be compiled with `runtime-benchmarks` feature.
 
 function usage() {
-    echo "Usage: $0 litentry|litmus pallet-name runtime|pallet"
+    echo "Usage: $0 litentry|litmus|rococo pallet-name runtime|pallet"
 }
 
 [ $# -ne 3 ] && (usage; exit 1)

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -18,7 +18,6 @@ NOCACHE_FLAG=
 
 case "$PROFILE" in
     release)
-        RUSTC_WRAPPER=sccache
         ;;
     production)
         NOCACHE_FLAG="--no-cache" ;;
@@ -49,10 +48,9 @@ GITREPO=litentry-parachain
 # Build the image
 echo "------------------------------------------------------------"
 echo "Building ${GITUSER}/${GITREPO}:${TAG} docker image ..."
-DOCKER_BUILDKIT=1 docker build ${NOCACHE_FLAG} --pull -f ./docker/Dockerfile \
+docker build ${NOCACHE_FLAG} --pull -f ./docker/Dockerfile \
     --build-arg PROFILE="$PROFILE" \
     --build-arg BUILD_ARGS="$ARGS" \
-    --build-arg RUSTC_WRAPPER="$RUSTC_WRAPPER" \
     -t ${GITUSER}/${GITREPO}:${TAG} .
 
 # Tag it with latest if no tag parameter was provided


### PR DESCRIPTION
resolves #1457 

This PR:
- removes the `tee-dev` from default feature in `node/Cargo.toml`
- make sure benchmark
- removes unused sccache wrapper in docker build