### PR TITLE
ts-test use generated types

### DIFF
--- a/tee-worker/ts-tests/bulk_identity.test.ts
+++ b/tee-worker/ts-tests/bulk_identity.test.ts
@@ -15,6 +15,7 @@ import { handleIdentityEvents } from './common/utils';
 import { assert } from 'chai';
 import { listenEvent, multiAccountTxSender } from './common/transactions';
 import { u8aToHex } from '@polkadot/util';
+import { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types';
 
 //Explain how to use this test, which has two important parameters:
 //1.The "number" parameter in describeLitentry represents the number of accounts generated, including Substrate wallets and Ethereum wallets.If you want to use a large number of accounts for testing, you can modify this parameter.
@@ -35,7 +36,7 @@ describeLitentry('multiple accounts test', 10, async (context) => {
         });
     });
     step('send test token to each account', async () => {
-        const txs: any = [];
+        const txs: SubmittableExtrinsic<ApiTypes>[] = [];
         for (let i = 0; i < substraetSigners.length; i++) {
             //1 token
             const tx = context.api.tx.balances.transfer(substraetSigners[i].address, '1000000000000');

--- a/tee-worker/ts-tests/bulk_vc.test.ts
+++ b/tee-worker/ts-tests/bulk_vc.test.ts
@@ -9,6 +9,7 @@ import { blake2AsHex } from '@polkadot/util-crypto';
 import { assert } from 'chai';
 import { HexString } from '@polkadot/util/types';
 import { listenEvent, multiAccountTxSender } from './common/transactions';
+import { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types';
 const assertion = <Assertion>{
     A1: 'A1',
     A2: ['A2'],
@@ -40,7 +41,8 @@ describeLitentry('multiple accounts test', 10, async (context) => {
         });
     });
     step('send test token to each account', async () => {
-        const txs: any = [];
+        const txs: SubmittableExtrinsic<ApiTypes>[] = [];
+
         for (let i = 0; i < substrateSigners.length; i++) {
             //1 token
             const tx = context.api.tx.balances.transfer(substrateSigners[i].address, '1000000000000');

--- a/tee-worker/ts-tests/common/call.ts
+++ b/tee-worker/ts-tests/common/call.ts
@@ -10,9 +10,10 @@ export async function sendRequest(
     api: ApiPromise
 ): Promise<WorkerRpcReturnValue> {
     const resp = await wsClient.sendRequest(request, { requestId: 1, timeout: 6000 });
-    const resp_json = api.createType('WorkerRpcReturnValue', resp.result).toJSON() as unknown as WorkerRpcReturnValue;
 
-    if (resp_json.status.type === 'Error') {
+    const resp_json = api.createType('WorkerRpcReturnValue', resp.result).toJSON() as WorkerRpcReturnValue;
+
+    if (resp_json.status === 'Error') {
         throw new Error('RPC call error');
     }
     return resp_json;

--- a/tee-worker/ts-tests/common/call.ts
+++ b/tee-worker/ts-tests/common/call.ts
@@ -1,25 +1,24 @@
 import { ApiPromise } from '@polkadot/api';
 import { Metadata, TypeRegistry } from '@polkadot/types';
 import WebSocketAsPromised from 'websocket-as-promised';
-import { WorkerRpcReturnValue, IdentityContext } from './type-definitions';
 import { HexString } from '@polkadot/util/types';
-
+import { RequestBody, WorkerRpcReturnValue } from '../common/type-definitions';
 //rpc call
 export async function sendRequest(
     wsClient: WebSocketAsPromised,
-    request: any,
+    request: RequestBody,
     api: ApiPromise
 ): Promise<WorkerRpcReturnValue> {
     const resp = await wsClient.sendRequest(request, { requestId: 1, timeout: 6000 });
-    const resp_json = api.createType('WorkerRpcReturnValue', resp.result).toJSON() as WorkerRpcReturnValue;
+    const resp_json = api.createType('WorkerRpcReturnValue', resp.result).toJSON() as unknown as WorkerRpcReturnValue;
 
-    if (resp_json.status === 'Error') {
+    if (resp_json.status.type === 'Error') {
         throw new Error('RPC call error');
     }
     return resp_json;
 }
 
-export async function getMetadata(wsClient: WebSocketAsPromised, api: ApiPromise): Promise<any> {
+export async function getMetadata(wsClient: WebSocketAsPromised, api: ApiPromise): Promise<Metadata> {
     let request = { jsonrpc: '2.0', method: 'state_getMetadata', params: [], id: 1 };
     let respJSON = await sendRequest(wsClient, request, api);
     const registry = new TypeRegistry();
@@ -34,7 +33,7 @@ export async function getSideChainStorage(
     api: ApiPromise,
     mrenclave: HexString,
     storageKey: string
-): Promise<any> {
+): Promise<WorkerRpcReturnValue> {
     let request = { jsonrpc: '2.0', method: rpcMethod, params: [mrenclave, storageKey], id: 1 };
     let respJSON = await sendRequest(wsClient, request, api);
     return respJSON;

--- a/tee-worker/ts-tests/common/helpers.ts
+++ b/tee-worker/ts-tests/common/helpers.ts
@@ -3,7 +3,6 @@ import { u8aConcat, u8aToU8a } from '@polkadot/util';
 import { HexString } from '@polkadot/util/types';
 import { Keyring } from '@polkadot/api';
 import type { KeyringPair } from '@polkadot/keyring/types';
-import { EvmIdentity, LitentryIdentity, LitentryValidationData } from './type-definitions';
 
 //format and setup
 const keyring = new Keyring({ type: 'sr25519' });

--- a/tee-worker/ts-tests/common/type-definitions.ts
+++ b/tee-worker/ts-tests/common/type-definitions.ts
@@ -10,13 +10,12 @@ import type {
     SubstrateNetwork as SubNet,
     Web2Network as Web2Net,
     EvmNetwork as EvmNet,
-    WorkerRpcReturnValue,
+    DirectRequestStatus,
 } from '../interfaces/identity/types';
 import { default as teeTypes } from '../interfaces/identity/definitions';
 
 export { teeTypes };
 
-export { WorkerRpcReturnValue };
 export type Web2Network = Web2Net['type'];
 export type SubstrateNetwork = SubNet['type'];
 export type EvmNetwork = EvmNet['type'];
@@ -25,6 +24,11 @@ export type WorkerRpcReturnString = {
     vec: string;
 };
 
+export type WorkerRpcReturnValue = {
+    value: `0x${string}`;
+    do_watch: boolean;
+    status: DirectRequestStatus['type'];
+};
 export type EnclaveResult = {
     mrEnclave: `0x${string}`;
     shieldingKey: `0x${string}`;

--- a/tee-worker/ts-tests/common/type-definitions.ts
+++ b/tee-worker/ts-tests/common/type-definitions.ts
@@ -2,168 +2,24 @@ import { ApiPromise, Keyring } from '@polkadot/api';
 import { KeyObject } from 'crypto';
 import { HexString } from '@polkadot/util/types';
 import WebSocketAsPromised = require('websocket-as-promised');
-import { KeyringPair } from '@polkadot/keyring/types';
+import type { KeyringPair } from '@polkadot/keyring/types';
 import { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types';
 import { Metadata } from '@polkadot/types';
-import { ethers } from 'ethers';
-export const teeTypes = {
-    WorkerRpcReturnString: {
-        vec: 'Bytes',
-    },
-    WorkerRpcReturnValue: {
-        value: 'Bytes',
-        do_watch: 'bool',
-        status: 'DirectRequestStatus',
-    },
-    TrustedOperation: {
-        _enum: {
-            indirect_call: '(TrustedCallSigned)',
-            direct_call: '(TrustedCallSigned)',
-            get: '(Getter)',
-        },
-    },
-    TrustedCallSigned: {
-        call: 'TrustedCall',
-        index: 'u32',
-        signature: 'MultiSignature',
-    },
-    Getter: {
-        _enum: {
-            public: '(PublicGetter)',
-            trusted: '(TrustedGetterSigned)',
-        },
-    },
-    PublicGetter: {
-        _enum: ['some_value'],
-    },
-    TrustedGetterSigned: {
-        getter: 'TrustedGetter',
-        signature: 'MultiSignature',
-    },
+import { Wallet } from 'ethers';
+import type {
+    SubstrateNetwork as SubNet,
+    Web2Network as Web2Net,
+    EvmNetwork as EvmNet,
+    WorkerRpcReturnValue,
+} from '../interfaces/identity/types';
+import { default as teeTypes } from '../interfaces/identity/definitions';
 
-    /// important
-    TrustedGetter: {
-        _enum: {
-            free_balance: '(AccountId)',
-        },
-    },
-    /// important
-    TrustedCall: {
-        _enum: {
-            balance_set_balance: '(AccountId, AccountId, Balance, Balance)',
-            balance_transfer: '(AccountId, AccountId, Balance)',
-            balance_unshield: '(AccountId, AccountId, Balance, mrEnclaveIdentifier)',
-        },
-    },
-    DirectRequestStatus: {
-        _enum: [
-            //TODO support TrustedOperationStatus(TrustedOperationStatus)
-            'Ok',
-            'TrustedOperationStatus',
-            'Error',
-        ],
-    },
+export { teeTypes };
 
-    /// identity
-    LitentryIdentity: {
-        _enum: {
-            Substrate: 'SubstrateIdentity',
-            Evm: 'EvmIdentity',
-            Web2: 'Web2Identity',
-        },
-    },
-    SubstrateIdentity: {
-        network: 'SubstrateNetwork',
-        address: 'Address32',
-    },
-    EvmIdentity: {
-        network: 'EvmNetwork',
-        address: 'Address20',
-    },
-    Web2Identity: {
-        network: 'Web2Network',
-        address: 'IdentityString',
-    },
-    Address32: '[u8;32]',
-    Address20: '[u8;20]',
-    IdentityString: 'Vec<u8>',
-    Web2Network: {
-        _enum: ['Twitter', 'Discord', 'Github'],
-    },
-    SubstrateNetwork: {
-        _enum: ['Polkadot', 'Kusama', 'Litentry', 'Litmus', 'LitentryRococo', 'Khala', 'TestNet'],
-    },
-    EvmNetwork: {
-        _enum: ['Ethereum', 'BSC'],
-    },
-
-    /// Validation Data
-    LitentryValidationData: {
-        _enum: {
-            Web2Validation: 'Web2ValidationData',
-            Web3Validation: 'Web3ValidationData',
-        },
-    },
-    Web2ValidationData: {
-        _enum: {
-            Twitter: 'TwitterValidationData',
-            Discord: 'DiscordValidationData',
-        },
-    },
-    TwitterValidationData: {
-        tweet_id: 'Vec<u8>',
-    },
-    DiscordValidationData: {
-        channel_id: 'Vec<u8>',
-        message_id: 'Vec<u8>',
-        guild_id: 'Vec<u8>',
-    },
-    Web3ValidationData: {
-        _enum: {
-            Substrate: 'Web3CommonValidationData',
-            Evm: 'Web3CommonValidationData',
-        },
-    },
-    Web3CommonValidationData: {
-        message: 'Vec<u8>',
-        signature: 'IdentityMultiSignature',
-    },
-
-    IdentityMultiSignature: {
-        _enum: {
-            Ed25519: 'ed25519::Signature',
-            Sr25519: 'sr25519::Signature',
-            Ecdsa: 'ecdsa::Signature',
-            Ethereum: 'EthereumSignature',
-        },
-    },
-    EthereumSignature: '([u8; 65])',
-
-    IdentityGenericEvent: {
-        who: 'AccountId',
-        identity: 'LitentryIdentity',
-        id_graph: 'Vec<(LitentryIdentity, IdentityContext)>',
-    },
-    IdentityContext: {
-        metadata: 'Option<Vec<u8>>',
-        linking_request_block: 'Option<BlockNumber>',
-        verification_request_block: 'Option<BlockNumber>',
-        is_verified: 'bool',
-    },
-
-    // vc management
-    VCRequested: {
-        account: 'AccountId',
-        mrEnclave: 'mrEnclaveIdentifier',
-        assertion: 'Assertion',
-    },
-};
-
-export type WorkerRpcReturnValue = {
-    value: HexString;
-    do_watch: boolean;
-    status: string;
-};
+export { WorkerRpcReturnValue };
+export type Web2Network = Web2Net['type'];
+export type SubstrateNetwork = SubNet['type'];
+export type EvmNetwork = EvmNet['type'];
 
 export type WorkerRpcReturnString = {
     vec: string;
@@ -181,13 +37,19 @@ export type PubicKeyJson = {
     e: Uint8Array;
 };
 
+interface EthersWalletItem {
+    [key: string]: Wallet;
+}
+interface SubstrateWalletItem {
+    [key: string]: KeyringPair;
+}
 export type IntegrationTestContext = {
     tee: WebSocketAsPromised;
     api: ApiPromise;
     teeShieldingKey: KeyObject;
     mrEnclave: HexString;
-    ethersWallet: any;
-    substrateWallet: any;
+    ethersWallet: EthersWalletItem;
+    substrateWallet: SubstrateWalletItem;
     metaData: Metadata;
     web3Signers: Web3Wallets[];
 };
@@ -198,6 +60,7 @@ export class AESOutput {
     nonce?: Uint8Array;
 }
 
+//identity types
 export type LitentryIdentity = {
     Substrate?: SubstrateIdentity;
     Evm?: EvmIdentity;
@@ -217,12 +80,6 @@ export type EvmIdentity = {
 export type Web2Identity = {
     network: Web2Network;
     address: string;
-};
-
-export type IdentityHandle = {
-    Address32?: HexString;
-    Address20?: HexString;
-    PlainString?: `0x${string}`;
 };
 
 export type LitentryValidationData = {
@@ -272,7 +129,7 @@ export type DiscordValidationData = {
 
 export type Web3Wallets = {
     substrateWallet: KeyringPair;
-    ethereumWallet: ethers.Wallet;
+    ethereumWallet: Wallet;
 };
 
 // export type DiscordValidationData = {}
@@ -281,10 +138,6 @@ export type Web3Network = {
     Substrate?: SubstrateNetwork;
     Evm?: EvmNetwork;
 };
-
-export type Web2Network = 'Twitter' | 'Discord' | 'Github';
-export type SubstrateNetwork = 'Polkadot' | 'Kusama' | 'Litentry' | 'Litmus' | 'LitentryRococo' | 'Khala' | 'TestNet';
-export type EvmNetwork = 'Ethereum' | 'BSC';
 
 export type IdentityGenericEvent = {
     who: HexString;
@@ -333,6 +186,13 @@ export type Assertion = {
 export type TransactionSubmit = {
     tx: SubmittableExtrinsic<ApiTypes>;
     nonce: number;
+};
+
+//call types
+export type RequestBody = {
+    id: number;
+    jsonrpc: string;
+    method: string;
 };
 
 export const JsonSchema = {

--- a/tee-worker/ts-tests/common/utils.ts
+++ b/tee-worker/ts-tests/common/utils.ts
@@ -19,6 +19,7 @@ import {
     EvmNetwork,
     Web2Network,
 } from './type-definitions';
+
 import { blake2AsHex, cryptoWaitReady, xxhashAsU8a } from '@polkadot/util-crypto';
 import { Metadata } from '@polkadot/types';
 import { SiLookupTypeId } from '@polkadot/types/interfaces';
@@ -31,7 +32,7 @@ import { Event, StorageEntryMetadataV14, StorageHasherV14 } from '@polkadot/type
 import { after, before, describe } from 'mocha';
 import { ethers } from 'ethers';
 import { assert, expect } from 'chai';
-import Ajv, { stringify } from 'ajv';
+import Ajv from 'ajv';
 import * as ed from '@noble/ed25519';
 import { blake2128Concat, getSubstrateSigner, identity, twox64Concat } from './helpers';
 import { getMetadata, sendRequest } from './call';
@@ -89,9 +90,11 @@ export async function initIntegrationTestContext(
         charlie: getSubstrateSigner().charlie,
         eve: getSubstrateSigner().eve,
     };
+
+    const { types } = teeTypes;
     const api = await ApiPromise.create({
         provider,
-        types: teeTypes,
+        types,
     });
 
     await cryptoWaitReady();
@@ -227,7 +230,7 @@ export function describeLitentry(title: string, walletsNumber: number, cb: (cont
             context.web3Signers = tmp.web3Signers;
         });
 
-        after(async function () {});
+        after(async function () { });
 
         cb(context);
     });
@@ -295,8 +298,8 @@ export async function checkJSON(vc: any, proofJson: any): Promise<boolean> {
     expect(isValid).to.be.true;
     expect(
         vc.type[0] === 'VerifiableCredential' &&
-            vc.issuer.id === proofJson.verificationMethod &&
-            proofJson.type === 'Ed25519Signature2020'
+        vc.issuer.id === proofJson.verificationMethod &&
+        proofJson.type === 'Ed25519Signature2020'
     ).to.be.true;
     return true;
 }
@@ -416,7 +419,7 @@ export async function checkUserShieldingKeys(
     };
     let resp = await sendRequest(context.tee, request, context.api);
 
-    return resp.value;
+    return resp.value as unknown as string;
 }
 export async function checkUserChallengeCode(
     context: IntegrationTestContext,
@@ -436,7 +439,7 @@ export async function checkUserChallengeCode(
         id: 1,
     };
     let resp = await sendRequest(context.tee, request, context.api);
-    return resp.value;
+    return resp.value as unknown as string;
 }
 
 export async function checkIDGraph(

--- a/tee-worker/ts-tests/common/utils.ts
+++ b/tee-worker/ts-tests/common/utils.ts
@@ -419,7 +419,7 @@ export async function checkUserShieldingKeys(
     };
     let resp = await sendRequest(context.tee, request, context.api);
 
-    return resp.value as unknown as string;
+    return resp.value;
 }
 export async function checkUserChallengeCode(
     context: IntegrationTestContext,
@@ -439,7 +439,7 @@ export async function checkUserChallengeCode(
         id: 1,
     };
     let resp = await sendRequest(context.tee, request, context.api);
-    return resp.value as unknown as string;
+    return resp.value;
 }
 
 export async function checkIDGraph(


### PR DESCRIPTION
resolves #1644 
Most of the generated types still need to be redefined manually, for example, we need to manually convert `bytes` to `string`. The only type that can be used directly from the generated types is the network type.