### PR TITLE
fix DI examples

### DIFF
--- a/tee-worker/ts-tests/examples/direct-invocation/index.ts
+++ b/tee-worker/ts-tests/examples/direct-invocation/index.ts
@@ -1,7 +1,7 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
-import { teeTypes } from '../../common/type-definitions';
+import { default as teeTypes } from '../../parachain-interfaces/identity/definitions';
 import { HexString } from '@polkadot/util/types';
 import {
     createSignedTrustedCallSetUserShieldingKey,
@@ -14,7 +14,7 @@ import {
     sendRequestFromPublicGetter,
     decodeNonce,
 } from './util';
-import { getEnclave, sleep, buildIdentityHelper } from '../../common/utils';
+import { getEnclave, sleep, buildIdentityHelper, initIntegrationTestContext } from '../../common/utils';
 import { Metadata, TypeRegistry } from '@polkadot/types';
 import sidechainMetaData from '../../litentry-sidechain-metadata.json';
 import { hexToU8a, compactStripLength, u8aToString } from '@polkadot/util';
@@ -35,12 +35,22 @@ async function runDirectCall() {
     const parachain_ws = new WsProvider(PARACHAIN_WS_ENDPINT);
     const sidechainRegistry = new TypeRegistry();
     const metaData = new Metadata(sidechainRegistry, sidechainMetaData.result as HexString);
-    sidechainRegistry.setMetadata(metaData);
+    const registry = new TypeRegistry();
+
     const { types } = teeTypes;
+
+    sidechainRegistry.setMetadata(metaData);
     const parachain_api = await ApiPromise.create({
         provider: parachain_ws,
         types,
     });
+
+    const context = await initIntegrationTestContext(
+        WORKER_TRUSTED_WS_ENDPOINT, // @fixme evil assertion; centralize env access
+        PARACHAIN_WS_ENDPINT, // @fixme evil assertion; centralize env access
+        0
+    );
+
     await cryptoWaitReady();
     const wsp = new WebSocketAsPromised(WORKER_TRUSTED_WS_ENDPOINT, {
         createWebSocket: (url: any) => new WebSocket(url),
@@ -90,7 +100,7 @@ async function runDirectCall() {
 
     nonce = parachain_api.createType('Index', NonceValue1);
     console.log('Send direct createIdentity call... hash:', hash);
-    const twitter_identity = await buildIdentityHelper('mock_user', 'Twitter', 'Web2');
+    const twitter_identity = await buildIdentityHelper('mock_user', 'Twitter', 'Web2', context);
     let createIdentityCall = createSignedTrustedCallCreateIdentity(
         parachain_api,
         mrenclave,

--- a/tee-worker/ts-tests/examples/direct-invocation/index.ts
+++ b/tee-worker/ts-tests/examples/direct-invocation/index.ts
@@ -35,21 +35,13 @@ async function runDirectCall() {
     const parachain_ws = new WsProvider(PARACHAIN_WS_ENDPINT);
     const sidechainRegistry = new TypeRegistry();
     const metaData = new Metadata(sidechainRegistry, sidechainMetaData.result as HexString);
-    const registry = new TypeRegistry();
-
-    const { types } = teeTypes;
-
     sidechainRegistry.setMetadata(metaData);
+    const { types } = teeTypes;
     const parachain_api = await ApiPromise.create({
         provider: parachain_ws,
         types,
     });
-
-    const context = await initIntegrationTestContext(
-        WORKER_TRUSTED_WS_ENDPOINT, // @fixme evil assertion; centralize env access
-        PARACHAIN_WS_ENDPINT, // @fixme evil assertion; centralize env access
-        0
-    );
+    const context = await initIntegrationTestContext(WORKER_TRUSTED_WS_ENDPOINT, PARACHAIN_WS_ENDPINT, 0);
 
     await cryptoWaitReady();
     const wsp = new WebSocketAsPromised(WORKER_TRUSTED_WS_ENDPOINT, {


### PR DESCRIPTION
Fixes di examples. I cannot run them on `dev` branch.

```
kziemianek@kziemianek:~/projects/litentry/litentry-parachain/tee-worker/ts-tests$ npm run di-examples

> di-examples
> ts-node examples/direct-invocation/index.ts

/home/kziemianek/projects/litentry/litentry-parachain/tee-worker/ts-tests/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
examples/direct-invocation/index.ts:4:10 - error TS2305: Module '"../../common/type-definitions"' has no exported member 'teeTypes'.

4 import { teeTypes } from '../../common/type-definitions';
           ~~~~~~~~
examples/direct-invocation/index.ts:93:36 - error TS2554: Expected 4 arguments, but got 3.

93     const twitter_identity = await buildIdentityHelper('mock_user', 'Twitter', 'Web2');
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  common/utils/identity-helper.ts:37:5
    37     context: IntegrationTestContext
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'context' was not provided.

    at createTSError (/home/kziemianek/projects/litentry/litentry-parachain/tee-worker/ts-tests/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/home/kziemianek/projects/litentry/litentry-parachain/tee-worker/ts-tests/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/home/kziemianek/projects/litentry/litentry-parachain/tee-worker/ts-tests/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/home/kziemianek/projects/litentry/litentry-parachain/tee-worker/ts-tests/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/home/kziemianek/projects/litentry/litentry-parachain/tee-worker/ts-tests/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1321:10)
    at Object.require.extensions.<computed> [as .ts] (/home/kziemianek/projects/litentry/litentry-parachain/tee-worker/ts-tests/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1125:32)
    at Function.Module._load (node:internal/modules/cjs/loader:965:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12) {
  diagnosticCodes: [ 2305, 2554 ]
}
```