### PR TITLE
Handle achainable assertion inputs

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/achainable/amount.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/amount.rs
@@ -21,7 +21,7 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 extern crate sgx_tstd as std;
 
 use crate::{achainable::request_achainable, *};
-use lc_data_providers::{achainable::Params, ConvertParameterString};
+use lc_data_providers::ConvertParameterString;
 
 const CREATED_OVER_AMOUNT_CONTRACTS: &str = "Created over {amount} contracts";
 const BALANCE_OVER_AMOUNT: &str = "Balance over {amount}";
@@ -103,9 +103,7 @@ pub fn build_amount(req: &AssertionBuildRequest, param: AchainableAmount) -> Res
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::Amount(param.clone());
-	let request_param = Params::try_from(achainable_param.clone())?;
-
-	let flag = request_achainable(addresses, request_param)?;
+	let flag = request_achainable(addresses, achainable_param.clone())?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut credential_unsigned) => {
 			let (desc, subtype, content) =

--- a/tee-worker/litentry/core/assertion-build/src/achainable/amount_holding.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/amount_holding.rs
@@ -21,7 +21,7 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 extern crate sgx_tstd as std;
 
 use crate::{achainable::request_achainable, *};
-use lc_data_providers::{achainable::Params, ConvertParameterString};
+use lc_data_providers::ConvertParameterString;
 
 const VC_SUBJECT_DESCRIPTION: &str = "Achainable amount holding";
 const VC_SUBJECT_TYPE: &str = "Amount holding";
@@ -39,8 +39,7 @@ pub fn build_amount_holding(
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::AmountHolding(param.clone());
-	let request_param = Params::try_from(achainable_param.clone())?;
-	let flag = request_achainable(addresses, request_param)?;
+	let flag = request_achainable(addresses, achainable_param.clone())?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut credential_unsigned) => {
 			credential_unsigned.add_subject_info(VC_SUBJECT_DESCRIPTION, VC_SUBJECT_TYPE);

--- a/tee-worker/litentry/core/assertion-build/src/achainable/amount_token.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/amount_token.rs
@@ -20,8 +20,6 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use lc_data_providers::achainable::Params;
-
 use crate::{achainable::request_achainable, *};
 
 pub fn build_amount_token(
@@ -37,8 +35,7 @@ pub fn build_amount_token(
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::AmountToken(param);
-	let request_param = Params::try_from(achainable_param.clone())?;
-	let _flag = request_achainable(addresses, request_param)?;
+	let _flag = request_achainable(addresses, achainable_param.clone())?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut _credential_unsigned) => Ok(_credential_unsigned),
 		Err(e) => {

--- a/tee-worker/litentry/core/assertion-build/src/achainable/amounts.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/amounts.rs
@@ -20,8 +20,6 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use lc_data_providers::achainable::Params;
-
 use crate::{achainable::request_achainable, *};
 
 pub fn build_amounts(req: &AssertionBuildRequest, param: AchainableAmounts) -> Result<Credential> {
@@ -34,8 +32,7 @@ pub fn build_amounts(req: &AssertionBuildRequest, param: AchainableAmounts) -> R
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::Amounts(param);
-	let request_param = Params::try_from(achainable_param.clone())?;
-	let _flag = request_achainable(addresses, request_param)?;
+	let _flag = request_achainable(addresses, achainable_param.clone())?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut _credential_unsigned) => Ok(_credential_unsigned),
 		Err(e) => {

--- a/tee-worker/litentry/core/assertion-build/src/achainable/between_percents.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/between_percents.rs
@@ -20,8 +20,6 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use lc_data_providers::achainable::Params;
-
 use crate::{achainable::request_achainable, *};
 
 pub fn build_between_percents(
@@ -40,9 +38,7 @@ pub fn build_between_percents(
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::BetweenPercents(param.clone());
-	let request_param = Params::try_from(achainable_param)?;
-
-	let _flag = request_achainable(addresses, request_param)?;
+	let _flag = request_achainable(addresses, achainable_param)?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut _credential_unsigned) => Ok(_credential_unsigned),
 		Err(e) => {

--- a/tee-worker/litentry/core/assertion-build/src/achainable/class_of_year.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/class_of_year.rs
@@ -22,7 +22,6 @@ extern crate sgx_tstd as std;
 
 use crate::{achainable::request_achainable_classofyear, *};
 use lc_credentials::Credential;
-use lc_data_providers::achainable::Params;
 use lc_stf_task_sender::AssertionBuildRequest;
 use litentry_primitives::{AchainableClassOfYear, AchainableParams};
 use log::debug;
@@ -68,23 +67,19 @@ pub fn build_class_of_year(
 		.flat_map(|(_, addresses)| addresses)
 		.collect::<Vec<String>>();
 
-	let achainable_param = AchainableParams::ClassOfYear(param.clone());
-	let request_param = Params::try_from(achainable_param)?;
-	// TODO:
-	// Because this is only for the purpose of obtaining created account year, the dates here can be arbitrary
-	let (found, created_date) = request_achainable_classofyear(addresses, request_param);
-
+	let achainable_param = AchainableParams::ClassOfYear(param);
+	let created_date = request_achainable_classofyear(addresses, achainable_param.clone())?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut credential_unsigned) => {
 			credential_unsigned.add_subject_info(VC_SUBJECT_DESCRIPTION, VC_SUBJECT_TYPE);
-			credential_unsigned.update_class_of_year(found, created_date);
+			credential_unsigned.update_class_of_year(created_date);
 
 			Ok(credential_unsigned)
 		},
 		Err(e) => {
 			error!("Generate unsigned credential failed {:?}", e);
 			Err(Error::RequestVCFailed(
-				Assertion::Achainable(AchainableParams::ClassOfYear(param)),
+				Assertion::Achainable(achainable_param),
 				e.into_error_detail(),
 			))
 		},

--- a/tee-worker/litentry/core/assertion-build/src/achainable/date.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/date.rs
@@ -20,8 +20,6 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use lc_data_providers::achainable::Params;
-
 use crate::{achainable::request_achainable, *};
 
 pub fn build_date(req: &AssertionBuildRequest, param: AchainableDate) -> Result<Credential> {
@@ -34,8 +32,7 @@ pub fn build_date(req: &AssertionBuildRequest, param: AchainableDate) -> Result<
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::Date(param.clone());
-	let request_param = Params::try_from(achainable_param)?;
-	let _flag = request_achainable(addresses, request_param)?;
+	let _flag = request_achainable(addresses, achainable_param)?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut _credential_unsigned) => Ok(_credential_unsigned),
 		Err(e) => {

--- a/tee-worker/litentry/core/assertion-build/src/achainable/date_interval.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/date_interval.rs
@@ -22,7 +22,6 @@ extern crate sgx_tstd as std;
 
 use crate::{achainable::request_achainable, *};
 use lc_credentials::Credential;
-use lc_data_providers::achainable::Params;
 
 pub fn build_date_interval(
 	req: &AssertionBuildRequest,
@@ -37,8 +36,7 @@ pub fn build_date_interval(
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::DateInterval(param.clone());
-	let request_param = Params::try_from(achainable_param)?;
-	let _flag = request_achainable(addresses, request_param)?;
+	let _flag = request_achainable(addresses, achainable_param)?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut _credential_unsigned) => Ok(_credential_unsigned),
 		Err(e) => {

--- a/tee-worker/litentry/core/assertion-build/src/achainable/date_percent.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/date_percent.rs
@@ -20,8 +20,6 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use lc_data_providers::achainable::Params;
-
 use crate::{achainable::request_achainable, *};
 
 pub fn build_date_percent(
@@ -37,8 +35,7 @@ pub fn build_date_percent(
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::DatePercent(param.clone());
-	let request_param = Params::try_from(achainable_param)?;
-	let _flag = request_achainable(addresses, request_param)?;
+	let _flag = request_achainable(addresses, achainable_param)?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut _credential_unsigned) => Ok(_credential_unsigned),
 		Err(e) => {

--- a/tee-worker/litentry/core/assertion-build/src/achainable/token.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/token.rs
@@ -20,8 +20,6 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use lc_data_providers::achainable::Params;
-
 use crate::{achainable::request_achainable, *};
 
 pub fn build_token(req: &AssertionBuildRequest, param: AchainableToken) -> Result<Credential> {
@@ -34,8 +32,7 @@ pub fn build_token(req: &AssertionBuildRequest, param: AchainableToken) -> Resul
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::Token(param.clone());
-	let request_param = Params::try_from(achainable_param)?;
-	let _flag = request_achainable(addresses, request_param)?;
+	let _flag = request_achainable(addresses, achainable_param)?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut _credential_unsigned) => Ok(_credential_unsigned),
 		Err(e) => {

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -513,14 +513,14 @@ impl Credential {
 		self.credential_subject.values.push(value);
 	}
 
-	pub fn update_class_of_year(&mut self, value: bool, date: String) {
+	pub fn update_class_of_year(&mut self, date: String) {
 		let mut and_logic = AssertionLogic::new_and();
 
 		let from = AssertionLogic::new_item("$account_created_year", Op::Equal, &date);
 		and_logic = and_logic.add_item(from);
 
 		self.credential_subject.assertions.push(and_logic);
-		self.credential_subject.values.push(value);
+		self.credential_subject.values.push(true);
 	}
 }
 

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -1124,10 +1124,8 @@ impl AchainableTagDeFi for AchainableClient {
 		let name_provider = "Uniswap V2 liquidity provider";
 		let chain: Web3Network = Web3Network::Ethereum;
 
-		if request_basic_type_with_token(self, address, name_trader, &chain, None)
-			.unwrap_or_default()
-			|| request_basic_type_with_token(self, address, name_provider, &chain, None)
-				.unwrap_or_default()
+		if request_basic_type_with_token(self, address, name_trader, &chain, None)?
+			|| request_basic_type_with_token(self, address, name_provider, &chain, None)?
 		{
 			return Ok(true)
 		}


### PR DESCRIPTION

1. Achainable assertion  return immediately / directly when request error occurred. related https://github.com/litentry/litentry-parachain/pull/2003 
2. When querying Uniswap users, verify the already agreed name value. If the input is incorrect, return error directly
`name: "Uniswap V2/V3 user"`