### PR TITLE
set latest parity/polkadot image supported version

### DIFF
--- a/docker/litentry-parachain-launch-config.yml
+++ b/docker/litentry-parachain-launch-config.yml
@@ -4,7 +4,7 @@
 #
 # Relaychain Configuration
 relaychain:
-  image: parity/polkadot:latest
+  image: parity/polkadot:v0.9.42
   chain: rococo-local
   env:
     RUST_LOG: parachain::candidate-backing=trace,parachain::candidate-selection=trace,parachain::pvf=trace,parachain::collator-protocol=trace,parachain::provisioner=trace

--- a/docker/litmus-parachain-launch-config.yml
+++ b/docker/litmus-parachain-launch-config.yml
@@ -4,7 +4,7 @@
 #
 # Relaychain Configuration
 relaychain:
-  image: parity/polkadot:latest
+  image: parity/polkadot:v0.9.42
   chain: rococo-local
   env:
     RUST_LOG: parachain::candidate-backing=trace,parachain::candidate-selection=trace,parachain::pvf=trace,parachain::collator-protocol=trace,parachain::provisioner=trace

--- a/docker/rococo-parachain-launch-config.yml
+++ b/docker/rococo-parachain-launch-config.yml
@@ -4,7 +4,7 @@
 #
 # Relaychain Configuration
 relaychain:
-  image: parity/polkadot:latest
+  image: parity/polkadot:v0.9.42
   chain: rococo-local
   env:
     RUST_LOG: parachain::candidate-backing=trace,parachain::candidate-selection=trace,parachain::pvf=trace,parachain::collator-protocol=trace,parachain::provisioner=trace


### PR DESCRIPTION
there were breaking changes in polkadot CLI and these changes are not supported by @open-web3/parachain-launch

related: #1774