### PR TITLE
Bugfix: address and network mismatch issues

### DIFF
--- a/primitives/core/src/assertion.rs
+++ b/primitives/core/src/assertion.rs
@@ -138,6 +138,22 @@ impl AchainableParams {
 			AchainableParams::Token(p) => p.name.clone(),
 		}
 	}
+
+	pub fn chain(&self) -> Web3Network {
+		match self {
+			AchainableParams::AmountHolding(p) => p.chain,
+			AchainableParams::AmountToken(p) => p.chain,
+			AchainableParams::Amount(p) => p.chain,
+			AchainableParams::Amounts(p) => p.chain,
+			AchainableParams::Basic(p) => p.chain,
+			AchainableParams::BetweenPercents(p) => p.chain,
+			AchainableParams::ClassOfYear(p) => p.chain,
+			AchainableParams::DateInterval(p) => p.chain,
+			AchainableParams::DatePercent(p) => p.chain,
+			AchainableParams::Date(p) => p.chain,
+			AchainableParams::Token(p) => p.chain,
+		}
+	}
 }
 
 #[rustfmt::skip]
@@ -186,10 +202,7 @@ impl Assertion {
 			// polkadot paticipation
 			Self::A14 => vec![Web3Network::Polkadot],
 			// Achainable Assertions
-			Self::Achainable(a) => {
-				let name = &a.name();
-				achainable_networks(name)
-			},
+			Self::Achainable(a) => vec![a.chain()],
 			// we don't care about any specific web3 network
 			_ => vec![],
 		}
@@ -212,75 +225,3 @@ pub const ASSERTION_FROM_DATE: [&str; 14] = [
 	"2023-01-01",
 	"2023-07-01",
 ];
-
-fn achainable_networks(name: &ParameterString) -> Vec<Web3Network> {
-	let name = &name.clone().to_vec();
-	let name = str::from_utf8(name).unwrap_or("");
-
-	if name == "Validator" ||
-		name == "TreasuryProposalBeneficiary" ||
-		name == "TipFinder" ||
-		name == "TipBeneficiary" ||
-		name == "OpenGovProposer" ||
-		name == "FellowshipProposer" ||
-		name == "FellowshipMember" ||
-		name == "ExCouncilor" ||
-		name == "Councilor" ||
-		name == "BountyCurator" ||
-		name == "Balance between percents"
-	{
-		return vec![Web3Network::Litmus, Web3Network::Polkadot]
-	} else if name == "Account found on {chain}" {
-		return vec![
-			Web3Network::Litentry,
-			Web3Network::Litmus,
-			Web3Network::Ethereum,
-			Web3Network::Polkadot,
-			Web3Network::Kusama,
-			Web3Network::Khala,
-			Web3Network::BSC,
-		]
-	} else if name == "Account total transactions under {amount}" ||
-		name == "Balance under {amount}" ||
-		name == "Balance over {amount}" ||
-		name == "Balance over {amount} dollars" ||
-		name == "Balance between {amounts}" ||
-		name == "Account created after {date}" ||
-		name == "Account created before {date}" ||
-		name == "Account created between {dates}" ||
-		name == "Balance hodling {amount} since {date}"
-	{
-		return vec![
-			Web3Network::Litentry,
-			Web3Network::Litmus,
-			Web3Network::Ethereum,
-			Web3Network::Polkadot,
-			Web3Network::Kusama,
-			Web3Network::Khala,
-		]
-	} else if name == "ERC20 balance over {amount}" ||
-		name == "Uniswap V2 liquidity provider" ||
-		name == "Uniswap V3 liquidity provider" ||
-		name == "Curve Trader" ||
-		name == "Curve Liquidity Provider" ||
-		name == "MetaMask trader" ||
-		name == "Uniswap V2 trader" ||
-		name == "Uniswap V3 trader" ||
-		name == "Uniswap V2 {token} liquidity provider" ||
-		name == "Uniswap V3 {token} liquidity provider" ||
-		name == "Aave V2 Lender" ||
-		name == "Aave V2 Borrower" ||
-		name == "Aave V3 Lender" ||
-		name == "Aave V3 Borrower" ||
-		name == "ERC20 hodling {amount} of {token} since {date}" ||
-		name == "Created over {amount} contracts"
-	{
-		return vec![Web3Network::Ethereum]
-	} else if name == "BEP20 balance over {amount}" {
-		return vec![Web3Network::BSC]
-	} else if name == "Balance dropped {percent} since {date}" {
-		return vec![Web3Network::Ethereum, Web3Network::BSC]
-	}
-
-	vec![]
-}

--- a/tee-worker/litentry/core/assertion-build/src/achainable/class_of_year.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/class_of_year.rs
@@ -68,11 +68,11 @@ pub fn build_class_of_year(
 		.collect::<Vec<String>>();
 
 	let achainable_param = AchainableParams::ClassOfYear(param);
-	let created_date = request_achainable_classofyear(addresses, achainable_param.clone())?;
+	let (ret, created_date) = request_achainable_classofyear(addresses, achainable_param.clone())?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut credential_unsigned) => {
 			credential_unsigned.add_subject_info(VC_SUBJECT_DESCRIPTION, VC_SUBJECT_TYPE);
-			credential_unsigned.update_class_of_year(created_date);
+			credential_unsigned.update_class_of_year(ret, created_date);
 
 			Ok(credential_unsigned)
 		},

--- a/tee-worker/litentry/core/assertion-build/src/achainable/mod.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/mod.rs
@@ -99,24 +99,29 @@ pub fn request_uniswap_v2_or_v3_user(
 	Ok(false)
 }
 
-const INVALID_CLASS_OF_YEAR: &str = "9999-12-31";
+const INVALID_CLASS_OF_YEAR: &str = "Invalid";
 pub fn request_achainable_classofyear(
 	addresses: Vec<String>,
 	param: AchainableParams,
-) -> Result<String> {
+) -> Result<(bool, String)> {
 	let request_param = Params::try_from(param.clone())?;
 	let mut client: AchainableClient = AchainableClient::new();
 
-	let mut longest_created_date = INVALID_CLASS_OF_YEAR.into();
+	let mut longest_created_year = INVALID_CLASS_OF_YEAR.into();
 	for address in &addresses {
 		let year = client.query_class_of_year(address, request_param.clone()).map_err(|e| {
 			Error::RequestVCFailed(Assertion::Achainable(param.clone()), e.into_error_detail())
 		})?;
 
-		if year < longest_created_date {
-			longest_created_date = year;
+		// If parse metadata field error, return Invalid immediately
+		if year.parse::<u32>().is_err() {
+			return Ok((false, INVALID_CLASS_OF_YEAR.into()))
+		}
+
+		if year < longest_created_year {
+			longest_created_year = year;
 		}
 	}
 
-	Ok(longest_created_date)
+	Ok((longest_created_year.parse::<u32>().is_ok(), longest_created_year))
 }

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -513,14 +513,14 @@ impl Credential {
 		self.credential_subject.values.push(value);
 	}
 
-	pub fn update_class_of_year(&mut self, date: String) {
+	pub fn update_class_of_year(&mut self, ret: bool, date: String) {
 		let mut and_logic = AssertionLogic::new_and();
 
 		let from = AssertionLogic::new_item("$account_created_year", Op::Equal, &date);
 		and_logic = and_logic.add_item(from);
 
 		self.credential_subject.assertions.push(and_logic);
-		self.credential_subject.values.push(true);
+		self.credential_subject.values.push(ret);
 	}
 }
 


### PR DESCRIPTION
1. Filter the address set under the specified network
2. When the result of class of year is `false`, the `dst field` needs to be displayed as `Invalid`


