### PR TITLE
chore: #1634 added breaking changes label to release notes

### DIFF
--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -278,6 +278,8 @@ jobs:
       - name: Generate release notes
         run: |
           ./scripts/generate-release-notes.sh ${{ github.workspace }}/.github/release_notes.md ${{ needs.set-release-type.outputs.release_type }} ${{ env.DIFF_TAG }}
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create release draft
         id: create-release-draft

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -167,18 +167,18 @@ Details:
 
 EOF
 
-labels=("C0-breaking" "C1-noteworthy")
+  labels=("C0-breaking" "C1-noteworthy")
 
-git log --no-merges --abbrev-commit --pretty="format:%h|%s%n" "$DIFF_TAG..$RELEASE_TAG" | grep -v "^$" | while read -r f; do
-  commit=$(echo "$f" | cut -d'|' -f1)
-  desc=$(echo "$f" | cut -d'|' -f2)
-  output="- [\`$commit\`]($REPO/commit/$commit) $desc"
-  
-  for ((i=0; i<${#labels[@]}; i++)); do
-    label=$(gh pr list --search "$commit" --label "${labels[i]}" --state merged)
-    [ -n "$label" ] && output+=" $REPO/labels/${labels[i]}"
+  git log --no-merges --abbrev-commit --pretty="format:%h|%s%n" "$DIFF_TAG..$RELEASE_TAG" | grep -v "^$" | while read -r f; do
+    commit=$(echo "$f" | cut -d'|' -f1)
+    desc=$(echo "$f" | cut -d'|' -f2)
+    output="- [\`$commit\`]($REPO/commit/$commit) $desc"
+    
+    for ((i=0; i<${#labels[@]}; i++)); do
+      label=$(gh pr list --search "$commit" --label "${labels[i]}" --state merged)
+      [ -n "$label" ] && output+=" $REPO/labels/${labels[i]}"
+    done
+    
+    echo "$output" >> "$1"
   done
-  
-  echo "$output" >> "$1"
-done
 fi


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

Implemeneted #1634 into release notes

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevent evidences if applicable



https://github.com/litentry/litentry-parachain/assets/120463031/b89955ae-14aa-4953-b4df-d0cd69beddc6

