### PR TITLE
Accept wrapped eip191 message when verifying the signature

### DIFF
--- a/tee-worker/app-libs/stf/src/helpers.rs
+++ b/tee-worker/app-libs/stf/src/helpers.rs
@@ -146,9 +146,3 @@ pub fn get_expected_raw_message(
 	payload.append(&mut encrypted_data);
 	blake2_256(payload.as_slice()).to_vec()
 }
-
-// Get the wrapped version of the raw msg: <Bytes>raw_msg</Bytes>,
-// see https://github.com/litentry/litentry-parachain/issues/1137
-pub fn get_expected_wrapped_message(raw_msg: Vec<u8>) -> Vec<u8> {
-	["<Bytes>".as_bytes(), raw_msg.as_slice(), "</Bytes>".as_bytes()].concat()
-}

--- a/tee-worker/app-libs/stf/src/trusted_call.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call.rs
@@ -202,13 +202,7 @@ impl TrustedCallSigned {
 		payload.append(&mut mrenclave.encode());
 		payload.append(&mut shard.encode());
 
-		// litentry: https://github.com/litentry/litentry-parachain/issues/1752
-		// the raw message is always wrapped up with `<Bytes></Bytes>` when using browser
-		// wallet extension, we need to support it as well
-		let wrapped_payload =
-			["<Bytes>".as_bytes(), payload.as_slice(), "</Bytes>".as_bytes()].concat();
 		self.signature.verify(payload.as_slice(), self.call.sender_identity())
-			|| self.signature.verify(wrapped_payload.as_slice(), self.call.sender_identity())
 	}
 
 	pub fn into_trusted_operation(self, direct: bool) -> TrustedOperation {

--- a/tee-worker/litentry/core/identity-verification/src/lib.rs
+++ b/tee-worker/litentry/core/identity-verification/src/lib.rs
@@ -36,7 +36,6 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 use frame_support::pallet_prelude::*;
 use lc_stf_task_sender::IdentityVerificationRequest;
 use litentry_primitives::ValidationData;
-use std::string::ToString;
 
 mod web2;
 mod web3;

--- a/tee-worker/litentry/core/identity-verification/src/web2/mod.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web2/mod.rs
@@ -64,6 +64,8 @@ pub fn verify(
 ) -> Result<()> {
 	debug!("verify web2 identity, who: {:?}", who);
 
+	ensure!(identity.is_web2(), Error::LinkIdentityFailed(ErrorDetail::InvalidIdentity),);
+
 	let (user_name, payload) = match data {
 		Web2ValidationData::Twitter(TwitterValidationData { ref tweet_id }) => {
 			let mut client = TwitterOfficialClient::v2();

--- a/tee-worker/litentry/core/identity-verification/src/web3/mod.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web3/mod.rs
@@ -32,6 +32,9 @@ pub fn verify(
 	data: &Web3ValidationData,
 ) -> Result<()> {
 	debug!("verify web3 identity, who: {}", account_id_to_string(&who));
+
+	ensure!(identity.is_web3(), Error::LinkIdentityFailed(ErrorDetail::InvalidIdentity),);
+
 	let raw_msg = get_expected_raw_message(who, identity, sidechain_nonce, key, nonce);
 
 	ensure!(

--- a/tee-worker/litentry/core/identity-verification/src/web3/mod.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web3/mod.rs
@@ -19,8 +19,8 @@ use ita_stf::helpers::{get_expected_raw_message, get_expected_wrapped_message};
 use itp_types::Index;
 use itp_utils::stringify::account_id_to_string;
 use litentry_primitives::{
-	recover_evm_address, ErrorDetail, Identity, LitentryMultiSignature, UserShieldingKeyNonceType,
-	UserShieldingKeyType, Web3CommonValidationData, Web3ValidationData,
+	compute_evm_msg_digest, recover_evm_address, ErrorDetail, Identity, LitentryMultiSignature,
+	UserShieldingKeyNonceType, UserShieldingKeyType, Web3CommonValidationData, Web3ValidationData,
 };
 use log::*;
 use sp_core::{ed25519, sr25519};
@@ -142,15 +142,4 @@ fn verify_evm_signature(
 		return Err(Error::LinkIdentityFailed(ErrorDetail::WrongSignatureType))
 	}
 	Ok(())
-}
-
-// we use an EIP-191 message has computing
-fn compute_evm_msg_digest(message: &[u8]) -> [u8; 32] {
-	let eip_191_message = [
-		"\x19Ethereum Signed Message:\n".as_bytes(),
-		message.len().to_string().as_bytes(),
-		message,
-	]
-	.concat();
-	keccak_256(&eip_191_message)
 }

--- a/tee-worker/litentry/core/identity-verification/src/web3/mod.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web3/mod.rs
@@ -15,19 +15,15 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{ensure, Error, Result, ToString};
-use ita_stf::helpers::{get_expected_raw_message, get_expected_wrapped_message};
+use ita_stf::helpers::get_expected_raw_message;
 use itp_types::Index;
 use itp_utils::stringify::account_id_to_string;
 use litentry_primitives::{
-	compute_evm_msg_digest, recover_evm_address, ErrorDetail, Identity, LitentryMultiSignature,
-	UserShieldingKeyNonceType, UserShieldingKeyType, Web3CommonValidationData, Web3ValidationData,
+	ErrorDetail, Identity, LitentryMultiSignature, UserShieldingKeyNonceType, UserShieldingKeyType,
+	Web3CommonValidationData, Web3ValidationData,
 };
 use log::*;
 use sp_core::{ed25519, sr25519};
-use sp_io::{
-	crypto::{ed25519_verify, secp256k1_ecdsa_recover_compressed, sr25519_verify},
-	hashing::{blake2_256, keccak_256},
-};
 
 pub fn verify(
 	who: &Identity,
@@ -38,108 +34,23 @@ pub fn verify(
 	data: &Web3ValidationData,
 ) -> Result<()> {
 	debug!("verify web3 identity, who: {}", account_id_to_string(&who));
-	match data {
-		Web3ValidationData::Substrate(substrate_validation_data) => verify_substrate_signature(
-			who,
-			identity,
-			sidechain_nonce,
-			key,
-			nonce,
-			substrate_validation_data,
-		),
-		Web3ValidationData::Evm(evm_validation_data) =>
-			verify_evm_signature(who, identity, sidechain_nonce, key, nonce, evm_validation_data),
-	}
-}
-
-fn verify_substrate_signature(
-	who: &Identity,
-	identity: &Identity,
-	sidechain_nonce: Index,
-	key: UserShieldingKeyType,
-	nonce: UserShieldingKeyNonceType,
-	validation_data: &Web3CommonValidationData,
-) -> Result<()> {
 	let raw_msg = get_expected_raw_message(who, identity, sidechain_nonce, key, nonce);
-	let wrapped_msg = get_expected_wrapped_message(raw_msg.clone());
 
 	ensure!(
-		raw_msg.as_slice() == validation_data.message.as_slice(),
+		raw_msg.as_slice() == data.message().as_slice(),
 		Error::LinkIdentityFailed(ErrorDetail::UnexpectedMessage)
 	);
-	let substrate_address = if let Identity::Substrate(address) = identity {
-		address.as_ref()
-	} else {
-		return Err(Error::LinkIdentityFailed(ErrorDetail::InvalidIdentity))
-	};
 
-	// we accept both the raw_msg's signature and the wrapped_msg's signature
-	ensure!(
-		verify_substrate_signature_internal(
-			&raw_msg,
-			&validation_data.signature,
-			substrate_address
-		) || verify_substrate_signature_internal(
-			&wrapped_msg,
-			&validation_data.signature,
-			substrate_address
-		),
-		Error::LinkIdentityFailed(ErrorDetail::VerifySubstrateSignatureFailed)
-	);
-	Ok(())
-}
-
-fn verify_substrate_signature_internal(
-	msg: &[u8],
-	signature: &LitentryMultiSignature,
-	address: &[u8; 32],
-) -> bool {
-	match signature {
-		LitentryMultiSignature::Sr25519(sig) =>
-			sr25519_verify(sig, msg, &sr25519::Public(*address)),
-		LitentryMultiSignature::Ed25519(sig) =>
-			ed25519_verify(sig, msg, &ed25519::Public(*address)),
-		// We can' use `ecdsa_verify` directly we don't have the raw 33-bytes publick key
-		// instead we only have AccountId which is blake2_256(pubkey)
-		LitentryMultiSignature::Ecdsa(sig) => {
-			// see https://github.com/paritytech/substrate/blob/493b58bd4a475080d428ce47193ee9ea9757a808/primitives/runtime/src/traits.rs#L132
-			let digest = blake2_256(msg);
-			if let Ok(recovered_substrate_pubkey) =
-				secp256k1_ecdsa_recover_compressed(&sig.0, &digest)
-			{
-				&blake2_256(&recovered_substrate_pubkey) == address
-			} else {
-				false
-			}
-		},
-		_ => false,
+	// TODO: just to make it backwards compatible
+	//       will merge it to `VerifyWeb3SignatureFailed` after the campaign
+	if !data.signature().verify(&raw_msg, identity) {
+		match data {
+			Web3ValidationData::Substrate(_) =>
+				return Err(Error::LinkIdentityFailed(ErrorDetail::VerifySubstrateSignatureFailed)),
+			Web3ValidationData::Evm(_) =>
+				return Err(Error::LinkIdentityFailed(ErrorDetail::VerifyEvmSignatureFailed)),
+		}
 	}
-}
 
-fn verify_evm_signature(
-	who: &Identity,
-	identity: &Identity,
-	sidechain_nonce: Index,
-	key: UserShieldingKeyType,
-	nonce: UserShieldingKeyNonceType,
-	validation_data: &Web3CommonValidationData,
-) -> Result<()> {
-	let msg = get_expected_raw_message(who, identity, sidechain_nonce, key, nonce);
-	let digest = compute_evm_msg_digest(&msg);
-	let evm_address = if let Identity::Evm(address) = identity {
-		address
-	} else {
-		return Err(Error::LinkIdentityFailed(ErrorDetail::InvalidIdentity))
-	};
-	if let LitentryMultiSignature::Ethereum(sig) = &validation_data.signature {
-		let recovered_evm_address = recover_evm_address(&digest, sig.as_ref())
-			.map_err(|_| Error::LinkIdentityFailed(ErrorDetail::RecoverEvmAddressFailed))?;
-		ensure!(
-			&recovered_evm_address == evm_address.as_ref(),
-			Error::LinkIdentityFailed(ErrorDetail::VerifyEvmSignatureFailed)
-		);
-	} else {
-		return Err(Error::LinkIdentityFailed(ErrorDetail::WrongSignatureType))
-	}
 	Ok(())
 }

--- a/tee-worker/litentry/core/identity-verification/src/web3/mod.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web3/mod.rs
@@ -14,16 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ensure, Error, Result, ToString};
+use crate::{ensure, Error, Result};
 use ita_stf::helpers::get_expected_raw_message;
 use itp_types::Index;
 use itp_utils::stringify::account_id_to_string;
 use litentry_primitives::{
-	ErrorDetail, Identity, LitentryMultiSignature, UserShieldingKeyNonceType, UserShieldingKeyType,
-	Web3CommonValidationData, Web3ValidationData,
+	ErrorDetail, Identity, UserShieldingKeyNonceType, UserShieldingKeyType, Web3ValidationData,
 };
 use log::*;
-use sp_core::{ed25519, sr25519};
 
 pub fn verify(
 	who: &Identity,

--- a/tee-worker/litentry/primitives/src/validation_data.rs
+++ b/tee-worker/litentry/primitives/src/validation_data.rs
@@ -62,6 +62,22 @@ pub enum Web3ValidationData {
 	Evm(Web3CommonValidationData),
 }
 
+impl Web3ValidationData {
+	pub fn message(&self) -> &ValidationString {
+		match self {
+			Self::Substrate(data) => &data.message,
+			Self::Evm(data) => &data.message,
+		}
+	}
+
+	pub fn signature(&self) -> &LitentryMultiSignature {
+		match self {
+			Self::Substrate(data) => &data.signature,
+			Self::Evm(data) => &data.signature,
+		}
+	}
+}
+
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ValidationData {

--- a/tee-worker/ts-tests/README.md
+++ b/tee-worker/ts-tests/README.md
@@ -32,16 +32,18 @@ Generate sidechain type: `corepack yarn workspace sidechain-api build`
 
 ## Usage
 
-Standard identity test: `corepack yarn test-identity:local`
+II identity test: `corepack yarn test-identity:local`
 
-Standard vc test: `corepack yarn test-vc:local`
+II vc test: `corepack yarn test-vc:local`
 
-Batch identity test: `corepack yarn test-batch:local`
+II batch identity test: `corepack yarn test-batch:local`
 
-Bulk identity test: `corepack yarn test-bulk-identity:local`
+Bulk II identity test: `corepack yarn test-bulk-identity:local`
 
-Bulk vc test: `corepack yarn test-bulk-vc:local`
+Bulk II vc test: `corepack yarn test-bulk-vc:local`
 
-Direct invocation identity test: `corepack yarn test-identity-direct-invocation:local`
+DI identity test: `corepack yarn test-identity-direct-invocation:local`
 
-Di examples: `corepack yarn workspace integration-tests di-examples`
+EVM DI examples: `corepack yarn workspace integration-tests evm-di-examples`
+
+Substrate DI examples: `corepack yarn workspace integration-tests substrate-di-examples`

--- a/tee-worker/ts-tests/integration-tests/batch.test.ts
+++ b/tee-worker/ts-tests/integration-tests/batch.test.ts
@@ -5,7 +5,8 @@ import {
     buildIdentityHelper,
     buildValidations,
     checkErrorDetail,
-    buildIdentityFromKeypair, PolkadotSigner,
+    buildIdentityFromKeypair,
+    PolkadotSigner,
 } from './common/utils';
 import { aesKey } from './common/call';
 import { u8aToHex } from '@polkadot/util';

--- a/tee-worker/ts-tests/integration-tests/batch.test.ts
+++ b/tee-worker/ts-tests/integration-tests/batch.test.ts
@@ -5,7 +5,7 @@ import {
     buildIdentityHelper,
     buildValidations,
     checkErrorDetail,
-    buildIdentityFromKeypair,
+    buildIdentityFromKeypair, PolkadotSigner,
 } from './common/utils';
 import { aesKey } from './common/call';
 import { u8aToHex } from '@polkadot/util';
@@ -50,7 +50,7 @@ describeLitentry('Test Batch Utility', 0, (context) => {
 
     step('batch test: link identities', async function () {
         const defaultNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum']);
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
 
         for (let index = 0; index < ethereumSigners.length; index++) {
             const signer = ethereumSigners[index];

--- a/tee-worker/ts-tests/integration-tests/bulk_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/bulk_identity.test.ts
@@ -5,7 +5,7 @@ import {
     buildIdentityTxs,
     buildIdentityHelper,
     buildIdentityFromKeypair,
-    batchAndWait,
+    batchAndWait, PolkadotSigner,
 } from './common/utils';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { ethers } from 'ethers';
@@ -52,7 +52,7 @@ describeLitentry('multiple accounts test', 2, async (context) => {
         const defaultNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum']) as unknown as Web3Network[];
 
         for (let index = 0; index < ethereumSigners.length; index++) {
-            const signerIdentity = await buildIdentityFromKeypair(substrateSigners[index], context);
+            const signerIdentity = await buildIdentityFromKeypair(new PolkadotSigner(substrateSigners[index]), context);
             const identity = await buildIdentityHelper(ethereumSigners[index].address, 'Evm', context);
             identities.push(identity);
             web3networks.push(defaultNetworks);

--- a/tee-worker/ts-tests/integration-tests/bulk_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/bulk_identity.test.ts
@@ -5,7 +5,8 @@ import {
     buildIdentityTxs,
     buildIdentityHelper,
     buildIdentityFromKeypair,
-    batchAndWait, PolkadotSigner,
+    batchAndWait,
+    PolkadotSigner,
 } from './common/utils';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { ethers } from 'ethers';

--- a/tee-worker/ts-tests/integration-tests/common/type-definitions.ts
+++ b/tee-worker/ts-tests/integration-tests/common/type-definitions.ts
@@ -1,7 +1,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { KeyObject } from 'crypto';
 import WebSocketAsPromised from 'websocket-as-promised';
-import { Metadata, Vec, TypeRegistry } from '@polkadot/types';
+import { Metadata, TypeRegistry } from '@polkadot/types';
 import { Wallet } from 'ethers';
 import type { PalletIdentityManagementTeeIdentityContext, LitentryPrimitivesIdentity } from 'sidechain-api';
 import type { KeyringPair } from '@polkadot/keyring/types';

--- a/tee-worker/ts-tests/integration-tests/common/utils/crypto.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/crypto.ts
@@ -1,8 +1,11 @@
 import type { HexString } from '@polkadot/util/types';
-import { hexToU8a, u8aToHex } from '@polkadot/util';
+import { hexToU8a, u8aToHex, stringToU8a } from '@polkadot/util';
 import { KeyObject } from 'crypto';
 import { AesOutput } from '../type-definitions';
 import crypto from 'crypto';
+import {KeyringPair} from "@polkadot/keyring/types";
+import {ethers} from "ethers";
+import {blake2AsU8a} from '@polkadot/util-crypto';
 
 export function encryptWithTeeShieldingKey(teeShieldingKey: KeyObject, plaintext: Uint8Array): Buffer {
     return crypto.publicEncrypt(
@@ -52,5 +55,71 @@ export function decryptWithAes(key: HexString, aesOutput: AesOutput, type: 'hex'
         return `0x${part1 + part2}`;
     } else {
         return u8aToHex(aesOutput as Uint8Array);
+    }
+}
+
+export interface Signer {
+    getAddressRaw(): Uint8Array;
+    sign(message: HexString | string | Uint8Array): Promise<Uint8Array>;
+    type(): SignerType
+    getAddressInSubstrateFormat(): Uint8Array;
+}
+
+type SignerType = 'ethereum' | 'sr25519' | 'ed25519' | 'ecdsa';
+
+export class PolkadotSigner implements Signer {
+    keypair: KeyringPair;
+
+    constructor(keypair: KeyringPair) {
+        this.keypair = keypair;
+    }
+
+    getAddressRaw(): Uint8Array {
+        return this.keypair.addressRaw;
+    }
+
+    sign(message: HexString | string | Uint8Array): Promise<Uint8Array> {
+        return new Promise(resolve => resolve(this.keypair.sign(message)));
+    }
+
+    type(): SignerType {
+        return this.keypair.type;
+    }
+
+    getAddressInSubstrateFormat(): Uint8Array {
+        return this.getAddressRaw();
+    }
+}
+
+export class EthersSigner implements Signer {
+    wallet: ethers.Wallet;
+
+    constructor(wallet: ethers.Wallet) {
+        this.wallet = wallet;
+    }
+
+    getAddressRaw(): Uint8Array {
+        console.log(this.wallet.address)
+        console.log(hexToU8a(this.wallet.address))
+        return hexToU8a(this.wallet.address);
+    }
+
+    sign(message: HexString | string | Uint8Array): Promise<Uint8Array> {
+        return this.wallet.signMessage(message).then((sig) => {
+            return hexToU8a(sig)
+        });
+    }
+
+    type(): SignerType {
+        return "ethereum";
+    }
+
+    getAddressInSubstrateFormat(): Uint8Array {
+        const prefix = stringToU8a("evm:")
+        const address = this.getAddressRaw();
+        const merged = new Uint8Array(prefix.length + address.length);
+        merged.set(prefix);
+        merged.set(address, 4);
+        return blake2AsU8a(merged, 256)
     }
 }

--- a/tee-worker/ts-tests/integration-tests/common/utils/crypto.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/crypto.ts
@@ -99,8 +99,6 @@ export class EthersSigner implements Signer {
     }
 
     getAddressRaw(): Uint8Array {
-        console.log(this.wallet.address);
-        console.log(hexToU8a(this.wallet.address));
         return hexToU8a(this.wallet.address);
     }
 

--- a/tee-worker/ts-tests/integration-tests/common/utils/crypto.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/crypto.ts
@@ -3,9 +3,9 @@ import { hexToU8a, u8aToHex, stringToU8a } from '@polkadot/util';
 import { KeyObject } from 'crypto';
 import { AesOutput } from '../type-definitions';
 import crypto from 'crypto';
-import {KeyringPair} from "@polkadot/keyring/types";
-import {ethers} from "ethers";
-import {blake2AsU8a} from '@polkadot/util-crypto';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { ethers } from 'ethers';
+import { blake2AsU8a } from '@polkadot/util-crypto';
 
 export function encryptWithTeeShieldingKey(teeShieldingKey: KeyObject, plaintext: Uint8Array): Buffer {
     return crypto.publicEncrypt(
@@ -61,7 +61,7 @@ export function decryptWithAes(key: HexString, aesOutput: AesOutput, type: 'hex'
 export interface Signer {
     getAddressRaw(): Uint8Array;
     sign(message: HexString | string | Uint8Array): Promise<Uint8Array>;
-    type(): SignerType
+    type(): SignerType;
     getAddressInSubstrateFormat(): Uint8Array;
 }
 
@@ -79,7 +79,7 @@ export class PolkadotSigner implements Signer {
     }
 
     sign(message: HexString | string | Uint8Array): Promise<Uint8Array> {
-        return new Promise(resolve => resolve(this.keypair.sign(message)));
+        return new Promise((resolve) => resolve(this.keypair.sign(message)));
     }
 
     type(): SignerType {
@@ -99,27 +99,27 @@ export class EthersSigner implements Signer {
     }
 
     getAddressRaw(): Uint8Array {
-        console.log(this.wallet.address)
-        console.log(hexToU8a(this.wallet.address))
+        console.log(this.wallet.address);
+        console.log(hexToU8a(this.wallet.address));
         return hexToU8a(this.wallet.address);
     }
 
     sign(message: HexString | string | Uint8Array): Promise<Uint8Array> {
         return this.wallet.signMessage(message).then((sig) => {
-            return hexToU8a(sig)
+            return hexToU8a(sig);
         });
     }
 
     type(): SignerType {
-        return "ethereum";
+        return 'ethereum';
     }
 
     getAddressInSubstrateFormat(): Uint8Array {
-        const prefix = stringToU8a("evm:")
+        const prefix = stringToU8a('evm:');
         const address = this.getAddressRaw();
         const merged = new Uint8Array(prefix.length + address.length);
         merged.set(prefix);
         merged.set(address, 4);
-        return blake2AsU8a(merged, 256)
+        return blake2AsU8a(merged, 256);
     }
 }

--- a/tee-worker/ts-tests/integration-tests/common/utils/identity-helper.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/identity-helper.ts
@@ -2,7 +2,7 @@ import { hexToU8a, u8aToHex } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
 import type { IdentityGenericEvent, IntegrationTestContext } from '../type-definitions';
 import { AesOutput } from '../type-definitions';
-import { decryptWithAes, encryptWithAes, encryptWithTeeShieldingKey } from './crypto';
+import {decryptWithAes, encryptWithAes, encryptWithTeeShieldingKey, Signer} from './crypto';
 import { ethers } from 'ethers';
 import type { TypeRegistry } from '@polkadot/types';
 import type { LitentryPrimitivesIdentity, PalletIdentityManagementTeeIdentityContext } from 'sidechain-api';
@@ -43,11 +43,11 @@ export async function buildIdentityHelper(
 }
 
 export async function buildIdentityFromKeypair(
-    keyringPair: KeyringPair,
+    signer: Signer,
     context: IntegrationTestContext
 ): Promise<LitentryPrimitivesIdentity> {
     const type: string = (() => {
-        switch (keyringPair.type) {
+        switch (signer.type()) {
             case 'ethereum':
                 return 'Evm';
             case 'sr25519':
@@ -60,7 +60,7 @@ export async function buildIdentityFromKeypair(
                 return 'Substrate';
         }
     })();
-    const address = keyringPair.addressRaw;
+    const address = signer.getAddressRaw();
     const identity = {
         [type]: address,
     };

--- a/tee-worker/ts-tests/integration-tests/common/utils/identity-helper.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/identity-helper.ts
@@ -2,7 +2,7 @@ import { hexToU8a, u8aToHex } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
 import type { IdentityGenericEvent, IntegrationTestContext } from '../type-definitions';
 import { AesOutput } from '../type-definitions';
-import {decryptWithAes, encryptWithAes, encryptWithTeeShieldingKey, Signer} from './crypto';
+import { decryptWithAes, encryptWithAes, encryptWithTeeShieldingKey, Signer } from './crypto';
 import { ethers } from 'ethers';
 import type { TypeRegistry } from '@polkadot/types';
 import type { LitentryPrimitivesIdentity, PalletIdentityManagementTeeIdentityContext } from 'sidechain-api';

--- a/tee-worker/ts-tests/integration-tests/examples/direct-invocation/evm-di-examples.ts
+++ b/tee-worker/ts-tests/integration-tests/examples/direct-invocation/evm-di-examples.ts
@@ -1,7 +1,7 @@
 import { runExample } from './example';
 
 (async () => {
-    await runExample('ethereum').catch((e) => {
+    await runExample('evm').catch((e) => {
         console.error(e);
     });
     process.exit(0);

--- a/tee-worker/ts-tests/integration-tests/examples/direct-invocation/example.ts
+++ b/tee-worker/ts-tests/integration-tests/examples/direct-invocation/example.ts
@@ -1,5 +1,4 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { KeyringPair } from '@polkadot/keyring/types';
 import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
 import { default as teeTypes } from '../../../parachain-api/build/interfaces/identity/definitions';
 import { HexString } from '@polkadot/util/types';
@@ -15,7 +14,6 @@ import {
     sendRequestFromGetter,
     getSidechainNonce,
     decodeIdGraph,
-    getKeyPair,
     getTopHash,
     parseAesOutput,
 } from './util';
@@ -26,7 +24,7 @@ import {
     initIntegrationTestContext,
     buildValidations,
     buildIdentityFromKeypair,
-    parseIdGraph,
+    parseIdGraph, Signer, PolkadotSigner, EthersSigner,
 } from '../../common/utils';
 import { aesKey, keyNonce } from '../../common/call';
 import { Metadata, TypeRegistry } from '@polkadot/types';
@@ -36,7 +34,6 @@ import type { LitentryPrimitivesIdentity, PalletIdentityManagementTeeIdentityCon
 import { assert } from 'chai';
 import Options from 'websocket-as-promised/types/options';
 import crypto from 'crypto';
-import { KeypairType } from '@polkadot/util-crypto/types';
 import WebSocketAsPromised from 'websocket-as-promised';
 import webSocket from 'ws';
 import { decryptWithAes } from '../../common/utils';
@@ -46,12 +43,14 @@ import { SetUserShieldingKeyResponse, LinkIdentityResponse, RequestVCResponse } 
 // TODO add self signed certificate
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
+import {KeyringPair} from "@polkadot/keyring/types";
 const substrateKeyring = new Keyring({ type: 'sr25519' });
 const PARACHAIN_WS_ENDPINT = 'ws://localhost:9944';
 const WORKER_TRUSTED_WS_ENDPOINT = 'wss://localhost:2000';
 
-export async function runExample(keyPairType: KeypairType) {
-    const keyring = new Keyring({ type: keyPairType });
+export type Mode = 'substrate' | 'evm'
+
+export async function runExample(mode: Mode) {
     const parachainWs = new WsProvider(PARACHAIN_WS_ENDPINT);
     const sidechainRegistry = new TypeRegistry();
     const metaData = new Metadata(sidechainRegistry, sidechainMetaData.result as HexString);
@@ -76,8 +75,9 @@ export async function runExample(keyPairType: KeypairType) {
 
     const key = await getTeeShieldingKey(wsp, parachainApi);
 
-    const alice: KeyringPair = getKeyPair('Alice', keyring);
-    const bob: KeyringPair = getKeyPair('Bob', keyring);
+    const alice: Signer = mode == 'substrate' ? new PolkadotSigner(context.substrateWallet['alice']) : new EthersSigner(context.ethersWallet['alice']);
+    const bob: Signer = mode == 'substrate' ? new PolkadotSigner(context.substrateWallet['bob']) : new EthersSigner(context.ethersWallet['bob']);
+
     const bobSubstrateKey: KeyringPair = substrateKeyring.addFromUri('//Bob', { name: 'Bob' });
 
     const mrenclave = (await getEnclave(parachainApi)).mrEnclave;
@@ -96,7 +96,7 @@ export async function runExample(keyPairType: KeypairType) {
     let nonce = await getSidechainNonce(wsp, parachainApi, mrenclave, key, aliceSubject);
 
     console.log('Send direct setUserShieldingKey call for alice ... hash:', hash);
-    let setUserShieldingKeyCall = createSignedTrustedCallSetUserShieldingKey(
+    let setUserShieldingKeyCall = await createSignedTrustedCallSetUserShieldingKey(
         parachainApi,
         mrenclave,
         nonce,
@@ -115,7 +115,7 @@ export async function runExample(keyPairType: KeypairType) {
         'SetUserShieldingKeyResponse',
         res.value
     ) as unknown as SetUserShieldingKeyResponse;
-    assert.equal(setUserShieldingKeyRes.account.toHex(), u8aToHex(alice.addressRaw));
+    assert.equal(setUserShieldingKeyRes.account.toHex(), u8aToHex(alice.getAddressInSubstrateFormat()));
     assert.equal(setUserShieldingKeyRes.req_ext_hash.toHex(), hash);
     let aesOutput = parseAesOutput(parachainApi, setUserShieldingKeyRes.id_graph.toHex());
     let idgraph = parseIdGraph(sidechainRegistry, aesOutput, aesKey);
@@ -140,14 +140,14 @@ export async function runExample(keyPairType: KeypairType) {
         'substrate',
         bobSubstrateKey
     );
-    let linkIdentityCall = createSignedTrustedCallLinkIdentity(
+    let linkIdentityCall = await createSignedTrustedCallLinkIdentity(
         parachainApi,
         mrenclave,
         nonce,
         alice,
         aliceSubject,
         sidechainRegistry.createType('LitentryPrimitivesIdentity', bobSubstrateIdentity).toHex(),
-        parachainApi.createType('LitentryValidationData', bobValidationData).toHex(),
+        parachainApi.createType('LitentryValidationData', bobValidationData.toU8a()).toHex(),
         parachainApi.createType('Vec<Web3Network>', ['Polkadot', 'Litentry']).toHex(),
         keyNonce,
         hash
@@ -160,13 +160,13 @@ export async function runExample(keyPairType: KeypairType) {
         'LinkIdentityResponse',
         res.value
     ) as unknown as LinkIdentityResponse;
-    assert.equal(linkIdentityRes.account.toHex(), u8aToHex(alice.addressRaw));
+    assert.equal(linkIdentityRes.account.toHex(), u8aToHex(alice.getAddressInSubstrateFormat()));
     assert.equal(linkIdentityRes.req_ext_hash.toHex(), hash);
     aesOutput = parseAesOutput(parachainApi, linkIdentityRes.id_graph.toHex());
     idgraph = parseIdGraph(sidechainRegistry, aesOutput, aesKey);
     assert.equal(idgraph.length, 2);
     // the first identity is the bob substrate identity
-    assertLinkedIdentity(idgraph[0], u8aToHex(bob.addressRaw));
+    assertLinkedIdentity(idgraph[0], u8aToHex(bobSubstrateKey.addressRaw));
     // the second identity is the substrate identity (prime identity)
     assertPrimeIdentity(idgraph[1], alice);
 
@@ -179,13 +179,13 @@ export async function runExample(keyPairType: KeypairType) {
     // ==============================================================================
 
     console.log('Send IDGraph getter for alice ...');
-    const idgraphGetter = createSignedTrustedGetterIdGraph(parachainApi, alice, aliceSubject);
+    const idgraphGetter = await createSignedTrustedGetterIdGraph(parachainApi, alice, aliceSubject);
     res = await sendRequestFromGetter(wsp, parachainApi, mrenclave, key, idgraphGetter);
     console.log('IDGraph getter returned', res.toHuman());
     idgraph = decodeIdGraph(sidechainRegistry, res.value);
     assert.equal(idgraph.length, 2);
     // the first identity is the bob substrate identity
-    assertLinkedIdentity(idgraph[0], u8aToHex(bob.addressRaw));
+    assertLinkedIdentity(idgraph[0], u8aToHex(bobSubstrateKey.addressRaw));
     // the second identity is the substrate identity (prime identity)
     assertPrimeIdentity(idgraph[1], alice);
 
@@ -194,7 +194,7 @@ export async function runExample(keyPairType: KeypairType) {
     // ==============================================================================
 
     console.log('Send UserShieldingKey getter for alice ...');
-    let userShieldingKeyGetter = createSignedTrustedGetterUserShieldingKey(parachainApi, alice, aliceSubject);
+    let userShieldingKeyGetter = await createSignedTrustedGetterUserShieldingKey(parachainApi, alice, aliceSubject);
     res = await sendRequestFromGetter(wsp, parachainApi, mrenclave, key, userShieldingKeyGetter);
     console.log('UserShieldingKey getter returned', res.toHuman());
     // the returned res.value of the trustedGetter is of Option<> type
@@ -213,14 +213,14 @@ export async function runExample(keyPairType: KeypairType) {
     hash = `0x${crypto.randomBytes(32).toString('hex')}`;
     nonce = await getSidechainNonce(wsp, parachainApi, mrenclave, key, aliceSubject);
     console.log('Send direct linkIdentity call (error case)... hash:', hash);
-    linkIdentityCall = createSignedTrustedCallLinkIdentity(
+    linkIdentityCall = await createSignedTrustedCallLinkIdentity(
         parachainApi,
         mrenclave,
         nonce,
         alice,
         aliceSubject,
         sidechainRegistry.createType('LitentryPrimitivesIdentity', bobSubstrateIdentity).toHex(),
-        parachainApi.createType('LitentryValidationData', bobValidationData).toHex(),
+        parachainApi.createType('LitentryValidationData', bobValidationData.toU8a()).toHex(),
         parachainApi.createType('Vec<Web3Network>', ['Polkadot', 'Litentry']).toHex(),
         keyNonce,
         hash
@@ -238,7 +238,7 @@ export async function runExample(keyPairType: KeypairType) {
     hash = `0x${crypto.randomBytes(32).toString('hex')}`;
     nonce = await getSidechainNonce(wsp, parachainApi, mrenclave, key, aliceSubject);
     console.log('Set new web3networks for alice ...');
-    let setIdentityNetworksCall = createSignedTrustedCallSetIdentityNetworks(
+    let setIdentityNetworksCall = await createSignedTrustedCallSetIdentityNetworks(
         parachainApi,
         mrenclave,
         nonce,
@@ -263,7 +263,7 @@ export async function runExample(keyPairType: KeypairType) {
     hash = `0x${crypto.randomBytes(32).toString('hex')}`;
     nonce = await getSidechainNonce(wsp, parachainApi, mrenclave, key, aliceSubject);
     console.log('Set incompatible web3networks for alice ...');
-    setIdentityNetworksCall = createSignedTrustedCallSetIdentityNetworks(
+    setIdentityNetworksCall = await createSignedTrustedCallSetIdentityNetworks(
         parachainApi,
         mrenclave,
         nonce,
@@ -288,7 +288,7 @@ export async function runExample(keyPairType: KeypairType) {
 
     // bob's shielding key should be none
     console.log('Send UserShieldingKey getter for bob ...');
-    userShieldingKeyGetter = createSignedTrustedGetterUserShieldingKey(parachainApi, bob, bobSubject);
+    userShieldingKeyGetter = await createSignedTrustedGetterUserShieldingKey(parachainApi, bob, bobSubject);
     res = await sendRequestFromGetter(wsp, parachainApi, mrenclave, key, userShieldingKeyGetter);
     console.log('UserShieldingKey getter returned', res.toHuman());
     k = parachainApi.createType('Option<Bytes>', hexToU8a(res.value.toHex()));
@@ -301,7 +301,7 @@ export async function runExample(keyPairType: KeypairType) {
     hash = `0x${crypto.randomBytes(32).toString('hex')}`;
     nonce = await getSidechainNonce(wsp, parachainApi, mrenclave, key, bobSubject);
     console.log('Send direct setUserShieldingKey call for bob, with wrapped bytes... hash:', hash);
-    setUserShieldingKeyCall = createSignedTrustedCallSetUserShieldingKey(
+    setUserShieldingKeyCall = await createSignedTrustedCallSetUserShieldingKey(
         parachainApi,
         mrenclave,
         nonce,
@@ -316,7 +316,7 @@ export async function runExample(keyPairType: KeypairType) {
 
     // verify that bob's key is set
     console.log('Send UserShieldingKey getter for bob ...');
-    userShieldingKeyGetter = createSignedTrustedGetterUserShieldingKey(parachainApi, bob, bobSubject);
+    userShieldingKeyGetter = await createSignedTrustedGetterUserShieldingKey(parachainApi, bob, bobSubject);
     res = await sendRequestFromGetter(wsp, parachainApi, mrenclave, key, userShieldingKeyGetter);
     console.log('UserShieldingKey getter returned', res.toHuman());
     k = parachainApi.createType('Option<Bytes>', hexToU8a(res.value.toHex()));
@@ -330,7 +330,7 @@ export async function runExample(keyPairType: KeypairType) {
     hash = `0x${crypto.randomBytes(32).toString('hex')}`;
     nonce = await getSidechainNonce(wsp, parachainApi, mrenclave, key, aliceSubject);
     console.log('request vc for alice ...');
-    const requestVcCall = createSignedTrustedCallRequestVc(
+    const requestVcCall = await createSignedTrustedCallRequestVc(
         parachainApi,
         mrenclave,
         nonce,
@@ -344,7 +344,7 @@ export async function runExample(keyPairType: KeypairType) {
     assert.isTrue(res.do_watch.isFalse);
     assert.isTrue(res.status.asTrustedOperationStatus[0].isInSidechainBlock);
     const requestVcRes = parachainApi.createType('RequestVCResponse', res.value) as unknown as RequestVCResponse;
-    assert.equal(requestVcRes.account.toHex(), u8aToHex(alice.addressRaw));
+    assert.equal(requestVcRes.account.toHex(), u8aToHex(alice.getAddressInSubstrateFormat()));
     assert.equal(requestVcRes.req_ext_hash.toHex(), hash);
     aesOutput = parseAesOutput(parachainApi, requestVcRes.vc_payload.toHex());
     const decryptedVcPayload = u8aToString(hexToU8a(decryptWithAes(aesKey, aesOutput, 'hex')));
@@ -353,16 +353,16 @@ export async function runExample(keyPairType: KeypairType) {
 
 function assertPrimeIdentity(
     idgraph: [LitentryPrimitivesIdentity, PalletIdentityManagementTeeIdentityContext],
-    alice: KeyringPair
+    signer: Signer
 ) {
-    if (alice.type === 'ethereum') {
+    if (signer.type() === 'ethereum') {
         assert.isTrue(idgraph[0].isEvm);
-        assert.equal(idgraph[0].asEvm.toHex(), u8aToHex(alice.addressRaw));
+        assert.equal(idgraph[0].asEvm.toHex(), u8aToHex(signer.getAddressRaw()));
         assert.isTrue(idgraph[1].status.isActive);
         assert.equal(idgraph[1].web3networks.toHuman()?.toString(), ['Ethereum', 'Polygon', 'BSC'].toString());
     } else {
         assert.isTrue(idgraph[0].isSubstrate);
-        assert.equal(idgraph[0].asSubstrate.toHex(), u8aToHex(alice.addressRaw));
+        assert.equal(idgraph[0].asSubstrate.toHex(), u8aToHex(signer.getAddressRaw()));
         assert.isTrue(idgraph[1].status.isActive);
         assert.equal(
             idgraph[1].web3networks.toHuman()?.toString(),

--- a/tee-worker/ts-tests/integration-tests/examples/direct-invocation/example.ts
+++ b/tee-worker/ts-tests/integration-tests/examples/direct-invocation/example.ts
@@ -24,7 +24,10 @@ import {
     initIntegrationTestContext,
     buildValidations,
     buildIdentityFromKeypair,
-    parseIdGraph, Signer, PolkadotSigner, EthersSigner,
+    parseIdGraph,
+    Signer,
+    PolkadotSigner,
+    EthersSigner,
 } from '../../common/utils';
 import { aesKey, keyNonce } from '../../common/call';
 import { Metadata, TypeRegistry } from '@polkadot/types';
@@ -43,12 +46,12 @@ import { SetUserShieldingKeyResponse, LinkIdentityResponse, RequestVCResponse } 
 // TODO add self signed certificate
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-import {KeyringPair} from "@polkadot/keyring/types";
+import { KeyringPair } from '@polkadot/keyring/types';
 const substrateKeyring = new Keyring({ type: 'sr25519' });
 const PARACHAIN_WS_ENDPINT = 'ws://localhost:9944';
 const WORKER_TRUSTED_WS_ENDPOINT = 'wss://localhost:2000';
 
-export type Mode = 'substrate' | 'evm'
+export type Mode = 'substrate' | 'evm';
 
 export async function runExample(mode: Mode) {
     const parachainWs = new WsProvider(PARACHAIN_WS_ENDPINT);
@@ -75,8 +78,14 @@ export async function runExample(mode: Mode) {
 
     const key = await getTeeShieldingKey(wsp, parachainApi);
 
-    const alice: Signer = mode == 'substrate' ? new PolkadotSigner(context.substrateWallet['alice']) : new EthersSigner(context.ethersWallet['alice']);
-    const bob: Signer = mode == 'substrate' ? new PolkadotSigner(context.substrateWallet['bob']) : new EthersSigner(context.ethersWallet['bob']);
+    const alice: Signer =
+        mode == 'substrate'
+            ? new PolkadotSigner(context.substrateWallet['alice'])
+            : new EthersSigner(context.ethersWallet['alice']);
+    const bob: Signer =
+        mode == 'substrate'
+            ? new PolkadotSigner(context.substrateWallet['bob'])
+            : new EthersSigner(context.ethersWallet['bob']);
 
     const bobSubstrateKey: KeyringPair = substrateKeyring.addFromUri('//Bob', { name: 'Bob' });
 

--- a/tee-worker/ts-tests/integration-tests/examples/direct-invocation/substrate-di-examples.ts
+++ b/tee-worker/ts-tests/integration-tests/examples/direct-invocation/substrate-di-examples.ts
@@ -1,4 +1,4 @@
-import {runExample} from './example';
+import { runExample } from './example';
 
 (async () => {
     await runExample('substrate').catch((e) => {

--- a/tee-worker/ts-tests/integration-tests/examples/direct-invocation/substrate-di-examples.ts
+++ b/tee-worker/ts-tests/integration-tests/examples/direct-invocation/substrate-di-examples.ts
@@ -1,7 +1,7 @@
-import { runExample } from './example';
+import {runExample} from './example';
 
 (async () => {
-    await runExample('sr25519').catch((e) => {
+    await runExample('substrate').catch((e) => {
         console.error(e);
     });
     process.exit(0);

--- a/tee-worker/ts-tests/integration-tests/examples/direct-invocation/util.ts
+++ b/tee-worker/ts-tests/integration-tests/examples/direct-invocation/util.ts
@@ -6,7 +6,7 @@ import { HexString } from '@polkadot/util/types';
 import { Bytes } from '@polkadot/types-codec';
 import { PubicKeyJson } from '../../common/type-definitions';
 import { WorkerRpcReturnValue, TrustedCallSigned, Getter } from 'parachain-api';
-import {encryptWithTeeShieldingKey, Signer} from '../../common/utils';
+import { encryptWithTeeShieldingKey, Signer } from '../../common/utils';
 import { decodeRpcBytesAsString } from '../../common/call';
 import { createPublicKey, KeyObject } from 'crypto';
 import WebSocketAsPromised from 'websocket-as-promised';

--- a/tee-worker/ts-tests/integration-tests/identity-direct-invocation.test.ts
+++ b/tee-worker/ts-tests/integration-tests/identity-direct-invocation.test.ts
@@ -6,7 +6,8 @@ import {
     buildIdentityFromKeypair,
     buildIdentityHelper,
     buildValidations,
-    initIntegrationTestContext, PolkadotSigner,
+    initIntegrationTestContext,
+    PolkadotSigner,
 } from './common/utils';
 import {
     assertFailedEvent,
@@ -67,7 +68,10 @@ describe('Test Identity (direct invocation)', function () {
     it('most of the bob cases are missing');
 
     step('linking identity with without user shielding key(charlie)', async function () {
-        const charlieSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.charlie), context);
+        const charlieSubject = await buildIdentityFromKeypair(
+            new PolkadotSigner(context.substrateWallet.charlie),
+            context
+        );
 
         const bobSubstrateIdentity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.bob.addressRaw),
@@ -492,7 +496,7 @@ describe('Test Identity (direct invocation)', function () {
 
         const events = await eventsPromise;
 
-        await assertFailedEvent(context, events, 'LinkIdentityFailed', 'VerifyEvmSignatureFailed');
+        await assertFailedEvent(context, events, 'LinkIdentityFailed', 'UnexpectedMessage');
     });
 
     step('linking aleady linked identity', async function () {

--- a/tee-worker/ts-tests/integration-tests/identity-direct-invocation.test.ts
+++ b/tee-worker/ts-tests/integration-tests/identity-direct-invocation.test.ts
@@ -6,7 +6,7 @@ import {
     buildIdentityFromKeypair,
     buildIdentityHelper,
     buildValidations,
-    initIntegrationTestContext,
+    initIntegrationTestContext, PolkadotSigner,
 } from './common/utils';
 import {
     assertFailedEvent,
@@ -60,14 +60,14 @@ describe('Test Identity (direct invocation)', function () {
             0
         );
         teeShieldingKey = await getTeeShieldingKey(context.tee, context.api);
-        aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
     });
 
     it('needs a lot more work to be complete');
     it('most of the bob cases are missing');
 
     step('linking identity with without user shielding key(charlie)', async function () {
-        const charlieSubject = await buildIdentityFromKeypair(context.substrateWallet.charlie, context);
+        const charlieSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.charlie), context);
 
         const bobSubstrateIdentity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.bob.addressRaw),
@@ -93,11 +93,11 @@ describe('Test Identity (direct invocation)', function () {
         );
         const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
 
-        const linkIdentityCall = createSignedTrustedCallLinkIdentity(
+        const linkIdentityCall = await createSignedTrustedCallLinkIdentity(
             context.api,
             context.mrEnclave,
             nonce,
-            context.substrateWallet.charlie,
+            new PolkadotSigner(context.substrateWallet.charlie),
             charlieSubject,
             context.sidechainRegistry.createType('LitentryPrimitivesIdentity', bobSubstrateIdentity).toHex(),
             context.api.createType('LitentryValidationData', bobValidationData).toHex(),
@@ -114,8 +114,8 @@ describe('Test Identity (direct invocation)', function () {
             linkIdentityCall
         );
 
-        /* 
-        In the case of an error, the RPC status will be false, right? 
+        /*
+        In the case of an error, the RPC status will be false, right?
         However, will we still have events occurring in Parachain? Based on the example provided.
         */
         assert.isTrue(res.do_watch.isFalse);
@@ -126,9 +126,9 @@ describe('Test Identity (direct invocation)', function () {
     });
 
     step('check user sidechain storage before user shielding key creating(alice)', async function () {
-        const shieldingKeyGetter = createSignedTrustedGetterUserShieldingKey(
+        const shieldingKeyGetter = await createSignedTrustedGetterUserShieldingKey(
             context.api,
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject
         );
 
@@ -147,7 +147,7 @@ describe('Test Identity (direct invocation)', function () {
     ['alice', 'bob'].forEach((name) => {
         step(`setting user shielding key (${name})`, async function () {
             const wallet = context.substrateWallet[name];
-            const subject = await buildIdentityFromKeypair(wallet, context);
+            const subject = await buildIdentityFromKeypair(new PolkadotSigner(wallet), context);
             const nonce = await getSidechainNonce(
                 context.tee,
                 context.api,
@@ -158,11 +158,11 @@ describe('Test Identity (direct invocation)', function () {
 
             const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
 
-            const setUserShieldingKeyCall = createSignedTrustedCallSetUserShieldingKey(
+            const setUserShieldingKeyCall = await createSignedTrustedCallSetUserShieldingKey(
                 context.api,
                 context.mrEnclave,
                 nonce,
-                wallet,
+                new PolkadotSigner(wallet),
                 subject,
                 aesKey,
                 requestIdentifier
@@ -188,9 +188,9 @@ describe('Test Identity (direct invocation)', function () {
     });
 
     step('check user shielding key from sidechain storage after user shielding key setting(alice)', async function () {
-        const shieldingKeyGetter = createSignedTrustedGetterUserShieldingKey(
+        const shieldingKeyGetter = await createSignedTrustedGetterUserShieldingKey(
             context.api,
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject
         );
 
@@ -207,9 +207,9 @@ describe('Test Identity (direct invocation)', function () {
     });
 
     step('check idgraph from sidechain storage before linking', async function () {
-        const idgraphGetter = createSignedTrustedGetterIdGraph(
+        const idgraphGetter = await createSignedTrustedGetterIdGraph(
             context.api,
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject
         );
         const res = await sendRequestFromGetter(
@@ -295,11 +295,11 @@ describe('Test Identity (direct invocation)', function () {
         for (const { nonce, identity, validation, networks } of linkIdentityRequestParams) {
             const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
             const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
-            const linkIdentityCall = createSignedTrustedCallLinkIdentity(
+            const linkIdentityCall = await createSignedTrustedCallLinkIdentity(
                 context.api,
                 context.mrEnclave,
                 context.api.createType('Index', nonce),
-                context.substrateWallet.alice,
+                new PolkadotSigner(context.substrateWallet.alice),
                 aliceSubject,
                 identity.toHex(),
                 validation.toHex(),
@@ -340,9 +340,9 @@ describe('Test Identity (direct invocation)', function () {
     });
 
     step('check user sidechain storage after linking', async function () {
-        const idgraphGetter = createSignedTrustedGetterIdGraph(
+        const idgraphGetter = await createSignedTrustedGetterIdGraph(
             context.api,
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject
         );
         const res = await sendRequestFromGetter(
@@ -381,7 +381,7 @@ describe('Test Identity (direct invocation)', function () {
     });
 
     step('linking invalid identity', async function () {
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.bob, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.bob), context);
 
         let currentNonce = (
             await getSidechainNonce(context.tee, context.api, context.mrEnclave, teeShieldingKey, aliceSubject)
@@ -406,11 +406,11 @@ describe('Test Identity (direct invocation)', function () {
         const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']);
         const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
         const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
-        const linkIdentityCall = createSignedTrustedCallLinkIdentity(
+        const linkIdentityCall = await createSignedTrustedCallLinkIdentity(
             context.api,
             context.mrEnclave,
             context.api.createType('Index', twitterNonce),
-            context.substrateWallet.bob,
+            new PolkadotSigner(context.substrateWallet.bob),
             aliceSubject,
             twitterIdentity.toHex(),
             evmValidation.toHex(),
@@ -467,11 +467,11 @@ describe('Test Identity (direct invocation)', function () {
         const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
         const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
 
-        const linkIdentityCall = createSignedTrustedCallLinkIdentity(
+        const linkIdentityCall = await createSignedTrustedCallLinkIdentity(
             context.api,
             context.mrEnclave,
             context.api.createType('Index', evmNonce),
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject,
             evmIdentity.toHex(),
             encodedVerifyIdentityValidation.toHex(),
@@ -514,11 +514,11 @@ describe('Test Identity (direct invocation)', function () {
 
         const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
         const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
-        const linkIdentityCall = createSignedTrustedCallLinkIdentity(
+        const linkIdentityCall = await createSignedTrustedCallLinkIdentity(
             context.api,
             context.mrEnclave,
             context.api.createType('Index', twitterNonce),
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject,
             twitterIdentity.toHex(),
             twitterValidation.toHex(),
@@ -583,11 +583,11 @@ describe('Test Identity (direct invocation)', function () {
         for (const { nonce, identity } of deactivateIdentityRequestParams) {
             const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
             const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
-            const deactivateIdentityCall = createSignedTrustedCallDeactivateIdentity(
+            const deactivateIdentityCall = await createSignedTrustedCallDeactivateIdentity(
                 context.api,
                 context.mrEnclave,
                 context.api.createType('Index', nonce),
-                context.substrateWallet.alice,
+                new PolkadotSigner(context.substrateWallet.alice),
                 aliceSubject,
                 identity.toHex(),
                 requestIdentifier
@@ -619,9 +619,9 @@ describe('Test Identity (direct invocation)', function () {
     });
 
     step('check idgraph from sidechain storage after deactivating', async function () {
-        const idgraphGetter = createSignedTrustedGetterIdGraph(
+        const idgraphGetter = await createSignedTrustedGetterIdGraph(
             context.api,
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject
         );
         const res = await sendRequestFromGetter(
@@ -690,11 +690,11 @@ describe('Test Identity (direct invocation)', function () {
         for (const { nonce, identity } of activateIdentityRequestParams) {
             const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
             const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
-            const deactivateIdentityCall = createSignedTrustedCallActivateIdentity(
+            const deactivateIdentityCall = await createSignedTrustedCallActivateIdentity(
                 context.api,
                 context.mrEnclave,
                 context.api.createType('Index', nonce),
-                context.substrateWallet.alice,
+                new PolkadotSigner(context.substrateWallet.alice),
                 aliceSubject,
                 identity.toHex(),
                 requestIdentifier
@@ -727,9 +727,9 @@ describe('Test Identity (direct invocation)', function () {
     });
 
     step('check idgraph from sidechain storage after activating', async function () {
-        const idgraphGetter = createSignedTrustedGetterIdGraph(
+        const idgraphGetter = await createSignedTrustedGetterIdGraph(
             context.api,
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject
         );
         const res = await sendRequestFromGetter(
@@ -773,11 +773,11 @@ describe('Test Identity (direct invocation)', function () {
 
         const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
         const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
-        const deactivateIdentityCall = createSignedTrustedCallDeactivateIdentity(
+        const deactivateIdentityCall = await createSignedTrustedCallDeactivateIdentity(
             context.api,
             context.mrEnclave,
             context.api.createType('Index', nonce),
-            context.substrateWallet.alice,
+            new PolkadotSigner(context.substrateWallet.alice),
             aliceSubject,
             substratePrimeIdentity.toHex(),
             requestIdentifier

--- a/tee-worker/ts-tests/integration-tests/identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/identity.test.ts
@@ -12,7 +12,7 @@ import {
     assertIdentityDeactivated,
     assertInitialIdGraphCreated,
     buildIdentityFromKeypair,
-    assertIdentityActivated,
+    assertIdentityActivated, PolkadotSigner,
 } from './common/utils';
 import { aesKey } from './common/call';
 import { hexToU8a, u8aConcat, u8aToHex, u8aToU8a, stringToU8a } from '@polkadot/util';
@@ -37,7 +37,7 @@ describeLitentry('Test Identity', 0, (context) => {
     let web3networks: Web3Network[][] = [];
 
     step('check user sidechain storage before create', async function () {
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
         const respShieldingKey = await checkUserShieldingKeys(
             context,
             'IdentityManagement',
@@ -93,7 +93,7 @@ describeLitentry('Test Identity', 0, (context) => {
     });
 
     step('check user shielding key from sidechain storage after setUserShieldingKey', async function () {
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
         const respShieldingKey = await checkUserShieldingKeys(
             context,
             'IdentityManagement',
@@ -104,7 +104,7 @@ describeLitentry('Test Identity', 0, (context) => {
     });
 
     step('check idgraph from sidechain storage before linking', async function () {
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
 
         // the main address should be already inside the IDGraph
         const mainIdentity = await buildIdentityHelper(
@@ -148,7 +148,7 @@ describeLitentry('Test Identity', 0, (context) => {
         //       it for each such request, similar to the construction of substrate tx
         //       However, beware that we should query the nonce of the enclave-signer-account
         //       not alice or bob, as it's the indirect calls are signed by the enclave signer
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
         const twitterValidations = await buildValidations(context, [aliceSubject], [twitterIdentity], 3, 'twitter');
 
         const evmValidations = await buildValidations(
@@ -212,7 +212,7 @@ describeLitentry('Test Identity', 0, (context) => {
                 },
             },
         };
-        const bobSubject = await buildIdentityFromKeypair(context.substrateWallet.bob, context);
+        const bobSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.bob), context);
 
         const msg = generateVerificationMessage(
             context,
@@ -262,7 +262,7 @@ describeLitentry('Test Identity', 0, (context) => {
     step('check IDGraph after LinkIdentity', async function () {
         const twitterIdentity = await buildIdentityHelper('mock_user', 'Twitter', context);
         const identityHex = context.sidechainRegistry.createType('LitentryPrimitivesIdentity', twitterIdentity).toHex();
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
 
         const respIdGraph = await checkIdGraph(context, 'IdentityManagement', 'IDGraphs', aliceSubject, identityHex);
         assert.isTrue(respIdGraph.linkBlock.toNumber() > 0, 'linkBlock should be greater than 0');
@@ -337,7 +337,7 @@ describeLitentry('Test Identity', 0, (context) => {
 
     step('link already linked identity', async function () {
         const twitterIdentity = await buildIdentityHelper('mock_user', 'Twitter', context);
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
 
         const aliceIdentities = [twitterIdentity];
 

--- a/tee-worker/ts-tests/integration-tests/identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/identity.test.ts
@@ -12,7 +12,8 @@ import {
     assertIdentityDeactivated,
     assertInitialIdGraphCreated,
     buildIdentityFromKeypair,
-    assertIdentityActivated, PolkadotSigner,
+    assertIdentityActivated,
+    PolkadotSigner,
 } from './common/utils';
 import { aesKey } from './common/call';
 import { hexToU8a, u8aConcat, u8aToHex, u8aToU8a, stringToU8a } from '@polkadot/util';
@@ -296,8 +297,7 @@ describeLitentry('Test Identity', 0, (context) => {
     step('link identities with wrong signature', async function () {
         const evmIdentity = eveIdentities[1];
 
-        // link eth identity with wrong validation data
-        // the `VerifyEvmSignatureFailed` error should be emitted prior to `AlreadyLinked` error
+        // link evm identity with wrong validation data(raw message)
         const ethereumSignature = (await context.ethersWallet.alice.signMessage(
             ethers.utils.arrayify(wrongMsg)
         )) as HexString;
@@ -332,7 +332,7 @@ describeLitentry('Test Identity', 0, (context) => {
             ['LinkIdentityFailed']
         );
 
-        await checkErrorDetail(aliceRespEvents, 'VerifyEvmSignatureFailed');
+        await checkErrorDetail(aliceRespEvents, 'UnexpectedMessage');
     });
 
     step('link already linked identity', async function () {

--- a/tee-worker/ts-tests/integration-tests/vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/vc.test.ts
@@ -6,7 +6,8 @@ import {
     buildIdentityTxs,
     handleIdentityEvents,
     handleVcEvents,
-    buildIdentityFromKeypair, PolkadotSigner,
+    buildIdentityFromKeypair,
+    PolkadotSigner,
 } from './common/utils';
 import { step } from 'mocha-steps';
 import type { Assertion, IdentityGenericEvent, TransactionSubmit } from './common/type-definitions';

--- a/tee-worker/ts-tests/integration-tests/vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/vc.test.ts
@@ -6,7 +6,7 @@ import {
     buildIdentityTxs,
     handleIdentityEvents,
     handleVcEvents,
-    buildIdentityFromKeypair,
+    buildIdentityFromKeypair, PolkadotSigner,
 } from './common/utils';
 import { step } from 'mocha-steps';
 import type { Assertion, IdentityGenericEvent, TransactionSubmit } from './common/type-definitions';
@@ -61,7 +61,7 @@ describeLitentry('VC test', 0, async (context) => {
         );
     });
     step('check user shielding key from sidechain storage after setUserShieldingKey', async function () {
-        const aliceSubject = await buildIdentityFromKeypair(context.substrateWallet.alice, context);
+        const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
         const shieldingKey = await checkUserShieldingKeys(
             context,
             'IdentityManagement',


### PR DESCRIPTION
### Context

resolves #1970 
resolves #1976 

We should accept EIP191 wrapped message when verifying evm signature.
This PR tries to make the verification process more clear by doing it in `LitentryMultiSignature` level, which is called when both linking identities and verifying trusted call signatures.

This PR should go to both `dev` and `staging` branches

TODO:
- looking for other EIP format? Like 712?
- unify the signature verification error once the campaign is over => for now I don't want to introduce changes to metadata
- https://github.com/litentry/litentry-parachain/issues/1979


