### PR TITLE
fix: peer update mechanism 

### DIFF
--- a/tee-worker/service/src/main.rs
+++ b/tee-worker/service/src/main.rs
@@ -97,6 +97,7 @@ use sp_core::{
 };
 use sp_keyring::AccountKeyring;
 use std::{
+	collections::HashSet,
 	env,
 	fs::File,
 	io::Read,
@@ -179,7 +180,7 @@ fn main() {
 		enclave.clone(),
 		node_api_factory.clone(),
 		initialization_handler.clone(),
-		Vec::new(),
+		HashSet::new(),
 	));
 	let sync_block_broadcaster =
 		Arc::new(SyncBlockBroadcaster::new(tokio_handle.clone(), worker.clone()));

--- a/tee-worker/service/src/worker.rs
+++ b/tee-worker/service/src/worker.rs
@@ -151,12 +151,8 @@ where
 			.create_api()
 			.map_err(|e| Error::Custom(format!("Failed to create NodeApi: {:?}", e).into()))?;
 		let enclaves = node_api.all_enclaves(None)?;
-		let whitelisted = node_api.all_scheduled_mrenclaves(None)?;
 		let mut peer_urls = HashSet::<String>::new();
 		for enclave in enclaves {
-			if !whitelisted.contains(&enclave.mr_enclave) {
-				continue
-			}
 			// FIXME: This is temporary only, as block broadcasting should be moved to trusted ws server.
 			let enclave_url = enclave.url.clone();
 			let worker_api_direct = DirectWorkerApi::new(enclave.url);

--- a/tee-worker/service/src/worker.rs
+++ b/tee-worker/service/src/worker.rs
@@ -160,7 +160,6 @@ where
 			match worker_api_direct.get_untrusted_worker_url() {
 				Ok(untrusted_worker_url) => {
 					peer_urls.insert(untrusted_worker_url);
-					ve
 				},
 				Err(e) => {
 					error!(

--- a/tee-worker/service/src/worker.rs
+++ b/tee-worker/service/src/worker.rs
@@ -160,6 +160,7 @@ where
 			match worker_api_direct.get_untrusted_worker_url() {
 				Ok(untrusted_worker_url) => {
 					peer_urls.insert(untrusted_worker_url);
+					ve
 				},
 				Err(e) => {
 					error!(
@@ -229,7 +230,7 @@ mod tests {
 		run_server(W2_URL).await.unwrap();
 		let untrusted_worker_port = "4000".to_string();
 		let peers = vec![format!("ws://{}", W1_URL), format!("ws://{}", W2_URL)];
-		let peers: HashSet<String> = vector.into_iter().collect();
+		let peers: HashSet<String> = peers.into_iter().collect();
 
 		let worker = Worker::new(
 			local_worker_config(W1_URL.into(), untrusted_worker_port.clone(), "30".to_string()),


### PR DESCRIPTION
Resolves #1546 

- [x] Use `HashSet<Url>` instead of `Vector<Url>` 
- [x] Search only for whitelist mrenclave peers -> Already done as the enclave registry has enclaves with whitelisted mrenclave peers  

