### PR TITLE
Use local crates when compiling tee-worker

### DIFF
--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -752,14 +752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "common-primitives"
-version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.39#0a7d5d5fd0a31539b94080870031661de4007bde"
-dependencies = [
- "sp-std 5.0.0",
-]
-
-[[package]]
 name = "config"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,7 +2602,7 @@ dependencies = [
  "sp-runtime",
  "substrate-api-client",
  "substrate-client-keystore",
- "teerex-primitives 0.1.0",
+ "teerex-primitives",
  "ws",
 ]
 
@@ -2667,7 +2659,7 @@ dependencies = [
  "serde 1.0.163",
  "serde_derive 1.0.163",
  "serde_json 1.0.96",
- "sgx-verify 0.1.4 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.39)",
+ "sgx-verify",
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
@@ -2677,7 +2669,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "substrate-api-client",
- "teerex-primitives 0.1.0",
+ "teerex-primitives",
  "thiserror 1.0.40",
  "tokio",
  "warp",
@@ -5531,7 +5523,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std 5.0.0",
- "teerex-primitives 0.1.0",
+ "teerex-primitives",
 ]
 
 [[package]]
@@ -5632,12 +5624,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.163",
- "sgx-verify 0.1.4",
+ "sgx-verify",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
  "sp-std 5.0.0",
- "teerex-primitives 0.1.0",
+ "teerex-primitives",
 ]
 
 [[package]]
@@ -5702,7 +5694,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std 5.0.0",
- "teerex-primitives 0.1.0",
+ "teerex-primitives",
 ]
 
 [[package]]
@@ -6837,9 +6829,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdef77228a4c05dc94211441595746732131ad7f6530c6c18f045da7b7ab937"
+checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.0",
@@ -7163,30 +7155,7 @@ dependencies = [
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-std 5.0.0",
- "teerex-primitives 0.1.0",
- "webpki 0.21.0",
- "x509-cert",
-]
-
-[[package]]
-name = "sgx-verify"
-version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.39#0a7d5d5fd0a31539b94080870031661de4007bde"
-dependencies = [
- "base64 0.13.1",
- "chrono 0.4.24",
- "der",
- "frame-support",
- "hex 0.4.3",
- "parity-scale-codec",
- "ring 0.16.20 (git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup)",
- "scale-info",
- "serde 1.0.163",
- "serde_json 1.0.96",
- "sp-core",
- "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
- "sp-std 5.0.0",
- "teerex-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.39)",
+ "teerex-primitives",
  "webpki 0.21.0",
  "x509-cert",
 ]
@@ -8347,21 +8316,7 @@ checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 name = "teerex-primitives"
 version = "0.1.0"
 dependencies = [
- "common-primitives 0.1.0",
- "parity-scale-codec",
- "scale-info",
- "serde 1.0.163",
- "sp-core",
- "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
- "sp-std 5.0.0",
-]
-
-[[package]]
-name = "teerex-primitives"
-version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.39#0a7d5d5fd0a31539b94080870031661de4007bde"
-dependencies = [
- "common-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.39)",
+ "common-primitives",
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.163",

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -3941,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdef77228a4c05dc94211441595746732131ad7f6530c6c18f045da7b7ab937"
+checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.0",

--- a/tee-worker/service/Cargo.toml
+++ b/tee-worker/service/Cargo.toml
@@ -61,7 +61,7 @@ its-rpc-handler = { path = "../sidechain/rpc-handler" }
 its-storage = { path = "../sidechain/storage" }
 
 # scs / integritee
-sgx-verify = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.39" }
+sgx-verify = { path = "../../pallets/teerex/sgx-verify", default-features = false }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.39-tag-v0.7.0" }
 teerex-primitives = { path = "../../primitives/teerex", default-features = false }
 


### PR DESCRIPTION

resolved: #1691 

After code inspection, all the crates used in the worker are local crates from pallets, except this crate(sgx-verify) is related to the dcap feature.