### PR TITLE
integritee service stop/restart update

### DIFF
--- a/.github/workflows/dev-sgx-restart.yml
+++ b/.github/workflows/dev-sgx-restart.yml
@@ -8,6 +8,7 @@ on:
         options: 
         - stop
         - restart
+        - restart-worker-only
 jobs:
   action:
     runs-on: tee-staging
@@ -16,8 +17,20 @@ jobs:
         if: "${{ github.event.inputs.action == 'stop' }}"
         run: |
           sudo systemctl stop integritee.service
-      - name: restarting the service
+          sudo /home/ubuntu/repo/litentry-parachain/tee-worker/scripts/litentry/stop_parachain.sh
+          sleep 5
+
+      - name: stoping the service
         if: "${{ github.event.inputs.action == 'restart' }}"
+        run: |
+          sudo systemctl stop integritee.service
+          sudo /home/ubuntu/repo/litentry-parachain/tee-worker/scripts/litentry/stop_parachain.sh
+          sleep 30  #after stoping the docker, it takes some time to release port 9944 by docker-proxy. 
+          sudo /home/ubuntu/repo/litentry-parachain/tee-worker/scripts/litentry/start_parachain.sh
+          sudo systemctl start integritee.service
+
+      - name: restarting the service
+        if: "${{ github.event.inputs.action == 'restart-worker-only' }}"
         run: |
           sudo systemctl stop integritee.service || true
           sleep 5

--- a/.github/workflows/dev-sgx-restart.yml
+++ b/.github/workflows/dev-sgx-restart.yml
@@ -20,7 +20,7 @@ jobs:
           sudo /home/ubuntu/repo/litentry-parachain/tee-worker/scripts/litentry/stop_parachain.sh
           sleep 5
 
-      - name: stoping the service
+      - name: restarting the service
         if: "${{ github.event.inputs.action == 'restart' }}"
         run: |
           sudo systemctl stop integritee.service
@@ -29,7 +29,7 @@ jobs:
           sudo /home/ubuntu/repo/litentry-parachain/tee-worker/scripts/litentry/start_parachain.sh
           sudo systemctl start integritee.service
 
-      - name: restarting the service
+      - name: restarting the worker only
         if: "${{ github.event.inputs.action == 'restart-worker-only' }}"
         run: |
           sudo systemctl stop integritee.service || true


### PR DESCRIPTION
after decoupling the integritee service with docker containers, the service needs to be stopped/restarted differently