### PR TITLE
Twitter follower assertion

### DIFF
--- a/primitives/core/src/assertion.rs
+++ b/primitives/core/src/assertion.rs
@@ -52,6 +52,7 @@ pub enum Assertion {
 	A10(ParameterString),                                   // (minimum_amount)
 	A11(ParameterString),                                   // (minimum_amount)
 	A13(u32),                                               // (Karma_amount) - TODO: unsupported
+	TwitterFollower(ParameterString)						// (target_twitter_screen_name)
 }
 
 pub const ASSERTION_FROM_DATE: [&str; 7] = [

--- a/primitives/core/src/assertion.rs
+++ b/primitives/core/src/assertion.rs
@@ -51,8 +51,9 @@ pub enum Assertion {
 	A9,
 	A10(ParameterString),                                   // (minimum_amount)
 	A11(ParameterString),                                   // (minimum_amount)
+	A12(ParameterString),									// (target_twitter_screen_name)
 	A13(u32),                                               // (Karma_amount) - TODO: unsupported
-	TwitterFollower(ParameterString)						// (target_twitter_screen_name)
+
 }
 
 pub const ASSERTION_FROM_DATE: [&str; 7] = [

--- a/tee-worker/litentry/core/assertion-build/src/a12.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a12.rs
@@ -43,16 +43,13 @@ pub fn build(
 	who: &AccountId,
 ) -> Result<Credential> {
 	debug!(
-		"Assertion TwitterFollower build, who: {:?}, identities: {:?}",
+		"Assertion 12 build, who: {:?}, identities: {:?}",
 		account_id_to_string(&who),
 		identities
 	);
 
 	let twitter_screen_name_s = vec_to_string(twitter_screen_name.to_vec()).map_err(|_| {
-		Error::RequestVCFailed(
-			Assertion::TwitterFollower(twitter_screen_name.clone()),
-			ErrorDetail::ParseError,
-		)
+		Error::RequestVCFailed(Assertion::A12(twitter_screen_name.clone()), ErrorDetail::ParseError)
 	})?;
 
 	let mut result = false;
@@ -70,9 +67,9 @@ pub fn build(
 					)
 					.map_err(|e| {
 						// invalid permissions, rate limitation, etc
-						log::warn!("TwitterFollower query_friendship error:{:?}", e);
+						log::warn!("A12 query_friendship error:{:?}", e);
 						Error::RequestVCFailed(
-							Assertion::TwitterFollower(twitter_screen_name.clone()),
+							Assertion::A12(twitter_screen_name.clone()),
 							ErrorDetail::StfError(ErrorString::truncate_from(
 								format!("{:?}", e).into(),
 							)),
@@ -99,11 +96,8 @@ pub fn build(
 			Ok(credential_unsigned)
 		},
 		Err(e) => {
-			error!("Generate unsigned credential A5 failed {:?}", e);
-			Err(Error::RequestVCFailed(
-				Assertion::TwitterFollower(twitter_screen_name),
-				e.into_error_detail(),
-			))
+			error!("Generate unsigned credential A12 failed {:?}", e);
+			Err(Error::RequestVCFailed(Assertion::A12(twitter_screen_name), e.into_error_detail()))
 		},
 	}
 }

--- a/tee-worker/litentry/core/assertion-build/src/a5.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a5.rs
@@ -25,7 +25,10 @@ use itp_stf_primitives::types::ShardIdentifier;
 use itp_types::AccountId;
 use itp_utils::stringify::account_id_to_string;
 use lc_credentials::Credential;
-use lc_data_providers::{twitter_official::TwitterOfficialClient, vec_to_string};
+use lc_data_providers::{
+	twitter_official::{TargetUser, TwitterOfficialClient},
+	vec_to_string,
+};
 use log::*;
 use std::{format, vec::Vec};
 
@@ -74,7 +77,10 @@ pub fn build(
 					})?;
 
 				let relationship = twitter_official_v1_1
-					.query_friendship(twitter_handler.clone(), tweet.author_id.as_bytes().to_vec())
+					.query_friendship(
+						twitter_handler.clone(),
+						TargetUser::Id(tweet.author_id.as_bytes().to_vec()),
+					)
 					.map_err(|e| {
 						// invalid permissions, rate limitation, etc
 						log::warn!("Assertion5 query_friendship error:{:?}", e);

--- a/tee-worker/litentry/core/assertion-build/src/lib.rs
+++ b/tee-worker/litentry/core/assertion-build/src/lib.rs
@@ -39,6 +39,7 @@ pub mod a5;
 pub mod a6;
 pub mod a7;
 pub mod a8;
+pub mod twitter_follower;
 
 use litentry_primitives::{
 	Assertion, ErrorDetail, ErrorString, EvmNetwork, Identity, IntoErrorDetail, ParameterString,

--- a/tee-worker/litentry/core/assertion-build/src/lib.rs
+++ b/tee-worker/litentry/core/assertion-build/src/lib.rs
@@ -32,6 +32,7 @@ pub mod sgx_reexport_prelude {
 pub mod a1;
 pub mod a10;
 pub mod a11;
+pub mod a12;
 pub mod a2;
 pub mod a3;
 pub mod a4;
@@ -39,7 +40,6 @@ pub mod a5;
 pub mod a6;
 pub mod a7;
 pub mod a8;
-pub mod twitter_follower;
 
 use litentry_primitives::{
 	Assertion, ErrorDetail, ErrorString, EvmNetwork, Identity, IntoErrorDetail, ParameterString,

--- a/tee-worker/litentry/core/assertion-build/src/twitter_follower.rs
+++ b/tee-worker/litentry/core/assertion-build/src/twitter_follower.rs
@@ -1,0 +1,109 @@
+// Copyright 2020-2023 Litentry Technologies GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use crate::*;
+use itp_stf_primitives::types::ShardIdentifier;
+use itp_types::AccountId;
+use itp_utils::stringify::account_id_to_string;
+use lc_credentials::Credential;
+use lc_data_providers::{
+	twitter_official::{TargetUser, TwitterOfficialClient},
+	vec_to_string,
+};
+use log::*;
+use std::{format, vec::Vec};
+
+const VC_SUBJECT_DESCRIPTION: &str = "The user has followed {:?}";
+const VC_SUBJECT_TYPE: &str = "A follower of the {:?}";
+const VC_SUBJECT_TAG: [&str; 1] = ["Twitter"];
+
+pub fn build(
+	twitter_screen_name: ParameterString,
+	identities: Vec<Identity>,
+	shard: &ShardIdentifier,
+	who: &AccountId,
+) -> Result<Credential> {
+	debug!(
+		"Assertion TwitterFollower build, who: {:?}, identities: {:?}",
+		account_id_to_string(&who),
+		identities
+	);
+
+	let twitter_screen_name_s = vec_to_string(twitter_screen_name.to_vec()).map_err(|_| {
+		Error::RequestVCFailed(
+			Assertion::TwitterFollower(twitter_screen_name.clone()),
+			ErrorDetail::ParseError,
+		)
+	})?;
+
+	let mut result = false;
+
+	let mut twitter_official_v1_1 = TwitterOfficialClient::v1_1();
+	for identity in identities {
+		if let Identity::Web2 { network, address } = identity {
+			if matches!(network, Web2Network::Twitter) {
+				let twitter_handler = address.to_vec();
+
+				let relationship = twitter_official_v1_1
+					.query_friendship(
+						twitter_handler.clone(),
+						TargetUser::Name(twitter_screen_name.to_vec()),
+					)
+					.map_err(|e| {
+						// invalid permissions, rate limitation, etc
+						log::warn!("TwitterFollower query_friendship error:{:?}", e);
+						Error::RequestVCFailed(
+							Assertion::TwitterFollower(twitter_screen_name.clone()),
+							ErrorDetail::StfError(ErrorString::truncate_from(
+								format!("{:?}", e).into(),
+							)),
+						)
+					})?;
+
+				if relationship.source.following {
+					result = true;
+					break
+				}
+			}
+		}
+	}
+
+	match Credential::new_default(who, &shard.clone()) {
+		Ok(mut credential_unsigned) => {
+			credential_unsigned.add_subject_info(
+				VC_SUBJECT_DESCRIPTION,
+				VC_SUBJECT_TYPE,
+				VC_SUBJECT_TAG.to_vec(),
+			);
+			credential_unsigned.add_twitter_follower_assertion(twitter_screen_name_s, result);
+
+			Ok(credential_unsigned)
+		},
+		Err(e) => {
+			error!("Generate unsigned credential A5 failed {:?}", e);
+			Err(Error::RequestVCFailed(
+				Assertion::TwitterFollower(twitter_screen_name),
+				e.into_error_detail(),
+			))
+		},
+	}
+}

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -463,6 +463,20 @@ impl Credential {
 		self.credential_subject.assertions.push(assertion);
 		self.credential_subject.values.push(true);
 	}
+
+	pub fn add_twitter_follower_assertion(&mut self, twitter_screen_name: String, value: bool) {
+		let is_following = AssertionLogic::new_item("$is_following", Op::Equal, "true");
+		let twitter_screen_name = AssertionLogic::new_item(
+			"$twitter_screen_name",
+			Op::Equal,
+			twitter_screen_name.as_str(),
+		);
+
+		let assertion =
+			AssertionLogic::new_and().add_item(is_following).add_item(twitter_screen_name);
+		self.credential_subject.assertions.push(assertion);
+		self.credential_subject.values.push(value);
+	}
 }
 
 /// Assertion To-Date

--- a/tee-worker/litentry/core/data-providers/src/twitter_official.rs
+++ b/tee-worker/litentry/core/data-providers/src/twitter_official.rs
@@ -322,7 +322,7 @@ mod tests {
 	}
 
 	#[test]
-	fn query_friendship_work() {
+	fn query_friendship_by_id_work() {
 		init();
 
 		let source = "twitterdev";
@@ -331,6 +331,20 @@ mod tests {
 		let result = client.query_friendship(
 			source.as_bytes().to_vec(),
 			TargetUser::Id(target_id.as_bytes().to_vec()),
+		);
+		assert!(result.is_ok(), "error: {:?}", result);
+	}
+
+	#[test]
+	fn query_friendship_by_name_work() {
+		init();
+
+		let source = "twitterdev";
+		let target_name = "twitter"; //user: twitter
+		let mut client = TwitterOfficialClient::v1_1();
+		let result = client.query_friendship(
+			source.as_bytes().to_vec(),
+			TargetUser::Name(target_name.as_bytes().to_vec()),
 		);
 		assert!(result.is_ok(), "error: {:?}", result);
 	}

--- a/tee-worker/litentry/core/data-providers/src/twitter_official.rs
+++ b/tee-worker/litentry/core/data-providers/src/twitter_official.rs
@@ -133,6 +133,26 @@ pub struct TwitterOfficialClient {
 	client: RestClient<HttpClient<DefaultSend>>,
 }
 
+pub enum TargetUser {
+	Name(Vec<u8>),
+	Id(Vec<u8>),
+}
+
+impl TargetUser {
+	pub fn to_query_param(self) -> Result<(String, String), Error> {
+		match self {
+			Self::Id(v) => {
+				let id_as_string = vec_to_string(v)?;
+				Ok(("target_id".to_string(), id_as_string))
+			},
+			Self::Name(v) => {
+				let name_as_string = vec_to_string(v)?;
+				Ok(("target_screen_name".to_string(), name_as_string))
+			},
+		}
+	}
+}
+
 /// rate limit: https://developer.twitter.com/en/docs/twitter-api/rate-limits
 impl TwitterOfficialClient {
 	pub fn v1_1() -> Self {
@@ -233,14 +253,17 @@ impl TwitterOfficialClient {
 	pub fn query_friendship(
 		&mut self,
 		source_user_name: Vec<u8>,
-		target_user_id: Vec<u8>,
+		target_user: TargetUser,
 	) -> Result<Relationship, Error> {
 		let source = vec_to_string(source_user_name)?;
-		let target_id = vec_to_string(target_user_id)?;
-		debug!("Twitter query_friendship, source user: {}, target user: {}", source, target_id);
+		let target_param = target_user.to_query_param()?;
+		debug!(
+			"Twitter query_friendship, source user: {}, target user: {}",
+			source, target_param.1
+		);
 
 		let query: Vec<(&str, &str)> =
-			vec![("source_screen_name", source.as_str()), ("target_id", target_id.as_str())];
+			vec![("source_screen_name", source.as_str()), (&target_param.0, &target_param.1)];
 
 		let resp = self
 			.client
@@ -305,8 +328,10 @@ mod tests {
 		let source = "twitterdev";
 		let target_id = "783214"; //user: twitter
 		let mut client = TwitterOfficialClient::v1_1();
-		let result =
-			client.query_friendship(source.as_bytes().to_vec(), target_id.as_bytes().to_vec());
+		let result = client.query_friendship(
+			source.as_bytes().to_vec(),
+			TargetUser::Id(target_id.as_bytes().to_vec()),
+		);
 		assert!(result.is_ok(), "error: {:?}", result);
 	}
 }

--- a/tee-worker/litentry/core/mock-server/src/twitter_official.rs
+++ b/tee-worker/litentry/core/mock-server/src/twitter_official.rs
@@ -115,31 +115,39 @@ pub(crate) fn query_friendship(
 		.and(warp::query::<HashMap<String, String>>())
 		.map(move |p: HashMap<String, String>| {
 			log::info!("query_friendship");
-			let default = String::default();
-			let source = p.get("source_screen_name").unwrap_or(&default);
-			let target_id = p.get("target_id").unwrap_or(&default);
+			if let Some(target_id) = p.get("target_id") {
+				if target_id == "783214" {
+					return Response::builder()
+						.body(serde_json::to_string(&prepare_mocked_relationship()).unwrap())
+				}
+			};
 
-			if source != "twitterdev" || target_id != "783214" {
-				Response::builder().status(400).body(String::from("Error query"))
-			} else {
-				let source_user = SourceTwitterUser {
-					id_str: "2244994945".into(),
-					screen_name: "TwitterDev".into(),
-					following: true,
-					followed_by: false,
-				};
-
-				let target_user = TargetTwitterUser {
-					id_str: "783214".into(),
-					screen_name: "Twitter".into(),
-					following: false,
-					followed_by: true,
-				};
-
-				let body = Relationship { source: source_user, target: target_user };
-				Response::builder().body(serde_json::to_string(&body).unwrap())
+			if let Some(target_screen_name) = p.get("target_screen_name") {
+				if target_screen_name == "twitter" {
+					return Response::builder()
+						.body(serde_json::to_string(&prepare_mocked_relationship()).unwrap())
+				}
 			}
+			Response::builder().status(400).body(String::from("Error query"))
 		})
+}
+
+fn prepare_mocked_relationship() -> Relationship {
+	let source_user = SourceTwitterUser {
+		id_str: "2244994945".into(),
+		screen_name: "TwitterDev".into(),
+		following: true,
+		followed_by: false,
+	};
+
+	let target_user = TargetTwitterUser {
+		id_str: "783214".into(),
+		screen_name: "Twitter".into(),
+		following: false,
+		followed_by: true,
+	};
+
+	Relationship { source: source_user, target: target_user }
 }
 
 pub(crate) fn query_user(

--- a/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
@@ -123,6 +123,13 @@ where
 				&self.req.who,
 			),
 
+			Assertion::TwitterFollower(s) => lc_assertion_build::twitter_follower::build(
+				s,
+				self.req.vec_identity.to_vec(),
+				&self.req.shard,
+				&self.req.who,
+			),
+
 			_ => {
 				unimplemented!()
 			},

--- a/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
@@ -123,7 +123,7 @@ where
 				&self.req.who,
 			),
 
-			Assertion::TwitterFollower(s) => lc_assertion_build::twitter_follower::build(
+			Assertion::A12(s) => lc_assertion_build::a12::build(
 				s,
 				self.req.vec_identity.to_vec(),
 				&self.req.shard,


### PR DESCRIPTION
Can be used to generate VC proving that account is following specified twitter acount at generation time.

closes: #1789