### PR TITLE
Add a configurable parentchain-start-block config parameter

### DIFF
--- a/tee-worker/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/tee-worker/core-primitives/enclave-api/ffi/src/lib.rs
@@ -78,6 +78,12 @@ extern "C" {
 		nonce: *const u32,
 	) -> sgx_status_t;
 
+	pub fn ignore_parentchain_block_import_validation_until(
+		eid: sgx_enclave_id_t,
+		retval: *mut sgx_status_t,
+		until: *const u32,
+	) -> sgx_status_t;
+
 	pub fn set_nonce(
 		eid: sgx_enclave_id_t,
 		retval: *mut sgx_status_t,

--- a/tee-worker/core-primitives/enclave-api/src/sidechain.rs
+++ b/tee-worker/core-primitives/enclave-api/src/sidechain.rs
@@ -33,6 +33,10 @@ pub trait Sidechain: Send + Sync + 'static {
 	) -> EnclaveResult<()>;
 
 	fn execute_trusted_calls(&self) -> EnclaveResult<()>;
+
+	/// Ignore the parentchain block import validation until the given block number
+	/// TODO: use the generic Header::Number trait
+	fn ignore_parentchain_block_import_validation_until(&self, until: u32) -> EnclaveResult<()>;
 }
 
 impl Sidechain for Enclave {
@@ -64,6 +68,19 @@ impl Sidechain for Enclave {
 		let mut retval = sgx_status_t::SGX_SUCCESS;
 
 		let result = unsafe { ffi::execute_trusted_calls(self.eid, &mut retval) };
+
+		ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+		ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+		Ok(())
+	}
+
+	fn ignore_parentchain_block_import_validation_until(&self, until: u32) -> EnclaveResult<()> {
+		let mut retval = sgx_status_t::SGX_SUCCESS;
+
+		let result = unsafe {
+			ffi::ignore_parentchain_block_import_validation_until(self.eid, &mut retval, &until)
+		};
 
 		ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 		ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));

--- a/tee-worker/core/parentchain/light-client/src/lib.rs
+++ b/tee-worker/core/parentchain/light-client/src/lib.rs
@@ -99,7 +99,7 @@ where
 
 	fn get_state(&self) -> &LightValidationState<Block>;
 
-	fn set_ignore_validation_until(&mut self, until: u32);
+	fn set_ignore_validation_until(&mut self, until: u32) -> Result<(), Error>;
 }
 
 pub trait ExtrinsicSender {

--- a/tee-worker/core/parentchain/light-client/src/lib.rs
+++ b/tee-worker/core/parentchain/light-client/src/lib.rs
@@ -98,6 +98,8 @@ where
 	fn set_state(&mut self, state: LightValidationState<Block>);
 
 	fn get_state(&self) -> &LightValidationState<Block>;
+
+	fn set_ignore_validation_until(&mut self, until: u32);
 }
 
 pub trait ExtrinsicSender {

--- a/tee-worker/core/parentchain/light-client/src/light_validation.rs
+++ b/tee-worker/core/parentchain/light-client/src/light_validation.rs
@@ -222,10 +222,10 @@ where
 
 		let relay = self.light_validation_state.get_tracked_relay_mut(relay_id)?;
 
-		if *header.number() > self.ignore_validation_until {
-			if relay.last_finalized_block_header.hash() != *header.parent_hash() {
-				return Err(Error::HeaderAncestryMismatch)
-			}
+		if *header.number() > self.ignore_validation_until
+			&& relay.last_finalized_block_header.hash() != *header.parent_hash()
+		{
+			return Err(Error::HeaderAncestryMismatch)
 		}
 
 		self.submit_finalized_headers(relay_id, header.clone(), vec![], justifications)
@@ -272,8 +272,9 @@ where
 		&self.light_validation_state
 	}
 
-	fn set_ignore_validation_until(&mut self, until: u32) {
+	fn set_ignore_validation_until(&mut self, until: u32) -> Result<(), Error> {
 		self.ignore_validation_until = until.into();
+		Ok(())
 	}
 }
 

--- a/tee-worker/core/parentchain/light-client/src/light_validation.rs
+++ b/tee-worker/core/parentchain/light-client/src/light_validation.rs
@@ -273,6 +273,7 @@ where
 	}
 
 	fn set_ignore_validation_until(&mut self, until: u32) -> Result<(), Error> {
+		info!("set ignore parentchain block import validation until: {}", until);
 		self.ignore_validation_until = until.into();
 		Ok(())
 	}

--- a/tee-worker/core/parentchain/light-client/src/light_validation.rs
+++ b/tee-worker/core/parentchain/light-client/src/light_validation.rs
@@ -39,6 +39,7 @@ pub struct LightValidation<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChai
 	light_validation_state: LightValidationState<Block>,
 	ocall_api: Arc<OcallApi>,
 	finality: Arc<Box<dyn Finality<Block> + Sync + Send + 'static>>,
+	ignore_validation_until: NumberFor<Block>,
 }
 
 impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
@@ -48,7 +49,12 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 		ocall_api: Arc<OcallApi>,
 		finality: Arc<Box<dyn Finality<Block> + Sync + Send + 'static>>,
 	) -> Self {
-		Self { light_validation_state: LightValidationState::new(), ocall_api, finality }
+		Self {
+			light_validation_state: LightValidationState::new(),
+			ocall_api,
+			finality,
+			ignore_validation_until: 0u32.into(),
+		}
 	}
 
 	fn initialize_relay(
@@ -125,9 +131,11 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 		let validator_set = relay.current_validator_set.clone();
 		let validator_set_id = relay.current_validator_set_id;
 
-		// Check that the new header is a descendant of the old header
-		let last_header = &relay.last_finalized_block_header;
-		Self::verify_ancestry(ancestry_proof, last_header.hash(), &header)?;
+		if *header.number() > self.ignore_validation_until {
+			// Check that the new header is a descendant of the old header
+			let last_header = &relay.last_finalized_block_header;
+			Self::verify_ancestry(ancestry_proof, last_header.hash(), &header)?;
+		}
 
 		if let Err(e) = self.finality.validate(
 			header.clone(),
@@ -214,8 +222,10 @@ where
 
 		let relay = self.light_validation_state.get_tracked_relay_mut(relay_id)?;
 
-		if relay.last_finalized_block_header.hash() != *header.parent_hash() {
-			return Err(Error::HeaderAncestryMismatch)
+		if *header.number() > self.ignore_validation_until {
+			if relay.last_finalized_block_header.hash() != *header.parent_hash() {
+				return Err(Error::HeaderAncestryMismatch)
+			}
 		}
 
 		self.submit_finalized_headers(relay_id, header.clone(), vec![], justifications)
@@ -260,6 +270,10 @@ where
 
 	fn get_state(&self) -> &LightValidationState<Block> {
 		&self.light_validation_state
+	}
+
+	fn set_ignore_validation_until(&mut self, until: u32) {
+		self.ignore_validation_until = until.into();
 	}
 }
 

--- a/tee-worker/core/parentchain/light-client/src/mocks/validator_mock.rs
+++ b/tee-worker/core/parentchain/light-client/src/mocks/validator_mock.rs
@@ -71,8 +71,8 @@ impl Validator<Block> for ValidatorMock {
 		&self.light_validation_state
 	}
 
-	fn set_ignore_validation_until(&mut self, until: u32) {
-		todo!()
+	fn set_ignore_validation_until(&mut self, until: u32) -> Result<()> {
+		Ok(())
 	}
 }
 

--- a/tee-worker/core/parentchain/light-client/src/mocks/validator_mock.rs
+++ b/tee-worker/core/parentchain/light-client/src/mocks/validator_mock.rs
@@ -70,6 +70,10 @@ impl Validator<Block> for ValidatorMock {
 	fn get_state(&self) -> &LightValidationState<Block> {
 		&self.light_validation_state
 	}
+
+	fn set_ignore_validation_until(&mut self, until: u32) {
+		todo!()
+	}
 }
 
 impl ExtrinsicSender for ValidatorMock {

--- a/tee-worker/enclave-runtime/Enclave.edl
+++ b/tee-worker/enclave-runtime/Enclave.edl
@@ -72,6 +72,10 @@ enclave {
 			[in] uint32_t* nonce
 		);
 
+		public sgx_status_t ignore_parentchain_block_import_validation_until(
+			[in] uint32_t* until
+		);
+
 		public sgx_status_t set_nonce(
 			[in] uint32_t* nonce
 		);

--- a/tee-worker/enclave-runtime/src/lib.rs
+++ b/tee-worker/enclave-runtime/src/lib.rs
@@ -39,12 +39,16 @@ use crate::{
 	rpc::worker_api_direct::sidechain_io_handler,
 	utils::{
 		get_node_metadata_repository_from_solo_or_parachain,
-		get_triggered_dispatcher_from_solo_or_parachain, utf8_str_from_raw, DecodeRaw,
+		get_triggered_dispatcher_from_solo_or_parachain,
+		get_validator_accessor_from_solo_or_parachain, utf8_str_from_raw, DecodeRaw,
 	},
 };
 use codec::{alloc::string::String, Decode};
-use itc_parentchain::block_import_dispatcher::{
-	triggered_dispatcher::TriggerParentchainBlockImport, DispatchBlockImport,
+use itc_parentchain::{
+	block_import_dispatcher::{
+		triggered_dispatcher::TriggerParentchainBlockImport, DispatchBlockImport,
+	},
+	light_client::{concurrent_access::ValidatorAccess, Validator},
 };
 use itp_block_import_queue::PushToBlockQueue;
 use itp_component_container::ComponentGetter;
@@ -381,6 +385,24 @@ pub unsafe extern "C" fn sync_parentchain(
 	if let Err(e) = dispatch_parentchain_blocks_for_import::<WorkerModeProvider>(blocks_to_sync) {
 		return e.into()
 	}
+
+	sgx_status_t::SGX_SUCCESS
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ignore_parentchain_block_import_validation_until(
+	until: *const u32,
+) -> sgx_status_t {
+	let validator_access = match get_validator_accessor_from_solo_or_parachain() {
+		Ok(r) => r,
+		Err(e) => {
+			error!("Component get failure: {:?}", e);
+			return sgx_status_t::SGX_ERROR_UNEXPECTED
+		},
+	};
+
+	let _ =
+		validator_access.execute_mut_on_validator(|v| Ok(v.set_ignore_validation_until(*until)));
 
 	sgx_status_t::SGX_SUCCESS
 }

--- a/tee-worker/enclave-runtime/src/lib.rs
+++ b/tee-worker/enclave-runtime/src/lib.rs
@@ -393,16 +393,15 @@ pub unsafe extern "C" fn sync_parentchain(
 pub unsafe extern "C" fn ignore_parentchain_block_import_validation_until(
 	until: *const u32,
 ) -> sgx_status_t {
-	let validator_access = match get_validator_accessor_from_solo_or_parachain() {
+	let va = match get_validator_accessor_from_solo_or_parachain() {
 		Ok(r) => r,
 		Err(e) => {
-			error!("Component get failure: {:?}", e);
+			error!("Can't get validator accessor: {:?}", e);
 			return sgx_status_t::SGX_ERROR_UNEXPECTED
 		},
 	};
 
-	let _ =
-		validator_access.execute_mut_on_validator(|v| Ok(v.set_ignore_validation_until(*until)));
+	let _ = va.execute_mut_on_validator(|v| v.set_ignore_validation_until(*until));
 
 	sgx_status_t::SGX_SUCCESS
 }

--- a/tee-worker/local-setup/github-action-config-one-worker.json
+++ b/tee-worker/local-setup/github-action-config-one-worker.json
@@ -14,7 +14,9 @@
         "4545",
         "--running-mode",
         "mock",
-        "--enable-mock-server"
+        "--enable-mock-server",
+        "--parentchain-start-block",
+        "0"
       ],
       "subcommand_flags": [
         "--skip-ra",

--- a/tee-worker/service/src/cli.yml
+++ b/tee-worker/service/src/cli.yml
@@ -96,6 +96,11 @@ args:
         help: Set the port for the mock-server HTTP server
         required: false
         default_value: "19527"
+    - parentchain-start-block:
+        long: parentchain-start-block
+        help: Set the parentchain block number to start syncing with
+        required: false
+        default_value: "0"
 
 subcommands:
     - run:

--- a/tee-worker/service/src/cli.yml
+++ b/tee-worker/service/src/cli.yml
@@ -90,15 +90,18 @@ args:
         default_value: "dev"
     - enable-mock-server:
         long: enable-mock-server
-        help: Set this flag to enable starting the mock server.
+        takes_value: false
+        help: Set this flag to enable the HTTP mock server for testing
     - mock-server-port:
         long: mock-server-port
-        help: Set the port for the mock-server HTTP server
+        help: Set the port for HTTP mock server
+        takes_value: true
         required: false
         default_value: "19527"
     - parentchain-start-block:
         long: parentchain-start-block
         help: Set the parentchain block number to start syncing with
+        takes_value: true
         required: false
         default_value: "0"
 

--- a/tee-worker/service/src/config.rs
+++ b/tee-worker/service/src/config.rs
@@ -63,6 +63,8 @@ pub struct Config {
 	pub running_mode: String,
 	pub enable_mock_server: bool,
 	pub mock_server_port: u16,
+	/// the parentchain block number to start syncing with
+	pub parentchain_start_block: u64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -84,6 +86,7 @@ impl Config {
 		running_mode: String,
 		enable_mock_server: bool,
 		mock_server_port: u16,
+		parentchain_start_block: u64,
 	) -> Self {
 		Self {
 			node_ip,
@@ -102,6 +105,7 @@ impl Config {
 			running_mode,
 			enable_mock_server,
 			mock_server_port,
+			parentchain_start_block,
 		}
 	}
 
@@ -167,6 +171,7 @@ impl From<&ArgMatches<'_>> for Config {
 		let run_config = m.subcommand_matches("run").map(RunConfig::from);
 		let is_mock_server_enabled = m.is_present("enable-mock-server");
 		let mock_server_port = m.value_of("mock-server-port").unwrap_or(DEFAULT_MOCK_SERVER_PORT);
+		let parentchain_start_block = m.value_of("parentchain-start-block").unwrap_or_default();
 		Self::new(
 			m.value_of("node-server").unwrap_or(DEFAULT_NODE_SERVER).into(),
 			m.value_of("node-port").unwrap_or(DEFAULT_NODE_PORT).into(),

--- a/tee-worker/service/src/config.rs
+++ b/tee-worker/service/src/config.rs
@@ -301,6 +301,7 @@ mod test {
 
 		// running mode for litentry: dev / staging / prod
 		let running_mode = "dev";
+		let parentchain_start_block = "0";
 
 		let mut args = ArgMatches::default();
 		args.args = HashMap::from([
@@ -315,6 +316,7 @@ mod test {
 			("trusted-worker-port", Default::default()),
 			("untrusted-http-port", Default::default()),
 			("running-mode", Default::default()),
+			("parentchain-start-block", Default::default()),
 		]);
 		// Workaround because MatchedArg is private.
 		args.args.get_mut("node-server").unwrap().vals = vec![node_ip.into()];
@@ -328,6 +330,8 @@ mod test {
 		args.args.get_mut("trusted-worker-port").unwrap().vals = vec![trusted_port.into()];
 		args.args.get_mut("untrusted-http-port").unwrap().vals = vec![untrusted_http_port.into()];
 		args.args.get_mut("running-mode").unwrap().vals = vec![running_mode.into()];
+		args.args.get_mut("parentchain-start-block").unwrap().vals =
+			vec![parentchain_start_block.into()];
 
 		let config = Config::from(&args);
 
@@ -341,6 +345,7 @@ mod test {
 		assert_eq!(config.mu_ra_external_address, Some(mu_ra_ext_addr.to_string()));
 		assert_eq!(config.untrusted_http_port, untrusted_http_port.to_string());
 		assert_eq!(config.running_mode, running_mode.to_string());
+		assert_eq!(config.parentchain_start_block, parentchain_start_block.to_string());
 	}
 
 	#[test]

--- a/tee-worker/service/src/config.rs
+++ b/tee-worker/service/src/config.rs
@@ -64,7 +64,7 @@ pub struct Config {
 	pub enable_mock_server: bool,
 	pub mock_server_port: u16,
 	/// the parentchain block number to start syncing with
-	pub parentchain_start_block: u64,
+	pub parentchain_start_block: u32,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -86,7 +86,7 @@ impl Config {
 		running_mode: String,
 		enable_mock_server: bool,
 		mock_server_port: u16,
-		parentchain_start_block: u64,
+		parentchain_start_block: u32,
 	) -> Self {
 		Self {
 			node_ip,
@@ -192,6 +192,7 @@ impl From<&ArgMatches<'_>> for Config {
 			m.value_of("running-mode").unwrap_or(DEFAULT_RUNNING_MODE).to_string(),
 			is_mock_server_enabled,
 			u16::from_str(mock_server_port).unwrap(),
+			u32::from_str(parentchain_start_block).unwrap(),
 		)
 	}
 }

--- a/tee-worker/service/src/main.rs
+++ b/tee-worker/service/src/main.rs
@@ -678,10 +678,15 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 
 	if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
 		println!("*** [+] Finished syncing light client, syncing parentchain...");
+		println!(
+			"*** [+] last_synced_header: {}, config.parentchain_start_block: {}",
+			last_synced_header.number, config.parentchain_start_block
+		);
 
 		// Syncing all parentchain blocks, this might take a while..
-		let mut last_synced_header =
-			parentchain_handler.sync_parentchain(last_synced_header).unwrap();
+		let mut last_synced_header = parentchain_handler
+			.sync_parentchain(last_synced_header, config.parentchain_start_block)
+			.unwrap();
 
 		// ------------------------------------------------------------------------
 		// Initialize the sidechain
@@ -693,6 +698,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 				parentchain_handler.clone(),
 				sidechain_storage,
 				&last_synced_header,
+				config.parentchain_start_block,
 			)
 			.unwrap();
 		}
@@ -905,7 +911,8 @@ fn subscribe_to_parentchain_new_headers<E: EnclaveBase + Sidechain>(
 			new_header.number
 		);
 
-		last_synced_header = parentchain_handler.sync_parentchain(last_synced_header)?;
+		// the overriden_start_block shouldn't matter here
+		last_synced_header = parentchain_handler.sync_parentchain(last_synced_header, 0)?;
 	}
 }
 

--- a/tee-worker/service/src/main.rs
+++ b/tee-worker/service/src/main.rs
@@ -201,6 +201,9 @@ fn main() {
 		let enclave = enclave.clone();
 		let trusted_server_url = format!("wss://localhost:{}", config.trusted_worker_port);
 		let base58_enclave = enclave.get_mrenclave().unwrap().encode().to_base58();
+		let mock_server_port = config
+			.try_parse_mock_server_port()
+			.expect("mock server port to be a valid port number");
 		thread::spawn(move || {
 			info!("*** Starting mock server");
 			let getter = Arc::new(move |account: &AccountId32, identity: &Identity| {
@@ -261,7 +264,7 @@ fn main() {
 					},
 				}
 			});
-			let _ = lc_mock_server::run(getter, config.mock_server_port);
+			let _ = lc_mock_server::run(getter, mock_server_port);
 		});
 	}
 
@@ -677,15 +680,18 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	}
 
 	if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
+		let parentchain_start_block = config
+			.try_parse_parentchain_start_block()
+			.expect("parentchain start block to be a valid number");
 		println!("*** [+] Finished syncing light client, syncing parentchain...");
 		println!(
 			"*** [+] last_synced_header: {}, config.parentchain_start_block: {}",
-			last_synced_header.number, config.parentchain_start_block
+			last_synced_header.number, parentchain_start_block
 		);
 
 		// Syncing all parentchain blocks, this might take a while..
 		let mut last_synced_header = parentchain_handler
-			.sync_parentchain(last_synced_header, config.parentchain_start_block)
+			.sync_parentchain(last_synced_header, parentchain_start_block)
 			.unwrap();
 
 		// ------------------------------------------------------------------------
@@ -698,7 +704,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 				parentchain_handler.clone(),
 				sidechain_storage,
 				&last_synced_header,
-				config.parentchain_start_block,
+				parentchain_start_block,
 			)
 			.unwrap();
 		}

--- a/tee-worker/service/src/sidechain_setup.rs
+++ b/tee-worker/service/src/sidechain_setup.rs
@@ -61,6 +61,7 @@ pub(crate) fn sidechain_init_block_production<Enclave, SidechainStorage, Parentc
 	parentchain_handler: Arc<ParentchainHandler>,
 	sidechain_storage: Arc<SidechainStorage>,
 	last_synced_header: &Header,
+	overriden_start_block: u32,
 ) -> ServiceResult<Header>
 where
 	Enclave: EnclaveBase + Sidechain,
@@ -77,6 +78,7 @@ where
 		updated_header = Some(parentchain_handler.sync_and_import_parentchain_until(
 			last_synced_header,
 			&register_enclave_xt_header.unwrap(),
+			overriden_start_block,
 		)?);
 	}
 

--- a/tee-worker/service/src/tests/commons.rs
+++ b/tee-worker/service/src/tests/commons.rs
@@ -52,7 +52,7 @@ pub fn local_worker_config(
 		None,
 		Default::default(),
 		false,
-		19527,
-		0,
+		"19527".to_string(),
+		"0".to_string(),
 	)
 }

--- a/tee-worker/service/src/tests/commons.rs
+++ b/tee-worker/service/src/tests/commons.rs
@@ -53,5 +53,6 @@ pub fn local_worker_config(
 		Default::default(),
 		false,
 		19527,
+		0,
 	)
 }

--- a/tee-worker/service/src/tests/mocks/enclave_api_mock.rs
+++ b/tee-worker/service/src/tests/mocks/enclave_api_mock.rs
@@ -100,4 +100,8 @@ impl Sidechain for EnclaveMock {
 	fn execute_trusted_calls(&self) -> EnclaveResult<()> {
 		todo!()
 	}
+
+	fn ignore_parentchain_block_import_validation_until(&self, _until: u32) -> EnclaveResult<()> {
+		todo!()
+	}
 }

--- a/tee-worker/service/src/tests/parentchain_handler_test.rs
+++ b/tee-worker/service/src/tests/parentchain_handler_test.rs
@@ -44,6 +44,8 @@ fn test_number_of_synced_blocks() {
 		parentchain_params,
 	);
 
-	let header = parentchain_handler.sync_parentchain(last_synced_block.block.header).unwrap();
+	let header = parentchain_handler
+		.sync_parentchain(last_synced_block.block.header, 0u32)
+		.unwrap();
 	assert_eq!(header.number, number_of_blocks);
 }


### PR DESCRIPTION
resolves #1399 

It allows us to start syncing with parachain from a given block number, configured via the command line. See: `tee-worker/local-setup/github-action-config-one-worker.json` as example.

Tested OK locally.