### PR TITLE
fix: downgrade srtool image compatible with polkadotv0.9.39

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           chain: ${{ github.event.inputs.chain }}-parachain
           runtime_dir: runtime/${{ github.event.inputs.chain }}
+          tag: "1.66.0"
 
       - name: Summary
         run: |


### PR DESCRIPTION
Resolves #1819 

The issue as correctly identified by @Kailai-Wang was due to the low version of polkadot being used. We can in the future refer to the release notes of Polkadot which mention against which version of `srtools` and `rustc` version it was tested against to build the `wasm`. 

I've tested the fix on my fork [here](https://github.com/felixfaisal/litentry-parachain/actions/runs/5485044759) 