### PR TITLE
test should always run with 'dev' flag

### DIFF
--- a/tee-worker/ts-tests/integration-tests/resuming_worker.test.ts
+++ b/tee-worker/ts-tests/integration-tests/resuming_worker.test.ts
@@ -71,8 +71,8 @@ function generateWorkerCommandArguments(
         `--node-port ${nodePort}`,
         `run`,
         `--skip-ra`,
+        `--dev`,
         ...(isLaunch && workerParams.requestStateOnLaunch ? ['--request-state'] : []),
-        ...(isLaunch ? ['--dev'] : []),
     ].join(' ');
 }
 


### PR DESCRIPTION
Inside test cases, worker should always run with 'dev' flag.



