### PR TITLE
Improve move-vcregistry-snapshot script output

### DIFF
--- a/scripts/ts-utils/move-vcregistry-snapshot.ts
+++ b/scripts/ts-utils/move-vcregistry-snapshot.ts
@@ -33,6 +33,8 @@ async function encodeExtrinsic() {
     let txs: any[] = [];
     console.log(colors.green('vcRegistry data length'), data.length);
     let i = 0
+    const hexData = []
+
     while (data.length > 0) {
         const batch = data.splice(0, BATCH_SIZE);
         const batchTxs = batch.map((entry: any) =>
@@ -44,15 +46,29 @@ async function encodeExtrinsic() {
             )
         );
         txs = txs.concat(batchTxs);
-
         if (data.length === 0 || txs.length >= BATCH_SIZE) {
             i++
             const extrinsics = defaultAPI.tx.utility.batch(batchTxs);
-            console.log(colors.green(`extrinsic ${i} encode`), extrinsics.toHex());
+            hexData.push({ batch: i, extrinsics: extrinsics.toHex(), })
+            // console.log(colors.green(`extrinsic ${i} encode`), extrinsics.toHex());
             txs = [];
+            if (data.length === 0) {
+                const extrinsicsFilename = `extrinsics-${new Date().toISOString().slice(0, 10)}.json`;
+                const extrinsicsFilepath = path.join(__dirname, extrinsicsFilename);
+
+                const formattedHexData = prettier.format(JSON.stringify(hexData), {
+                    parser: "json",
+                    printWidth: 120,
+                    tabWidth: 2,
+                    singleQuote: true,
+                    trailingComma: "es5",
+                });
+
+                fs.writeFileSync(extrinsicsFilepath, formattedHexData);
+                console.log(colors.green(`Extrinsics saved to ${extrinsicsFilename} successfully.`));
+            }
         }
     }
-    console.log(colors.green('done'));
     process.exit();
 }
 


### PR DESCRIPTION
### Context

Previously, our extrinsic encode hex was being displayed in the terminal. However, when we have accumulated a significant amount of vc registry data making it difficult to use and causing terminal slowdown. see screenshot:
<img width="2502" alt="image" src="https://github.com/litentry/litentry-parachain/assets/104152026/2909d0aa-178b-4fe2-bfa7-4c6e1897c13f">


As you can see ,we have 23 batch of extrinsic encode hex in the terminal :(...
So I saving the encode hex values into JSON files.Testing has been conducted, and it has been confirmed that the saved hex values are functioning properly.