### PR TITLE
feat: #1697 added support for new discord username, while old usernam…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ gethdata
 tee-worker/.env
 tee-worker/ts-tests/.env.local
 ts-tests/config.local.json
+
+# Docker files
+docker/.yarn

--- a/tee-worker/README.md
+++ b/tee-worker/README.md
@@ -10,9 +10,9 @@ source /opt/intel/sgxsdk/environment
 # run clean if only SGX_MODE change
 make clean
 make SGX_MODE=SW
-./local-setup/launch.py local-setup/github-action-config-one-worker.json
+./local-setup/launch.py local-setup/development-worker.json local-docker
 # run the ts test script below if container started
-cd  ./tee-worker/ts-tests
+cd ./tee-worker/ts-tests
 yarn
 yarn run test-identity:local
 # other ts test

--- a/tee-worker/litentry/core/assertion-build/src/a2.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a2.rs
@@ -98,7 +98,7 @@ mod tests {
 		let guild_id_u: u64 = 919848390156767232;
 		let guild_id_vec: Vec<u8> = format!("{}", guild_id_u).as_bytes().to_vec();
 
-		let handler_vec: Vec<u8> = "againstwar%234779".to_string().as_bytes().to_vec();
+		let handler_vec: Vec<u8> = "againstwar".to_string().as_bytes().to_vec();
 		let identities: Vec<IdentityNetworkTuple> =
 			vec![(Identity::Discord(IdentityString::truncate_from(handler_vec.clone())), vec![])];
 

--- a/tee-worker/litentry/core/assertion-build/src/a3.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a3.rs
@@ -124,7 +124,7 @@ mod tests {
 		let channel_id_vec: Vec<u8> = format!("{}", channel_id_u).as_bytes().to_vec();
 		let role_id_vec: Vec<u8> = format!("{}", role_id_u).as_bytes().to_vec();
 
-		let handler_vec: Vec<u8> = "againstwar%234779".to_string().as_bytes().to_vec();
+		let handler_vec: Vec<u8> = "againstwar".to_string().as_bytes().to_vec();
 		let identities: Vec<IdentityNetworkTuple> =
 			vec![(Identity::Discord(IdentityString::truncate_from(handler_vec.clone())), vec![])];
 

--- a/tee-worker/litentry/core/data-providers/src/discord_litentry.rs
+++ b/tee-worker/litentry/core/data-providers/src/discord_litentry.rs
@@ -159,7 +159,7 @@ mod tests {
 	fn check_join_work() {
 		init();
 		let guild_id = "919848390156767232".as_bytes().to_vec();
-		let handler = "againstwar#4779".as_bytes().to_vec();
+		let handler = "againstwar".as_bytes().to_vec();
 		let mut client = DiscordLitentryClient::new();
 		let response = client.check_join(guild_id, handler);
 		assert!(response.is_ok(), "check join discord error: {:?}", response);
@@ -171,7 +171,7 @@ mod tests {
 		let guild_id = "919848390156767232".as_bytes().to_vec();
 		let channel_id = "919848392035794945".as_bytes().to_vec();
 		let role_id = "1034083718425493544".as_bytes().to_vec();
-		let handler = "ericzhang.eth#0114".as_bytes().to_vec();
+		let handler = "ericzhang.eth".as_bytes().to_vec();
 		let mut client = DiscordLitentryClient::new();
 		let response = client.check_id_hubber(guild_id, channel_id, role_id, handler);
 		assert!(response.is_ok(), "check discord id hubber error: {:?}", response);

--- a/tee-worker/litentry/core/data-providers/src/discord_official.rs
+++ b/tee-worker/litentry/core/data-providers/src/discord_official.rs
@@ -40,8 +40,6 @@ pub struct DiscordMessage {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DiscordMessageAuthor {
 	pub id: String, //user_id
-	// NOTE: username doesn't contain discriminator(the user's 4-digit discord-tag),
-	// so it can't compared with user handler
 	pub username: String,
 }
 

--- a/tee-worker/litentry/core/identity-verification/src/web2/mod.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web2/mod.rs
@@ -98,18 +98,20 @@ pub fn verify(
 				.get_user_info(message.author.id.clone())
 				.map_err(|e| Error::LinkIdentityFailed(e.into_error_detail()))?;
 
-			let mut user_name_with_discriminator = message.author.username.clone();
-			user_name_with_discriminator.push_str(&'#'.to_string());
-			user_name_with_discriminator.push_str(&user.discriminator);
-
+			let mut user_name = message.author.username.clone();
+			// if discord user's username is upgraded complete, the discriminator value from api will be "0".
+			if user.discriminator != "0" {
+				user_name.push_str(&'#'.to_string());
+				user_name.push_str(&user.discriminator);
+			}
 			let payload = payload_from_discord(&message)?;
-			Ok((user_name_with_discriminator, payload))
+			Ok((user_name, payload))
 		},
 	}?;
 
 	// compare the username:
 	// - twitter's username is case insensitive
-	// - discord's username (with 4 digit discriminator) is case sensitive
+	// - discord's username is case sensitive
 	match identity {
 		Identity::Twitter(address) => {
 			let handle = std::str::from_utf8(address.as_slice())

--- a/tee-worker/litentry/core/mock-server/src/discord_litentry.rs
+++ b/tee-worker/litentry/core/mock-server/src/discord_litentry.rs
@@ -29,7 +29,7 @@ pub(crate) fn check_join(
 			let guild_id = p.get("guildid").unwrap_or(&default);
 			let handler = p.get("handler").unwrap_or(&default);
 			let expected_guild_id = "919848390156767232";
-			let expected_handler = "againstwar#4779";
+			let expected_handler = "againstwar";
 
 			if expected_guild_id == guild_id.as_str() && expected_handler == handler.as_str() {
 				let body = DiscordResponse {
@@ -60,7 +60,7 @@ pub(crate) fn check_id_hubber(
 			let expected_guild_id = "919848390156767232";
 			let expected_channel_id = "919848392035794945";
 			let expected_role_id = "1034083718425493544";
-			let expected_handler = "ericzhang.eth#0114";
+			let expected_handler = "ericzhang.eth";
 
 			if expected_guild_id == guild_id.as_str()
 				&& expected_handler == handler.as_str()


### PR DESCRIPTION
…e would still work

resolved #1697

### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevent evidences if applicable

Tested with and without discriminator discord username via IDH, both works.



https://github.com/litentry/litentry-parachain/assets/120463031/a102be4a-5fbd-4061-9070-5345f5887a07


https://github.com/litentry/litentry-parachain/assets/120463031/ecafa741-8f6b-436d-9456-bc40cfd3f61e

