### PR TITLE
Update uniswap v2/v3 user assertion logic

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/achainable/basic.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/basic.rs
@@ -55,12 +55,12 @@ pub fn build_basic(req: &AssertionBuildRequest, param: AchainableBasic) -> Resul
 	let achainable_param = AchainableParams::Basic(param.clone());
 	check_uniswap_v23_user_inputs(&achainable_param, &param)?;
 
-	let flag = request_uniswap_v2_or_v3_user(addresses, achainable_param.clone())?;
+	let (v2_user, v3_user) = request_uniswap_v2_or_v3_user(addresses, achainable_param.clone())?;
 	match Credential::new(&req.who, &req.shard) {
 		Ok(mut credential_unsigned) => {
 			let (desc, subtype) = get_uniswap_v23_info();
 			credential_unsigned.add_subject_info(desc, subtype);
-			credential_unsigned.update_uniswap_v23_info(flag);
+			credential_unsigned.update_uniswap_v23_info(v2_user, v3_user);
 
 			Ok(credential_unsigned)
 		},

--- a/tee-worker/litentry/core/assertion-build/src/achainable/mod.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/mod.rs
@@ -81,22 +81,23 @@ pub fn request_achainable(addresses: Vec<String>, param: AchainableParams) -> Re
 pub fn request_uniswap_v2_or_v3_user(
 	addresses: Vec<String>,
 	param: AchainableParams,
-) -> Result<bool> {
+) -> Result<(bool, bool)> {
 	let _request_param = Params::try_from(param.clone())?;
-
 	let mut client: AchainableClient = AchainableClient::new();
 
+	let mut v2_user = false;
+	let mut v3_user = false;
 	for address in &addresses {
-		if client.uniswap_v2_user(address).map_err(|e| {
+		v2_user |= client.uniswap_v2_user(address).map_err(|e| {
 			Error::RequestVCFailed(Assertion::Achainable(param.clone()), e.into_error_detail())
-		})? || client.uniswap_v3_user(address).map_err(|e| {
+		})?;
+
+		v3_user |= client.uniswap_v3_user(address).map_err(|e| {
 			Error::RequestVCFailed(Assertion::Achainable(param.clone()), e.into_error_detail())
-		})? {
-			return Ok(true)
-		}
+		})?
 	}
 
-	Ok(false)
+	Ok((v2_user, v3_user))
 }
 
 const INVALID_CLASS_OF_YEAR: &str = "Invalid";

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -503,14 +503,17 @@ impl Credential {
 		self.credential_subject.values.push(value);
 	}
 
-	pub fn update_uniswap_v23_info(&mut self, value: bool) {
-		let uniswap_v2 = AssertionLogic::new_item("$is_uniswap_v2_user", Op::Equal, "true");
-		let uniswap_v3 = AssertionLogic::new_item("$is_uniswap_v3_user", Op::Equal, "true");
+	pub fn update_uniswap_v23_info(&mut self, v2_user: bool, v3_user: bool) {
+		let uniswap_v2 =
+			AssertionLogic::new_item("$is_uniswap_v2_user", Op::Equal, &v2_user.to_string());
+		let uniswap_v3 =
+			AssertionLogic::new_item("$is_uniswap_v3_user", Op::Equal, &v3_user.to_string());
 
-		let assertion = AssertionLogic::new_or().add_item(uniswap_v2).add_item(uniswap_v3);
-
+		let assertion = AssertionLogic::new_and().add_item(uniswap_v2).add_item(uniswap_v3);
 		self.credential_subject.assertions.push(assertion);
-		self.credential_subject.values.push(value);
+
+		// Always true
+		self.credential_subject.values.push(true);
 	}
 
 	pub fn update_class_of_year(&mut self, ret: bool, date: String) {


### PR DESCRIPTION
As discussed in [channel](https://litentry.slack.com/archives/C03KR96989G/p1691663053824849?thread_ts=1691619239.842269&cid=C03KR96989G)

```
        and: {
        {
            src:$is_uniswap_v2_user,
            op:==,
            dst:true
        },
        {
            src: is_uniswap_v3_user,
            op: ==,
            dst: true
         }
        }
value: [true]
```

Example: [uniswap-v2/v3-user](https://www.notion.so/web3builders/UniswapV2-3-user-e6cbb0bcffde4ba89c3b6863b9e799db)

