### PR TITLE
First test using the trusted getter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,6 +518,7 @@ jobs:
           - test_name: lit-set-heartbeat-timeout
           - test_name: lit-vc-test
           - test_name: lit-identity-test
+          - test_name: lit-identity-direct-invocation-test
           - test_name: lit-parentchain-nonce
           - test_name: lit-batch-test
 

--- a/tee-worker/docker/lit-identity-direct-invocation-test.yml
+++ b/tee-worker/docker/lit-identity-direct-invocation-test.yml
@@ -1,0 +1,24 @@
+services:
+    lit-identity-direct-invocation-test:
+        image: integritee-cli:dev
+        container_name: litentry-identity-direct-invocation-test
+        volumes:
+            - ../ts-tests:/ts-tests
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            integritee-node:
+                condition: service_healthy
+            integritee-worker-1:
+                condition: service_healthy
+            integritee-worker-2:
+                condition: service_healthy
+        networks:
+            - integritee-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-identity-direct-invocation 2>&1' "
+        restart: "no"
+networks:
+    integritee-test-network:
+        driver: bridge

--- a/tee-worker/ts-tests/common/utils/context.ts
+++ b/tee-worker/ts-tests/common/utils/context.ts
@@ -45,12 +45,7 @@ export async function initIntegrationTestContext(
         dave: new ethers.Wallet(getEthereumSigner().dave),
         eve: new ethers.Wallet(getEthereumSigner().eve),
     };
-    const substrateWallet = {
-        alice: getSubstrateSigner().alice,
-        bob: getSubstrateSigner().bob,
-        charlie: getSubstrateSigner().charlie,
-        eve: getSubstrateSigner().eve,
-    };
+    const substrateWallet = getSubstrateSigner();
 
     const { types } = teeTypes;
     const api = await ApiPromise.create({
@@ -66,7 +61,7 @@ export async function initIntegrationTestContext(
 
     const web3Signers = await generateWeb3Wallets(walletsNumber);
     const { mrEnclave, teeShieldingKey } = await getEnclave(api);
-    return <IntegrationTestContext>{
+    return {
         tee: wsp,
         api,
         teeShieldingKey,
@@ -79,7 +74,7 @@ export async function initIntegrationTestContext(
 }
 
 export async function getEnclave(api: ApiPromise): Promise<{
-    mrEnclave: string;
+    mrEnclave: `0x${string}`;
     teeShieldingKey: KeyObject;
 }> {
     const count = await api.query.teerex.enclaveCount();

--- a/tee-worker/ts-tests/identity-direct-invocation.test.ts
+++ b/tee-worker/ts-tests/identity-direct-invocation.test.ts
@@ -1,0 +1,62 @@
+import { KeyObject } from 'crypto';
+import { step } from 'mocha-steps';
+import { assert } from 'chai';
+import { hexToU8a } from '@polkadot/util';
+
+import { initIntegrationTestContext } from './common/utils';
+import {
+    createSignedTrustedGetterUserShieldingKey,
+    getTEEShieldingKey,
+    sendRequestFromTrustedGetter,
+} from './examples/direct-invocation/util'; // @fixme move to a better place
+import { IntegrationTestContext } from './common/type-definitions';
+
+describe('Test Identity (direct invocation)', function () {
+    let context: IntegrationTestContext = undefined as any;
+    let teeShieldingKey: KeyObject = undefined as any;
+
+    this.timeout(6000000);
+
+    before(async () => {
+        context = await initIntegrationTestContext(
+            process.env.WORKER_END_POINT!, // @fixme evil assertion; centralize env access
+            process.env.SUBSTRATE_END_POINT!, // @fixme evil assertion; centralize env access
+            0
+        );
+        teeShieldingKey = await getTEEShieldingKey(context.tee, context.api);
+    });
+
+    it('needs a lot more work to be complete');
+
+    step('check user sidechain storage before create', async function () {
+        const shieldingKeyGetter = createSignedTrustedGetterUserShieldingKey(
+            context.api,
+            context.substrateWallet.alice
+        );
+
+        const shieldingKeyGetResult = await sendRequestFromTrustedGetter(
+            context.tee,
+            context.api,
+            context.mrEnclave,
+            teeShieldingKey,
+            shieldingKeyGetter
+        );
+
+        const k = context.api.createType('Option<Bytes>', hexToU8a(shieldingKeyGetResult.value.toHex()));
+        assert.isTrue(k.isNone, 'shielding key should be empty before set');
+
+        // @fixme NOT FINISHED YET
+        // const twitter_identity = await buildIdentityHelper('mock_user', 'Twitter', 'Web2');
+        // const identity_hex = context.api.createType('LitentryIdentity', twitter_identity).toHex();
+
+        // const resp_challengecode = await checkUserChallengeCode(
+        //     context,
+        //     'IdentityManagement',
+        //     'ChallengeCodes',
+        //     u8aToHex(context.substrateWallet.alice.addressRaw),
+        //     identity_hex
+        // );
+
+        // assert.equal(resp_challengecode, '0x', 'challengecode should be empty before create');
+    });
+});

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -701,7 +701,7 @@ describeLitentry('Test Identity', 0, (context) => {
         const [event] = await handleIdentityEvents(context, aesKey, resp_events, 'UserShieldingKeySet');
         await assertInitialIDGraphCreated(context.api, context.substrateWallet.eve, event);
 
-        let identities = [];
+        let identities: LitentryIdentity[] = [];
         for (let i = 0; i < 64; i++) {
             let identity = await buildIdentityHelper('mock_user', 'Twitter', 'Web2');
             identities.push(identity);

--- a/tee-worker/ts-tests/package.json
+++ b/tee-worker/ts-tests/package.json
@@ -10,6 +10,7 @@
 		"gen-type:meta": "ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --package . --output ./interfaces --endpoint ./litentry-sidechain-metadata.json",
 		"test-identity:staging": "cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register 'identity.test.ts'",
 		"test-identity:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'identity.test.ts'",
+		"test-identity-direct-invocation:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'identity-direct-invocation.test.ts'",
 		"test-resuming-worker:staging": "cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register 'resuming_worker.test.ts'",
 		"test-resuming-worker:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'resuming_worker.test.ts'",
 		"test-vc:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'vc.test.ts'",

--- a/tee-worker/ts-tests/package.json
+++ b/tee-worker/ts-tests/package.json
@@ -11,6 +11,7 @@
 		"test-identity:staging": "cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register 'identity.test.ts'",
 		"test-identity:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'identity.test.ts'",
 		"test-identity-direct-invocation:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'identity-direct-invocation.test.ts'",
+		"test-identity-direct-invocation:staging": "cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register 'identity-direct-invocation.test.ts'",
 		"test-resuming-worker:staging": "cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register 'resuming_worker.test.ts'",
 		"test-resuming-worker:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'resuming_worker.test.ts'",
 		"test-vc:local": "cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register 'vc.test.ts'",


### PR DESCRIPTION
First baby step towards #1682.

This step mimics the setup and the very first step of `identity.test.ts` but using the [trusted getter](https://github.com/litentry/litentry-parachain/pull/1732) to fetch the shielding key.

The same getter will also be needed to fetch the results of DI calls.

Includes a few small drive-by refactorings and fixes.