### PR TITLE
Force connections to wait for swap

### DIFF
--- a/tee-worker/app-libs/stf/src/trusted_call_result.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call_result.rs
@@ -20,7 +20,7 @@
 
 use crate::AccountId;
 use codec::{Decode, Encode};
-use itp_stf_interface::EncodeResult;
+use itp_stf_interface::StfExecutionResult;
 use itp_types::H256;
 use litentry_primitives::{AesOutput, Assertion};
 use std::vec::Vec;
@@ -36,18 +36,21 @@ pub enum TrustedCallResult {
 	RequestVC(RequestVCResult),
 }
 
-impl EncodeResult for TrustedCallResult {
+impl StfExecutionResult for TrustedCallResult {
 	fn get_encoded_result(self) -> Vec<u8> {
 		match self {
 			Self::Empty => Vec::default(),
-			// true means that there are more results to come, see rpc_responder
-			Self::Streamed => true.encode(),
+			Self::Streamed => Vec::default(),
 			Self::SetUserShieldingKey(result) => result.encode(),
 			Self::LinkIdentity(result) => result.encode(),
 			Self::DeactivateIdentity(result) => result.encode(),
 			Self::ActivateIdentity(result) => result.encode(),
 			Self::RequestVC(result) => result.encode(),
 		}
+	}
+
+	fn force_connection_wait(&self) -> bool {
+		matches!(self, Self::Streamed)
 	}
 }
 

--- a/tee-worker/core-primitives/stf-executor/src/mocks.rs
+++ b/tee-worker/core-primitives/stf-executor/src/mocks.rs
@@ -84,7 +84,13 @@ where
 			.map(|c| {
 				let operation_hash = c.hash();
 				let top_or_hash = TrustedOperationOrHash::from_top(c.clone());
-				ExecutedOperation::success(operation_hash, top_or_hash, Vec::new(), Vec::new())
+				ExecutedOperation::success(
+					operation_hash,
+					top_or_hash,
+					Vec::new(),
+					Vec::new(),
+					false,
+				)
 			})
 			.collect();
 

--- a/tee-worker/core-primitives/stf-interface/src/lib.rs
+++ b/tee-worker/core-primitives/stf-interface/src/lib.rs
@@ -56,7 +56,7 @@ where
 	NodeMetadataRepository::MetadataType: NodeMetadataTrait,
 {
 	type Error: Encode;
-	type Result: EncodeResult;
+	type Result: StfExecutionResult;
 
 	/// Execute a call on a specific state. Callbacks are added as an `OpaqueCall`.
 	///
@@ -87,7 +87,7 @@ where
 	NodeMetadataRepository::MetadataType: NodeMetadataTrait,
 {
 	type Error: Encode;
-	type Result: EncodeResult;
+	type Result: StfExecutionResult;
 
 	/// Execute a call. Callbacks are added as an `OpaqueCall`.
 	///
@@ -113,12 +113,16 @@ pub trait ExecuteGetter {
 	fn get_storage_hashes_to_update(self) -> Vec<Vec<u8>>;
 }
 
-pub trait EncodeResult {
+pub trait StfExecutionResult {
 	fn get_encoded_result(self) -> Vec<u8>;
+	fn force_connection_wait(&self) -> bool;
 }
 
-impl EncodeResult for () {
+impl StfExecutionResult for () {
 	fn get_encoded_result(self) -> Vec<u8> {
 		Vec::default()
+	}
+	fn force_connection_wait(&self) -> bool {
+		false
 	}
 }

--- a/tee-worker/core-primitives/top-pool-author/src/author.rs
+++ b/tee-worker/core-primitives/top-pool-author/src/author.rs
@@ -344,8 +344,8 @@ where
 		self.process_top(ext, shard, TopSubmissionMode::SubmitWatch)
 	}
 
-	fn set_rpc_response_value(&self, rpc_response_value: Vec<(TxHash<TopPool>, Vec<u8>)>) {
-		self.top_pool.set_rpc_response_value(rpc_response_value)
+	fn update_connection_state(&self, updates: Vec<(TxHash<TopPool>, (Vec<u8>, bool))>) {
+		self.top_pool.update_connection_state(updates)
 	}
 
 	fn swap_rpc_connection_hash(&self, old_hash: TxHash<TopPool>, new_hash: TxHash<TopPool>) {

--- a/tee-worker/core-primitives/top-pool-author/src/mocks.rs
+++ b/tee-worker/core-primitives/top-pool-author/src/mocks.rs
@@ -189,7 +189,7 @@ impl AuthorApi<H256, H256> for AuthorApiMock<H256, H256> {
 		todo!()
 	}
 
-	fn set_rpc_response_value(&self, _rpc_responses_value: Vec<(H256, Vec<u8>)>) {}
+	fn update_connection_state(&self, _updates: Vec<(H256, (Vec<u8>, bool))>) {}
 
 	fn swap_rpc_connection_hash(&self, _old_hash: H256, _new_hash: H256) {}
 }

--- a/tee-worker/core-primitives/top-pool-author/src/traits.rs
+++ b/tee-worker/core-primitives/top-pool-author/src/traits.rs
@@ -70,7 +70,7 @@ pub trait AuthorApi<Hash, BlockHash> {
 	fn watch_top(&self, ext: Vec<u8>, shard: ShardIdentifier) -> PoolFuture<Hash, RpcError>;
 
 	/// Litentry: set the rpc response value
-	fn set_rpc_response_value(&self, rpc_response_value: Vec<(Hash, Vec<u8>)>);
+	fn update_connection_state(&self, updates: Vec<(Hash, (Vec<u8>, bool))>);
 
 	/// Litentry: swap the old hash with the new one in rpc connection registry
 	fn swap_rpc_connection_hash(&self, old_hash: Hash, new_hash: Hash);

--- a/tee-worker/core-primitives/top-pool/src/basic_pool.rs
+++ b/tee-worker/core-primitives/top-pool/src/basic_pool.rs
@@ -246,8 +246,8 @@ where
 		self.pool.validated_pool().on_block_imported(hashes, block_hash);
 	}
 
-	fn set_rpc_response_value(&self, rpc_response_value: Vec<(TxHash<Self>, Vec<u8>)>) {
-		self.pool.validated_pool().set_rpc_response_value(rpc_response_value);
+	fn update_connection_state(&self, updates: Vec<(TxHash<Self>, (Vec<u8>, bool))>) {
+		self.pool.validated_pool().update_connection_state(updates);
 	}
 
 	fn swap_rpc_connection_hash(&self, old_hash: TxHash<Self>, new_hash: TxHash<Self>) {

--- a/tee-worker/core-primitives/top-pool/src/listener.rs
+++ b/tee-worker/core-primitives/top-pool/src/listener.rs
@@ -155,9 +155,9 @@ where
 		}
 	}
 
-	/// Litentry: set the rpc response value for a given TrustedOperation `tx`.
-	pub fn set_rpc_response_value(&mut self, tx: &H, encoded_value: Vec<u8>) {
-		self.fire(tx, |s| s.set_rpc_response_value(encoded_value));
+	/// Litentry: set the rpc response value and force_wait flag for a given TrustedOperation `tx`.
+	pub fn update_connection_state(&mut self, tx: &H, encoded_value: Vec<u8>, force_wait: bool) {
+		self.fire(tx, |s| s.update_connection_state(encoded_value, force_wait));
 	}
 
 	/// Litentry: swap the old hash with the new one in rpc connection registry

--- a/tee-worker/core-primitives/top-pool/src/mocks/rpc_responder_mock.rs
+++ b/tee-worker/core-primitives/top-pool/src/mocks/rpc_responder_mock.rs
@@ -53,7 +53,12 @@ where
 		Ok(())
 	}
 
-	fn set_value(&self, _hash: Self::Hash, _encoded_value: Vec<u8>) -> DirectRpcResult<()> {
+	fn update_connection_state(
+		&self,
+		_hash: Self::Hash,
+		_encoded_value: Vec<u8>,
+		_force_wait: bool,
+	) -> DirectRpcResult<()> {
 		Ok(())
 	}
 

--- a/tee-worker/core-primitives/top-pool/src/mocks/trusted_operation_pool_mock.rs
+++ b/tee-worker/core-primitives/top-pool/src/mocks/trusted_operation_pool_mock.rs
@@ -213,7 +213,7 @@ impl TrustedOperationPool for TrustedOperationPoolMock {
 
 	fn on_block_imported(&self, _hashes: &[Self::Hash], _block_hash: SidechainBlockHash) {}
 
-	fn set_rpc_response_value(&self, _rpc_response_value: Vec<(TxHash<Self>, Vec<u8>)>) {}
+	fn update_connection_state(&self, _updates: Vec<(TxHash<Self>, (Vec<u8>, bool))>) {}
 
 	fn swap_rpc_connection_hash(&self, _old_hash: TxHash<Self>, _new_hash: TxHash<Self>) {}
 }

--- a/tee-worker/core-primitives/top-pool/src/primitives.rs
+++ b/tee-worker/core-primitives/top-pool/src/primitives.rs
@@ -262,7 +262,8 @@ pub trait TrustedOperationPool: Send + Sync {
 	fn on_block_imported(&self, hashes: &[Self::Hash], block_hash: SidechainBlockHash);
 
 	/// Litentry: set the rpc response value
-	fn set_rpc_response_value(&self, rpc_response_value: Vec<(TxHash<Self>, Vec<u8>)>);
+	#[allow(clippy::type_complexity)]
+	fn update_connection_state(&self, updates: Vec<(TxHash<Self>, (Vec<u8>, bool))>);
 
 	/// Litentry: swap the old hash with the new one in rpc connection registry
 	fn swap_rpc_connection_hash(&self, old_hash: TxHash<Self>, new_hash: TxHash<Self>);

--- a/tee-worker/core-primitives/top-pool/src/validated_pool.rs
+++ b/tee-worker/core-primitives/top-pool/src/validated_pool.rs
@@ -693,9 +693,14 @@ where
 		}
 	}
 
-	pub fn set_rpc_response_value(&self, rpc_response_value: Vec<(ExtrinsicHash<B>, Vec<u8>)>) {
-		for (top_hash, encoded_value) in rpc_response_value {
-			self.listener.write().unwrap().set_rpc_response_value(&top_hash, encoded_value);
+	#[allow(clippy::type_complexity)]
+	pub fn update_connection_state(&self, updates: Vec<(ExtrinsicHash<B>, (Vec<u8>, bool))>) {
+		for (top_hash, (encoded_value, force_wait)) in updates {
+			self.listener.write().unwrap().update_connection_state(
+				&top_hash,
+				encoded_value,
+				force_wait,
+			);
 		}
 	}
 

--- a/tee-worker/core-primitives/top-pool/src/watcher.rs
+++ b/tee-worker/core-primitives/top-pool/src/watcher.rs
@@ -128,10 +128,14 @@ where
 		}
 	}
 
-	// Litentry: set the new rpc response value
-	pub fn set_rpc_response_value(&mut self, encoded_value: Vec<u8>) {
-		if let Err(e) = self.rpc_response_sender.set_value(self.hash().clone(), encoded_value) {
-			warn!("failed to set response value to rpc client: {:?}", e);
+	// Litentry: set the new rpc response value and force_wait flag
+	pub fn update_connection_state(&mut self, encoded_value: Vec<u8>, force_wait: bool) {
+		if let Err(e) = self.rpc_response_sender.update_connection_state(
+			self.hash().clone(),
+			encoded_value,
+			force_wait,
+		) {
+			warn!("failed to update connection state: {:?}", e);
 		}
 	}
 

--- a/tee-worker/core/direct-rpc-server/src/mocks/send_rpc_response_mock.rs
+++ b/tee-worker/core/direct-rpc-server/src/mocks/send_rpc_response_mock.rs
@@ -51,7 +51,12 @@ where
 		Ok(())
 	}
 
-	fn set_value(&self, _hash: Self::Hash, _encoded_value: Vec<u8>) -> DirectRpcResult<()> {
+	fn update_connection_state(
+		&self,
+		_hash: Self::Hash,
+		_encoded_value: Vec<u8>,
+		_force_wait: bool,
+	) -> DirectRpcResult<()> {
 		Ok(())
 	}
 

--- a/tee-worker/core/direct-rpc-server/src/rpc_connection_registry.rs
+++ b/tee-worker/core/direct-rpc-server/src/rpc_connection_registry.rs
@@ -21,7 +21,7 @@ use std::sync::SgxRwLock as RwLock;
 #[cfg(feature = "std")]
 use std::sync::RwLock;
 
-use crate::{RpcConnectionRegistry, RpcHash};
+use crate::{ForceWait, RpcConnectionRegistry, RpcHash};
 use itp_rpc::RpcResponse;
 use std::{collections::HashMap, fmt::Debug};
 
@@ -32,7 +32,8 @@ where
 	Hash: RpcHash,
 	Token: Copy + Send + Sync + Debug,
 {
-	connection_map: HashMapLock<<Self as RpcConnectionRegistry>::Hash, (Token, RpcResponse)>,
+	connection_map:
+		HashMapLock<<Self as RpcConnectionRegistry>::Hash, (Token, RpcResponse, ForceWait)>,
 }
 
 impl<Hash, Token> ConnectionRegistry<Hash, Token>
@@ -68,12 +69,18 @@ where
 	type Hash = Hash;
 	type Connection = Token;
 
-	fn store(&self, hash: Self::Hash, connection: Self::Connection, rpc_response: RpcResponse) {
+	fn store(
+		&self,
+		hash: Self::Hash,
+		connection: Self::Connection,
+		rpc_response: RpcResponse,
+		force_wait: ForceWait,
+	) {
 		let mut map = self.connection_map.write().expect("Lock poisoning");
-		map.insert(hash, (connection, rpc_response));
+		map.insert(hash, (connection, rpc_response, force_wait));
 	}
 
-	fn withdraw(&self, hash: &Self::Hash) -> Option<(Self::Connection, RpcResponse)> {
+	fn withdraw(&self, hash: &Self::Hash) -> Option<(Self::Connection, RpcResponse, ForceWait)> {
 		let mut map = self.connection_map.write().expect("Lock poisoning");
 		map.remove(hash)
 	}
@@ -91,8 +98,8 @@ pub mod tests {
 
 		let hash = "first".to_string();
 
-		registry.store(hash.clone(), 1, dummy_rpc_response());
-		registry.store(hash.clone(), 2, dummy_rpc_response());
+		registry.store(hash.clone(), 1, dummy_rpc_response(), false);
+		registry.store(hash.clone(), 2, dummy_rpc_response(), false);
 
 		let connection_token = registry.withdraw(&hash).unwrap().0;
 		assert_eq!(2, connection_token);
@@ -110,7 +117,7 @@ pub mod tests {
 		let registry = TestRegistry::new();
 		let hash = "first".to_string();
 
-		registry.store(hash.clone(), 1, dummy_rpc_response());
+		registry.store(hash.clone(), 1, dummy_rpc_response(), false);
 
 		let connection = registry.withdraw(&hash);
 

--- a/tee-worker/core/direct-rpc-server/src/rpc_responder.rs
+++ b/tee-worker/core/direct-rpc-server/src/rpc_responder.rs
@@ -19,7 +19,6 @@ use crate::{
 	response_channel::ResponseChannel, DirectRpcError, DirectRpcResult, RpcConnectionRegistry,
 	RpcHash, SendRpcResponse,
 };
-use codec::Encode;
 use itp_rpc::{RpcResponse, RpcReturnValue};
 use itp_types::{DirectRequestStatus, TrustedOperationStatus};
 use itp_utils::{FromHexPrefixed, ToHexPrefixed};
@@ -78,7 +77,7 @@ where
 		debug!("updating status event, hash: {}, status: {:?}", hash.to_hex(), status_update);
 
 		// withdraw removes it from the registry
-		let (connection_token, rpc_response) = self
+		let (connection_token, rpc_response, force_wait) = self
 			.connection_registry
 			.withdraw(&hash)
 			.ok_or(DirectRpcError::InvalidConnectionHash)?;
@@ -89,16 +88,9 @@ where
 			.map_err(|e| DirectRpcError::Other(Box::new(e)))?;
 
 		// Litentry:
-		// a trick to use `result.value` as the flag to forcily watch this connection.
-		// If it's `true.encode()` it means we have streamed trustedCalls and there's more to come
-		// TODO: how about relying on req_ext_hash? See comment in `trusted_call.rs`
-		let do_watch = continue_watching(&status_update)
-			|| (result.value == true.encode()
-				&& matches!(
-					// use "upcoming" status_update, the `result.status` contains the previous status
-					status_update,
-					TrustedOperationStatus::InSidechainBlock(_),
-				));
+		// connections are per trusted call, but if we expect trusted call to have a side effect of creating another trusted call (callback)
+		// we force connection to wait for potential TOP execution
+		let do_watch = continue_watching(&status_update) || force_wait;
 
 		// update response
 		result.do_watch = do_watch;
@@ -111,7 +103,7 @@ where
 		self.encode_and_send_response(connection_token, &new_response)?;
 
 		if do_watch {
-			self.connection_registry.store(hash, connection_token, new_response);
+			self.connection_registry.store(hash, connection_token, new_response, force_wait);
 		}
 
 		debug!("updating status event successful");
@@ -123,7 +115,7 @@ where
 		debug!("sending state");
 
 		// withdraw removes it from the registry
-		let (connection_token, mut response) = self
+		let (connection_token, mut response, _force_wait) = self
 			.connection_registry
 			.withdraw(&hash)
 			.ok_or(DirectRpcError::InvalidConnectionHash)?;
@@ -145,11 +137,16 @@ where
 		Ok(())
 	}
 
-	fn set_value(&self, hash: Self::Hash, encoded_value: Vec<u8>) -> DirectRpcResult<()> {
+	fn update_connection_state(
+		&self,
+		hash: Self::Hash,
+		encoded_value: Vec<u8>,
+		force_wait: bool,
+	) -> DirectRpcResult<()> {
 		debug!("set response value");
 
 		// withdraw removes it from the registry
-		let (connection_token, rpc_response) = self
+		let (connection_token, rpc_response, _) = self
 			.connection_registry
 			.withdraw(&hash)
 			.ok_or(DirectRpcError::InvalidConnectionHash)?;
@@ -161,7 +158,7 @@ where
 
 		result.value = encoded_value;
 		new_response.result = result.to_hex();
-		self.connection_registry.store(hash, connection_token, new_response);
+		self.connection_registry.store(hash, connection_token, new_response, force_wait);
 
 		debug!("set response value OK");
 		Ok(())
@@ -170,13 +167,14 @@ where
 	fn swap_hash(&self, old_hash: Self::Hash, new_hash: Self::Hash) -> DirectRpcResult<()> {
 		debug!("swap hash, old: {:?}, new: {:?}", old_hash, new_hash);
 
-		let (connection_token, rpc_response) = self
+		let (connection_token, rpc_response, force_wait) = self
 			.connection_registry
 			.withdraw(&old_hash)
 			.ok_or(DirectRpcError::InvalidConnectionHash)?;
 
-		// leave `rpc_response` untouched - it should be overwritten later anyway
-		self.connection_registry.store(new_hash, connection_token, rpc_response);
+		// leave `rpc_response` untouched - it should be overwritten later anyway and keep on force waiting
+		self.connection_registry
+			.store(new_hash, connection_token, rpc_response, force_wait);
 		debug!("swap hash OK");
 		Ok(())
 	}
@@ -320,7 +318,7 @@ pub mod tests {
 		let connection_registry = TestConnectionRegistry::new();
 		let rpc_response = RpcResponseBuilder::new().with_id(2).build();
 
-		connection_registry.store(connection_hash.clone(), 1, rpc_response);
+		connection_registry.store(connection_hash.clone(), 1, rpc_response, false);
 		Arc::new(connection_registry)
 	}
 }

--- a/tee-worker/core/direct-rpc-server/src/rpc_ws_handler.rs
+++ b/tee-worker/core/direct-rpc-server/src/rpc_ws_handler.rs
@@ -76,6 +76,7 @@ where
 					connection_hash,
 					connection_token.into(),
 					rpc_response,
+					false,
 				);
 			}
 		}

--- a/tee-worker/core/offchain-worker-executor/src/executor.rs
+++ b/tee-worker/core/offchain-worker-executor/src/executor.rs
@@ -137,6 +137,7 @@ impl<
 						TrustedOperationOrHash::Hash(h),
 						Vec::new(),
 						Vec::new(),
+						false,
 					)
 				})
 				.collect();

--- a/tee-worker/enclave-runtime/src/test/mocks/rpc_responder_mock.rs
+++ b/tee-worker/enclave-runtime/src/test/mocks/rpc_responder_mock.rs
@@ -47,7 +47,12 @@ where
 		Ok(())
 	}
 
-	fn set_value(&self, _hash: Self::Hash, _encoded_value: Vec<u8>) -> DirectRpcResult<()> {
+	fn update_connection_state(
+		&self,
+		_hash: Self::Hash,
+		_encoded_value: Vec<u8>,
+		_force_wait: bool,
+	) -> DirectRpcResult<()> {
 		Ok(())
 	}
 

--- a/tee-worker/sidechain/consensus/aura/src/slot_proposer.rs
+++ b/tee-worker/sidechain/consensus/aura/src/slot_proposer.rs
@@ -121,8 +121,8 @@ where
 		let number_executed_transactions = executed_operation_hashes.len();
 
 		// store the rpc response value to top pool
-		let rpc_responses_values = batch_execution_result.get_rpc_responses_values();
-		self.top_pool_author.set_rpc_response_value(rpc_responses_values);
+		let rpc_responses_values = batch_execution_result.get_connection_updates();
+		self.top_pool_author.update_connection_state(rpc_responses_values);
 
 		// Remove all not successfully executed operations from the top pool.
 		let failed_operations = batch_execution_result.get_failed_operations();


### PR DESCRIPTION
Add explicit flag to `ConnectionRegistry` so connections can be forced to wait for the swap.

fixes: #2060 