### PR TITLE
Collect docker logs for parachain ts-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: ${{ matrix.chain }}-ts-tests-artifacts
+          name: ${{ matrix.chain }}-ts-tests-artifact
           path: /tmp/parachain_dev/
           if-no-files-found: ignore
           retention-days: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,23 @@ jobs:
         run: |
           make test-ts-docker-${{ matrix.chain }}
 
+      - name: Collect docker logs if test fails
+        continue-on-error: true
+        uses: jwalton/gh-docker-logs@v2
+        if: failure()
+        with:
+          tail: all
+          dest: docker-logs
+
+      - name: Upload docker logs if test fails
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ${{ matrix.chain }}-ts-tests-docker-logs
+          path: docker-logs
+          if-no-files-found: ignore
+          retention-days: 3
+
       - name: Archive logs if test fails
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: General CI
 
-# this file is a joint CI of parachain and tee-worker, it contains:
+# This file is a joint CI of parachain and tee-worker, it contains:
 # - build (of docker images)
 # - format check
 # - unit tests


### PR DESCRIPTION
### Context

As topic. A minor PR to collect docker logs and upload them when parachain ts-tests fail.
We launch the parachain in docker so `/tmp/parachain_dev` is not enough.
