### PR TITLE
check identity existence while creating prime identity

### DIFF
--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -142,6 +142,10 @@ pub mod pallet {
 			ensure!(!who.is_web2(), Error::<T>::NotSupportedIdentity);
 			if IDGraphs::<T>::get(&who, &who).is_none() {
 				ensure!(
+					!LinkedIdentities::<T>::contains_key(&who),
+					Error::<T>::IdentityAlreadyLinked
+				);
+				ensure!(
 					who.matches_web3networks(networks.as_ref()),
 					Error::<T>::WrongWeb3NetworkTypes
 				);

--- a/tee-worker/litentry/pallets/identity-management/src/tests.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/tests.rs
@@ -81,7 +81,7 @@ fn set_user_shielding_key_fails_for_linked_identity() {
 			Error::<Test>::IdentityAlreadyLinked
 		);
 
-		// assert_eq!(crate::IDGraphLens::<Test>::get(&who_alice), 0);
+		assert_eq!(crate::IDGraphLens::<Test>::get(&who), 0);
 	});
 }
 


### PR DESCRIPTION
Prevents from creating idgraphs containing already linked identities as prime identity

fixes: #2030 