### PR TITLE
Remove author_name from Twitter api model

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/a6.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a6.rs
@@ -58,7 +58,7 @@ pub fn build(
 		if let Identity::Web2 { network, address } = identity {
 			if matches!(network, Web2Network::Twitter) {
 				let twitter_handler = address.to_vec();
-				match client.query_user(twitter_handler) {
+				match client.query_user_by_name(twitter_handler) {
 					Ok(user) =>
 						if let Some(metrics) = user.public_metrics {
 							sum += metrics.followers_count;

--- a/tee-worker/litentry/core/data-providers/src/discord_official.rs
+++ b/tee-worker/litentry/core/data-providers/src/discord_official.rs
@@ -74,10 +74,6 @@ impl UserInfo for DiscordMessage {
 	fn get_user_id(&self) -> Option<String> {
 		Some(self.author.id.clone())
 	}
-
-	fn get_user_name(&self) -> Option<String> {
-		Some(self.author.username.clone())
-	}
 }
 
 pub struct DiscordOfficialClient {

--- a/tee-worker/litentry/core/data-providers/src/lib.rs
+++ b/tee-worker/litentry/core/data-providers/src/lib.rs
@@ -178,7 +178,6 @@ impl IntoErrorDetail for Error {
 
 pub trait UserInfo {
 	fn get_user_id(&self) -> Option<String>;
-	fn get_user_name(&self) -> Option<String>;
 }
 
 pub fn vec_to_string(vec: Vec<u8>) -> Result<String, Error> {

--- a/tee-worker/litentry/core/data-providers/src/twitter_official.rs
+++ b/tee-worker/litentry/core/data-providers/src/twitter_official.rs
@@ -49,7 +49,6 @@ pub struct ResponseMeta {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Tweet {
 	pub author_id: String,
-	pub author_name: String,
 	pub id: String,
 	pub text: String,
 }
@@ -127,10 +126,6 @@ impl RestPath<String> for Retweeted {
 impl UserInfo for Tweet {
 	fn get_user_id(&self) -> Option<String> {
 		Some(self.author_id.clone())
-	}
-
-	fn get_user_name(&self) -> Option<String> {
-		Some(self.author_name.clone())
 	}
 }
 
@@ -236,15 +231,33 @@ impl TwitterOfficialClient {
 	}
 
 	/// V2, rate limit: 300/15min(per App) 900/15min(per User)
-	pub fn query_user(&mut self, user_name: Vec<u8>) -> Result<TwitterUser, Error> {
+	pub fn query_user_by_name(&mut self, user_name: Vec<u8>) -> Result<TwitterUser, Error> {
 		let user = vec_to_string(user_name)?;
-		debug!("Twitter query user, user: {}", user);
+		debug!("Twitter query user by name, name: {}", user);
 
 		let query = vec![("user.fields", "public_metrics")];
 		let resp = self
 			.client
 			.get_with::<String, TwitterAPIV2Response<TwitterUser>>(
 				format!("/2/users/by/username/{}", user),
+				query.as_slice(),
+			)
+			.map_err(|e| Error::RequestError(format!("{:?}", e)))?;
+
+		let user = resp.data.ok_or_else(|| Error::RequestError("user not found".to_string()))?;
+		Ok(user)
+	}
+
+	/// V2, rate limit: 300/15min(per App) 900/15min(per User)
+	pub fn query_user_by_id(&mut self, id: Vec<u8>) -> Result<TwitterUser, Error> {
+		let id = vec_to_string(id)?;
+		debug!("Twitter query user by id, id: {}", id);
+
+		let query = vec![("user.fields", "public_metrics")];
+		let resp = self
+			.client
+			.get_with::<String, TwitterAPIV2Response<TwitterUser>>(
+				format!("/2/users/{}", id),
 				query.as_slice(),
 			)
 			.map_err(|e| Error::RequestError(format!("{:?}", e)))?;
@@ -307,7 +320,6 @@ mod tests {
 
 		assert_eq!(tweet.id, tweet_id);
 		assert_eq!(tweet.author_id, "mock_user_id");
-		assert_eq!(tweet.author_name, "mock_user");
 		assert_eq!(tweet.text, "38336b4b37f7d61060c3a490d978efb44af5bc78ec8e418b44ffce649f25455d")
 	}
 
@@ -328,9 +340,18 @@ mod tests {
 
 		let user = "twitterdev";
 		let mut client = TwitterOfficialClient::v2();
-		let result = client.query_user(user.as_bytes().to_vec());
+		let result = client.query_user_by_name(user.as_bytes().to_vec());
 		assert!(result.is_ok(), "error: {:?}", result);
-		// task.abort();
+	}
+
+	#[test]
+	fn query_user_by_id_work() {
+		init();
+
+		let user_id = "2244994945";
+		let mut client = TwitterOfficialClient::v2();
+		let result = client.query_user_by_id(user_id.as_bytes().to_vec());
+		assert!(result.is_ok(), "error: {:?}", result);
 	}
 
 	#[test]

--- a/tee-worker/litentry/core/identity-verification/src/web2/mod.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web2/mod.rs
@@ -72,9 +72,13 @@ pub fn verify(
 				.query_tweet(tweet_id.to_vec())
 				.map_err(|e| Error::LinkIdentityFailed(e.into_error_detail()))?;
 
-			let user_name = tweet
-				.get_user_name()
+			let user_id = tweet
+				.get_user_id()
 				.ok_or(Error::LinkIdentityFailed(ErrorDetail::WrongWeb2Handle))?;
+			let user = client
+				.query_user_by_id(user_id.into_bytes())
+				.map_err(|e| Error::LinkIdentityFailed(e.into_error_detail()))?;
+			let user_name = user.username;
 
 			let payload = payload_from_tweet(&tweet)?;
 

--- a/tee-worker/litentry/core/mock-server/src/lib.rs
+++ b/tee-worker/litentry/core/mock-server/src/lib.rs
@@ -66,7 +66,8 @@ where
 			let (addr, srv) = warp::serve(
 				twitter_official::query_tweet(getter.clone())
 					.or(twitter_official::query_retweeted_by())
-					.or(twitter_official::query_user())
+					.or(twitter_official::query_user_by_name())
+					.or(twitter_official::query_user_by_id())
 					.or(twitter_official::query_friendship())
 					.or(twitter_litentry::check_follow())
 					.or(discord_official::query_message())


### PR DESCRIPTION
Removes `author_name` from model reflecting twitter api.

fixes: #1831 