### PR TITLE
Add credentialSubject.endpoint pointing VCMP and VCRegistry storage

### DIFF
--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -4402,6 +4402,7 @@ dependencies = [
  "lazy_static",
  "lc-assertion-build",
  "lc-credentials",
+ "lc-data-providers",
  "lc-identity-verification",
  "lc-stf-task-sender",
  "litentry-primitives",

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -2698,6 +2698,7 @@ dependencies = [
  "lazy_static",
  "lc-assertion-build",
  "lc-credentials",
+ "lc-data-providers",
  "lc-identity-verification",
  "lc-stf-task-sender",
  "litentry-primitives",

--- a/tee-worker/enclave-runtime/src/stf_task_handler.rs
+++ b/tee-worker/enclave-runtime/src/stf_task_handler.rs
@@ -58,6 +58,7 @@ pub unsafe extern "C" fn run_stf_task_handler(
 	mut_handle.set_discord_auth_token(data_providers_static.discord_auth_token);
 	mut_handle.set_graphql_url(data_providers_static.graphql_url);
 	mut_handle.set_graphql_auth_key(data_providers_static.graphql_auth_key);
+	mut_handle.set_credential_endpoint(data_providers_static.credential_endpoint);
 
 	if let Err(e) = run_stf_task_handler_internal() {
 		error!("Error while running stf task handler thread: {:?}", e);

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -151,11 +151,7 @@ impl CredentialSubject {
 		self.id.is_empty()
 	}
 
-	// Endpoint Format:
-	// http://localhost:8080/pallets/VCManagement/storage/VCRegistry?keys[]={0xae5940361e60ac780a0f9260bb7dcd938f4599e1626c967bb6cc686f2f9924bd}
-	pub fn set_endpoint(&mut self, sidecar_endpoint: &String) {
-		let endpoint =
-			sidecar_endpoint.to_string() + "/pallets/VCManagement/storage/VCRegistry?keys[]=";
+	pub fn set_endpoint(&mut self, endpoint: String) {
 		self.endpoint = endpoint;
 	}
 }

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -150,6 +150,14 @@ impl CredentialSubject {
 	pub fn is_empty(&self) -> bool {
 		self.id.is_empty()
 	}
+
+	// Endpoint Format:
+	// http://localhost:8080/pallets/VCManagement/storage/VCRegistry?keys[]={0xae5940361e60ac780a0f9260bb7dcd938f4599e1626c967bb6cc686f2f9924bd}
+	pub fn set_endpoint(&mut self, sidecar_endpoint: &String) {
+		let endpoint =
+			sidecar_endpoint.to_string() + "/pallets/VCManagement/storage/VCRegistry?keys[]=";
+		self.endpoint = endpoint;
+	}
 }
 
 /// Verifiable Credentials JSON Schema 2022, W3C, 8 November 2022

--- a/tee-worker/litentry/core/credentials/src/templates/credential.json
+++ b/tee-worker/litentry/core/credentials/src/templates/credential.json
@@ -28,7 +28,7 @@
         "values":[
 
         ],
-        "endpoint":"https://litentry.com/parachain/extrinsic"
+        "endpoint":""
     },
     "proof":{
         "createdBlockNumber":0,

--- a/tee-worker/litentry/core/data-providers/src/lib.rs
+++ b/tee-worker/litentry/core/data-providers/src/lib.rs
@@ -78,6 +78,7 @@ pub struct DataProvidersStatic {
 	pub discord_auth_token: String,
 	pub graphql_url: String,
 	pub graphql_auth_key: String,
+	pub credential_endpoint: String,
 }
 impl Default for DataProvidersStatic {
 	fn default() -> Self {
@@ -95,6 +96,7 @@ impl DataProvidersStatic {
 			discord_auth_token: "".to_string(),
 			graphql_url: "https://graph.tdf-labs.io/".to_string(),
 			graphql_auth_key: "".to_string(),
+			credential_endpoint: "".to_string(),
 		}
 	}
 	pub fn set_twitter_official_url(&mut self, v: String) {
@@ -128,6 +130,10 @@ impl DataProvidersStatic {
 	pub fn set_graphql_auth_key(&mut self, v: String) {
 		debug!("set_graphql_auth_key: {:?}", v);
 		self.graphql_auth_key = v;
+	}
+	pub fn set_credential_endpoint(&mut self, v: String) {
+		debug!("set_credential_endpoint: {:?}", v);
+		self.credential_endpoint = v;
 	}
 }
 

--- a/tee-worker/litentry/core/stf-task/receiver/Cargo.toml
+++ b/tee-worker/litentry/core/stf-task/receiver/Cargo.toml
@@ -52,6 +52,7 @@ frame-support = { default-features = false, git = "https://github.com/paritytech
 ita-sgx-runtime = { path = "../../../../app-libs/sgx-runtime", default-features = false }
 lc-assertion-build = { path = "../../assertion-build", default-features = false }
 lc-credentials = { path = "../../credentials", default-features = false }
+lc-data-providers = { path = "../../data-providers", default-features = false }
 lc-identity-verification = { path = "../../identity-verification", default-features = false }
 lc-stf-task-sender = { path = "../sender", default-features = false }
 litentry-primitives = { path = "../../../primitives", default-features = false }
@@ -81,6 +82,7 @@ sgx = [
     "lc-identity-verification/sgx",
     "lc-assertion-build/sgx",
     "lc-credentials/sgx",
+    "lc-data-providers/sgx",
 ]
 std = [
     "futures",
@@ -109,4 +111,5 @@ std = [
     "frame-support/std",
     "sp-std/std",
     "lc-credentials/std",
+    "lc-data-providers/std",
 ]

--- a/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
@@ -28,6 +28,7 @@ use itp_stf_state_handler::handle_state::HandleState;
 use itp_top_pool_author::traits::AuthorApi;
 use itp_types::OpaqueCall;
 use itp_utils::stringify::account_id_to_string;
+use lc_data_providers::G_DATA_PROVIDERS;
 use lc_stf_task_sender::AssertionBuildRequest;
 use litentry_primitives::{
 	aes_encrypt_default, AesOutput, Assertion, ErrorDetail, ErrorString, VCMPError,
@@ -161,6 +162,10 @@ where
 				ErrorDetail::StfError(ErrorString::truncate_from(format!("{e:?}").into())),
 			)
 		})?;
+		
+		let endpoint_ip = G_DATA_PROVIDERS.read().unwrap().credential_endpoint.clone();
+		credential.credential_subject.set_endpoint(&endpoint_ip);
+
 		credential.issuer.id = account_id_to_string(&enclave_account);
 		let payload = credential.to_json().map_err(|_| {
 			VCMPError::RequestVCFailed(self.req.assertion.clone(), ErrorDetail::ParseError)

--- a/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
@@ -162,9 +162,9 @@ where
 				ErrorDetail::StfError(ErrorString::truncate_from(format!("{e:?}").into())),
 			)
 		})?;
-		
-		let endpoint_ip = G_DATA_PROVIDERS.read().unwrap().credential_endpoint.clone();
-		credential.credential_subject.set_endpoint(&endpoint_ip);
+
+		let credential_endpoint = G_DATA_PROVIDERS.read().unwrap().credential_endpoint.clone();
+		credential.credential_subject.set_endpoint(credential_endpoint);
 
 		credential.issuer.id = account_id_to_string(&enclave_account);
 		let payload = credential.to_json().map_err(|_| {

--- a/tee-worker/service/src/main.rs
+++ b/tee-worker/service/src/main.rs
@@ -885,5 +885,9 @@ fn data_provider(config: &Config) -> DataProvidersStatic {
 	if let Ok(v) = env::var("GRAPHQL_AUTH_KEY") {
 		data_provider_config.set_graphql_auth_key(v);
 	}
+	if let Ok(v) = env::var("CREDENTIAL_ENDPOINT") {
+		data_provider_config.set_credential_endpoint(v);
+	}
+
 	data_provider_config
 }

--- a/tee-worker/service/src/running-mode-config.json
+++ b/tee-worker/service/src/running-mode-config.json
@@ -8,7 +8,7 @@
         "discord_auth_token": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         "graphql_url": "https://graph.tdf-labs.io/",
         "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533",
-        "credential_endpoint": "http://localhost:8080"
+        "credential_endpoint": "http://localhost:9933"
     },
     "mock": {
         "twitter_official_url": "http://localhost:9527",
@@ -19,7 +19,7 @@
         "discord_auth_token": "",
         "graphql_url": "http://localhost:9527",
         "graphql_auth_key": "",
-        "credential_endpoint": "http://localhost:8080"
+        "credential_endpoint": "http://localhost:9933"
     },
     "prod": {
         "twitter_official_url": "https://api.twitter.com",
@@ -30,7 +30,7 @@
         "discord_auth_token": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         "graphql_url": "https://graph.tdf-labs.io/",
         "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533",
-        "credential_endpoint": "57.129.1.73:8080"
+        "credential_endpoint": ""
     },
     "staging": {
         "twitter_official_url": "https://api.twitter.com",
@@ -41,6 +41,6 @@
         "discord_auth_token": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         "graphql_url": "https://graph.tdf-labs.io/",
         "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533",
-        "credential_endpoint": "http://tee-staging.litentry.io:8080"
+        "credential_endpoint": "wss://tee-staging.litentry.io"
     }
 }

--- a/tee-worker/service/src/running-mode-config.json
+++ b/tee-worker/service/src/running-mode-config.json
@@ -7,7 +7,8 @@
         "discord_litentry_url": "http://54.255.182.249:9527",
         "discord_auth_token": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         "graphql_url": "https://graph.tdf-labs.io/",
-        "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533"
+        "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533",
+        "credential_endpoint": "http://localhost:8080"
     },
     "mock": {
         "twitter_official_url": "http://localhost:9527",
@@ -17,7 +18,8 @@
         "discord_litentry_url": "http://localhost:9527",
         "discord_auth_token": "",
         "graphql_url": "http://localhost:9527",
-        "graphql_auth_key": ""
+        "graphql_auth_key": "",
+        "credential_endpoint": "http://localhost:8080"
     },
     "prod": {
         "twitter_official_url": "https://api.twitter.com",
@@ -27,7 +29,8 @@
         "discord_litentry_url": "",
         "discord_auth_token": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         "graphql_url": "https://graph.tdf-labs.io/",
-        "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533"
+        "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533",
+        "credential_endpoint": "57.129.1.73:8080"
     },
     "staging": {
         "twitter_official_url": "https://api.twitter.com",
@@ -37,6 +40,7 @@
         "discord_litentry_url": "http://54.255.182.249:9527",
         "discord_auth_token": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         "graphql_url": "https://graph.tdf-labs.io/",
-        "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533"
+        "graphql_auth_key": "ac2115ec-e327-4862-84c5-f25b6b7d4533",
+        "credential_endpoint": "http://tee-staging.litentry.io:8080"
     }
 }


### PR DESCRIPTION
resolved #1436 

Display json-rpc http server address

~endpoint format:
`"endpoint":"http://localhost:8080/pallets/VCManagement/storage/VCRegistry?keys[]="`~

~If need to query `VCRegistry` storage, need to add `vc_index` to the back, like this:
`http://localhost:8080/pallets/VCManagement/storage/VCRegistry?keys[]=0x8e0ed0e0267e5ca5a0bd16a39af8f6d57afb42c2922ec7aff131eacae5ebf32d`~

~Notice:~

~1. Need to install substrate-api-sidecar.
2. Need to update the corresponding sidecar address, credential_endpoint in running-mode-config.json.~

~Here is the [testcase](https://github.com/zTgx/litentry-test-suit/blob/92266740a237b156333163b3539588faa6daed12/tests/test_vc_management.rs#L458).~
