### PR TITLE
Cargo update and minor template update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,70 +1,20 @@
-## Summary
 
-### Changes
+### Context
 
-<!-- What changes are being made? Is this a change a bugfix or new functionality?  -->
+<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->
 
-### Type of change
+### Labels
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing client application to not work as expected)
-- [ ] Documentation update
-- [ ] Examples (adding tests)
+Please apply following PR-related labels when appropriate:
+- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
+- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement
 
-## Why
-
-<!-- Why are these changes needed? A link to the issue may be sufficient -->
-
-## How (Optional)
+### How (Optional)
 
 <!-- How were these changes implemented? -->
 
-## Breaking change checklist
+### Testing Evidences
 
-<!-- Have you done all of these things?  -->
-<!-- to check an item, place an "x" in the box like so: "- [x] Automated tests" -->
-
-- [ ] If any of below files is changed, pls add the breaking-change label to this PR, choose from C0-breaking, C1-noteworthy
-
-1 PalletIdentityManagementCall
-- [ ] pallets/identity-management/src/lib.rs
-- [ ] tee-worker/litentry/pallets/identity-management/src/lib.rs
-
-1.1 setShieldingKey
-- [ ] pallets/identity-management/src/lib.rs#set_user_shielding_key
-- [ ] pallets/identity-management/src/lib.rs#user_shielding_key_set
-- [ ] tee-worker/litentry/pallets/identity-management/src/lib.rs#set_user_shielding_key
-
-1.2 createIdentity
-
-- [ ] pallets/identity-management/src/lib.rs#create_identity
-- [ ] pallets/identity-management/src/lib.rs#identity_created
-- [ ] pallets/tee-worker/litentry/pallets/identity-management/src/lib.rs#create_identity
-- [ ] pallets/ tee-worker/app-libs/stf/src/trusted_call_litentry.rs#create_identity_internal
-
-1.3 verifyIdentity
-- [ ] pallets/identity-management/src/lib.rs#verify_identity
-- [ ] pallets/identity-management/src/lib.rs#identity_verified
-- [ ] pallets/tee-worker/litentry/pallets/identity-management/src/lib.rs#verify_identity
-
-2 PalletVCManagementCall
-- [ ] pallets/vc-management/src/lib.rs
-- [ ] tee-worker/litentry/core/identity-verification
-- [ ] tee-worker/litentry/core/assertion-build/src
-
-2.1 Verify Credential
-- [ ] tee-worker/litentry/core/credentials/src/lib.rs
-- [ ] tee-worker/litentry/core/credentials/src/templates/credential_schema.json
-- [ ] tee-worker/litentry/core/credentials/src/templates/credential.json
-
-2.2 Request VC
-- [ ] pallets/vc-management/src/lib.rs#request_vc
-- [ ] pallets/vc-management/src/lib.rs# vc_issued
-
-
-## Any Testing Evidences
-
-- Please attach any relevent evidences
+Please attach any relevent evidences if applicable
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.2",
+ "gimli 0.27.3",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -165,7 +165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -323,9 +323,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
 
 [[package]]
 name = "asn1-rs"
@@ -340,7 +340,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -356,7 +356,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -420,9 +420,9 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.19",
+ "rustix 0.37.20",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -493,7 +493,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide 0.6.2",
- "object 0.30.3",
+ "object 0.30.4",
  "rustc-demangle",
 ]
 
@@ -677,8 +677,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
- "constant_time_eq 0.2.5",
+ "arrayvec 0.7.3",
+ "constant_time_eq 0.2.6",
 ]
 
 [[package]]
@@ -688,21 +688,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
- "constant_time_eq 0.2.5",
+ "arrayvec 0.7.3",
+ "constant_time_eq 0.2.6",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
+checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "cc",
  "cfg-if",
- "constant_time_eq 0.2.5",
+ "constant_time_eq 0.2.6",
  "digest 0.10.7",
 ]
 
@@ -763,9 +763,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbd1d11282a1eb134d3c3b7cf8ce213b5161c6e5f73fb1b98618482c606b64"
+checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.2"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.1"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1172,9 +1172,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "convert_case"
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -1263,7 +1263,7 @@ version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "253531aca9b6f56103c9420369db3263e784df39aa1c90685a1f69cfbba0623e"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -1403,14 +1403,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -2059,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109308c20e8445959c2792e81871054c6a17e6976489a93d2769641a2ba5839c"
+checksum = "e88abab2f5abbe4c56e8f1fb431b784d710b709888f35755a160e62e33fe38e8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf4c6755cdf10798b97510e0e2b3edb9573032bd9379de8fffa59d68165494f"
+checksum = "5c0c11acd0e63bae27dcd2afced407063312771212b7a823b4fd72d633be30fb"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2086,15 +2086,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882074421238e84fe3b4c65d0081de34e5b323bf64555d3e61991f76eb64a7bb"
+checksum = "8d3816ed957c008ccd4728485511e3d9aaf7db419aa321e3d2c5a2f3411e36c8"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a076022ece33e7686fb76513518e219cca4fce5750a8ae6d1ce6c0f48fd1af9"
+checksum = "a26acccf6f445af85ea056362561a24ef56cdc15fcc685f03aec50b9c702cb6d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2812,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -3404,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3430,7 +3430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
  "opaque-debug 0.3.0",
- "polyval 0.6.0",
+ "polyval 0.6.1",
 ]
 
 [[package]]
@@ -3446,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -3717,7 +3717,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.9",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -3741,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3781,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -3935,13 +3935,13 @@ checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.3",
  "widestring",
- "winapi",
+ "windows-sys 0.48.0",
  "winreg",
 ]
 
@@ -3959,7 +3959,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes 1.0.11",
- "rustix 0.37.19",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -3989,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4038,7 +4038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "async-lock",
  "async-trait",
  "beef",
@@ -4129,7 +4129,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -4300,9 +4300,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -4335,7 +4335,7 @@ dependencies = [
  "bytes",
  "futures 0.3.28",
  "futures-timer",
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "instant",
  "libp2p-core 0.38.0",
  "libp2p-dns",
@@ -4386,7 +4386,7 @@ dependencies = [
  "rand 0.8.5",
  "rw-stream-sink",
  "sec1",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "smallvec",
  "thiserror",
  "unsigned-varint",
@@ -4470,7 +4470,7 @@ dependencies = [
  "multihash 0.17.0",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror",
  "zeroize",
 ]
@@ -4481,7 +4481,7 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2766dcd2be8c87d5e1f35487deb22d765f49c6ae1251b3633efe3b25698bd3d2"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "asynchronous-codec",
  "bytes",
  "either",
@@ -4495,7 +4495,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "smallvec",
  "thiserror",
  "uint",
@@ -4517,7 +4517,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "trust-dns-proto",
  "void",
@@ -4570,7 +4570,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "snow",
  "static_assertions",
  "thiserror",
@@ -4678,7 +4678,7 @@ dependencies = [
  "libc",
  "libp2p-core 0.38.0",
  "log",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
 ]
 
@@ -5161,9 +5161,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -5171,9 +5171,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "lru"
@@ -5283,7 +5283,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix 0.37.19",
+ "rustix 0.37.20",
 ]
 
 [[package]]
@@ -5315,9 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -5518,7 +5518,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "unsigned-varint",
 ]
@@ -5796,7 +5796,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "itoa",
 ]
 
@@ -5856,9 +5856,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
@@ -5883,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -6037,7 +6037,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -6048,7 +6048,7 @@ checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -7372,11 +7372,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+checksum = "430d26d62e66cbff6ae144e8eebd43c0235922dec7e3aa0d2016c32d4575bf45"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "bitvec",
  "byte-slice-cast",
  "bytes",
@@ -7387,9 +7387,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "a1620b1e3fc72ebaee01ff56fca838bab537c5d093a18b3549c3bbea374aa0b6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7433,7 +7433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -7452,15 +7452,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -7513,9 +7513,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
@@ -7558,7 +7558,7 @@ checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -8823,9 +8823,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -8944,9 +8944,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -9202,7 +9202,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -9269,7 +9269,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.3.21",
+ "time 0.3.22",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -9282,7 +9282,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.3.21",
+ "time 0.3.22",
  "yasna",
 ]
 
@@ -9310,7 +9310,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -9362,11 +9362,11 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr",
  "regex-syntax 0.7.2",
 ]
@@ -9855,9 +9855,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno 0.3.1",
@@ -9894,9 +9894,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -9938,9 +9938,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safe_arch"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+checksum = "62a7484307bd40f8f7ccbacccac730108f2cae119a3b11c74485b48aa9ea650f"
 dependencies = [
  "bytemuck",
 ]
@@ -11223,18 +11223,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11243,9 +11243,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",
@@ -11326,9 +11326,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -11504,7 +11504,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "subtle",
 ]
 
@@ -11516,6 +11516,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11888,7 +11898,7 @@ dependencies = [
  "blake2",
  "byteorder",
  "digest 0.10.7",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "sp-std 5.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.37)",
  "twox-hash",
@@ -11902,7 +11912,7 @@ dependencies = [
  "blake2",
  "byteorder",
  "digest 0.10.7",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "sp-std 5.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39)",
  "twox-hash",
@@ -13044,15 +13054,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.19",
- "windows-sys 0.45.0",
+ "rustix 0.37.20",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -13171,9 +13182,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",
@@ -13208,7 +13219,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -13254,7 +13265,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite 0.2.9",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -13539,7 +13550,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -13759,12 +13770,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
+ "idna 0.4.0",
  "percent-encoding",
 ]
 
@@ -13776,11 +13787,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -13834,11 +13845,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -13862,9 +13872,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -13872,9 +13882,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -13887,9 +13897,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -13899,9 +13909,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13909,9 +13919,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13922,9 +13932,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-instrument"
@@ -14129,7 +14139,7 @@ dependencies = [
  "log",
  "rustix 0.36.14",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "toml",
  "windows-sys 0.42.0",
  "zstd",
@@ -14347,9 +14357,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14417,10 +14427,10 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "stun",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
  "tokio",
  "turn",
  "url",
@@ -14480,7 +14490,7 @@ dependencies = [
  "sec1",
  "serde",
  "sha1",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "signature",
  "subtle",
  "thiserror",
@@ -14522,7 +14532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08dfd7a6e3987e255c4dbe710dde5d94d0f0574f8a21afa95d171376c143106"
 dependencies = [
  "log",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tokio",
  "webrtc-util",
@@ -14722,9 +14732,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0496a71f3cc6bc4bf0ed91346426a5099e93d89807e663162dc5a1069ff65"
+checksum = "40018623e2dba2602a9790faba8d33f2ebdebf4b86561b83928db735f8784728"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -14732,9 +14742,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.5.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -15011,20 +15021,21 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -15086,7 +15097,7 @@ dependencies = [
  "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -15104,7 +15115,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -15194,18 +15205,18 @@ dependencies = [
 
 [[package]]
 name = "xous"
-version = "0.9.44"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30684dda3583f528d5b05bddc96527e1783255e867a5e81c10721d6abb9e169c"
+checksum = "648387c0ac9e051154d7b9fa56ce5845bffa576387ed2b18a3b5977341c77982"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6b15ea09891f09b02d763422dc99733c96e62d0f8ab476c6bc663c90b17e72"
+checksum = "24aad5ecdee87526a97eaaa7f26d22c0fe419667727598d694bda183dfa31847"
 dependencies = [
  "log",
  "num-derive",
@@ -15216,9 +15227,9 @@ dependencies = [
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.42"
+version = "0.9.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b470fbf177d58767fa001acfcb5294a88d3938d3935865ff6b8f1db40f1004e"
+checksum = "92baa5a52f91e40d015a53db1891c66ee7c715b22d1e9731a6fb29e3d9df1061"
 dependencies = [
  "log",
  "num-derive",
@@ -15231,9 +15242,9 @@ dependencies = [
 
 [[package]]
 name = "xous-ipc"
-version = "0.9.44"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d520fe08642d55a56f700b6d30c7a556f38818e7c3e5d9a0856dde0b79ed4d67"
+checksum = "510be937e654eeed0b60f627b4615e7a89e3cba88e20f1198ed16a87ea4b5fde"
 dependencies = [
  "bitflags",
  "rkyv",
@@ -15260,7 +15271,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
@@ -120,7 +120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
 dependencies = [
  "aead 0.5.2",
- "aes 0.8.2",
+ "aes 0.8.3",
  "cipher 0.4.4",
  "ctr 0.9.2",
  "ghash 0.5.0",
@@ -323,9 +323,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asn1-rs"
@@ -677,7 +677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "constant_time_eq 0.2.6",
 ]
 
@@ -688,7 +688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "constant_time_eq 0.2.6",
 ]
 
@@ -699,7 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "cc",
  "cfg-if",
  "constant_time_eq 0.2.6",
@@ -1263,7 +1263,7 @@ version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "253531aca9b6f56103c9420369db3263e784df39aa1c90685a1f69cfbba0623e"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -4038,7 +4038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "async-lock",
  "async-trait",
  "beef",
@@ -4481,7 +4481,7 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2766dcd2be8c87d5e1f35487deb22d765f49c6ae1251b3633efe3b25698bd3d2"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "asynchronous-codec",
  "bytes",
  "either",
@@ -5796,7 +5796,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "itoa",
 ]
 
@@ -7372,11 +7372,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430d26d62e66cbff6ae144e8eebd43c0235922dec7e3aa0d2016c32d4575bf45"
+checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "bitvec",
  "byte-slice-cast",
  "bytes",
@@ -7387,9 +7387,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1620b1e3fc72ebaee01ff56fca838bab537c5d093a18b3549c3bbea374aa0b6"
+checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7519,9 +7519,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -7529,9 +7529,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -7539,9 +7539,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
 dependencies = [
  "pest",
  "pest_meta",
@@ -7552,9 +7552,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
 dependencies = [
  "once_cell",
  "pest",
@@ -13401,9 +13401,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,7 +17,7 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 async-trait = "0.1.68"
-clap = { version = "4.3.2", features = ["derive"] }
+clap = { version = "4.3", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 futures = { version = "0.3.28", features = ["compat"] }
 hex-literal = "0.4.1"

--- a/pallets/parentchain/Cargo.toml
+++ b/pallets/parentchain/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 
 [dependencies]
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.18", default-features = false }
+log = { version = "0.4", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.13", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 # substrate dependencies
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }

--- a/pallets/sidechain/Cargo.toml
+++ b/pallets/sidechain/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 
 [dependencies]
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.18", default-features = false }
+log = { version = "0.4", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.13", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 # local
 pallet-teerex = { path = "../teerex", default-features = false }

--- a/pallets/teeracle/Cargo.toml
+++ b/pallets/teeracle/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.18", default-features = false }
+log = { version = "0.4", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
 
 # local

--- a/pallets/teerex/Cargo.toml
+++ b/pallets/teerex/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.18", default-features = false }
+log = { version = "0.4", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/pallets/test-utils/Cargo.toml
+++ b/pallets/test-utils/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 hex-literal = { version = "0.4.1" }
-log = { version = "0.4.18", default-features = false }
+log = { version = "0.4", default-features = false }
 
 [dependencies.teerex-primitives]
 default-features = false

--- a/primitives/sidechain/Cargo.toml
+++ b/primitives/sidechain/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.159", default-features = false }
+serde = { version = "1.0", default-features = false }
 
 
 # substrate dependencies

--- a/primitives/teerex/Cargo.toml
+++ b/primitives/teerex/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 common-primitives = { path = "../common", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.159", default-features = false }
+serde = { version = "1.0", default-features = false }
 
 # substrate dependencies
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }

--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -227,9 +227,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
@@ -3174,7 +3174,7 @@ dependencies = [
 name = "itp-attestation-handler"
 version = "0.8.0"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "base64 0.13.1",
  "bit-vec",
@@ -5195,7 +5195,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "itoa 1.0.6",
 ]
 
@@ -5724,11 +5724,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430d26d62e66cbff6ae144e8eebd43c0235922dec7e3aa0d2016c32d4575bf45"
+checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "bitvec",
  "byte-slice-cast",
  "bytes 1.4.0",
@@ -5739,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1620b1e3fc72ebaee01ff56fca838bab537c5d093a18b3549c3bbea374aa0b6"
+checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5907,9 +5907,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
 dependencies = [
  "thiserror 1.0.40",
  "ucd-trie",
@@ -5917,9 +5917,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5927,9 +5927,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
 dependencies = [
  "pest",
  "pest_meta",
@@ -5940,9 +5940,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
 dependencies = [
  "once_cell 1.18.0",
  "pest",
@@ -8642,9 +8642,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 dependencies = [
  "lazy_static",
- "regex 1.8.3",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -18,7 +18,7 @@ version = "0.2.0"
 source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.39-tag-v0.7.0#84af198434ea210eb0cd90cb8239748c376a079a"
 dependencies = [
  "ac-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-application-crypto",
  "sp-core",
@@ -39,11 +39,11 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
@@ -78,7 +78,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.2",
+ "gimli 0.27.3",
 ]
 
 [[package]]
@@ -124,8 +124,8 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.9",
- "once_cell 1.17.2",
+ "getrandom 0.2.10",
+ "once_cell 1.18.0",
  "version_check",
 ]
 
@@ -136,8 +136,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if 1.0.0",
- "getrandom 0.2.9",
- "once_cell 1.17.2",
+ "getrandom 0.2.10",
+ "once_cell 1.18.0",
  "version_check",
 ]
 
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr 2.5.0",
 ]
@@ -227,9 +227,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
 
 [[package]]
 name = "async-trait"
@@ -291,7 +291,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.6.2",
- "object 0.30.3",
+ "object 0.30.4",
  "rustc-demangle",
 ]
 
@@ -355,7 +355,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "hash-db",
- "log 0.4.18",
+ "log 0.4.19",
 ]
 
 [[package]]
@@ -373,7 +373,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -390,7 +390,7 @@ dependencies = [
  "peeking_take_while",
  "proc-macro2",
  "quote",
- "regex 1.8.3",
+ "regex 1.8.4",
  "rustc-hash",
  "shlex",
  "syn 1.0.109",
@@ -490,14 +490,14 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbd1d11282a1eb134d3c3b7cf8ce213b5161c6e5f73fb1b98618482c606b64"
+checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
 dependencies = [
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -513,7 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr 2.5.0",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -654,7 +654,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.15",
- "serde 1.0.163",
+ "serde 1.0.164",
  "time",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -707,7 +707,7 @@ dependencies = [
  "clap_derive",
  "clap_lex",
  "indexmap 1.9.3",
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.16.0",
@@ -770,8 +770,8 @@ dependencies = [
  "pathdiff",
  "ron",
  "rust-ini",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "toml",
  "yaml-rust 0.4.5",
 ]
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -847,7 +847,7 @@ version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42ea692c7b450ad18b8c9889661505d51c09ec4380cf1c2d278dbb2da22cae1"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -882,22 +882,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1248,8 +1248,8 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.18",
- "regex 1.8.3",
+ "log 0.4.19",
+ "regex 1.8.4",
  "termcolor",
 ]
 
@@ -1261,8 +1261,8 @@ checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
  "humantime",
  "is-terminal",
- "log 0.4.18",
- "regex 1.8.3",
+ "log 0.4.19",
+ "regex 1.8.4",
  "termcolor",
 ]
 
@@ -1328,7 +1328,7 @@ dependencies = [
  "parity-scale-codec",
  "rlp",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sha3",
  "triehash",
 ]
@@ -1361,12 +1361,12 @@ dependencies = [
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "primitive-types",
  "rlp",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sha3",
 ]
 
@@ -1379,7 +1379,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -1469,7 +1469,7 @@ dependencies = [
  "either",
  "futures 0.3.28",
  "futures-timer",
- "log 0.4.18",
+ "log 0.4.19",
  "num-traits 0.2.15",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -1552,11 +1552,11 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
- "percent-encoding 2.2.0",
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
@@ -1567,10 +1567,10 @@ dependencies = [
  "hex 0.4.3",
  "impl-serde",
  "libsecp256k1",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -1585,7 +1585,7 @@ dependencies = [
  "evm",
  "frame-support",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-runtime",
  "sp-std 5.0.0",
@@ -1606,11 +1606,11 @@ dependencies = [
  "frame-support-procedural",
  "frame-system",
  "linregress",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "paste",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -1646,7 +1646,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -1658,7 +1658,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -1671,12 +1671,12 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
- "log 0.4.18",
- "once_cell 1.17.2",
+ "log 0.4.19",
+ "once_cell 1.18.0",
  "parity-scale-codec",
  "paste",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "smallvec 1.10.0",
  "sp-api",
  "sp-arithmetic",
@@ -1736,10 +1736,10 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "frame-support",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -2039,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2060,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -2079,8 +2079,8 @@ dependencies = [
  "aho-corasick 0.7.20",
  "bstr",
  "fnv 1.0.7",
- "log 0.4.18",
- "regex 1.8.3",
+ "log 0.4.19",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -2330,7 +2330,7 @@ name = "http_req"
 version = "0.8.1"
 source = "git+https://github.com/integritee-network/http_req?branch=master#3723e88235f2b29bc1a31835853b072ffd0455fd"
 dependencies = [
- "log 0.4.18",
+ "log 0.4.19",
  "rustls 0.19.1",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2342,7 +2342,7 @@ name = "http_req"
 version = "0.8.1"
 source = "git+https://github.com/integritee-network/http_req#3723e88235f2b29bc1a31835853b072ffd0455fd"
 dependencies = [
- "log 0.4.18",
+ "log 0.4.19",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
  "sgx_tstd",
  "unicase 2.6.0 (git+https://github.com/mesalock-linux/unicase-sgx)",
@@ -2422,7 +2422,7 @@ dependencies = [
  "ct-logs",
  "futures-util 0.3.28",
  "hyper",
- "log 0.4.18",
+ "log 0.4.19",
  "rustls 0.19.1",
  "rustls-native-certs",
  "tokio",
@@ -2445,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2479,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi 0.3.13",
  "unicode-normalization 0.1.22",
@@ -2511,7 +2511,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -2543,7 +2543,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -2589,7 +2589,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-balances",
  "pallet-evm",
  "parity-scale-codec",
@@ -2598,8 +2598,8 @@ dependencies = [
  "rayon",
  "sc-keystore",
  "scale-value",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_crypto_helper",
  "sp-application-crypto",
  "sp-core",
@@ -2655,7 +2655,7 @@ dependencies = [
  "lc-data-providers",
  "lc-mock-server",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "mockall",
  "pallet-balances",
  "parity-scale-codec",
@@ -2664,9 +2664,9 @@ dependencies = [
  "primitive-types",
  "prometheus",
  "scale-info",
- "serde 1.0.163",
- "serde_derive 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
+ "serde_json 1.0.97",
  "sgx-verify",
  "sgx_crypto_helper",
  "sgx_types",
@@ -2726,8 +2726,8 @@ dependencies = [
  "hyper-multipart-rfc7578",
  "hyper-tls",
  "parity-multiaddr",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "serde_urlencoded",
  "tokio",
  "tokio-util 0.6.10",
@@ -2744,7 +2744,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix 0.37.19",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -2756,16 +2756,16 @@ dependencies = [
  "itp-enclave-metrics",
  "itp-ocall-api",
  "lazy_static",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "substrate-fixed",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -2794,7 +2794,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -2829,7 +2829,7 @@ dependencies = [
  "lc-scheduled-enclave",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-balances",
  "pallet-parentchain",
  "pallet-sudo",
@@ -2855,9 +2855,9 @@ dependencies = [
  "itp-utils",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -2880,7 +2880,7 @@ dependencies = [
  "itp-test",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -2911,7 +2911,7 @@ dependencies = [
  "itc-parentchain-block-importer",
  "itp-block-import-queue",
  "itp-types",
- "log 0.4.18",
+ "log 0.4.19",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -2930,7 +2930,7 @@ dependencies = [
  "itp-settings",
  "itp-stf-executor",
  "itp-types",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -2965,7 +2965,7 @@ dependencies = [
  "itp-utils",
  "lc-scheduled-enclave",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-identity-management",
  "pallet-vc-management",
  "parity-scale-codec",
@@ -2995,7 +2995,7 @@ dependencies = [
  "itp-test",
  "itp-types",
  "lazy_static",
- "log 0.4.18",
+ "log 0.4.19",
  "num-traits 0.2.15",
  "parity-scale-codec",
  "sgx_tstd",
@@ -3016,10 +3016,10 @@ dependencies = [
  "frame-support",
  "frame-system",
  "itp-types",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -3035,15 +3035,15 @@ dependencies = [
  "http 0.2.9",
  "http_req 0.8.1 (git+https://github.com/integritee-network/http_req?branch=master)",
  "http_req 0.8.1 (git+https://github.com/integritee-network/http_req)",
- "log 0.4.18",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "log 0.4.19",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sgx_types",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -3058,18 +3058,18 @@ dependencies = [
  "itp-stf-primitives",
  "itp-types",
  "itp-utils",
- "log 0.4.18",
+ "log 0.4.19",
  "openssl",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rustls 0.19.1",
- "serde_derive 1.0.163",
- "serde_json 1.0.96",
+ "serde_derive 1.0.164",
+ "serde_json 1.0.97",
  "sgx_crypto_helper",
  "substrate-api-client",
  "teerex-primitives",
  "thiserror 1.0.40",
- "url 2.3.1",
+ "url 2.4.0",
  "ws",
 ]
 
@@ -3088,9 +3088,9 @@ dependencies = [
  "its-storage",
  "its-test",
  "jsonrpsee",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "tokio",
 ]
@@ -3102,7 +3102,7 @@ dependencies = [
  "bit-vec",
  "chrono 0.4.26",
  "env_logger 0.9.3",
- "log 0.4.18",
+ "log 0.4.19",
  "mio 0.6.21",
  "mio 0.6.23",
  "mio-extras 2.0.6 (git+https://github.com/integritee-network/mio-extras-sgx?rev=963234b)",
@@ -3117,7 +3117,7 @@ dependencies = [
  "thiserror 1.0.9",
  "tungstenite 0.14.0",
  "tungstenite 0.15.0",
- "url 2.3.1",
+ "url 2.4.0",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
  "yasna 0.3.1",
@@ -3174,7 +3174,7 @@ dependencies = [
 name = "itp-attestation-handler"
 version = "0.8.0"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "base64 0.13.1",
  "bit-vec",
@@ -3189,13 +3189,13 @@ dependencies = [
  "itp-sgx-io",
  "itp-time-utils",
  "itp-types",
- "log 0.4.18",
+ "log 0.4.19",
  "num-bigint 0.2.5",
  "parity-scale-codec",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3)",
  "rustls 0.19.1",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_rand",
  "sgx_tcrypto",
  "sgx_tse",
@@ -3241,9 +3241,9 @@ dependencies = [
  "itp-types",
  "lc-data-providers",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
@@ -3276,7 +3276,7 @@ dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
  "itp-types",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3331,7 +3331,7 @@ dependencies = [
  "itp-sgx-runtime-primitives",
  "itp-types",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "primitive-types",
  "sp-core",
@@ -3389,8 +3389,8 @@ version = "0.9.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
 ]
 
@@ -3406,13 +3406,13 @@ dependencies = [
  "derive_more",
  "itp-settings",
  "itp-sgx-io",
- "log 0.4.18",
+ "log 0.4.19",
  "ofb",
  "parity-scale-codec",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_crypto_helper",
  "sgx_rand",
  "sgx_tstd",
@@ -3427,10 +3427,10 @@ dependencies = [
  "derive_more",
  "environmental 1.1.3",
  "itp-hashing",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "postcard",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sp-core",
 ]
@@ -3472,7 +3472,7 @@ dependencies = [
  "itp-time-utils",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_crypto_helper",
  "sgx_tstd",
@@ -3517,7 +3517,7 @@ dependencies = [
  "itp-time-utils",
  "itp-types",
  "lazy_static",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
@@ -3534,7 +3534,7 @@ name = "itp-stf-state-observer"
 version = "0.9.0"
 dependencies = [
  "itp-types",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "thiserror 1.0.40",
@@ -3617,10 +3617,10 @@ dependencies = [
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "linked-hash-map 0.5.2",
  "linked-hash-map 0.5.6",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "parity-util-mem",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sgx_types",
  "sp-application-crypto",
@@ -3648,7 +3648,7 @@ dependencies = [
  "itp-utils",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_crypto_helper",
  "sgx_tstd",
@@ -3672,8 +3672,8 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "primitive-types",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-runtime",
  "sp-std 5.0.0",
@@ -3709,7 +3709,7 @@ dependencies = [
  "itp-types",
  "its-primitives",
  "its-state",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3729,7 +3729,7 @@ dependencies = [
  "itp-utils",
  "its-primitives",
  "its-test",
- "log 0.4.18",
+ "log 0.4.19",
  "sgx_tstd",
  "sp-consensus-slots",
  "sp-core",
@@ -3771,7 +3771,7 @@ dependencies = [
  "its-test",
  "its-validateer-fetch",
  "lc-scheduled-enclave",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-core",
@@ -3800,7 +3800,7 @@ dependencies = [
  "its-primitives",
  "its-state",
  "its-test",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3833,7 +3833,7 @@ dependencies = [
  "its-test",
  "lazy_static",
  "lc-scheduled-enclave",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-consensus-slots",
@@ -3856,9 +3856,9 @@ dependencies = [
  "its-storage",
  "its-test",
  "jsonrpsee",
- "log 0.4.18",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "log 0.4.19",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "thiserror 1.0.40",
  "tokio",
 ]
@@ -3869,7 +3869,7 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -3888,7 +3888,7 @@ dependencies = [
  "its-primitives",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
@@ -3919,9 +3919,9 @@ dependencies = [
  "itp-sgx-externalities",
  "itp-storage",
  "its-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sp-core",
  "sp-io 7.0.0",
@@ -3939,12 +3939,12 @@ dependencies = [
  "itp-types",
  "its-primitives",
  "its-test",
- "log 0.4.18",
+ "log 0.4.19",
  "mockall",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rocksdb",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "temp-dir",
  "thiserror 1.0.40",
@@ -3991,9 +3991,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4006,7 +4006,7 @@ checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
 dependencies = [
  "pest",
  "pest_derive",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -4018,10 +4018,10 @@ dependencies = [
  "futures 0.3.28",
  "futures-executor 0.3.28",
  "futures-util 0.3.28",
- "log 0.4.18",
- "serde 1.0.163",
- "serde_derive 1.0.163",
- "serde_json 1.0.96",
+ "log 0.4.19",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
+ "serde_json 1.0.97",
 ]
 
 [[package]]
@@ -4063,11 +4063,11 @@ dependencies = [
  "hyper-rustls",
  "jsonrpsee-types",
  "jsonrpsee-utils",
- "log 0.4.18",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "log 0.4.19",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "thiserror 1.0.40",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4083,9 +4083,9 @@ dependencies = [
  "jsonrpsee-types",
  "jsonrpsee-utils",
  "lazy_static",
- "log 0.4.18",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "log 0.4.19",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "socket2",
  "thiserror 1.0.40",
  "tokio",
@@ -4116,9 +4116,9 @@ dependencies = [
  "futures-channel 0.3.28",
  "futures-util 0.3.28",
  "hyper",
- "log 0.4.18",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "log 0.4.19",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "soketto",
  "thiserror 1.0.40",
 ]
@@ -4133,12 +4133,12 @@ dependencies = [
  "futures-util 0.3.28",
  "hyper",
  "jsonrpsee-types",
- "log 0.4.18",
+ "log 0.4.19",
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "rustc-hash",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "thiserror 1.0.40",
 ]
 
@@ -4152,18 +4152,18 @@ dependencies = [
  "fnv 1.0.7",
  "futures 0.3.28",
  "jsonrpsee-types",
- "log 0.4.18",
+ "log 0.4.19",
  "pin-project",
  "rustls 0.19.1",
  "rustls-native-certs",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "soketto",
  "thiserror 1.0.40",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.6.10",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4176,10 +4176,10 @@ dependencies = [
  "futures-util 0.3.28",
  "jsonrpsee-types",
  "jsonrpsee-utils",
- "log 0.4.18",
+ "log 0.4.19",
  "rustc-hash",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "soketto",
  "thiserror 1.0.40",
  "tokio",
@@ -4196,7 +4196,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -4261,10 +4261,10 @@ dependencies = [
  "lc-data-providers",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -4273,7 +4273,7 @@ dependencies = [
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4299,16 +4299,16 @@ dependencies = [
  "itp-utils",
  "lc-data-providers",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?tag=sgx_1.1.3)",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx)",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-runtime",
@@ -4316,7 +4316,7 @@ dependencies = [
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4335,15 +4335,15 @@ dependencies = [
  "lazy_static",
  "lc-mock-server",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4371,10 +4371,10 @@ dependencies = [
  "lc-data-providers",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -4382,7 +4382,7 @@ dependencies = [
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4394,9 +4394,9 @@ dependencies = [
  "lazy_static",
  "lc-data-providers",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "tokio",
  "warp",
@@ -4412,7 +4412,7 @@ dependencies = [
  "itp-types",
  "lazy_static",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -4456,17 +4456,17 @@ dependencies = [
  "lc-identity-verification",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-std 5.0.0",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4485,24 +4485,24 @@ dependencies = [
  "itp-utils",
  "lazy_static",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-runtime",
  "sp-std 5.0.0",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -4548,7 +4548,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sha2 0.9.9",
  "typenum 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4643,8 +4643,8 @@ dependencies = [
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?tag=sgx_1.1.3)",
  "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "scale-info",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-runtime",
@@ -4653,9 +4653,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
@@ -4681,9 +4681,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "mach"
@@ -4740,7 +4740,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix 0.37.19",
+ "rustix 0.37.20",
 ]
 
 [[package]]
@@ -4754,9 +4754,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -4855,9 +4855,9 @@ dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys",
  "libc",
- "log 0.4.18",
+ "log 0.4.19",
  "miow",
- "net2 0.2.38",
+ "net2 0.2.39",
  "slab 0.4.8",
  "winapi 0.2.8",
 ]
@@ -4880,7 +4880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.18",
+ "log 0.4.19",
  "mio 0.6.23",
  "slab 0.4.8",
 ]
@@ -4891,7 +4891,7 @@ version = "2.0.6"
 source = "git+https://github.com/integritee-network/mio-extras-sgx?rev=963234b#963234bf55e44f9efff921938255126c48deef3a"
 dependencies = [
  "lazycell",
- "log 0.4.18",
+ "log 0.4.19",
  "mio 0.6.21",
  "mio 0.6.23",
  "sgx_tstd",
@@ -4906,7 +4906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
- "net2 0.2.38",
+ "net2 0.2.39",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -4949,7 +4949,7 @@ dependencies = [
  "futures-util 0.3.28",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.18",
+ "log 0.4.19",
  "memchr 2.5.0",
  "mime",
  "spin 0.9.8",
@@ -5016,7 +5016,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.18",
+ "log 0.4.19",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -5038,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -5195,7 +5195,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "itoa 1.0.6",
 ]
 
@@ -5318,9 +5318,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr 2.5.0",
 ]
@@ -5344,9 +5344,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -5370,7 +5370,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -5416,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "pallet-aura"
@@ -5458,7 +5458,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -5479,7 +5479,7 @@ dependencies = [
  "frame-system",
  "hex 0.4.3",
  "impl-trait-for-tuples",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "rlp",
@@ -5498,7 +5498,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -5522,7 +5522,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-teerex",
  "parity-scale-codec",
  "scale-info",
@@ -5542,13 +5542,13 @@ dependencies = [
  "frame-system",
  "hex 0.4.3",
  "litentry-primitives",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
- "serde_derive 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -5575,10 +5575,10 @@ version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -5593,7 +5593,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -5626,11 +5626,11 @@ version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx-verify",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -5647,7 +5647,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
@@ -5666,7 +5666,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -5694,7 +5694,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
@@ -5715,33 +5715,33 @@ dependencies = [
  "byteorder 1.4.3",
  "data-encoding",
  "multihash",
- "percent-encoding 2.2.0",
- "serde 1.0.163",
+ "percent-encoding 2.3.0",
+ "serde 1.0.164",
  "static_assertions",
  "unsigned-varint 0.7.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+checksum = "430d26d62e66cbff6ae144e8eebd43c0235922dec7e3aa0d2016c32d4575bf45"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "bitvec",
  "byte-slice-cast",
  "bytes 1.4.0",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "a1620b1e3fc72ebaee01ff56fca838bab537c5d093a18b3549c3bbea374aa0b6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5797,7 +5797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -5816,15 +5816,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec 1.10.0",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -5835,7 +5835,7 @@ checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
 dependencies = [
  "lazy_static",
  "num 0.2.1",
- "regex 1.8.3",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -5901,9 +5901,9 @@ source = "git+https://github.com/mesalock-linux/rust-url-sgx?tag=sgx_1.1.3#23832
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
@@ -5944,9 +5944,9 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
  "pest",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -6004,7 +6004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
 dependencies = [
  "postcard-cobs",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -6035,7 +6035,7 @@ dependencies = [
  "itertools",
  "normalize-line-endings",
  "predicates-core",
- "regex 1.8.3",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -6074,7 +6074,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
  "toml_edit",
 ]
 
@@ -6116,9 +6116,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -6307,7 +6307,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -6396,7 +6396,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror 1.0.40",
 ]
@@ -6432,11 +6432,11 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr 2.5.0",
  "regex-syntax 0.7.2",
 ]
@@ -6500,7 +6500,7 @@ checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
  "spin 0.5.2",
  "untrusted",
  "web-sys",
@@ -6514,8 +6514,8 @@ source = "git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup#8b
 dependencies = [
  "cc",
  "libc",
- "log 0.4.18",
- "once_cell 1.17.2",
+ "log 0.4.19",
+ "once_cell 1.18.0",
  "rkyv",
  "spin 0.5.2",
  "untrusted",
@@ -6587,7 +6587,7 @@ checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
  "base64 0.13.1",
  "bitflags",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -6679,9 +6679,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
@@ -6737,7 +6737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.1",
- "log 0.4.18",
+ "log 0.4.19",
  "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "sct 0.6.1",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6787,9 +6787,9 @@ dependencies = [
 
 [[package]]
 name = "safe_arch"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+checksum = "62a7484307bd40f8f7ccbacccac730108f2cae119a3b11c74485b48aa9ea650f"
 dependencies = [
  "bytemuck",
 ]
@@ -6811,7 +6811,7 @@ dependencies = [
  "array-bytes",
  "async-trait",
  "parking_lot 0.12.1",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
@@ -6826,7 +6826,7 @@ checksum = "8dd7aca73785181cc41f0bbe017263e682b585ca660540ba569133901d013ecf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -6852,7 +6852,7 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -6879,7 +6879,7 @@ dependencies = [
  "scale-bits",
  "scale-decode",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "thiserror 1.0.40",
  "yap",
 ]
@@ -7058,11 +7058,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
- "serde_derive 1.0.163",
+ "serde_derive 1.0.164",
 ]
 
 [[package]]
@@ -7071,8 +7071,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b926cfbabfe8011609dda0350cb24d884955d294909ac71c0db7027366c77e3e"
 dependencies = [
- "serde 1.0.163",
- "serde_derive 1.0.163",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
 ]
 
 [[package]]
@@ -7096,9 +7096,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7130,14 +7130,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "indexmap 1.9.3",
  "itoa 1.0.6",
  "ryu",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -7149,7 +7149,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.6",
  "ryu",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -7164,8 +7164,8 @@ dependencies = [
  "parity-scale-codec",
  "ring 0.16.20 (git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup)",
  "scale-info",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-std 5.0.0",
@@ -7202,11 +7202,11 @@ dependencies = [
  "itertools",
  "libc",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde-big-array 0.1.5",
  "serde-big-array 0.3.0",
  "serde_derive 1.0.118",
- "serde_derive 1.0.163",
+ "serde_derive 1.0.164",
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
@@ -7402,9 +7402,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -7519,7 +7519,7 @@ dependencies = [
  "bytes 1.4.0",
  "futures 0.3.28",
  "httparse 1.8.0",
- "log 0.4.18",
+ "log 0.4.19",
  "rand 0.8.5",
  "sha-1 0.9.8",
 ]
@@ -7530,7 +7530,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "hash-db",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-api-proc-macro",
  "sp-core",
@@ -7561,7 +7561,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-std 5.0.0",
@@ -7576,7 +7576,7 @@ dependencies = [
  "num-traits 0.2.15",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-std 5.0.0",
  "static_assertions",
 ]
@@ -7600,7 +7600,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "async-trait",
  "futures 0.3.28",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-core",
  "sp-inherents",
@@ -7636,7 +7636,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-std 5.0.0",
  "sp-timestamp",
 ]
@@ -7659,18 +7659,18 @@ dependencies = [
  "impl-serde",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.18",
+ "log 0.4.19",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "primitive-types",
  "rand 0.8.5",
- "regex 1.8.3",
+ "regex 1.8.4",
  "scale-info",
  "schnorrkel",
  "secp256k1",
  "secrecy",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core-hashing 5.0.0",
  "sp-debug-derive",
  "sp-externalities",
@@ -7692,7 +7692,7 @@ dependencies = [
  "blake2",
  "byteorder 1.4.3",
  "digest 0.10.7",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "sp-std 5.0.0",
  "twox-hash",
@@ -7707,7 +7707,7 @@ dependencies = [
  "blake2",
  "byteorder 1.4.3",
  "digest 0.10.7",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "sp-std 6.0.0",
  "twox-hash",
@@ -7751,10 +7751,10 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "finality-grandpa",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -7787,7 +7787,7 @@ dependencies = [
  "hash-db",
  "itp-sgx-externalities",
  "libsecp256k1",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sgx_tstd",
@@ -7811,7 +7811,7 @@ dependencies = [
  "ed25519-dalek",
  "futures 0.3.28",
  "libsecp256k1",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "secp256k1",
  "sp-core",
@@ -7848,7 +7848,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "schnorrkel",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-externalities",
  "thiserror 1.0.40",
@@ -7871,7 +7871,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "backtrace",
  "lazy_static",
- "regex 1.8.3",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -7880,7 +7880,7 @@ version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "rustc-hash",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
 ]
 
@@ -7892,12 +7892,12 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "paste",
  "rand 0.8.5",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
@@ -7968,7 +7968,7 @@ version = "0.13.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "hash-db",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -8001,7 +8001,7 @@ dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-debug-derive",
  "sp-std 5.0.0",
 ]
@@ -8013,7 +8013,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "async-trait",
  "futures-timer",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
@@ -8074,7 +8074,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core-hashing-proc-macro",
  "sp-runtime",
  "sp-std 5.0.0",
@@ -8100,7 +8100,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-std 5.0.0",
  "wasmi",
@@ -8114,7 +8114,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "smallvec 1.10.0",
  "sp-arithmetic",
  "sp-core",
@@ -8154,8 +8154,8 @@ dependencies = [
  "num-format",
  "proc-macro2",
  "quote",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "unicode-xid",
 ]
 
@@ -8217,13 +8217,13 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
- "log 0.4.18",
+ "log 0.4.19",
  "pallet-balances",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "primitive-types",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-rpc",
  "sp-runtime",
@@ -8256,7 +8256,7 @@ dependencies = [
  "hex 0.4.3",
  "parking_lot 0.12.1",
  "sc-keystore",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-application-crypto",
  "sp-core",
  "sp-keyring",
@@ -8270,7 +8270,7 @@ source = "git+https://github.com/encointer/substrate-fixed?tag=v0.5.9#a4fb461aae
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "typenum 1.16.0 (git+https://github.com/encointer/typenum?tag=v1.16.0)",
 ]
 
@@ -8333,7 +8333,7 @@ dependencies = [
  "common-primitives",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-std 5.0.0",
@@ -8347,15 +8347,16 @@ checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.19",
- "windows-sys 0.45.0",
+ "rustix 0.37.20",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8434,7 +8435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
 ]
 
 [[package]]
@@ -8456,11 +8457,11 @@ checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
 dependencies = [
  "anyhow",
  "hmac 0.12.1",
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror 1.0.40",
  "unicode-normalization 0.1.22",
  "wasm-bindgen",
@@ -8560,7 +8561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util 0.3.28",
- "log 0.4.18",
+ "log 0.4.19",
  "tokio",
  "tungstenite 0.18.0",
 ]
@@ -8575,7 +8576,7 @@ dependencies = [
  "futures-core 0.3.28",
  "futures-io 0.3.28",
  "futures-sink 0.3.28",
- "log 0.4.18",
+ "log 0.4.19",
  "pin-project-lite",
  "tokio",
 ]
@@ -8600,7 +8601,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -8633,7 +8634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.18",
+ "log 0.4.19",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8656,7 +8657,7 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
  "valuable",
 ]
 
@@ -8667,7 +8668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
- "log 0.4.18",
+ "log 0.4.19",
  "tracing-core",
 ]
 
@@ -8677,7 +8678,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
  "tracing-core",
 ]
 
@@ -8691,9 +8692,9 @@ dependencies = [
  "chrono 0.4.26",
  "lazy_static",
  "matchers",
- "regex 1.8.3",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "regex 1.8.4",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sharded-slab",
  "smallvec 1.10.0",
  "thread_local",
@@ -8711,7 +8712,7 @@ checksum = "3390c0409daaa6027d6681393316f4ccd3ff82e1590a1e4725014e3ae2bf1920"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
- "log 0.4.18",
+ "log 0.4.19",
  "rustc-hex",
  "smallvec 1.10.0",
 ]
@@ -8780,12 +8781,12 @@ dependencies = [
  "bytes 1.4.0",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.18",
+ "log 0.4.19",
  "rand 0.8.5",
  "rustls 0.19.1",
  "sha-1 0.9.8",
  "thiserror 1.0.40",
- "url 2.3.1",
+ "url 2.4.0",
  "utf-8 0.7.6",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.21.1",
@@ -8802,11 +8803,11 @@ dependencies = [
  "bytes 1.4.0",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.18",
+ "log 0.4.19",
  "rand 0.8.5",
  "sha1 0.10.5",
  "thiserror 1.0.40",
- "url 2.3.1",
+ "url 2.4.0",
  "utf-8 0.7.6",
 ]
 
@@ -8965,13 +8966,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
- "percent-encoding 2.2.0",
+ "idna 0.4.0",
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
@@ -9024,11 +9025,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log 0.4.18",
  "try-lock",
 ]
 
@@ -9044,16 +9044,16 @@ dependencies = [
  "headers",
  "http 0.2.9",
  "hyper",
- "log 0.4.18",
+ "log 0.4.19",
  "mime",
  "mime_guess",
  "multer",
- "percent-encoding 2.2.0",
+ "percent-encoding 2.3.0",
  "pin-project",
  "rustls-pemfile",
  "scoped-tls",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
@@ -9083,9 +9083,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -9093,13 +9093,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "log 0.4.18",
- "once_cell 1.17.2",
+ "log 0.4.19",
+ "once_cell 1.18.0",
  "proc-macro2",
  "quote",
  "syn 2.0.18",
@@ -9108,9 +9108,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9118,9 +9118,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9131,9 +9131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasmi"
@@ -9175,7 +9175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
 dependencies = [
  "indexmap 1.9.3",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -9189,12 +9189,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "indexmap 1.9.3",
  "libc",
- "log 0.4.18",
+ "log 0.4.19",
  "object 0.29.0",
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
  "paste",
  "psm",
- "serde 1.0.163",
+ "serde 1.0.164",
  "target-lexicon",
  "wasmparser",
  "wasmtime-environ",
@@ -9222,9 +9222,9 @@ dependencies = [
  "cranelift-entity",
  "gimli 0.26.2",
  "indexmap 1.9.3",
- "log 0.4.18",
+ "log 0.4.19",
  "object 0.29.0",
- "serde 1.0.163",
+ "serde 1.0.164",
  "target-lexicon",
  "thiserror 1.0.40",
  "wasmparser",
@@ -9243,10 +9243,10 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli 0.26.2",
- "log 0.4.18",
+ "log 0.4.19",
  "object 0.29.0",
  "rustc-demangle",
- "serde 1.0.163",
+ "serde 1.0.164",
  "target-lexicon",
  "wasmtime-environ",
  "wasmtime-jit-icache-coherence",
@@ -9260,7 +9260,7 @@ version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed41cbcbf74ce3ff6f1d07d1b707888166dc408d1a880f651268f4f7c9194b2"
 dependencies = [
- "once_cell 1.17.2",
+ "once_cell 1.18.0",
 ]
 
 [[package]]
@@ -9285,7 +9285,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "indexmap 1.9.3",
  "libc",
- "log 0.4.18",
+ "log 0.4.19",
  "mach",
  "memfd",
  "memoffset 0.6.5",
@@ -9305,16 +9305,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e5572c5727c1ee7e8f28717aaa8400e4d22dcbd714ea5457d85b5005206568"
 dependencies = [
  "cranelift-entity",
- "serde 1.0.163",
+ "serde 1.0.164",
  "thiserror 1.0.40",
  "wasmparser",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9379,9 +9379,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0496a71f3cc6bc4bf0ed91346426a5099e93d89807e663162dc5a1069ff65"
+checksum = "40018623e2dba2602a9790faba8d33f2ebdebf4b86561b83928db735f8784728"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -9588,9 +9588,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr 2.5.0",
 ]
@@ -9604,14 +9604,14 @@ dependencies = [
  "byteorder 1.4.3",
  "bytes 0.4.12",
  "httparse 1.8.0",
- "log 0.4.18",
+ "log 0.4.19",
  "mio 0.6.23",
  "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.2",
  "slab 0.4.8",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -9653,10 +9653,10 @@ dependencies = [
  "bounded-collections",
  "derivative",
  "impl-trait-for-tuples",
- "log 0.4.18",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-weights",
  "xcm-procedural",
 ]
@@ -9674,20 +9674,20 @@ dependencies = [
 
 [[package]]
 name = "xous"
-version = "0.9.44"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30684dda3583f528d5b05bddc96527e1783255e867a5e81c10721d6abb9e169c"
+checksum = "648387c0ac9e051154d7b9fa56ce5845bffa576387ed2b18a3b5977341c77982"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6b15ea09891f09b02d763422dc99733c96e62d0f8ab476c6bc663c90b17e72"
+checksum = "24aad5ecdee87526a97eaaa7f26d22c0fe419667727598d694bda183dfa31847"
 dependencies = [
- "log 0.4.18",
+ "log 0.4.19",
  "num-derive",
  "num-traits 0.2.15",
  "xous",
@@ -9696,11 +9696,11 @@ dependencies = [
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.42"
+version = "0.9.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b470fbf177d58767fa001acfcb5294a88d3938d3935865ff6b8f1db40f1004e"
+checksum = "92baa5a52f91e40d015a53db1891c66ee7c715b22d1e9731a6fb29e3d9df1061"
 dependencies = [
- "log 0.4.18",
+ "log 0.4.19",
  "num-derive",
  "num-traits 0.2.15",
  "rkyv",
@@ -9711,9 +9711,9 @@ dependencies = [
 
 [[package]]
 name = "xous-ipc"
-version = "0.9.44"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d520fe08642d55a56f700b6d30c7a556f38818e7c3e5d9a0856dde0b79ed4d67"
+checksum = "510be937e654eeed0b60f627b4615e7a89e3cba88e20f1198ed16a87ea4b5fde"
 dependencies = [
  "bitflags",
  "rkyv",

--- a/tee-worker/core/parentchain/test/Cargo.toml
+++ b/tee-worker/core/parentchain/test/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 [dependencies]
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
-log = { version = "0.4.14", default-features = false }
+log = { version = "0.4", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.13", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 # substrate dependencies
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 dependencies = [
  "lazy_static",
- "regex 1.8.2",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -18,7 +18,7 @@ version = "0.2.0"
 source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.39-tag-v0.7.0#84af198434ea210eb0cd90cb8239748c376a079a"
 dependencies = [
  "ac-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-application-crypto",
  "sp-core",
@@ -39,11 +39,11 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
@@ -101,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.3",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "version_check",
 ]
 
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "version_check",
 ]
 
@@ -127,12 +127,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr 2.5.0",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "array-bytes"
@@ -154,9 +160,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
 
 [[package]]
 name = "auto_impl"
@@ -166,7 +172,7 @@ checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -343,11 +349,11 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbd1d11282a1eb134d3c3b7cf8ce213b5161c6e5f73fb1b98618482c606b64"
+checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -436,20 +442,20 @@ name = "chrono"
 version = "0.4.11"
 source = "git+https://github.com/mesalock-linux/chrono-sgx#f964ae7f5f65bd2c9cd6f44a067e7980afc08ca0"
 dependencies = [
- "num-integer 0.1.41",
+ "num-integer",
  "num-traits 0.2.10",
  "sgx_tstd",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
- "num-integer 0.1.45",
+ "android-tzdata",
  "num-traits 0.2.15",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -511,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -597,7 +603,7 @@ checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -608,7 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -619,7 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79116f119dd1dba1abf1f3405f03b9b0e79a27a3883864bfebded8a3dc768cd"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -631,7 +637,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -774,7 +780,7 @@ dependencies = [
  "lc-stf-task-receiver",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "multibase",
  "parity-scale-codec",
  "primitive-types",
@@ -807,7 +813,7 @@ version = "0.9.0"
 source = "git+https://github.com/integritee-network/env_logger-sgx#55745829b2ae8a77f0915af3671ec8a9a00cace9"
 dependencies = [
  "humantime",
- "log 0.4.17",
+ "log",
  "regex 1.3.1",
  "sgx_tstd",
  "termcolor",
@@ -883,7 +889,7 @@ dependencies = [
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "primitive-types",
  "rlp",
@@ -994,7 +1000,7 @@ source = "git+https://github.com/integritee-network/frontier.git?branch=polkadot
 dependencies = [
  "hex 0.4.3",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -1040,7 +1046,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -1064,7 +1070,7 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
@@ -1094,7 +1100,7 @@ dependencies = [
  "frame-support-procedural-tools",
  "itertools",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -1106,7 +1112,7 @@ dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -1116,7 +1122,7 @@ version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -1126,7 +1132,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "frame-support",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -1247,7 +1253,7 @@ source = "git+https://github.com/mesalock-linux/futures-rs-sgx#d54882f24ddf7d613
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -1451,7 +1457,7 @@ name = "http_req"
 version = "0.8.1"
 source = "git+https://github.com/integritee-network/http_req#3723e88235f2b29bc1a31835853b072ffd0455fd"
 dependencies = [
- "log 0.4.17",
+ "log",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
  "sgx_tstd",
  "unicase",
@@ -1511,7 +1517,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -1521,7 +1527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -1582,10 +1588,10 @@ dependencies = [
  "itp-enclave-metrics",
  "itp-ocall-api",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "substrate-fixed",
  "thiserror 1.0.9",
@@ -1649,7 +1655,7 @@ dependencies = [
  "lc-scheduled-enclave",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "pallet-balances",
  "pallet-parentchain",
  "pallet-sudo",
@@ -1673,9 +1679,9 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "jsonrpc-core",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -1694,7 +1700,7 @@ dependencies = [
  "itp-stf-state-handler",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.17",
+ "log",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
@@ -1721,7 +1727,7 @@ version = "0.9.0"
 dependencies = [
  "itc-parentchain-block-importer",
  "itp-block-import-queue",
- "log 0.4.17",
+ "log",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -1739,7 +1745,7 @@ dependencies = [
  "itp-settings",
  "itp-stf-executor",
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -1768,7 +1774,7 @@ dependencies = [
  "itp-utils",
  "lc-scheduled-enclave",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "pallet-identity-management",
  "pallet-vc-management",
  "parity-scale-codec",
@@ -1796,7 +1802,7 @@ dependencies = [
  "itp-storage",
  "itp-types",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "num-traits 0.2.15",
  "parity-scale-codec",
  "sgx_tstd",
@@ -1816,7 +1822,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -1832,9 +1838,9 @@ dependencies = [
  "base64 0.13.1",
  "http",
  "http_req",
- "log 0.4.17",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "log",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sgx_types",
  "thiserror 1.0.9",
@@ -1846,8 +1852,8 @@ name = "itc-tls-websocket-server"
 version = "0.9.0"
 dependencies = [
  "bit-vec",
- "chrono 0.4.24",
- "log 0.4.17",
+ "chrono 0.4.26",
+ "log",
  "mio",
  "mio-extras",
  "rcgen",
@@ -1898,7 +1904,7 @@ dependencies = [
 name = "itp-attestation-handler"
 version = "0.8.0"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "bit-vec",
  "chrono 0.4.11",
@@ -1911,7 +1917,7 @@ dependencies = [
  "itp-sgx-io",
  "itp-time-utils",
  "itp-types",
- "log 0.4.17",
+ "log",
  "num-bigint",
  "parity-scale-codec",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3)",
@@ -1962,7 +1968,7 @@ dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -1998,7 +2004,7 @@ dependencies = [
  "itp-sgx-runtime-primitives",
  "itp-types",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "primitive-types",
  "sp-core",
@@ -2052,8 +2058,8 @@ version = "0.9.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
 ]
 
@@ -2069,7 +2075,7 @@ dependencies = [
  "derive_more",
  "itp-settings",
  "itp-sgx-io",
- "log 0.4.17",
+ "log",
  "ofb",
  "parity-scale-codec",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
@@ -2088,10 +2094,10 @@ dependencies = [
  "derive_more",
  "environmental 1.1.3",
  "itp-hashing",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "postcard",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sp-core",
 ]
@@ -2133,7 +2139,7 @@ dependencies = [
  "itp-time-utils",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_crypto_helper",
  "sgx_tstd",
@@ -2177,7 +2183,7 @@ dependencies = [
  "itp-time-utils",
  "itp-types",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
  "sgx_tcrypto",
@@ -2192,7 +2198,7 @@ name = "itp-stf-state-observer"
 version = "0.9.0"
 dependencies = [
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "thiserror 1.0.9",
@@ -2270,9 +2276,9 @@ dependencies = [
  "its-primitives",
  "jsonrpc-core",
  "linked-hash-map",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sgx_types",
  "sp-application-crypto",
@@ -2297,7 +2303,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "jsonrpc-core",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -2310,15 +2316,15 @@ dependencies = [
 name = "itp-types"
 version = "0.9.0"
 dependencies = [
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "frame-system",
  "itp-sgx-runtime-primitives",
  "litentry-primitives",
  "pallet-balances",
  "parity-scale-codec",
  "primitive-types",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -2353,7 +2359,7 @@ dependencies = [
  "itp-types",
  "its-primitives",
  "its-state",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -2370,7 +2376,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "its-primitives",
- "log 0.4.17",
+ "log",
  "sgx_tstd",
  "sp-consensus-slots",
  "sp-core",
@@ -2405,7 +2411,7 @@ dependencies = [
  "its-state",
  "its-validateer-fetch",
  "lc-scheduled-enclave",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-core",
@@ -2429,7 +2435,7 @@ dependencies = [
  "its-block-verification",
  "its-primitives",
  "its-state",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -2455,7 +2461,7 @@ dependencies = [
  "its-state",
  "lazy_static",
  "lc-scheduled-enclave",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-consensus-slots",
@@ -2468,7 +2474,7 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -2486,7 +2492,7 @@ dependencies = [
  "itp-utils",
  "its-primitives",
  "jsonrpc-core",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
  "sgx_tstd",
@@ -2516,9 +2522,9 @@ dependencies = [
  "itp-sgx-externalities",
  "itp-storage",
  "its-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sp-core",
  "sp-io",
@@ -2545,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2558,7 +2564,7 @@ version = "18.0.0"
 source = "git+https://github.com/scs/jsonrpc?branch=no_std_v18#0faf53c491c3222b96242a973d902dd06e9b6674"
 dependencies = [
  "futures 0.3.8",
- "log 0.4.17",
+ "log",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
  "serde_derive 1.0.118",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
@@ -2573,7 +2579,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -2624,10 +2630,10 @@ dependencies = [
  "lc-data-providers",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-io",
@@ -2642,7 +2648,7 @@ name = "lc-credentials"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.11",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "futures 0.3.8",
  "hex 0.4.0",
  "http",
@@ -2656,14 +2662,14 @@ dependencies = [
  "itp-utils",
  "lc-data-providers",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "rand 0.7.3",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx)",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-runtime",
@@ -2682,10 +2688,10 @@ dependencies = [
  "itc-rest-client",
  "lazy_static",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "thiserror 1.0.9",
  "url",
@@ -2712,10 +2718,10 @@ dependencies = [
  "lc-data-providers",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-io",
@@ -2734,7 +2740,7 @@ dependencies = [
  "itp-types",
  "lazy_static",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -2773,10 +2779,10 @@ dependencies = [
  "lc-identity-verification",
  "lc-stf-task-sender",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-std",
@@ -2798,10 +2804,10 @@ dependencies = [
  "itp-utils",
  "lazy_static",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-runtime",
  "sp-std",
@@ -2811,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libsecp256k1"
@@ -2828,7 +2834,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -2879,8 +2885,8 @@ dependencies = [
  "rand 0.7.3",
  "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "scale-info",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sp-core",
  "sp-runtime",
@@ -2895,12 +2901,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "sgx_tstd",
 ]
-
-[[package]]
-name = "log"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "matches"
@@ -2960,7 +2960,7 @@ version = "0.6.21"
 source = "git+https://github.com/mesalock-linux/mio-sgx?tag=sgx_1.1.3#5b0e56a3066231c7a8d1876c7be3a19b08ffdfd5"
 dependencies = [
  "iovec",
- "log 0.4.17",
+ "log",
  "net2",
  "sgx_libc",
  "sgx_trts",
@@ -2974,7 +2974,7 @@ version = "2.0.6"
 source = "git+https://github.com/integritee-network/mio-extras-sgx?rev=963234b#963234bf55e44f9efff921938255126c48deef3a"
 dependencies = [
  "lazycell",
- "log 0.4.17",
+ "log",
  "mio",
  "sgx_tstd",
  "sgx_types",
@@ -3022,7 +3022,7 @@ source = "git+https://github.com/mesalock-linux/num-sgx#22645415542cc67551890dfd
 dependencies = [
  "num-bigint",
  "num-complex",
- "num-integer 0.1.41",
+ "num-integer",
  "num-iter",
  "num-rational",
  "num-traits 0.2.10",
@@ -3034,7 +3034,7 @@ version = "0.2.5"
 source = "git+https://github.com/mesalock-linux/num-bigint-sgx#76a5bed94dc31c32bd1670dbf72877abcf9bbc09"
 dependencies = [
  "autocfg 1.1.0",
- "num-integer 0.1.41",
+ "num-integer",
  "num-traits 0.2.10",
  "sgx_tstd",
 ]
@@ -3056,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -3071,21 +3071,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg 1.1.0",
- "num-traits 0.2.15",
-]
-
-[[package]]
 name = "num-iter"
 version = "0.1.39"
 source = "git+https://github.com/mesalock-linux/num-iter-sgx#f19fc44fcad0b82a040e5a24c511e5049cc04b60"
 dependencies = [
- "num-integer 0.1.41",
+ "num-integer",
  "num-traits 0.2.10",
  "sgx_tstd",
 ]
@@ -3097,7 +3087,7 @@ source = "git+https://github.com/mesalock-linux/num-rational-sgx#be65f9ce439f3c9
 dependencies = [
  "autocfg 0.1.8",
  "num-bigint",
- "num-integer 0.1.41",
+ "num-integer",
  "num-traits 0.2.10",
  "sgx_tstd",
 ]
@@ -3139,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -3192,7 +3182,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -3211,7 +3201,7 @@ dependencies = [
  "frame-system",
  "hex 0.4.3",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "rlp",
@@ -3229,7 +3219,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -3252,7 +3242,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
- "log 0.4.17",
+ "log",
  "pallet-teerex",
  "parity-scale-codec",
  "scale-info",
@@ -3271,12 +3261,12 @@ dependencies = [
  "frame-system",
  "hex 0.4.3",
  "litentry-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
- "serde_derive 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -3303,7 +3293,7 @@ version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.18",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -3320,7 +3310,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -3352,7 +3342,7 @@ version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.18",
+ "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -3371,7 +3361,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
@@ -3415,7 +3405,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
@@ -3427,28 +3417,28 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+checksum = "430d26d62e66cbff6ae144e8eebd43c0235922dec7e3aa0d2016c32d4575bf45"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "bitvec",
  "byte-slice-cast",
  "bytes 1.4.0",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "a1620b1e3fc72ebaee01ff56fca838bab537c5d093a18b3549c3bbea374aa0b6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -3493,7 +3483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
 dependencies = [
  "postcard-cobs",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -3527,7 +3517,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "toml_edit",
 ]
 
@@ -3539,7 +3529,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
  "version_check",
 ]
@@ -3551,7 +3541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "version_check",
 ]
 
@@ -3569,9 +3559,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -3592,7 +3582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -3618,9 +3608,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -3710,8 +3700,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
- "syn 2.0.16",
+ "quote 1.0.28",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3728,11 +3718,11 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr 2.5.0",
  "regex-syntax 0.7.2",
 ]
@@ -3781,7 +3771,7 @@ checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "spin",
  "untrusted",
  "web-sys",
@@ -3795,8 +3785,8 @@ source = "git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup#8b
 dependencies = [
  "cc",
  "libc",
- "log 0.4.17",
- "once_cell 1.17.1",
+ "log",
+ "once_cell 1.18.0",
  "rkyv",
  "spin",
  "untrusted",
@@ -3824,7 +3814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a169f6bc5a81033e86ed39d0f4150e2608160b73d2b93c6e8e6a3efa873f14"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -3846,7 +3836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -3898,7 +3888,7 @@ version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?tag=sgx_1.1.3#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.17",
+ "log",
  "ring 0.16.19",
  "sct",
  "sgx_tstd",
@@ -3911,7 +3901,7 @@ version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.17",
+ "log",
  "ring 0.16.19",
  "sct",
  "sgx_tstd",
@@ -3924,7 +3914,7 @@ version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.17",
+ "log",
  "ring 0.16.19",
  "sct",
  "sgx_tstd",
@@ -3957,7 +3947,7 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -3968,7 +3958,7 @@ checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -4078,11 +4068,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
- "serde_derive 1.0.163",
+ "serde_derive 1.0.164",
 ]
 
 [[package]]
@@ -4100,19 +4090,19 @@ version = "1.0.118"
 source = "git+https://github.com/mesalock-linux/serde-sgx#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
- "syn 2.0.16",
+ "quote 1.0.28",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -4140,13 +4130,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -4154,15 +4144,15 @@ name = "sgx-verify"
 version = "0.1.4"
 dependencies = [
  "base64 0.13.1",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "der",
  "frame-support",
  "hex 0.4.3",
  "parity-scale-codec",
  "ring 0.16.20 (git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup)",
  "scale-info",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-io",
  "sp-std",
@@ -4392,9 +4382,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4469,7 +4459,7 @@ name = "sp-api"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-api-proc-macro",
  "sp-core",
@@ -4486,7 +4476,7 @@ dependencies = [
  "blake2",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -4567,7 +4557,7 @@ dependencies = [
  "hash-db",
  "hash256-std-hasher",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "merlin",
  "parity-scale-codec",
  "primitive-types",
@@ -4592,7 +4582,7 @@ dependencies = [
  "blake2",
  "byteorder 1.4.3",
  "digest 0.10.7",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3 0.10.8",
  "sp-std",
  "twox-hash",
@@ -4604,7 +4594,7 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "sp-core-hashing",
  "syn 1.0.109",
 ]
@@ -4615,7 +4605,7 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -4636,7 +4626,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "finality-grandpa",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -4666,7 +4656,7 @@ dependencies = [
  "hash-db",
  "itp-sgx-externalities",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -4697,7 +4687,7 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
@@ -4735,7 +4725,7 @@ dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -4846,7 +4836,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -4897,9 +4887,9 @@ checksum = "eb47a8ad42e5fc72d5b1eb104a5546937eaf39843499948bb666d6e93c62423b"
 dependencies = [
  "Inflector",
  "proc-macro2",
- "quote 1.0.27",
- "serde 1.0.163",
- "serde_json 1.0.96",
+ "quote 1.0.28",
+ "serde 1.0.164",
+ "serde_json 1.0.97",
  "unicode-xid 0.2.4",
 ]
 
@@ -4920,7 +4910,7 @@ dependencies = [
  "frame-metadata 15.0.0",
  "frame-support",
  "hex 0.4.3",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
@@ -4962,18 +4952,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "unicode-ident",
 ]
 
@@ -4999,7 +4989,7 @@ dependencies = [
  "common-primitives",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io",
  "sp-std",
@@ -5037,7 +5027,7 @@ version = "1.0.9"
 source = "git+https://github.com/mesalock-linux/thiserror-sgx?tag=sgx_1.1.3#c2f806b88616e06aab0af770366a76885d974fdc"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
@@ -5048,8 +5038,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
- "syn 2.0.16",
+ "quote 1.0.28",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -5112,7 +5102,7 @@ checksum = "3390c0409daaa6027d6681393316f4ccd3ff82e1590a1e4725014e3ae2bf1920"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
- "log 0.4.17",
+ "log",
  "smallvec 1.10.0",
 ]
 
@@ -5151,7 +5141,7 @@ dependencies = [
  "bytes 1.0.1",
  "http",
  "httparse",
- "log 0.4.17",
+ "log",
  "rand 0.7.3",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?tag=sgx_1.1.3)",
  "sgx_tstd",
@@ -5221,9 +5211,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -5284,9 +5274,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -5294,53 +5284,53 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "log 0.4.17",
- "once_cell 1.17.1",
+ "log",
+ "once_cell 1.18.0",
  "proc-macro2",
- "quote 1.0.27",
- "syn 2.0.16",
+ "quote 1.0.28",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.27",
+ "quote 1.0.28",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
- "syn 2.0.16",
+ "quote 1.0.28",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5408,9 +5398,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr 2.5.0",
 ]
@@ -5444,7 +5434,7 @@ dependencies = [
  "bounded-collections",
  "derivative",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-weights",
@@ -5458,26 +5448,26 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.39#c22e
 dependencies = [
  "Inflector",
  "proc-macro2",
- "quote 1.0.27",
+ "quote 1.0.28",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "xous"
-version = "0.9.43"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b04f965ee6c47c7c4d84811d85755f0f6df68f787438e9036bd3f13e3f15d8f"
+checksum = "648387c0ac9e051154d7b9fa56ce5845bffa576387ed2b18a3b5977341c77982"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df214255809786798d30c32517b81feb098943e5cbe8b65ba126626b7e119098"
+checksum = "24aad5ecdee87526a97eaaa7f26d22c0fe419667727598d694bda183dfa31847"
 dependencies = [
- "log 0.4.17",
+ "log",
  "num-derive",
  "num-traits 0.2.15",
  "xous",
@@ -5486,11 +5476,11 @@ dependencies = [
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.41"
+version = "0.9.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a168479ad6e25763c997d1ac38ebfa79da2e3b5fac74a1ac230a742501411"
+checksum = "92baa5a52f91e40d015a53db1891c66ee7c715b22d1e9731a6fb29e3d9df1061"
 dependencies = [
- "log 0.4.17",
+ "log",
  "num-derive",
  "num-traits 0.2.15",
  "rkyv",
@@ -5501,9 +5491,9 @@ dependencies = [
 
 [[package]]
 name = "xous-ipc"
-version = "0.9.43"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75970c319441cc92ad8effaf8a0182eeada940d54f7429c05ae2b72f54bf2018"
+checksum = "510be937e654eeed0b60f627b4615e7a89e3cba88e20f1198ed16a87ea4b5fde"
 dependencies = [
  "bitflags",
  "rkyv",
@@ -5537,6 +5527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote 1.0.27",
- "syn 2.0.16",
+ "quote 1.0.28",
+ "syn 2.0.18",
 ]

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "auto_impl"
@@ -1904,7 +1904,7 @@ dependencies = [
 name = "itp-attestation-handler"
 version = "0.8.0"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "bit-vec",
  "chrono 0.4.11",
@@ -3417,11 +3417,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430d26d62e66cbff6ae144e8eebd43c0235922dec7e3aa0d2016c32d4575bf45"
+checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "bitvec",
  "byte-slice-cast",
  "bytes 1.4.0",
@@ -3432,9 +3432,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1620b1e3fc72ebaee01ff56fca838bab537c5d093a18b3549c3bbea374aa0b6"
+checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/tee-worker/sidechain/block-verification/Cargo.toml
+++ b/tee-worker/sidechain/block-verification/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/integritee-network/pallets/"
 version = "0.9.0"
 
 [dependencies]
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 thiserror = { version = "1.0.26", optional = true }
 
 # local deps

--- a/tee-worker/sidechain/primitives/Cargo.toml
+++ b/tee-worker/sidechain/primitives/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2.4.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.13", default-features = false }
+serde = { version = "1.0", default-features = false }
 
 
 # substrate dependencies


### PR DESCRIPTION

This PR updated the `Cargo.lock` for both parachain and tee-worker, aiming to supersede the individual dependabot PR(s).

Additionally it tries to shorten the PR template to make it more concise (hopefully)