### PR TITLE
Update LitentryRococo ss58

### DIFF
--- a/mock-tee-primitives/src/identity.rs
+++ b/mock-tee-primitives/src/identity.rs
@@ -64,6 +64,7 @@ pub enum SubstrateNetwork {
 	Kusama,
 	Litentry,
 	Litmus,
+	LitentryRococo,
 }
 
 impl SubstrateNetwork {
@@ -74,6 +75,7 @@ impl SubstrateNetwork {
 			Self::Kusama => 2,
 			Self::Litentry => 31,
 			Self::Litmus => 131,
+			Self::LitentryRococo => 42,
 		}
 	}
 }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot:
 	// last digit is used for minor updates, like 9110 -> 9111 in polkadot
-	spec_version: 9151,
+	spec_version: 9152,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -167,7 +167,8 @@ pub fn native_version() -> NativeVersion {
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 
-	pub const SS58Prefix: u16 = 131;
+	// using generic substrate prefix
+	pub const SS58Prefix: u16 = 42;
 }
 
 impl frame_system::Config for Runtime {

--- a/tee-worker/litentry/core/assertion-build/src/a4.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a4.rs
@@ -80,10 +80,12 @@ pub fn build(
 			verified_network,
 			VerifiedCredentialsNetwork::Litentry
 				| VerifiedCredentialsNetwork::Litmus
+				| VerifiedCredentialsNetwork::LitentryRococo
 				| VerifiedCredentialsNetwork::Ethereum
 		) {
 			let q_min_balance: f64 = if verified_network == VerifiedCredentialsNetwork::Litentry
 				|| verified_network == VerifiedCredentialsNetwork::Litmus
+				|| verified_network == VerifiedCredentialsNetwork::LitentryRococo
 			{
 				(min_balance / (10 ^ 12)) as f64
 			} else {

--- a/tee-worker/litentry/core/assertion-build/src/a8.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a8.rs
@@ -45,6 +45,7 @@ lazy_static! {
 
 		let litentry = VerifiedCredentialsNetwork::from(SubstrateNetwork::Litentry);
 		let litmus = VerifiedCredentialsNetwork::from(SubstrateNetwork::Litmus);
+		let litentry_rococo = VerifiedCredentialsNetwork::from(SubstrateNetwork::LitentryRococo);
 		let polkadot = VerifiedCredentialsNetwork::from(SubstrateNetwork::Polkadot);
 		let kusama = VerifiedCredentialsNetwork::from(SubstrateNetwork::Kusama);
 		let khala = VerifiedCredentialsNetwork::from(SubstrateNetwork::Khala);
@@ -52,6 +53,7 @@ lazy_static! {
 
 		m.insert(litentry);
 		m.insert(litmus);
+		m.insert(litentry_rococo);
 		m.insert(polkadot);
 		m.insert(kusama);
 		m.insert(khala);
@@ -88,6 +90,12 @@ fn assertion_networks_to_vc_networks(
 								let litmus =
 									VerifiedCredentialsNetwork::from(SubstrateNetwork::Litmus);
 								set.insert(litmus);
+							},
+							"litentry_rococo" => {
+								let litentry_rococo = VerifiedCredentialsNetwork::from(
+									SubstrateNetwork::LitentryRococo,
+								);
+								set.insert(litentry_rococo);
 							},
 							"polkadot" => {
 								let polkadot =
@@ -145,6 +153,9 @@ fn vc_network_to_vec(networks: HashSet<VerifiedCredentialsNetwork>) -> Vec<&'sta
 			},
 			VerifiedCredentialsNetwork::Litmus => {
 				rets.push("litmus");
+			},
+			VerifiedCredentialsNetwork::LitentryRococo => {
+				rets.push("litentry_rococo");
 			},
 			VerifiedCredentialsNetwork::Polkadot => {
 				rets.push("polkadot");
@@ -309,6 +320,7 @@ mod tests {
 		let mut right = HashSet::<VerifiedCredentialsNetwork>::new();
 		right.insert(VerifiedCredentialsNetwork::Litentry);
 		right.insert(VerifiedCredentialsNetwork::Litmus);
+		right.insert(VerifiedCredentialsNetwork::LitentryRococo);
 		right.insert(VerifiedCredentialsNetwork::Polkadot);
 		right.insert(VerifiedCredentialsNetwork::Kusama);
 		right.insert(VerifiedCredentialsNetwork::Khala);
@@ -327,6 +339,7 @@ mod tests {
 		let mut right = HashSet::<VerifiedCredentialsNetwork>::new();
 		right.insert(VerifiedCredentialsNetwork::Litentry);
 		right.insert(VerifiedCredentialsNetwork::Litmus);
+		right.insert(VerifiedCredentialsNetwork::LitentryRococo);
 		right.insert(VerifiedCredentialsNetwork::Polkadot);
 		right.insert(VerifiedCredentialsNetwork::Kusama);
 		right.insert(VerifiedCredentialsNetwork::Khala);

--- a/tee-worker/litentry/core/data-providers/src/graphql.rs
+++ b/tee-worker/litentry/core/data-providers/src/graphql.rs
@@ -51,6 +51,7 @@ impl Default for GraphQLClient {
 pub enum VerifiedCredentialsNetwork {
 	Litentry,
 	Litmus,
+	LitentryRococo,
 	Polkadot,
 	Kusama,
 	Khala,
@@ -62,6 +63,7 @@ impl From<SubstrateNetwork> for VerifiedCredentialsNetwork {
 		match network {
 			SubstrateNetwork::Litmus => Self::Litmus,
 			SubstrateNetwork::Litentry => Self::Litentry,
+			SubstrateNetwork::LitentryRococo => Self::LitentryRococo,
 			SubstrateNetwork::Polkadot => Self::Polkadot,
 			SubstrateNetwork::Kusama => Self::Kusama,
 			SubstrateNetwork::Khala => Self::Khala,

--- a/tee-worker/litentry/primitives/src/identity.rs
+++ b/tee-worker/litentry/primitives/src/identity.rs
@@ -74,7 +74,7 @@ pub enum SubstrateNetwork {
 	Litmus,
 	LitentryRococo,
 	Khala,
-	TestNet,
+	TestNet, // when we launch it with standalone (integritee-)node
 }
 
 impl SubstrateNetwork {

--- a/tee-worker/litentry/primitives/src/identity.rs
+++ b/tee-worker/litentry/primitives/src/identity.rs
@@ -72,6 +72,7 @@ pub enum SubstrateNetwork {
 	Kusama,
 	Litentry,
 	Litmus,
+	LitentryRococo,
 	Khala,
 	TestNet,
 }
@@ -84,6 +85,7 @@ impl SubstrateNetwork {
 			Self::Kusama => 2,
 			Self::Litentry => 31,
 			Self::Litmus => 131,
+			Self::LitentryRococo => 42,
 			Self::Khala => 30,
 			Self::TestNet => 13,
 		}
@@ -95,6 +97,7 @@ impl SubstrateNetwork {
 			2 => Self::Kusama,
 			31 => Self::Litentry,
 			131 => Self::Litmus,
+			42 => Self::LitentryRococo,
 			30 => Self::Khala,
 			_ => Self::TestNet,
 		}

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -345,7 +345,7 @@ describeLitentry('Test Identity', (context) => {
             Substrate: <SubstrateIdentity>{
                 address: `0x${Buffer.from(context.defaultSigner[0].publicKey).toString('hex')}`,
                 // When testing with integritee-node, change network to: TestNet
-                network: 'Litmus',
+                network: 'LitentryRococo',
             },
         };
 

--- a/tee-worker/ts-tests/type-definitions.ts
+++ b/tee-worker/ts-tests/type-definitions.ts
@@ -275,7 +275,7 @@ export type Web3Network = {
 };
 
 export type Web2Network = 'Twitter' | 'Discord' | 'Github';
-export type SubstrateNetwork = 'Polkadot' | 'Kusama' | 'Litentry' | 'Litmus' | 'Khala' | 'TestNet';
+export type SubstrateNetwork = 'Polkadot' | 'Kusama' | 'Litentry' | 'Litmus' | 'LitentryRococo' | 'Khala' | 'TestNet';
 export type EvmNetwork = 'Ethereum' | 'BSC';
 
 export type IdentityGenericEvent = {

--- a/tee-worker/ts-tests/type-definitions.ts
+++ b/tee-worker/ts-tests/type-definitions.ts
@@ -90,7 +90,7 @@ export const teeTypes = {
         _enum: ['Twitter', 'Discord', 'Github'],
     },
     SubstrateNetwork: {
-        _enum: ['Polkadot', 'Kusama', 'Litentry', 'Litmus', 'Khala', 'TestNet'],
+        _enum: ['Polkadot', 'Kusama', 'Litentry', 'Litmus', 'LitentryRococo', 'Khala', 'TestNet'],
     },
     EvmNetwork: {
         _enum: ['Ethereum', 'BSC'],


### PR DESCRIPTION
resolves #1493 

Use `42` (substrate default) for litentry-rococo ss58 prefix. A runtime upgrade is needed later.