### PR TITLE
Close the direct connection until top is in `Ready` status

### DIFF
--- a/tee-worker/cli/src/trusted_operation.rs
+++ b/tee-worker/cli/src/trusted_operation.rs
@@ -326,12 +326,16 @@ pub(crate) fn wait_until(
 	}
 }
 
+// TODO(Kai@Litentry):
+// only close the connection(return to the caller) when the top status is at least
+// `ready` so that the nonce for pending trusted calls can be correctly retrieved.
+// Let's check how it works.
+// Also see https://github.com/litentry/litentry-parachain/issues/1549
 fn connection_can_be_closed(top_status: TrustedOperationStatus) -> bool {
 	!matches!(
 		top_status,
-		TrustedOperationStatus::Submitted
+		TrustedOperationStatus::Ready
 			| TrustedOperationStatus::Future
-			| TrustedOperationStatus::Ready
 			| TrustedOperationStatus::Broadcast
 	)
 }


### PR DESCRIPTION
resolves #1549 

Please also check the comment in the original issue.