### PR TITLE
Add missing `cli` mount in docker-compose files

### DIFF
--- a/tee-worker/docker/lit-batch-test.yml
+++ b/tee-worker/docker/lit-batch-test.yml
@@ -4,6 +4,7 @@ services:
     container_name: litentry-batch-test
     volumes:
       - ../ts-tests:/ts-tests
+      - ../cli:/usr/local/worker-cli
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/tee-worker/docker/lit-id-graph-stats.yml
+++ b/tee-worker/docker/lit-id-graph-stats.yml
@@ -2,6 +2,8 @@ services:
   lit-id-graph-stats:
     image: integritee-cli:dev
     container_name: litentry-id-graph-stats
+    volumes:
+      - ../cli:/usr/local/worker-cli
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/tee-worker/docker/lit-identity-direct-invocation-test.yml
+++ b/tee-worker/docker/lit-identity-direct-invocation-test.yml
@@ -1,25 +1,25 @@
 services:
-    lit-identity-direct-invocation-test:
-        image: integritee-cli:dev
-        container_name: litentry-identity-direct-invocation-test
-        volumes:
-            - ../ts-tests:/ts-tests
-            - ../cli:/usr/local/worker-cli
-        build:
-            context: ..
-            dockerfile: build.Dockerfile
-            target: deployed-client
-        depends_on:
-            integritee-node:
-                condition: service_healthy
-            integritee-worker-1:
-                condition: service_healthy
-            integritee-worker-2:
-                condition: service_healthy
-        networks:
-            - integritee-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-identity-direct-invocation 2>&1' "
-        restart: "no"
+  lit-identity-direct-invocation-test:
+    image: integritee-cli:dev
+    container_name: litentry-identity-direct-invocation-test
+    volumes:
+      - ../ts-tests:/ts-tests
+      - ../cli:/usr/local/worker-cli
+    build:
+      context: ..
+      dockerfile: build.Dockerfile
+      target: deployed-client
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
+    networks:
+      - integritee-test-network
+    entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-identity-direct-invocation 2>&1' "
+    restart: "no"
 networks:
-    integritee-test-network:
-        driver: bridge
+  integritee-test-network:
+    driver: bridge

--- a/tee-worker/docker/lit-identity-direct-invocation-test.yml
+++ b/tee-worker/docker/lit-identity-direct-invocation-test.yml
@@ -4,6 +4,7 @@ services:
         container_name: litentry-identity-direct-invocation-test
         volumes:
             - ../ts-tests:/ts-tests
+            - ../cli:/usr/local/worker-cli
         build:
             context: ..
             dockerfile: build.Dockerfile

--- a/tee-worker/docker/lit-identity-test.yml
+++ b/tee-worker/docker/lit-identity-test.yml
@@ -4,6 +4,7 @@ services:
     container_name: litentry-identity-test
     volumes:
       - ../ts-tests:/ts-tests
+      - ../cli:/usr/local/worker-cli
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/tee-worker/docker/lit-parentchain-nonce.yml
+++ b/tee-worker/docker/lit-parentchain-nonce.yml
@@ -2,6 +2,8 @@ services:
   lit-parentchain-nonce:
     image: integritee-cli:dev
     container_name: litentry-parentchain-nonce
+    volumes:
+      - ../cli:/usr/local/worker-cli
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/tee-worker/docker/lit-resume-worker.yml
+++ b/tee-worker/docker/lit-resume-worker.yml
@@ -4,6 +4,7 @@ services:
     container_name: litentry-worker
     volumes:
       - ../ts-tests:/ts-tests
+      - ../cli:/usr/local/worker-cli
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/tee-worker/docker/lit-set-heartbeat-timeout.yml
+++ b/tee-worker/docker/lit-set-heartbeat-timeout.yml
@@ -2,6 +2,8 @@ services:
   lit-set-heartbeat-timeout:
     image: integritee-cli:dev
     container_name: litentry-set-heartbeat-timeout
+    volumes:
+      - ../cli:/usr/local/worker-cli
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/tee-worker/docker/lit-user-shielding-key.yml
+++ b/tee-worker/docker/lit-user-shielding-key.yml
@@ -2,6 +2,8 @@ services:
   lit-user-shielding-key:
     image: integritee-cli:dev
     container_name: litentry-user-shielding-key
+    volumes:
+      - ../cli:/usr/local/worker-cli
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/tee-worker/docker/lit-vc-test.yml
+++ b/tee-worker/docker/lit-vc-test.yml
@@ -4,6 +4,7 @@ services:
     container_name: litentry-vc-test
     volumes:
       - ../ts-tests:/ts-tests
+      - ../cli:/usr/local/worker-cli
     build:
       context: ..
       dockerfile: build.Dockerfile


### PR DESCRIPTION
### Context

As topic, without this the `cli/` changes won't take effect without rebuilding tee docker image. 