### PR TITLE
fix: change the method of determining the Substrate network.

### DIFF
--- a/tee-worker/ts-tests/common/helpers.ts
+++ b/tee-worker/ts-tests/common/helpers.ts
@@ -56,7 +56,7 @@ export function identity(data: HexString | Uint8Array): Uint8Array {
     return u8aToU8a(data);
 }
 
-// https://github.com/paritytech/ss58-registry/blob/main/c.json
+// see https://github.com/litentry/litentry-parachain/blob/97f80f711e8ec308cbf230b9b35cd40b191d8217/tee-worker/litentry/primitives/src/identity.rs#L80
 export const SubstrateNetworkMapping: Record<number, SubstrateNetwork['type']> = {
     0: 'Polkadot',
     2: 'Kusama',

--- a/tee-worker/ts-tests/common/helpers.ts
+++ b/tee-worker/ts-tests/common/helpers.ts
@@ -4,7 +4,7 @@ import { Keyring } from '@polkadot/api';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { HexString } from '@polkadot/util/types';
 import './config';
-
+import { SubstrateNetwork } from '../parachain-interfaces/identity/types';
 //format and setup
 const keyring = new Keyring({ type: 'sr25519' });
 export function getSubstrateSigner(): {
@@ -57,12 +57,12 @@ export function identity(data: HexString | Uint8Array): Uint8Array {
 }
 
 // https://github.com/paritytech/ss58-registry/blob/main/c.json
-export enum SubstrateNetwork {
-    Polkadot = 0,
-    Kusama = 2,
-    Litentry = 31,
-    Litmus = 131,
-    LitentryRococo = 42,
-    Khala = 30,
-    TestNet = 13,
-}
+export const SubstrateNetworkMapping: Record<number, SubstrateNetwork['type']> = {
+    0: 'Polkadot',
+    2: 'Kusama',
+    31: 'Litentry',
+    131: 'Litmus',
+    42: 'LitentryRococo',
+    30: 'Khala',
+    13: 'TestNet',
+};

--- a/tee-worker/ts-tests/common/helpers.ts
+++ b/tee-worker/ts-tests/common/helpers.ts
@@ -56,4 +56,13 @@ export function identity(data: HexString | Uint8Array): Uint8Array {
     return u8aToU8a(data);
 }
 
-export const env_network = process.env.NODE_ENV === 'local' ? 'TestNet' : 'LitentryRococo';
+// https://github.com/paritytech/ss58-registry/blob/main/c.json
+export enum SubstrateNetwork {
+    Polkadot = 0,
+    Kusama = 2,
+    Litentry = 31,
+    Litmus = 131,
+    LitentryRococo = 42,
+    Khala = 30,
+    TestNet = 13,
+}

--- a/tee-worker/ts-tests/common/helpers.ts
+++ b/tee-worker/ts-tests/common/helpers.ts
@@ -5,7 +5,7 @@ import type { KeyringPair } from '@polkadot/keyring/types';
 import type { HexString } from '@polkadot/util/types';
 import './config';
 import { SubstrateNetwork } from '../parachain-interfaces/identity/types';
-//format and setup
+// format and setup
 const keyring = new Keyring({ type: 'sr25519' });
 export function getSubstrateSigner(): {
     alice: KeyringPair;

--- a/tee-worker/ts-tests/common/type-definitions.ts
+++ b/tee-worker/ts-tests/common/type-definitions.ts
@@ -51,6 +51,7 @@ export type IntegrationTestContext = {
     metaData: Metadata;
     sidechainRegistry: TypeRegistry;
     web3Signers: Web3Wallets[];
+    chainID: number;
 };
 
 export class AESOutput {

--- a/tee-worker/ts-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/common/utils/assertion.ts
@@ -10,7 +10,7 @@ import type { EnclaveResult, IntegrationTestContext } from '../type-definitions'
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { HexString } from '@polkadot/util/types';
 import { JsonSchema } from '../type-definitions';
-import { SubstrateNetwork } from '../../common/helpers';
+import { SubstrateNetworkMapping } from '../../common/helpers';
 import colors from 'colors';
 
 export async function assertInitialIDGraphCreated(
@@ -30,7 +30,7 @@ export async function assertInitialIDGraphCreated(
         // Check identity in idgraph
         const expected_identity = await buildIdentityHelper(
             u8aToHex(signer[index].addressRaw),
-            SubstrateNetwork[context.chainID],
+            SubstrateNetworkMapping[context.chainID],
             'Substrate',
             context
         );
@@ -74,7 +74,7 @@ export async function assertIdentityVerified(
         // Check prime identity in idGraph
         const expected_prime_identity = await buildIdentityHelper(
             u8aToHex(signer.addressRaw),
-            SubstrateNetwork[context.chainID],
+            SubstrateNetworkMapping[context.chainID],
             'Substrate',
             context
         );

--- a/tee-worker/ts-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/common/utils/assertion.ts
@@ -10,7 +10,7 @@ import type { EnclaveResult, IntegrationTestContext } from '../type-definitions'
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { HexString } from '@polkadot/util/types';
 import { JsonSchema } from '../type-definitions';
-import { env_network } from '../../common/helpers';
+import { SubstrateNetwork } from '../../common/helpers';
 import colors from 'colors';
 
 export async function assertInitialIDGraphCreated(
@@ -30,7 +30,7 @@ export async function assertInitialIDGraphCreated(
         // Check identity in idgraph
         const expected_identity = await buildIdentityHelper(
             u8aToHex(signer[index].addressRaw),
-            env_network,
+            SubstrateNetwork[context.chainID],
             'Substrate',
             context
         );
@@ -74,7 +74,7 @@ export async function assertIdentityVerified(
         // Check prime identity in idGraph
         const expected_prime_identity = await buildIdentityHelper(
             u8aToHex(signer.addressRaw),
-            env_network,
+            SubstrateNetwork[context.chainID],
             'Substrate',
             context
         );

--- a/tee-worker/ts-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/common/utils/assertion.ts
@@ -187,7 +187,7 @@ export async function checkErrorDetail(events: Event[], expectedDetail: string) 
 export async function verifySignature(data: any, index: HexString, proofJson: any, api: ApiPromise) {
     const count = await api.query.teerex.enclaveCount();
     const res = (await api.query.teerex.enclaveRegistry(count)).toHuman() as EnclaveResult;
-    //check vc index
+    // Check vc index
     expect(index).to.be.eq(data.id);
 
     const signature = Buffer.from(hexToU8a(`0x${proofJson.proofValue}`));
@@ -211,7 +211,7 @@ export async function checkVc(vcObj: any, index: HexString, proof: any, api: Api
     return true;
 }
 
-//Check VC json fields
+// Check VC json fields
 export async function checkJSON(vc: any, proofJson: any): Promise<boolean> {
     //check JsonSchema
     const ajv = new Ajv();
@@ -220,8 +220,8 @@ export async function checkJSON(vc: any, proofJson: any): Promise<boolean> {
     expect(isValid).to.be.true;
     expect(
         vc.type[0] === 'VerifiableCredential' &&
-            vc.issuer.id === proofJson.verificationMethod &&
-            proofJson.type === 'Ed25519Signature2020'
+        vc.issuer.id === proofJson.verificationMethod &&
+        proofJson.type === 'Ed25519Signature2020'
     ).to.be.true;
     return true;
 }

--- a/tee-worker/ts-tests/common/utils/context.ts
+++ b/tee-worker/ts-tests/common/utils/context.ts
@@ -48,6 +48,7 @@ export async function initIntegrationTestContext(
         types,
     });
 
+    const chainID = api.registry.chainSS58 as number;
     await cryptoWaitReady();
 
     const wsp = await initWorkerConnection(workerEndpoint);
@@ -65,6 +66,7 @@ export async function initIntegrationTestContext(
         metaData,
         sidechainRegistry,
         web3Signers,
+        chainID,
     };
 }
 

--- a/tee-worker/ts-tests/common/utils/identity-helper.ts
+++ b/tee-worker/ts-tests/common/utils/identity-helper.ts
@@ -11,7 +11,13 @@ import type { LitentryValidationData } from '../../parachain-interfaces/identity
 import type { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { HexString } from '@polkadot/util/types';
-import type { IdentityGenericEvent, IntegrationTestContext } from '../type-definitions';
+import type {
+    EvmNetwork,
+    IdentityGenericEvent,
+    IntegrationTestContext,
+    SubstrateNetwork,
+    Web2Network,
+} from '../type-definitions';
 //<challeng-code> + <litentry-AccountId32> + <Identity>
 export function generateVerificationMessage(
     context: IntegrationTestContext,
@@ -26,7 +32,7 @@ export function generateVerificationMessage(
 
 export async function buildIdentityHelper(
     address: HexString | string,
-    network: string,
+    network: SubstrateNetwork | EvmNetwork | Web2Network,
     type: LitentryPrimitivesIdentity['type'],
     context: IntegrationTestContext
 ): Promise<LitentryPrimitivesIdentity> {

--- a/tee-worker/ts-tests/common/utils/identity-helper.ts
+++ b/tee-worker/ts-tests/common/utils/identity-helper.ts
@@ -11,13 +11,7 @@ import type { LitentryValidationData } from '../../parachain-interfaces/identity
 import type { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { HexString } from '@polkadot/util/types';
-import type {
-    EvmNetwork,
-    IdentityGenericEvent,
-    IntegrationTestContext,
-    SubstrateNetwork,
-    Web2Network,
-} from '../type-definitions';
+import type { IdentityGenericEvent, IntegrationTestContext } from '../type-definitions';
 //<challeng-code> + <litentry-AccountId32> + <Identity>
 export function generateVerificationMessage(
     context: IntegrationTestContext,
@@ -32,7 +26,7 @@ export function generateVerificationMessage(
 
 export async function buildIdentityHelper(
     address: HexString | string,
-    network: SubstrateNetwork | EvmNetwork | Web2Network,
+    network: string,
     type: LitentryPrimitivesIdentity['type'],
     context: IntegrationTestContext
 ): Promise<LitentryPrimitivesIdentity> {

--- a/tee-worker/ts-tests/common/utils/identity-helper.ts
+++ b/tee-worker/ts-tests/common/utils/identity-helper.ts
@@ -18,7 +18,7 @@ import type {
     SubstrateNetwork,
     Web2Network,
 } from '../type-definitions';
-//<challeng-code> + <litentry-AccountId32> + <Identity>
+// <challeng-code> + <litentry-AccountId32> + <Identity>
 export function generateVerificationMessage(
     context: IntegrationTestContext,
     challengeCode: Uint8Array,
@@ -50,7 +50,7 @@ export async function buildIdentityHelper(
     return encoded_identity;
 }
 
-//If multiple transactions are built from multiple accounts, pass the signers as an array. If multiple transactions are built from a single account, signers cannot be an array.
+// If multiple transactions are built from multiple accounts, pass the signers as an array. If multiple transactions are built from a single account, signers cannot be an array.
 export async function buildIdentityTxs(
     context: IntegrationTestContext,
     signers: KeyringPair[] | KeyringPair,

--- a/tee-worker/ts-tests/common/utils/integration-setup.ts
+++ b/tee-worker/ts-tests/common/utils/integration-setup.ts
@@ -22,6 +22,8 @@ export function describeLitentry(title: string, walletsNumber: number, cb: (cont
             metaData: {} as Metadata,
             sidechainRegistry: {} as TypeRegistry,
             web3Signers: [] as Web3Wallets[],
+            // default LitentryRococo
+            chainID: 42,
         };
 
         before('Starting Litentry(parachain&tee)', async function () {
@@ -40,6 +42,7 @@ export function describeLitentry(title: string, walletsNumber: number, cb: (cont
             context.metaData = tmp.metaData;
             context.sidechainRegistry = tmp.sidechainRegistry;
             context.web3Signers = tmp.web3Signers;
+            context.chainID = tmp.chainID;
         });
 
         after(async function () {});

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -12,7 +12,7 @@ import {
     assertInitialIDGraphCreated,
     checkUserShieldingKeys,
 } from './common/utils';
-import { SubstrateNetwork } from './common/helpers';
+import { SubstrateNetworkMapping } from './common/helpers';
 import { hexToU8a, u8aConcat, u8aToHex, u8aToU8a, stringToU8a } from '@polkadot/util';
 import { step } from 'mocha-steps';
 import { assert } from 'chai';
@@ -119,7 +119,7 @@ describeLitentry('Test Identity', 0, (context) => {
         // the main address should be already inside the IDGraph
         const main_identity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.alice.addressRaw),
-            SubstrateNetwork[context.chainID],
+            SubstrateNetworkMapping[context.chainID],
             'Substrate',
             context
         );
@@ -579,7 +579,7 @@ describeLitentry('Test Identity', 0, (context) => {
         // remove prime identity
         const substratePrimeIdentity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.alice.addressRaw),
-            SubstrateNetwork[context.chainID],
+            SubstrateNetworkMapping[context.chainID],
             'Substrate',
             context
         );

--- a/tee-worker/ts-tests/identity.test.ts
+++ b/tee-worker/ts-tests/identity.test.ts
@@ -12,7 +12,7 @@ import {
     assertInitialIDGraphCreated,
     checkUserShieldingKeys,
 } from './common/utils';
-import { env_network } from './common/helpers';
+import { SubstrateNetwork } from './common/helpers';
 import { hexToU8a, u8aConcat, u8aToHex, u8aToU8a, stringToU8a } from '@polkadot/util';
 import { step } from 'mocha-steps';
 import { assert } from 'chai';
@@ -119,7 +119,7 @@ describeLitentry('Test Identity', 0, (context) => {
         // the main address should be already inside the IDGraph
         const main_identity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.alice.addressRaw),
-            env_network,
+            SubstrateNetwork[context.chainID],
             'Substrate',
             context
         );
@@ -579,7 +579,7 @@ describeLitentry('Test Identity', 0, (context) => {
         // remove prime identity
         const substratePrimeIdentity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.alice.addressRaw),
-            env_network,
+            SubstrateNetwork[context.chainID],
             'Substrate',
             context
         );


### PR DESCRIPTION
[The previous Substrate network type determination](https://github.com/litentry/litentry-parachain/blob/dev/tee-worker/ts-tests/common/helpers.ts#L59) was incorrect, as it was not related to whether the network was locally launched. In fact, it is associated with the SS58 registry. This PR aims to fix this issue.