### PR TITLE
Revert to old version of listenEvent

### DIFF
--- a/tee-worker/ts-tests/bulk_identity.test.ts
+++ b/tee-worker/ts-tests/bulk_identity.test.ts
@@ -13,9 +13,7 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { ethers } from 'ethers';
 import { LitentryIdentity, LitentryValidationData } from './common/type-definitions';
 import { handleIdentityEvents } from './common/utils';
-import { assert } from 'chai';
 import { multiAccountTxSender } from './common/transactions';
-import { u8aToHex } from '@polkadot/util';
 import { SubmittableResult } from '@polkadot/api';
 
 //Explain how to use this test, which has two important parameters:
@@ -44,15 +42,16 @@ describeLitentry('multiple accounts test', 2, async (context) => {
             txs.push(tx);
         }
 
-        await new Promise((resolve) => {
+        await new Promise((resolve, reject) => {
             context.api.tx.utility
                 .batch(txs)
                 .signAndSend(context.substrateWallet.alice, async (result: SubmittableResult) => {
-                    if (result.status.isInBlock) {
+                    if (result.status.isFinalized) {
                         console.log(`Transaction included at blockHash ${result.status.asInBlock}`);
                         resolve(result.status);
                     } else if (result.status.isInvalid) {
                         console.log(`Transaction is ${result.status}`);
+                        reject(result.status);
                     }
                 });
         });

--- a/tee-worker/ts-tests/common/utils.ts
+++ b/tee-worker/ts-tests/common/utils.ts
@@ -777,7 +777,7 @@ export async function assertInitialIDGraphCreated(api: ApiPromise, signer: Keyri
     // check identity in idgraph
     const expected_identity = api.createType(
         'LitentryIdentity',
-        await buildIdentityHelper(u8aToHex(signer.addressRaw), 'TestNet', 'Substrate')
+        await buildIdentityHelper(u8aToHex(signer.addressRaw), 'LitentryRococo', 'Substrate')
     ) as LitentryIdentity;
 
     assert.equal(JSON.stringify(event.idGraph[0][0]), JSON.stringify(expected_identity));

--- a/tee-worker/ts-tests/common/utils.ts
+++ b/tee-worker/ts-tests/common/utils.ts
@@ -777,10 +777,10 @@ export async function assertInitialIDGraphCreated(api: ApiPromise, signer: Keyri
     // check identity in idgraph
     const expected_identity = api.createType(
         'LitentryIdentity',
-        await buildIdentityHelper(u8aToHex(signer.addressRaw), 'LitentryRococo', 'Substrate')
+        await buildIdentityHelper(u8aToHex(signer.addressRaw), 'TestNet', 'Substrate')
     ) as LitentryIdentity;
 
-    assert.isTrue(isEqual(event.idGraph[0][0], expected_identity));
+    assert.equal(JSON.stringify(event.idGraph[0][0]), JSON.stringify(expected_identity));
     // check identityContext in idgraph
     assert.equal(event.idGraph[0][1].linking_request_block, 0);
     assert.equal(event.idGraph[0][1].verification_request_block, 0);

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -119,7 +119,7 @@ describeLitentry('Test Identity', 0, (context) => {
         // the main address should be already inside the IDGraph
         const main_identity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.alice.addressRaw),
-            'TestNet',
+            'LitentryRococo',
             'Substrate'
         );
         const identity_hex = context.api.createType('LitentryIdentity', main_identity).toHex();

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -574,7 +574,7 @@ describeLitentry('Test Identity', 0, (context) => {
         // remove prime identity
         const substratePrimeIdentity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.alice.addressRaw),
-            'TestNet',
+            'LitentryRococo',
             'Substrate'
         );
 

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -101,13 +101,17 @@ describeLitentry('Test Identity', 0, (context) => {
         await assertInitialIDGraphCreated(context.api, context.substrateWallet.bob, bob);
     });
 
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
     step('check user shielding key from sidechain storage after setUserShieldingKey', async function () {
+        await sleep(6000);
         const resp_shieldingKey = await checkUserShieldingKeys(
             context,
             'IdentityManagement',
             'UserShieldingKeys',
             u8aToHex(context.substrateWallet.alice.addressRaw)
         );
+        await sleep(6000);
         assert.equal(resp_shieldingKey, aesKey, 'resp_shieldingKey should be equal aesKey after set');
     });
 
@@ -115,7 +119,7 @@ describeLitentry('Test Identity', 0, (context) => {
         // the main address should be already inside the IDGraph
         const main_identity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.alice.addressRaw),
-            'LitentryRococo',
+            'TestNet',
             'Substrate'
         );
         const identity_hex = context.api.createType('LitentryIdentity', main_identity).toHex();
@@ -284,7 +288,7 @@ describeLitentry('Test Identity', 0, (context) => {
         const twitter_identity = alice_identities[0];
         const ethereum_validation = alice_validations[1];
 
-        //verify twitter identity with ethereum validation
+        //verify twitter identity with ethereum validation----------
         let alice_txs = await buildIdentityTxs(
             context,
             context.substrateWallet.alice,
@@ -570,7 +574,7 @@ describeLitentry('Test Identity', 0, (context) => {
         // remove prime identity
         const substratePrimeIdentity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.alice.addressRaw),
-            'LitentryRococo',
+            'TestNet',
             'Substrate'
         );
 


### PR DESCRIPTION
Attempt to address the issue in [this comment](https://github.com/litentry/litentry-parachain/pull/1624#issuecomment-1534374083).

@Verin1005 I tried to match events to extrinsics [the canonical way](https://polkadot.js.org/docs/api/cookbook/blocks#how-do-i-map-extrinsics-to-their-events); the main issue I kept running into was being unable to determine the index within the block for individual extrinsics bundled in a single `batchAll` call inside `sendTxsWithUtility`.

The closest I could find in terms of documentation was [this question about `batch` on StackExchange](https://substrate.stackexchange.com/questions/174/correlate-events-with-extrinsics-in-a-utility-batch-call-in-polkadot), but I can't quite tell if `batchAll` emits the same set of events :P

To unblock the fix for #1571, I'm just restoring the previous version of `listenEvent` (modulo a tiny refactoring).