### PR TITLE
rename vc `*_timestamp` fields

### DIFF
--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -3633,6 +3633,8 @@ dependencies = [
 name = "itp-time-utils"
 version = "0.9.0"
 dependencies = [
+ "chrono 0.4.11",
+ "chrono 0.4.26",
  "sgx_tstd",
 ]
 

--- a/tee-worker/core-primitives/time-utils/Cargo.toml
+++ b/tee-worker/core-primitives/time-utils/Cargo.toml
@@ -5,12 +5,18 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 
 [dependencies]
+chrono = { version = "0.4.19", features = ["alloc"], optional = true }
+
+
+chrono_sgx = { package = "chrono", git = "https://github.com/mesalock-linux/chrono-sgx", optional = true }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [features]
 default = ["std"]
 std = [
+    "chrono",
 ]
 sgx = [
     "sgx_tstd",
+    "chrono_sgx",
 ]

--- a/tee-worker/core-primitives/time-utils/Cargo.toml
+++ b/tee-worker/core-primitives/time-utils/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4.19", features = ["alloc"], optional = true }
 
-
 chrono_sgx = { package = "chrono", git = "https://github.com/mesalock-linux/chrono-sgx", optional = true }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 

--- a/tee-worker/core-primitives/time-utils/src/lib.rs
+++ b/tee-worker/core-primitives/time-utils/src/lib.rs
@@ -24,7 +24,14 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use std::time::{Duration, SystemTime};
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate chrono_sgx as chrono;
+
+use chrono::{DateTime, Utc};
+use std::{
+	string::String,
+	time::{Duration, SystemTime},
+};
 
 /// Returns the current timestamp based on the unix epoch in seconds.
 pub fn now_as_secs() -> u64 {
@@ -34,6 +41,11 @@ pub fn now_as_secs() -> u64 {
 /// Returns current duration since unix epoch in millis as u64.
 pub fn now_as_millis() -> u64 {
 	duration_now().as_millis() as u64
+}
+
+pub fn now_as_iso8601() -> String {
+	let date_time: DateTime<Utc> = SystemTime::now().into();
+	date_time.to_rfc3339()
 }
 
 /// Returns the current timestamp based on the unix epoch in nanoseconds.

--- a/tee-worker/core-primitives/time-utils/src/lib.rs
+++ b/tee-worker/core-primitives/time-utils/src/lib.rs
@@ -27,7 +27,7 @@ extern crate sgx_tstd as std;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate chrono_sgx as chrono;
 
-use chrono::{DateTime, Utc};
+use chrono::{offset::FixedOffset, DateTime, Utc};
 use std::{
 	string::String,
 	time::{Duration, SystemTime},
@@ -46,6 +46,10 @@ pub fn now_as_millis() -> u64 {
 pub fn now_as_iso8601() -> String {
 	let date_time: DateTime<Utc> = SystemTime::now().into();
 	date_time.to_rfc3339()
+}
+
+pub fn from_iso8601(datetime_str: &str) -> Option<DateTime<FixedOffset>> {
+	DateTime::parse_from_rfc3339(datetime_str).ok()
 }
 
 /// Returns the current timestamp based on the unix epoch in nanoseconds.

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -2311,6 +2311,7 @@ dependencies = [
 name = "itp-time-utils"
 version = "0.9.0"
 dependencies = [
+ "chrono 0.4.11",
  "sgx_tstd",
 ]
 

--- a/tee-worker/litentry/core/credentials/src/error.rs
+++ b/tee-worker/litentry/core/credentials/src/error.rs
@@ -33,8 +33,6 @@ pub enum Error {
 	EmptyCredentialSubject,
 	#[error("Empty Issuance Timestamp")]
 	EmptyIssuanceTimestamp,
-	#[error("Empty Proof Timestamp")]
-	EmptyProofTimestamp,
 	#[error("Invalid Proof")]
 	InvalidProof,
 	#[error("Credential Is Too Long")]

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -37,7 +37,7 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 
 use codec::{Decode, Encode};
 use itp_stf_primitives::types::ShardIdentifier;
-use itp_time_utils::{now_as_iso8601, now_as_millis};
+use itp_time_utils::{from_iso8601, now_as_iso8601};
 use itp_types::AccountId;
 use itp_utils::stringify::account_id_to_string;
 use litentry_primitives::{Identity, Web3Network};
@@ -214,10 +214,7 @@ pub struct Credential {
 	pub credential_subject: CredentialSubject,
 	/// The TEE enclave who issued the credential
 	pub issuer: Issuer,
-	pub issuance_timestamp: u64,
-	/// (Optional)
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub expiration_timestamp: Option<u64>,
+	pub issuance_date: String,
 	/// Digital proof with the signature of Issuer
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub proof: Option<Proof>,
@@ -249,8 +246,7 @@ impl Credential {
 				.to_account_id()
 				.ok_or_else(|| Error::RuntimeError("Not a valid account".to_string()))?,
 		);
-		vc.issuance_timestamp = now_as_millis();
-		vc.expiration_timestamp = None;
+		vc.issuance_date = now_as_iso8601();
 		vc.credential_schema = None;
 		vc.proof = None;
 
@@ -295,9 +291,7 @@ impl Credential {
 			return Err(Error::EmptyCredentialSubject)
 		}
 
-		if self.issuance_timestamp == 0 {
-			return Err(Error::EmptyIssuanceTimestamp)
-		}
+		from_iso8601(&self.issuance_date).ok_or(Error::EmptyIssuanceTimestamp)?;
 
 		if self.id.is_empty() {
 			return Err(Error::InvalidCredential)

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -37,7 +37,7 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 
 use codec::{Decode, Encode};
 use itp_stf_primitives::types::ShardIdentifier;
-use itp_time_utils::now_as_millis;
+use itp_time_utils::{now_as_iso8601, now_as_millis};
 use itp_types::AccountId;
 use itp_utils::stringify::account_id_to_string;
 use litentry_primitives::{Identity, Web3Network};
@@ -170,8 +170,8 @@ pub struct CredentialSchema {
 #[derive(Serialize, Deserialize, Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo)]
 #[serde(rename_all = "camelCase")]
 pub struct Proof {
-	/// The timestamp when the signature was created
-	pub created: u64,
+	/// The ISO-8601 datetime of signature creation
+	pub created: String,
 	/// The cryptographic signature suite that used to generate signature
 	#[serde(rename = "type")]
 	pub proof_type: ProofType,
@@ -186,7 +186,7 @@ pub struct Proof {
 impl Proof {
 	pub fn new(sig: &Vec<u8>, issuer: &AccountId) -> Self {
 		Proof {
-			created: now_as_millis(),
+			created: now_as_iso8601(),
 			proof_type: ProofType::Ed25519Signature2020,
 			proof_purpose: PROOF_PURPOSE.to_string(),
 			proof_value: format!("{}", HexDisplay::from(sig)),
@@ -327,13 +327,6 @@ impl Credential {
 
 		if vc.proof.is_none() {
 			return Err(Error::InvalidProof)
-		} else {
-			let proof = vc.proof.unwrap();
-			if proof.created == 0 {
-				return Err(Error::EmptyProofTimestamp)
-			}
-
-			//ToDo: validate proof signature
 		}
 
 		Ok(())

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -171,7 +171,7 @@ pub struct CredentialSchema {
 #[serde(rename_all = "camelCase")]
 pub struct Proof {
 	/// The timestamp when the signature was created
-	pub created_timestamp: u64,
+	pub created: u64,
 	/// The cryptographic signature suite that used to generate signature
 	#[serde(rename = "type")]
 	pub proof_type: ProofType,
@@ -186,7 +186,7 @@ pub struct Proof {
 impl Proof {
 	pub fn new(sig: &Vec<u8>, issuer: &AccountId) -> Self {
 		Proof {
-			created_timestamp: now_as_millis(),
+			created: now_as_millis(),
 			proof_type: ProofType::Ed25519Signature2020,
 			proof_purpose: PROOF_PURPOSE.to_string(),
 			proof_value: format!("{}", HexDisplay::from(sig)),
@@ -329,7 +329,7 @@ impl Credential {
 			return Err(Error::InvalidProof)
 		} else {
 			let proof = vc.proof.unwrap();
-			if proof.created_timestamp == 0 {
+			if proof.created == 0 {
 				return Err(Error::EmptyProofTimestamp)
 			}
 

--- a/tee-worker/litentry/core/credentials/src/templates/credential.json
+++ b/tee-worker/litentry/core/credentials/src/templates/credential.json
@@ -28,7 +28,7 @@
         "endpoint":""
     },
     "proof":{
-        "created":0,
+        "created":"2023-07-25T13:31:43.712Z",
         "type":"Ed25519Signature2020",
         "proofPurpose":"assertionMethod",
         "proofValue":"",

--- a/tee-worker/litentry/core/credentials/src/templates/credential.json
+++ b/tee-worker/litentry/core/credentials/src/templates/credential.json
@@ -13,8 +13,7 @@
         "name":""
     },
     "subject":"",
-    "issuanceTimestamp":0,
-    "expirationTimestamp":0,
+    "issuanceDate":"",
     "credentialSubject":{
         "id":"",
         "description":"",
@@ -28,7 +27,7 @@
         "endpoint":""
     },
     "proof":{
-        "created":"2023-07-25T13:31:43.712Z",
+        "created":"",
         "type":"Ed25519Signature2020",
         "proofPurpose":"assertionMethod",
         "proofValue":"",

--- a/tee-worker/litentry/core/credentials/src/templates/credential.json
+++ b/tee-worker/litentry/core/credentials/src/templates/credential.json
@@ -28,7 +28,7 @@
         "endpoint":""
     },
     "proof":{
-        "createdTimestamp":0,
+        "created":0,
         "type":"Ed25519Signature2020",
         "proofPurpose":"assertionMethod",
         "proofValue":"",

--- a/tee-worker/litentry/core/credentials/src/templates/credential_schema.json
+++ b/tee-worker/litentry/core/credentials/src/templates/credential_schema.json
@@ -71,7 +71,7 @@
             "type":"object",
             "properties":{
                 "created":{
-                    "type":"integer"
+                    "type":"string"
                 },
                 "type":{
                     "enum":[

--- a/tee-worker/litentry/core/credentials/src/templates/credential_schema.json
+++ b/tee-worker/litentry/core/credentials/src/templates/credential_schema.json
@@ -70,7 +70,7 @@
         "proof":{
             "type":"object",
             "properties":{
-                "createdTimestamp":{
+                "created":{
                     "type":"integer"
                 },
                 "type":{

--- a/tee-worker/litentry/core/credentials/src/templates/credential_schema.json
+++ b/tee-worker/litentry/core/credentials/src/templates/credential_schema.json
@@ -27,8 +27,8 @@
                 }
             }
         },
-        "issuanceTimestamp":{
-            "type":"integer"
+        "issuanceDate":{
+            "type":"string"
         },
         "credentialSubject":{
             "type":"object",

--- a/tee-worker/ts-tests/integration-tests/common/type-definitions.ts
+++ b/tee-worker/ts-tests/integration-tests/common/type-definitions.ts
@@ -134,8 +134,8 @@ export const jsonSchema = {
                 },
             },
         },
-        issuanceTimestamp: {
-            type: 'integer',
+        issuanceDate: {
+            type: 'string',
         },
         credentialSubject: {
             type: 'object',
@@ -191,5 +191,5 @@ export const jsonSchema = {
             },
         },
     },
-    required: ['id', 'type', 'credentialSubject', 'issuer', 'issuanceTimestamp', 'proof'],
+    required: ['id', 'type', 'credentialSubject', 'issuer', 'issuanceDate', 'proof'],
 };

--- a/tee-worker/ts-tests/integration-tests/common/type-definitions.ts
+++ b/tee-worker/ts-tests/integration-tests/common/type-definitions.ts
@@ -173,8 +173,8 @@ export const jsonSchema = {
         proof: {
             type: 'object',
             properties: {
-                createdTimestamp: {
-                    type: 'integer',
+                created: {
+                    type: 'string',
                 },
                 type: {
                     enum: ['Ed25519Signature2020'],


### PR DESCRIPTION
Fields holding datetime should be represented by ISO-8601 datetime format instead of numerical timestamp.

renames created_timestamp -> created
renames issuanceTimestamp -> issuanceDate
removes expirationTimestamp

