### PR TITLE
Use an enclave admin as origin

### DIFF
--- a/pallets/identity-management/src/mock.rs
+++ b/pallets/identity-management/src/mock.rs
@@ -129,7 +129,7 @@ impl pallet_teerex::Config for Test {
 	type Currency = Balances;
 	type MomentsPerDay = MomentsPerDay;
 	type WeightInfo = ();
-	type EnclaveAdminOrigin = EnsureRoot<Self::AccountId>;
+	type SetEnclaveAdminOrigin = EnsureRoot<Self::AccountId>;
 }
 
 impl pallet_identity_management::Config for Test {

--- a/pallets/sidechain/src/mock.rs
+++ b/pallets/sidechain/src/mock.rs
@@ -131,7 +131,7 @@ impl pallet_teerex::Config for Test {
 	type Currency = Balances;
 	type MomentsPerDay = MomentsPerDay;
 	type WeightInfo = ();
-	type EnclaveAdminOrigin = EnsureRoot<Self::AccountId>;
+	type SetEnclaveAdminOrigin = EnsureRoot<Self::AccountId>;
 }
 
 parameter_types! {

--- a/pallets/teeracle/src/benchmarking.rs
+++ b/pallets/teeracle/src/benchmarking.rs
@@ -50,10 +50,15 @@ benchmarks! {
 		let rate = U32F32::from_num(43.65);
 		let data_source: DataSource = "https://api.coingecko.com".into();
 
+		Teerex::<T>::set_enclave_admin(
+			RawOrigin::Root.into(),
+			signer.clone(),
+		).unwrap();
+
 		// we need different parameters, unfortunately - since the way to calculate
 		// MRENCLAVE differs depending on if `skip-ias-check` feature is present.
 		Teerex::<T>::update_scheduled_enclave(
-			RawOrigin::Root.into(),
+			RawOrigin::Signed(signer.clone()).into(),
 			0u32,
 			#[cfg(feature = "skip-ias-check")]
 			MrEnclave::decode(&mut TEST4_SETUP.cert).unwrap_or_default(),
@@ -87,10 +92,15 @@ benchmarks! {
 		let oracle_blob: crate::OracleDataBlob<T> =
 			vec![1].try_into().expect("Can Convert to OracleDataBlob<T>; QED");
 
+		Teerex::<T>::set_enclave_admin(
+			RawOrigin::Root.into(),
+			signer.clone(),
+		).unwrap();
+
 		// we need different parameters, unfortunately - since the way to calculate
 		// MRENCLAVE differs depending on if `skip-ias-check` feature is present.
 		Teerex::<T>::update_scheduled_enclave(
-			RawOrigin::Root.into(),
+			RawOrigin::Signed(signer.clone()).into(),
 			0u32,
 			#[cfg(feature = "skip-ias-check")]
 			MrEnclave::decode(&mut TEST4_SETUP.cert).unwrap_or_default(),

--- a/pallets/teeracle/src/mock.rs
+++ b/pallets/teeracle/src/mock.rs
@@ -131,7 +131,7 @@ impl pallet_teerex::Config for Test {
 	type Currency = Balances;
 	type MomentsPerDay = MomentsPerDay;
 	type WeightInfo = ();
-	type EnclaveAdminOrigin = EnsureRoot<Self::AccountId>;
+	type SetEnclaveAdminOrigin = EnsureRoot<Self::AccountId>;
 }
 
 impl Config for Test {

--- a/pallets/teerex/src/benchmarking.rs
+++ b/pallets/teerex/src/benchmarking.rs
@@ -76,10 +76,15 @@ benchmarks! {
 		timestamp::Pallet::<T>::set_timestamp(TEST4_SETUP.timestamp.checked_into().unwrap());
 		let signer: T::AccountId = get_signer(TEST4_SETUP.signer_pub);
 
+		Teerex::<T>::set_enclave_admin(
+			RawOrigin::Root.into(),
+			signer.clone(),
+		).unwrap();
+
 		// we need different parameters, unfortunately - since the way to calculate
 		// MRENCLAVE differs depending on if `skip-ias-check` feature is present.
 		Teerex::<T>::update_scheduled_enclave(
-			RawOrigin::Root.into(),
+			RawOrigin::Signed(signer.clone()).into(),
 			0u32,
 			#[cfg(feature = "skip-ias-check")]
 			MrEnclave::decode(&mut TEST4_SETUP.cert).unwrap_or_default(),

--- a/pallets/teerex/src/lib.rs
+++ b/pallets/teerex/src/lib.rs
@@ -77,13 +77,16 @@ pub mod pallet {
 		type Currency: Currency<<Self as frame_system::Config>::AccountId>;
 		type MomentsPerDay: Get<Self::Moment>;
 		type WeightInfo: WeightInfo;
-		/// origin to manage enclave and parameters
-		type EnclaveAdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+		/// The origin who can set the admin account
+		type SetEnclaveAdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 	}
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
+		EnclaveAdminChanged {
+			old_admin: Option<T::AccountId>,
+		},
 		AddedEnclave(T::AccountId, Vec<u8>),
 		RemovedEnclave(T::AccountId),
 		Forwarded(ShardIdentifier),
@@ -100,6 +103,10 @@ pub mod pallet {
 			data: Vec<u8>,
 		},
 	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn enclave_admin)]
+	pub type EnclaveAdmin<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
 	// Watch out: we start indexing with 1 instead of zero in order to
 	// avoid ambiguity between Null and 0.
@@ -383,7 +390,8 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			timeout: u64,
 		) -> DispatchResultWithPostInfo {
-			T::EnclaveAdminOrigin::ensure_origin(origin)?;
+			let sender = ensure_signed(origin)?;
+			ensure!(Some(sender) == Self::enclave_admin(), Error::<T>::RequireAdmin);
 			<HeartbeatTimeout<T>>::put(T::Moment::saturated_from(timeout));
 			Self::deposit_event(Event::SetHeartbeatTimeout(timeout));
 			Ok(().into())
@@ -453,7 +461,8 @@ pub mod pallet {
 			sidechain_block_number: u32,
 			mr_enclave: MrEnclave,
 		) -> DispatchResultWithPostInfo {
-			T::EnclaveAdminOrigin::ensure_origin(origin)?;
+			let sender = ensure_signed(origin)?;
+			ensure!(Some(sender) == Self::enclave_admin(), Error::<T>::RequireAdmin);
 			ScheduledEnclave::<T>::insert(sidechain_block_number, mr_enclave);
 			Self::deposit_event(Event::UpdatedScheduledEnclave(sidechain_block_number, mr_enclave));
 			Ok(().into())
@@ -482,7 +491,8 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			sidechain_block_number: u32,
 		) -> DispatchResultWithPostInfo {
-			T::EnclaveAdminOrigin::ensure_origin(origin)?;
+			let sender = ensure_signed(origin)?;
+			ensure!(Some(sender) == Self::enclave_admin(), Error::<T>::RequireAdmin);
 			ensure!(
 				ScheduledEnclave::<T>::contains_key(sidechain_block_number),
 				Error::<T>::ScheduledEnclaveNotExist
@@ -542,10 +552,27 @@ pub mod pallet {
 
 			Ok(().into())
 		}
+
+		/// Change the admin account
+		/// similar to sudo.set_key, the old account will be supplied in event
+		#[pallet::call_index(13)]
+		#[pallet::weight((1000, DispatchClass::Normal, Pays::No))]
+		pub fn set_enclave_admin(
+			origin: OriginFor<T>,
+			new: T::AccountId,
+		) -> DispatchResultWithPostInfo {
+			T::SetEnclaveAdminOrigin::ensure_origin(origin)?;
+			Self::deposit_event(Event::EnclaveAdminChanged { old_admin: Self::enclave_admin() });
+			<EnclaveAdmin<T>>::put(new);
+			// Do not pay a fee
+			Ok(Pays::No.into())
+		}
 	}
 
 	#[pallet::error]
 	pub enum Error<T> {
+		/// This operation needs the admin permission
+		RequireAdmin,
 		/// Failed to decode enclave signer.
 		EnclaveSignerDecodeError,
 		/// Sender does not match attested enclave in report.

--- a/pallets/teerex/src/mock.rs
+++ b/pallets/teerex/src/mock.rs
@@ -135,7 +135,7 @@ impl Config for Test {
 	type Currency = Balances;
 	type MomentsPerDay = MomentsPerDay;
 	type WeightInfo = ();
-	type EnclaveAdminOrigin = EnsureRoot<Self::AccountId>;
+	type SetEnclaveAdminOrigin = EnsureRoot<Self::AccountId>;
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -794,7 +794,7 @@ impl pallet_teerex::Config for Runtime {
 	type Currency = Balances;
 	type MomentsPerDay = MomentsPerDay;
 	type WeightInfo = ();
-	type EnclaveAdminOrigin = EnsureRootOrAllCouncil;
+	type SetEnclaveAdminOrigin = EnsureRootOrAllCouncil;
 }
 
 impl pallet_sidechain::Config for Runtime {

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -872,7 +872,7 @@ impl pallet_teerex::Config for Runtime {
 	//       we are missing `register_dcap_enclave` and `register_quoting_enclave`
 	//       it should be re-benchmarked once the upstream fixes it
 	type WeightInfo = ();
-	type EnclaveAdminOrigin = EnsureRootOrAllCouncil;
+	type SetEnclaveAdminOrigin = EnsureRootOrAllCouncil;
 }
 
 impl pallet_sidechain::Config for Runtime {

--- a/tee-worker/cli/lit_set_heartbeat_timeout.sh
+++ b/tee-worker/cli/lit_set_heartbeat_timeout.sh
@@ -35,7 +35,7 @@ NODEURL=${NODEURL:-"ws://127.0.0.1"}
 WORKER1PORT=${WORKER1PORT:-2000}
 WORKER1URL=${WORKER1URL:-"wss://127.0.0.1"}
 
-CLIENT_BIN=${CLIENT_BIN:-"./../bin/integritee-cli"}
+CLIENT_BIN=${CLIENT_BIN:-"./bin/integritee-cli"}
 
 LOG_FOLDER="./../log"
 
@@ -44,7 +44,6 @@ echo "Using node uri $NODEURL:$NPORT"
 echo "Using trusted-worker uri $WORKER1URL:$WORKER1PORT"
 echo ""
 
-ACC=//Alice
 TIMEOUT=5000 # 5 seconds, smaller than 12s (the block duration)
 
 CLIENT="$CLIENT_BIN -p $NPORT -P $WORKER1PORT -u $NODEURL -U $WORKER1URL"
@@ -69,11 +68,11 @@ fi
 
 # indirect call that will be sent to the parachain, it will be synchronously handled
 sleep 10
-echo "* Set $ACC 's heartbeat timeout to $TIMEOUT"
-${CLIENT} set-heartbeat-timeout "$ACC" "$TIMEOUT"
+echo "* Set heartbeat timeout to $TIMEOUT"
+${CLIENT} set-heartbeat-timeout "$TIMEOUT"
 echo ""
 
-sleep 60
+sleep 120
 
 read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
 if [[ -z $MRENCLAVE ]]

--- a/tee-worker/cli/src/base_cli/commands/litentry/set_heartbeat_timeout.rs
+++ b/tee-worker/cli/src/base_cli/commands/litentry/set_heartbeat_timeout.rs
@@ -15,20 +15,16 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-	command_utils::{get_chain_api, *},
+	command_utils::{get_accountid_from_str, get_chain_api, get_pair_from_str},
 	Cli,
 };
 
 use itp_node_api::api_client::TEEREX;
 use log::*;
-use sp_core::sr25519 as sr25519_core;
 use substrate_api_client::{compose_call, compose_extrinsic, UncheckedExtrinsicV4, XtStatus};
 
 #[derive(Parser)]
 pub struct SetHeartbeatTimeoutCommand {
-	/// Sender's parentchain AccountId in ss58check format
-	account: String,
-
 	/// Heartbeat timeout
 	timeout: u64,
 }
@@ -37,17 +33,24 @@ impl SetHeartbeatTimeoutCommand {
 	pub(crate) fn run(&self, cli: &Cli) {
 		let chain_api = get_chain_api(cli);
 
-		// get the sender
-		let from = get_pair_from_str(&self.account);
-		let chain_api = chain_api.set_signer(sr25519_core::Pair::from(from));
+		let alice = get_pair_from_str("//Alice");
+		let chain_api = chain_api.set_signer(alice.into());
 
-		// this call can only be called by sudo
-		#[allow(clippy::redundant_clone)]
-		let call = compose_call!(chain_api.metadata.clone(), TEEREX, "set_heartbeat_timeout", self.timeout);
-		#[allow(clippy::redundant_clone)]
+		// set //Alice as enclave admin
+		let call = compose_call!(
+			chain_api.metadata,
+			TEEREX,
+			"set_enclave_admin",
+			get_accountid_from_str("//Alice")
+		);
 		let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic!(chain_api, "Sudo", "sudo", call);
+		let _ = chain_api.send_extrinsic(xt.hex_encode(), XtStatus::Finalized).unwrap();
 
+		// call set_heartbeat_timeout
+		let xt: UncheckedExtrinsicV4<_, _> =
+			compose_extrinsic!(chain_api, TEEREX, "set_heartbeat_timeout", self.timeout);
 		let tx_hash = chain_api.send_extrinsic(xt.hex_encode(), XtStatus::Finalized).unwrap();
+
 		println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
 	}
 }


### PR DESCRIPTION

It's a prerequisite of the incoming "enclave update" PR.

We need it because the `update_scheduled_enclave` can only be parsed if a raw signed origin type calls it - the indirect-call-executor can't parse `sudo` calls.
