### PR TITLE
fix identity ts tests

### DIFF
--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -13,7 +13,7 @@ import { jsonSchema } from '../type-definitions';
 import { aesKey } from '../call';
 import colors from 'colors';
 import { CorePrimitivesErrorErrorDetail, FrameSystemEventRecord, WorkerRpcReturnValue } from 'parachain-api';
-import { Signer } from './crypto'
+import { Signer } from './crypto';
 export async function assertFailedEvent(
     context: IntegrationTestContext,
     events: FrameSystemEventRecord[],
@@ -46,7 +46,7 @@ export async function assertFailedEvent(
 }
 export async function assertInitialIdGraphCreated(context: IntegrationTestContext, signer: Signer, events: any[]) {
     assert.isAtLeast(events.length, 1, 'Check InitialIDGraph error: events length should be greater than 1');
-    const keyringType = signer.type()
+    const keyringType = signer.type();
 
     for (let index = 0; index < events.length; index++) {
         const eventData = events[index].data;
@@ -267,9 +267,9 @@ export async function checkJson(vc: any, proofJson: any): Promise<boolean> {
 }
 
 /* 
-    assert linked event
+    Compares ordered identities with corresponding ordered events
 
-    steps:
+    for each event following steps are executed:
     1. compare event account with signer
     2. compare event identity with expected identity
     3. compare event prime identity with expected prime identity
@@ -283,6 +283,14 @@ export async function assertLinkedEvent(
     events: any[],
     expectedIdentities: LitentryPrimitivesIdentity[]
 ) {
+    events.forEach((ev) => {
+        console.log(ev.toHuman());
+    });
+
+    expectedIdentities.forEach((i) => {
+        console.log(i.toHuman());
+    });
+
     assert.isAtLeast(events.length, 1, 'Check assertLinkedEvent error: events length should be greater than 1');
 
     const eventIdGraph = parseIdGraph(context.sidechainRegistry, events[events.length - 1].data.idGraph, aesKey);

--- a/tee-worker/ts-tests/integration-tests/evm_ii_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/evm_ii_identity.test.ts
@@ -7,7 +7,7 @@ import {
     buildIdentityHelper,
     buildValidations,
     initIntegrationTestContext,
-    EthersSigner
+    EthersSigner,
 } from './common/utils';
 import {
     assertFailedEvent,
@@ -28,7 +28,6 @@ import {
     getTeeShieldingKey,
     sendRequestFromGetter,
     sendRequestFromTrustedCall,
-
 } from './examples/direct-invocation/util'; // @fixme move to a better place
 import type { IntegrationTestContext } from './common/type-definitions';
 import { aesKey, keyNonce } from './common/call';
@@ -106,7 +105,11 @@ describe('Test Identity (evm direct invocation)', function () {
 
         // check event length
         assert.equal(userShieldingKeySetEvents.length, 1, 'userShieldingKeySetEvents.length should be 1');
-        await assertInitialIdGraphCreated(context, new EthersSigner(context.ethersWallet.alice), userShieldingKeySetEvents);
+        await assertInitialIdGraphCreated(
+            context,
+            new EthersSigner(context.ethersWallet.alice),
+            userShieldingKeySetEvents
+        );
     });
 
     step('check user shielding key from sidechain storage after user shielding key setting(alice)', async function () {
@@ -129,7 +132,11 @@ describe('Test Identity (evm direct invocation)', function () {
     });
 
     step('check idgraph from sidechain storage before linking', async function () {
-        const idgraphGetter = await createSignedTrustedGetterIdGraph(context.api, new EthersSigner(context.ethersWallet.alice), aliceEvmSubject);
+        const idgraphGetter = await createSignedTrustedGetterIdGraph(
+            context.api,
+            new EthersSigner(context.ethersWallet.alice),
+            aliceEvmSubject
+        );
         const res = await sendRequestFromGetter(
             context.tee,
             context.api,
@@ -167,7 +174,10 @@ describe('Test Identity (evm direct invocation)', function () {
             undefined,
             [context.ethersWallet.bob]
         );
-        const bobEvmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']) as unknown as Vec<Web3Network>; // @fixme #1878
+        const bobEvmNetworks = context.api.createType('Vec<Web3Network>', [
+            'Ethereum',
+            'Bsc',
+        ]) as unknown as Vec<Web3Network>; // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: bobEvmNonce,
             identity: bobEvmIdentity,
@@ -189,7 +199,10 @@ describe('Test Identity (evm direct invocation)', function () {
             'substrate',
             context.substrateWallet.eve
         );
-        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Litentry', 'Khala']) as unknown as Vec<Web3Network>;  // @fixme #1878
+        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', [
+            'Litentry',
+            'Khala',
+        ]) as unknown as Vec<Web3Network>; // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: eveSubstrateNonce,
             identity: eveSubstrateIdentity,
@@ -237,11 +250,18 @@ describe('Test Identity (evm direct invocation)', function () {
 
         // check event data
         assert.equal(linkedIdentityEvents.length, 2);
-        await assertLinkedEvent(context, new EthersSigner(context.ethersWallet.alice), linkedIdentityEvents, [bobEvmIdentity, eveSubstrateIdentity]);
+        await assertLinkedEvent(context, new EthersSigner(context.ethersWallet.alice), linkedIdentityEvents, [
+            bobEvmIdentity,
+            eveSubstrateIdentity,
+        ]);
     });
 
     step('check user sidechain storage after linking', async function () {
-        const idgraphGetter = await createSignedTrustedGetterIdGraph(context.api, new EthersSigner(context.ethersWallet.alice), aliceEvmSubject);
+        const idgraphGetter = await createSignedTrustedGetterIdGraph(
+            context.api,
+            new EthersSigner(context.ethersWallet.alice),
+            aliceEvmSubject
+        );
         const res = await sendRequestFromGetter(
             context.tee,
             context.api,
@@ -353,7 +373,11 @@ describe('Test Identity (evm direct invocation)', function () {
     });
 
     step('check idgraph from sidechain storage after deactivating', async function () {
-        const idgraphGetter = await createSignedTrustedGetterIdGraph(context.api, new EthersSigner(context.ethersWallet.alice), aliceEvmSubject);
+        const idgraphGetter = await createSignedTrustedGetterIdGraph(
+            context.api,
+            new EthersSigner(context.ethersWallet.alice),
+            aliceEvmSubject
+        );
         const res = await sendRequestFromGetter(
             context.tee,
             context.api,
@@ -452,7 +476,11 @@ describe('Test Identity (evm direct invocation)', function () {
     });
 
     step('check idgraph from sidechain storage after activating', async function () {
-        const idgraphGetter = await createSignedTrustedGetterIdGraph(context.api, new EthersSigner(context.ethersWallet.alice), aliceEvmSubject);
+        const idgraphGetter = await createSignedTrustedGetterIdGraph(
+            context.api,
+            new EthersSigner(context.ethersWallet.alice),
+            aliceEvmSubject
+        );
         const res = await sendRequestFromGetter(
             context.tee,
             context.api,
@@ -486,7 +514,11 @@ describe('Test Identity (evm direct invocation)', function () {
         const nonce = getNextNonce();
 
         // prime identity
-        const substratePrimeIdentity = await buildIdentityHelper(u8aToHex(new EthersSigner(context.ethersWallet.alice).getAddressRaw()), 'Evm', context);
+        const substratePrimeIdentity = await buildIdentityHelper(
+            u8aToHex(new EthersSigner(context.ethersWallet.alice).getAddressRaw()),
+            'Evm',
+            context
+        );
 
         const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
         const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);

--- a/tee-worker/ts-tests/integration-tests/identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/identity.test.ts
@@ -29,28 +29,28 @@ import { sendRequest } from './common/call';
 import * as base58 from 'micro-base58';
 import { decodeRpcBytesAsString } from './common/call';
 
-async function getEnclaveSignerPublicKey (context: IntegrationTestContext): Promise<string> {
+async function getEnclaveSignerPublicKey(context: IntegrationTestContext): Promise<string> {
     const request = { jsonrpc: '2.0', method: 'author_getEnclaveSignerAccount', params: [], id: 1 };
     const response = await sendRequest(context.tee, request, context.api);
     if (!response.status.isOk) {
-        throw new Error("Get author_getEnclaveSignerAccount response error!");
+        throw new Error('Get author_getEnclaveSignerAccount response error!');
     }
     const enclaveSignerAccount = decodeRpcBytesAsString(response.value);
-    console.log("enclaveSignerAccount", enclaveSignerAccount);
+    console.log('enclaveSignerAccount', enclaveSignerAccount);
     return enclaveSignerAccount;
 }
 
 async function getNonce(base58mrEnclave: string, workerAddr: string, context: IntegrationTestContext): Promise<number> {
     const request = { jsonrpc: '2.0', method: 'author_getNextNonce', params: [base58mrEnclave, workerAddr], id: 1 };
     const res = await sendRequest(context.tee, request, context.api);
-    console.log("workerAddr", workerAddr);
+    console.log('workerAddr', workerAddr);
     const resHex = res.value.toString();
     let nonce = 0;
-    if(resHex){
-        nonce = context.api.createType('Index', ('0x' + resHex.slice(2)?.match(/../g)?.reverse().join(''))).toNumber();
-    }   
-    console.log("resHex:", resHex);
-    console.log("nonce is:", nonce);
+    if (resHex) {
+        nonce = context.api.createType('Index', '0x' + resHex.slice(2)?.match(/../g)?.reverse().join('')).toNumber();
+    }
+    console.log('resHex:', resHex);
+    console.log('nonce is:', nonce);
     return nonce;
 }
 
@@ -69,7 +69,7 @@ describeLitentry('Test Identity', 0, (context) => {
 
     step('init', async () => {
         base58mrEnclave = base58.encode(Buffer.from(context.mrEnclave.slice(2), 'hex'));
-        workerAddress = await getEnclaveSignerPublicKey (context);
+        workerAddress = await getEnclaveSignerPublicKey(context);
     });
 
     step('check user sidechain storage before create', async function () {
@@ -160,13 +160,13 @@ describeLitentry('Test Identity', 0, (context) => {
         // - alice's evm identity
         // - eve's substrate identity (as she can't link her own substrate again)
         let nonce = await getNonce(base58mrEnclave, workerAddress, context);
-        const twitterIdentity = await buildIdentityHelper('mock_user', 'Twitter', context);
         const evmIdentity = await buildIdentityHelper(context.ethersWallet.alice.address, 'Evm', context);
         const eveSubstrateIdentity = await buildIdentityHelper(
             u8aToHex(context.substrateWallet.eve.addressRaw),
             'Substrate',
             context
         );
+        const twitterIdentity = await buildIdentityHelper('mock_user', 'Twitter', context);
 
         // Bob links:
         // - charlie's substrate identity
@@ -176,17 +176,16 @@ describeLitentry('Test Identity', 0, (context) => {
             context
         );
 
-        eveIdentities = [twitterIdentity, evmIdentity, eveSubstrateIdentity];
+        eveIdentities = [evmIdentity, eveSubstrateIdentity, twitterIdentity];
         charlieIdentities = [charlieSubstrateIdentity];
 
         const aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
-        const twitterValidations = await buildValidations(context, [aliceSubject], [twitterIdentity], nonce, 'twitter');
 
         const evmValidations = await buildValidations(
             context,
             [aliceSubject],
             [evmIdentity],
-            nonce + 1,
+            nonce,
             'ethereum',
             undefined,
             [context.ethersWallet.alice]
@@ -196,12 +195,20 @@ describeLitentry('Test Identity', 0, (context) => {
             context,
             [aliceSubject],
             [eveSubstrateIdentity],
-            nonce + 2,
+            nonce + 1,
             'substrate',
             context.substrateWallet.eve
         );
 
-        eveValidations = [...twitterValidations, ...evmValidations, ...eveSubstrateValidations];
+        const twitterValidations = await buildValidations(
+            context,
+            [aliceSubject],
+            [twitterIdentity],
+            nonce + 2,
+            'twitter'
+        );
+
+        eveValidations = [...evmValidations, ...eveSubstrateValidations, ...twitterValidations];
 
         const twitterNetworks = context.api.createType('Vec<Web3Network>', []) as unknown as Web3Network[];
         const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']) as unknown as Web3Network[];
@@ -210,7 +217,7 @@ describeLitentry('Test Identity', 0, (context) => {
             'Polkadot',
         ]) as unknown as Web3Network[];
 
-        web3networks = [twitterNetworks, evmNetworks, eveSubstrateNetworks];
+        web3networks = [evmNetworks, eveSubstrateNetworks, twitterNetworks];
 
         const aliceTxs = await buildIdentityTxs(
             context,
@@ -229,7 +236,12 @@ describeLitentry('Test Identity', 0, (context) => {
             ['IdentityLinked']
         );
 
-        await assertLinkedEvent(context, new PolkadotSigner(context.substrateWallet.alice), aliceRespEvents, eveIdentities);
+        await assertLinkedEvent(
+            context,
+            new PolkadotSigner(context.substrateWallet.alice),
+            aliceRespEvents,
+            eveIdentities
+        );
 
         // Bob check extension substrate identity
         // https://github.com/litentry/litentry-parachain/issues/1137
@@ -245,13 +257,8 @@ describeLitentry('Test Identity', 0, (context) => {
         };
         const bobSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.bob), context);
         nonce = await getNonce(base58mrEnclave, workerAddress, context);
-        console.log("nonce for step link identities", nonce);
-        const msg = generateVerificationMessage(
-            context,
-            bobSubject,
-            charlieSubstrateIdentity,
-            nonce
-        );
+        console.log('nonce for step link identities', nonce);
+        const msg = generateVerificationMessage(context, bobSubject, charlieSubstrateIdentity, nonce);
         console.log('post verification msg to substrate: ', msg);
         substrateExtensionValidationData.Web3Validation.Substrate.message = msg;
         // sign the wrapped version as in polkadot-extension
@@ -286,7 +293,12 @@ describeLitentry('Test Identity', 0, (context) => {
             'identityManagement',
             ['IdentityLinked']
         );
-        await assertLinkedEvent(context, new PolkadotSigner(context.substrateWallet.bob), bobRespEvents, charlieIdentities);
+        await assertLinkedEvent(
+            context,
+            new PolkadotSigner(context.substrateWallet.bob),
+            bobRespEvents,
+            charlieIdentities
+        );
     });
 
     step('check IDGraph after LinkIdentity', async function () {
@@ -300,8 +312,8 @@ describeLitentry('Test Identity', 0, (context) => {
     });
 
     step('link invalid identities', async function () {
-        const twitterIdentity = eveIdentities[0];
-        const ethereumValidation = eveValidations[1];
+        const twitterIdentity = eveIdentities[2];
+        const ethereumValidation = eveValidations[0];
 
         // link twitter identity with ethereum validation data
         // the `InvalidIdentity` error should be emitted prior to `AlreadyLinked` error
@@ -324,7 +336,7 @@ describeLitentry('Test Identity', 0, (context) => {
     });
 
     step('link identities with wrong signature', async function () {
-        const evmIdentity = eveIdentities[1];
+        const evmIdentity = eveIdentities[0];
 
         // link evm identity with wrong validation data(raw message)
         const ethereumSignature = (await context.ethersWallet.alice.signMessage(
@@ -371,7 +383,7 @@ describeLitentry('Test Identity', 0, (context) => {
         const aliceIdentities = [twitterIdentity];
 
         const nonce = await getNonce(base58mrEnclave, workerAddress, context);
-        console.log("nonce for step link already linked identity", nonce);
+        console.log('nonce for step link already linked identity', nonce);
         const aliceTwitterValidations = await buildValidations(
             context,
             [aliceSubject],

--- a/tee-worker/ts-tests/integration-tests/substrate_ii_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/substrate_ii_identity.test.ts
@@ -629,11 +629,7 @@ describe('Test Identity (direct invocation)', function () {
         }
         assert.equal(deactivatedIdentityEvents.length, 3);
 
-        await assertIdentity(context, deactivatedIdentityEvents, [
-            twitterIdentity,
-            evmIdentity,
-            eveSubstrateIdentity,
-        ]);
+        await assertIdentity(context, deactivatedIdentityEvents, [twitterIdentity, evmIdentity, eveSubstrateIdentity]);
     });
 
     step('check idgraph from sidechain storage after deactivating', async function () {
@@ -742,11 +738,7 @@ describe('Test Identity (direct invocation)', function () {
             assert.isTrue(isIdentityActivated);
         }
         assert.equal(activatedIdentityEvents.length, 3);
-        await assertIdentity(context, activatedIdentityEvents, [
-            twitterIdentity,
-            evmIdentity,
-            eveSubstrateIdentity,
-        ]);
+        await assertIdentity(context, activatedIdentityEvents, [twitterIdentity, evmIdentity, eveSubstrateIdentity]);
     });
 
     step('check idgraph from sidechain storage after activating', async function () {


### PR DESCRIPTION
Fixes identity ts tests.

```
  1) Test Identity
       link identities:

      AssertionError: expected '{"evm":"0xff93b45308fd417df303d6515ab…' to equal '{"twitter":"0x6d6f636b5f75736572"}'
      + expected - actual

      -{"evm":"0xff93b45308fd417df303d6515ab04d9e89a750ca"}
      +{"twitter":"0x6d6f636b5f75736572"}
      
```

Web3 identities are immediately verified so corresponding events appear faster than those related to web2 identities.

