### PR TITLE
npm script di examples

### DIFF
--- a/tee-worker/ts-tests/examples/direct-invocation/README.md
+++ b/tee-worker/ts-tests/examples/direct-invocation/README.md
@@ -12,8 +12,8 @@ cd <path-to-tee-worker>
 2. run the ts demo
 
 ```
-cd <path-to-tee-worker/ts-tests/examples/direct-invocation>
-ts-node index.ts
+cd <path-to-tee-worker/ts-tests
+npm run di-examples
 ```
 
 ### Notes

--- a/tee-worker/ts-tests/examples/direct-invocation/README.md
+++ b/tee-worker/ts-tests/examples/direct-invocation/README.md
@@ -12,7 +12,7 @@ cd <path-to-tee-worker>
 2. run the ts demo
 
 ```
-cd <path-to-tee-worker/ts-tests
+cd <path-to-tee-worker/ts-tests>
 npm run di-examples
 ```
 

--- a/tee-worker/ts-tests/package.json
+++ b/tee-worker/ts-tests/package.json
@@ -19,7 +19,8 @@
 		"test-bulk-vc:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'bulk_vc.test.ts'",
 		"test-bulk-vc:staging": "cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register 'bulk_vc.test.ts'",
 		"test-bulk-identity:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'bulk_identity.test.ts'",
-		"test-bulk-identity:staging": "cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register 'bulk_identity.test.ts'"
+		"test-bulk-identity:staging": "cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register 'bulk_identity.test.ts'",
+		"di-examples": "ts-node examples/direct-invocation/index.ts"
 	},
 	"dependencies": {
 		"@noble/ed25519": "^1.7.3",


### PR DESCRIPTION
I tried to run direct invocation examples and followed steps in instruction but it required global ts-node package instalation.
To make it work out of the box locally installed can be used instead.