### PR TITLE
Add IDGraph getter and twitter identity linking in DI-sample

### DIFF
--- a/tee-worker/app-libs/stf/src/getter.rs
+++ b/tee-worker/app-libs/stf/src/getter.rs
@@ -183,7 +183,9 @@ impl ExecuteGetter for TrustedGetterSigned {
 			// litentry
 			TrustedGetter::user_shielding_key(who) =>
 				IdentityManagement::user_shielding_keys(&who).map(|key| key.encode()),
-			TrustedGetter::id_graph(who) => Some(IdentityManagement::get_id_graph(&who).encode()),
+			// use get_id_graph_with_max_len for deterministic result
+			TrustedGetter::id_graph(who) =>
+				Some(IdentityManagement::get_id_graph_with_max_len(&who, usize::MAX).encode()),
 			// TODO: we need to re-think it
 			//       currently, _who is ignored meaning it's actually not a "trusted" getter.
 			//       In fact, in the production no one should have access to the concrete identities

--- a/tee-worker/app-libs/stf/src/getter.rs
+++ b/tee-worker/app-libs/stf/src/getter.rs
@@ -183,9 +183,8 @@ impl ExecuteGetter for TrustedGetterSigned {
 			// litentry
 			TrustedGetter::user_shielding_key(who) =>
 				IdentityManagement::user_shielding_keys(&who).map(|key| key.encode()),
-			// use get_id_graph_with_max_len for deterministic result
 			TrustedGetter::id_graph(who) =>
-				Some(IdentityManagement::get_id_graph_with_max_len(&who, usize::MAX).encode()),
+				Some(IdentityManagement::get_id_graph(&who, usize::MAX).encode()),
 			// TODO: we need to re-think it
 			//       currently, _who is ignored meaning it's actually not a "trusted" getter.
 			//       In fact, in the production no one should have access to the concrete identities

--- a/tee-worker/app-libs/stf/src/trusted_call.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call.rs
@@ -476,8 +476,7 @@ where
 				) {
 					Ok(key) => {
 						debug!("pushing user_shielding_key_set event ...");
-						let id_graph =
-							IMT::get_id_graph_with_max_len(&who, RETURNED_IDGRAPH_MAX_LEN);
+						let id_graph = IMT::get_id_graph(&who, RETURNED_IDGRAPH_MAX_LEN);
 						calls.push(OpaqueCall::from_tuple(&(
 							call_index,
 							account,
@@ -577,8 +576,7 @@ where
 					parent_ss58_prefix,
 				) {
 					Ok(key) => {
-						let id_graph =
-							IMT::get_id_graph_with_max_len(&who, RETURNED_IDGRAPH_MAX_LEN);
+						let id_graph = IMT::get_id_graph(&who, RETURNED_IDGRAPH_MAX_LEN);
 						debug!("pushing identity_linked event ...");
 						calls.push(OpaqueCall::from_tuple(&(
 							call_index,

--- a/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
@@ -127,7 +127,7 @@ impl TrustedCallSigned {
 			StfError::RequestVCFailed(assertion, ErrorDetail::UserShieldingKeyNotFound)
 		);
 
-		let id_graph = IMT::get_id_graph(&who);
+		let id_graph = IMT::get_id_graph(&who, usize::MAX);
 		let vec_identity: Vec<Identity> = id_graph
 			.into_iter()
 			.filter(|item| item.1.status == IdentityStatus::Active)

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -243,13 +243,9 @@ pub mod pallet {
 			IDGraphs::<T>::remove(owner, identity);
 		}
 
-		pub fn get_id_graph(who: &T::AccountId) -> IDGraph<T> {
-			IDGraphs::<T>::iter_prefix(who).collect::<_>()
-		}
-
 		// get the most recent `max_len` elements in IDGraph
-		pub fn get_id_graph_with_max_len(who: &T::AccountId, max_len: usize) -> IDGraph<T> {
-			let mut id_graph = Self::get_id_graph(who);
+		pub fn get_id_graph(who: &T::AccountId, max_len: usize) -> IDGraph<T> {
+			let mut id_graph = IDGraphs::<T>::iter_prefix(who).collect::<IDGraph<T>>();
 			id_graph.sort_by(|a, b| Ord::cmp(&b.1.link_block, &a.1.link_block));
 			id_graph.truncate(max_len);
 			id_graph

--- a/tee-worker/litentry/pallets/identity-management/src/tests.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/tests.rs
@@ -118,7 +118,7 @@ fn remove_identity_works() {
 			IdentityContext { link_block: 1, status: IdentityStatus::Active }
 		);
 
-		let id_graph = IMT::get_id_graph(&BOB);
+		let id_graph = IMT::get_id_graph(&BOB, usize::MAX);
 		assert_eq!(id_graph.len(), 2);
 		assert_eq!(crate::IDGraphLens::<Test>::get(&BOB), 2);
 
@@ -130,7 +130,7 @@ fn remove_identity_works() {
 		));
 		assert_eq!(IMT::id_graphs(BOB, alice_web3_identity()), None);
 
-		let id_graph = IMT::get_id_graph(&BOB);
+		let id_graph = IMT::get_id_graph(&BOB, usize::MAX);
 		// "1": because of the main id is added by default when first calling set_user_shielding_key.
 		assert_eq!(id_graph.len(), 1);
 		assert_eq!(crate::IDGraphLens::<Test>::get(&BOB), 1);
@@ -150,34 +150,6 @@ fn remove_identity_works() {
 #[test]
 fn get_id_graph_works() {
 	new_test_ext(true).execute_with(|| {
-		let ss58_prefix = 131_u16;
-		assert_ok!(IMT::link_identity(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			alice_web3_identity(),
-			ss58_prefix,
-		));
-
-		let alice_web2_identity = Identity::Web2 {
-			network: Web2Network::Twitter,
-			address: IdentityString::try_from("litentry".as_bytes().to_vec()).unwrap(),
-		};
-		assert_ok!(IMT::link_identity(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			alice_web2_identity.clone(),
-			ss58_prefix,
-		));
-
-		let id_graph = IMT::get_id_graph(&BOB);
-		// "+1": because of the main id is added by default when first calling set_user_shielding_key.
-		assert_eq!(id_graph.len(), 2 + 1);
-	});
-}
-
-#[test]
-fn get_id_graph_with_max_len_works() {
-	new_test_ext(true).execute_with(|| {
 		// fill in 21 identities, starting from 1 to reserve place for prime_id
 		// set the block number too as it's used to tell "recent"
 		for i in 1..22 {
@@ -190,10 +162,10 @@ fn get_id_graph_with_max_len_works() {
 			));
 		}
 		// the full id_graph should have 22 elements, including the prime_id
-		assert_eq!(IMT::get_id_graph(&BOB).len(), 22);
+		assert_eq!(IMT::get_id_graph(&BOB, usize::MAX).len(), 22);
 
 		// only get the recent 15 identities
-		let id_graph = IMT::get_id_graph_with_max_len(&BOB, 15);
+		let id_graph = IMT::get_id_graph(&BOB, 15);
 		for i in id_graph.clone() {
 			println!("{:?}", String::from_utf8(i.0.flat()).unwrap());
 		}
@@ -204,7 +176,7 @@ fn get_id_graph_with_max_len_works() {
 		assert_eq!(String::from_utf8(id_graph.get(14).unwrap().0.flat()).unwrap(), "did:twitter:web2:_:alice7");
 
 		// try to get more than id_graph length
-		let id_graph = IMT::get_id_graph_with_max_len(&BOB, 30);
+		let id_graph = IMT::get_id_graph(&BOB, 30);
 		assert_eq!(id_graph.len(), 22);
 		assert_eq!(String::from_utf8(id_graph.get(0).unwrap().0.flat()).unwrap(), "did:twitter:web2:_:alice21");
 		assert_eq!(String::from_utf8(id_graph.get(21).unwrap().0.flat()).unwrap(), "did:litmus:web3:substrate:0x0202020202020202020202020202020202020202020202020202020202020202");

--- a/tee-worker/scripts/litentry/start_parachain.sh
+++ b/tee-worker/scripts/litentry/start_parachain.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # 30333: default p2p port for relaychain node
 # 4545: default untrusted-http-port for tee-worker (see config.json)
 for p in ${CollatorWSPort:-9944} ${CollatorPort:-30333} ${UntrustedHttpPort:-4545}; do
-  if [ ! -z "$(netstat -nat | grep $p)" ]; then
+  if [ ! -z "$(netstat -nat | grep :$p)" ]; then
     echo "port $p is in use, quit now"
     exit 1
   fi

--- a/tee-worker/ts-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/common/utils/assertion.ts
@@ -209,8 +209,8 @@ export async function checkJSON(vc: any, proofJson: any): Promise<boolean> {
     expect(isValid).to.be.true;
     expect(
         vc.type[0] === 'VerifiableCredential' &&
-        vc.issuer.id === proofJson.verificationMethod &&
-        proofJson.type === 'Ed25519Signature2020'
+            vc.issuer.id === proofJson.verificationMethod &&
+            proofJson.type === 'Ed25519Signature2020'
     ).to.be.true;
     return true;
 }

--- a/tee-worker/ts-tests/examples/direct-invocation/index.ts
+++ b/tee-worker/ts-tests/examples/direct-invocation/index.ts
@@ -9,6 +9,7 @@ import {
     getTEEShieldingKey,
     createSignedTrustedCallLinkIdentity,
     createSignedTrustedGetterUserShieldingKey,
+    createSignedTrustedGetterIDGraph,
     sendRequestFromGetter,
     getSidechainNonce,
 } from './util';
@@ -17,9 +18,8 @@ import { aesKey, keyNonce } from '../../common/call';
 import { Metadata, TypeRegistry } from '@polkadot/types';
 import sidechainMetaData from '../../litentry-sidechain-metadata.json';
 import { hexToU8a } from '@polkadot/util';
-import type { LitentryPrimitivesIdentity } from '@polkadot/types/lookup';
-import type { LitentryValidationData } from '../../parachain-interfaces/identity/types';
 import { assert } from 'chai';
+import type { LitentryPrimitivesIdentity, PalletIdentityManagementTeeIdentityContext } from '@polkadot/types/lookup';
 
 // in order to handle self-signed certificates we need to turn off the validation
 // TODO add self signed certificate
@@ -63,8 +63,6 @@ async function runDirectCall() {
 
     let nonce = await getSidechainNonce(wsp, parachain_api, mrenclave, key, alice.address);
 
-    // a hardcoded AES key which is used overall in tests - maybe we need to put it in a common place
-    const key_alice = '0x22fc82db5b606998ad45099b7978b5b4f9dd4ea6017e57370ac56141caaabd12';
     // similar to `reqExtHash` in indirect calls, we need some "identifiers" to pair the response
     // with the request. Ideally it's the hash of the trusted operation, but we need it before constructing
     // a trusted call, hence a random number is used here - better ideas are welcome
@@ -81,13 +79,12 @@ async function runDirectCall() {
     let res = await sendRequestFromTrustedCall(wsp, parachain_api, mrenclave, key, setUserShieldingKeyCall);
     console.log('setUserShieldingKey call returned', res.toHuman());
 
-    sleep(10);
+    await sleep(10);
 
     hash = `0x${require('crypto').randomBytes(32).toString('hex')}`;
-
     nonce = await getSidechainNonce(wsp, parachain_api, mrenclave, key, alice.address);
 
-    console.log('Send direct createIdentity call... hash:', hash);
+    console.log('Send direct linkIdentity call... hash:', hash);
     const twitter_identity = await buildIdentityHelper('mock_user', 'Twitter', 'Web2', context);
     let linkIdentityCall = createSignedTrustedCallLinkIdentity(
         parachain_api,
@@ -99,7 +96,7 @@ async function runDirectCall() {
             .createType('LitentryValidationData', {
                 Web2Validation: {
                     Twitter: {
-                        tweet_id: `0x${Buffer.from('100', 'utf8').toString('hex')}`,
+                        tweet_id: `0x${Buffer.from(nonce.toString(), 'utf8').toString('hex')}`,
                     },
                 },
             })
@@ -110,7 +107,19 @@ async function runDirectCall() {
     res = await sendRequestFromTrustedCall(wsp, parachain_api, mrenclave, key, linkIdentityCall);
     console.log('linkIdentity call returned', res.toHuman());
 
-    sleep(10);
+    // we should have listened to the parachain event, for demo purpose we only wait for enough
+    // time and check the IDGraph
+    await sleep(30);
+
+    console.log('Send IDGraph getter for alice ...');
+    let idgraphGetter = createSignedTrustedGetterIDGraph(parachain_api, alice);
+    res = await sendRequestFromGetter(wsp, parachain_api, mrenclave, key, idgraphGetter);
+    console.log('IDGraph getter returned', res.toHuman());
+    // somehow createType('Option<Vec<(....)>>') doesn't work, why?
+    let idgraphBytes = sidechainRegistry.createType('Option<Bytes>', hexToU8a(res.value.toHex()));
+    assert.isTrue(idgraphBytes.isSome);
+    let idgraphArray = sidechainRegistry.createType('Vec<(LitentryPrimitivesIdentity, PalletIdentityManagementTeeIdentityContext)>', idgraphBytes.unwrap()) as unknown as [LitentryPrimitivesIdentity, PalletIdentityManagementTeeIdentityContext][];
+    assert.equal(idgraphArray.length, 2);
 
     console.log('Send UserShieldingKey getter for alice ...');
     let UserShieldingKeyGetter = createSignedTrustedGetterUserShieldingKey(parachain_api, alice);
@@ -134,7 +143,7 @@ async function runDirectCall() {
     k = parachain_api.createType('Option<Bytes>', hexToU8a(res.value.toHex()));
     assert.isTrue(k.isNone);
 
-    sleep(10);
+    await sleep(10);
 
     nonce = await getSidechainNonce(wsp, parachain_api, mrenclave, key, bob.address);
 

--- a/tee-worker/ts-tests/examples/direct-invocation/util.ts
+++ b/tee-worker/ts-tests/examples/direct-invocation/util.ts
@@ -200,12 +200,7 @@ export function createSignedTrustedGetterUserShieldingKey(parachain_api: ApiProm
 }
 
 export function createSignedTrustedGetterIDGraph(parachain_api: ApiPromise, who: KeyringPair) {
-    let getterSigned = createSignedTrustedGetter(
-        parachain_api,
-        ['id_graph', '(AccountId)'],
-        who,
-        who.address
-    );
+    let getterSigned = createSignedTrustedGetter(parachain_api, ['id_graph', '(AccountId)'], who, who.address);
     return parachain_api.createType('Getter', { trusted: getterSigned });
 }
 

--- a/tee-worker/ts-tests/examples/direct-invocation/util.ts
+++ b/tee-worker/ts-tests/examples/direct-invocation/util.ts
@@ -199,6 +199,16 @@ export function createSignedTrustedGetterUserShieldingKey(parachain_api: ApiProm
     return parachain_api.createType('Getter', { trusted: getterSigned });
 }
 
+export function createSignedTrustedGetterIDGraph(parachain_api: ApiPromise, who: KeyringPair) {
+    let getterSigned = createSignedTrustedGetter(
+        parachain_api,
+        ['id_graph', '(AccountId)'],
+        who,
+        who.address
+    );
+    return parachain_api.createType('Getter', { trusted: getterSigned });
+}
+
 export const getSidechainNonce = async (
     wsp: any,
     parachain_api: ApiPromise,
@@ -297,7 +307,6 @@ export const createRequest = async (
     return parachain_api.createType('Request', { shard: hexToU8a(mrenclave), cyphertext }).toU8a();
 };
 
-// HexString
 export function decodeNonce(nonceInHex: string) {
     const optionalType = Option(Vector(u8));
     const encodedNonce = optionalType.dec(nonceInHex) as number[];


### PR DESCRIPTION
### Context

resolves #1763 

It fixes the twitter link error and checks the idgraph after the linking.

TODO: somehow `createType('Option<Vec<(....)>>')` doesn't work, I need to split the decoding into two steps.