### PR TITLE
fix: #1684 use block number instead of timeout limit in test

### DIFF
--- a/tee-worker/ts-tests/bulk_vc.test.ts
+++ b/tee-worker/ts-tests/bulk_vc.test.ts
@@ -2,7 +2,7 @@ import { step } from 'mocha-steps';
 import { checkVc, describeLitentry, encryptWithTeeShieldingKey } from './common/utils';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { ethers } from 'ethers';
-import { u8aToHex } from '@polkadot/util';
+import { u8aToHex, stringToU8a } from '@polkadot/util';
 import { Assertion, IndexingNetwork, TransactionSubmit } from './common/type-definitions';
 import { handleVcEvents } from './common/utils';
 import { blake2AsHex } from '@polkadot/util-crypto';
@@ -56,7 +56,7 @@ describeLitentry('multiple accounts test', 10, async (context) => {
     });
     //test with multiple accounts
     step('test set usershieldingkey with multiple accounts', async () => {
-        const ciphertext = encryptWithTeeShieldingKey(context.teeShieldingKey, aesKey).toString('hex');
+        const ciphertext = encryptWithTeeShieldingKey(context.teeShieldingKey, stringToU8a(aesKey)).toString('hex');
         let txs: TransactionSubmit[] = [];
         for (let i = 0; i < substrateSigners.length; i++) {
             const tx = context.api.tx.identityManagement.setUserShieldingKey(context.mrEnclave, `0x${ciphertext}`);

--- a/tee-worker/ts-tests/common/utils/context.ts
+++ b/tee-worker/ts-tests/common/utils/context.ts
@@ -12,7 +12,8 @@ import { IntegrationTestContext, teeTypes, EnclaveResult, Web3Wallets } from '..
 const crypto = require('crypto');
 
 // maximum milliseconds that we wait in listening events before we timeout
-const listenTimeoutInMilliSeconds = 3 * 60 * 1000;
+// set to 5 minutes as identity-hub to ensure all tests have enough time to get events
+const listenTimeoutInMilliSeconds = 5 * 60 * 1000;
 
 export async function getListenTimeoutInBlocks(api: ApiPromise) {
     const slotDuration = await api.call.auraApi.slotDuration();

--- a/tee-worker/ts-tests/common/utils/context.ts
+++ b/tee-worker/ts-tests/common/utils/context.ts
@@ -11,14 +11,8 @@ import { IntegrationTestContext, teeTypes, EnclaveResult, Web3Wallets } from '..
 
 const crypto = require('crypto');
 
-// maximum milliseconds that we wait in listening events before we timeout
-// set to 5 minutes as identity-hub to ensure all tests have enough time to get events
-const listenTimeoutInMilliSeconds = 5 * 60 * 1000;
-
-export async function getListenTimeoutInBlocks(api: ApiPromise) {
-    const slotDuration = await api.call.auraApi.slotDuration();
-    return listenTimeoutInMilliSeconds / parseInt(slotDuration.toString());
-}
+// maximum block number that we wait in listening events before we timeout
+export const defaultListenTimeoutInBlockNumber = 15;
 
 export async function initWorkerConnection(endpoint: string): Promise<WebSocketAsPromised> {
     const wsp = new WebSocketAsPromised(endpoint, <Options>(<unknown>{

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -353,7 +353,7 @@ describeLitentry('Test Identity', 0, (context) => {
             context.substrateWallet.alice,
             alice_txs,
             'identityManagement',
-            ['IdentityVerified', 'VerifyIdentityFailed'] // allow possible failed events to be collected
+            ['IdentityVerified']
         );
         let bob_txs = await buildIdentityTxs(
             context,
@@ -368,7 +368,7 @@ describeLitentry('Test Identity', 0, (context) => {
             context.substrateWallet.bob,
             bob_txs,
             'identityManagement',
-            ['IdentityVerified', 'VerifyIdentityFailed'] // allow possible failed events to be collected
+            ['IdentityVerified']
         );
         const verified_event_datas = await handleIdentityEvents(context, aesKey, alice_resp_events, 'IdentityVerified');
         const [substrate_extension_identity_verified] = await handleIdentityEvents(

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -353,7 +353,7 @@ describeLitentry('Test Identity', 0, (context) => {
             context.substrateWallet.alice,
             alice_txs,
             'identityManagement',
-            ['IdentityVerified']
+            ['IdentityVerified', 'VerifyIdentityFailed'] // allow possible failed events to be collected
         );
         let bob_txs = await buildIdentityTxs(
             context,
@@ -368,7 +368,7 @@ describeLitentry('Test Identity', 0, (context) => {
             context.substrateWallet.bob,
             bob_txs,
             'identityManagement',
-            ['IdentityVerified']
+            ['IdentityVerified', 'VerifyIdentityFailed'] // allow possible failed events to be collected
         );
         const verified_event_datas = await handleIdentityEvents(context, aesKey, alice_resp_events, 'IdentityVerified');
         const [substrate_extension_identity_verified] = await handleIdentityEvents(


### PR DESCRIPTION
…il test assertion when there is a VerifyIdentityFailed event from chain

fixed #1684 

The error shown here
<img width="1718" alt="Screenshot 2023-05-12 at 00 18 39" src="https://github.com/litentry/litentry-parachain/assets/7630809/77cf27ef-1ff6-4616-8dcc-124fcd816b42">

 will fail the test now.
