### PR TITLE
Update A8 upper bound

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/a8.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a8.rs
@@ -84,7 +84,7 @@ Total transactions count range of assertion results:
 100		<= X < 200			=> true
 200		<= X < 300			=> true
 300		<= X < 500			=> true
-500 	<= X < u64::Max		=> true
+500 	<= X 				=> true
 */
 fn get_total_tx_ranges(total_txs: u64) -> (u64, u64) {
 	let min: u64;


### PR DESCRIPTION
fix #2045 

```json
        "assertions":[
            {
                "and":[
                    {
                        "src":"$total_txs",
                        "op":">=",
                        "dst":"500"
                    },
                    {
                        "or":[
                            {
                                "src":"$network",
                                "op":"==",
                                "dst":"Ethereum"
                            }
                        ]
                    }
                ]
            }
        ],

```




