### PR TITLE
A workaround for truncated chain spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,24 +156,24 @@ jobs:
           make fmtcheck
           make taplocheck
 
-      # - name: Tee-worker fmt check
-      #   working-directory: ./tee-worker
-      #   run: |
-      #     cargo fmt --all -- --check
-      #     taplo fmt --check
+      - name: Tee-worker fmt check
+        working-directory: ./tee-worker
+        run: |
+          cargo fmt --all -- --check
+          taplo fmt --check
 
-      # - name: Enclave-runtime fmt check
-      #   working-directory: ./tee-worker/enclave-runtime
-      #   run: |
-      #     cargo fmt --all -- --check
+      - name: Enclave-runtime fmt check
+        working-directory: ./tee-worker/enclave-runtime
+        run: |
+          cargo fmt --all -- --check
 
-      # - name: Tee-worker install npm deps
-      #   working-directory: ./tee-worker/ts-tests
-      #   run: corepack yarn install
+      - name: Tee-worker install npm deps
+        working-directory: ./tee-worker/ts-tests
+        run: corepack yarn install
 
-      # - name: Tee-worker check ts code format
-      #   working-directory: ./tee-worker/ts-tests
-      #   run: corepack yarn check-format
+      - name: Tee-worker check ts code format
+        working-directory: ./tee-worker/ts-tests
+        run: corepack yarn check-format
 
       - name: Fail early
         if: failure()
@@ -457,11 +457,11 @@ jobs:
         run: |
           docker load -i litentry-parachain-dev.tar
 
-      # - name: Run ts tests for ${{ matrix.chain }}
-      #   if: needs.set-condition.outputs.run_parachain_test == 'true'
-      #   timeout-minutes: 20
-      #   run: |
-      #     make test-ts-docker-${{ matrix.chain }}
+      - name: Run ts tests for ${{ matrix.chain }}
+        if: needs.set-condition.outputs.run_parachain_test == 'true'
+        timeout-minutes: 20
+        run: |
+          make test-ts-docker-${{ matrix.chain }}
 
       - name: Collect docker logs if test fails
         continue-on-error: true
@@ -620,28 +620,24 @@ jobs:
           ls -l docker/generated-rococo/
           ls -l tee-worker/docker/litentry/
           shasum tee-worker/docker/litentry/*.json
-          if [ $(stat -c %s docker/generated-rococo/rococo-local.json) -ne 5040588 ]; then
-            echo "unexpected rococo-local.json size"
-            exit 1
-          fi
 
-      # - name: Build litentry parachain docker images
-      #   run: |
-      #     cd tee-worker/docker
-      #     docker compose -f litentry-parachain.build.yml build
+      - name: Build litentry parachain docker images
+        run: |
+          cd tee-worker/docker
+          docker compose -f litentry-parachain.build.yml build
 
-      # - name: Integration Test ${{ matrix.test_name }}
-      #   if: needs.set-condition.outputs.run_tee_test == 'true'
-      #   timeout-minutes: 40
-      #   run: |
-      #     cd tee-worker/docker
-      #     docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
+      - name: Integration Test ${{ matrix.test_name }}
+        if: needs.set-condition.outputs.run_tee_test == 'true'
+        timeout-minutes: 40
+        run: |
+          cd tee-worker/docker
+          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
 
-      # - name: Stop docker containers
-      #   if: needs.set-condition.outputs.run_tee_test == 'true'
-      #   run: |
-      #     cd tee-worker/docker
-      #     docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
+      - name: Stop docker containers
+        if: needs.set-condition.outputs.run_tee_test == 'true'
+        run: |
+          cd tee-worker/docker
+          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
 
       - name: Collect Docker Logs
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,13 +167,13 @@ jobs:
         run: |
           cargo fmt --all -- --check
 
-      - name: Tee-worker install npm deps
-        working-directory: ./tee-worker/ts-tests
-        run: corepack yarn install
+      # - name: Tee-worker install npm deps
+      #   working-directory: ./tee-worker/ts-tests
+      #   run: corepack yarn install
 
-      - name: Tee-worker check ts code format
-        working-directory: ./tee-worker/ts-tests
-        run: corepack yarn check-format
+      # - name: Tee-worker check ts code format
+      #   working-directory: ./tee-worker/ts-tests
+      #   run: corepack yarn check-format
 
       - name: Fail early
         if: failure()
@@ -457,11 +457,11 @@ jobs:
         run: |
           docker load -i litentry-parachain-dev.tar
 
-      - name: Run ts tests for ${{ matrix.chain }}
-        if: needs.set-condition.outputs.run_parachain_test == 'true'
-        timeout-minutes: 20
-        run: |
-          make test-ts-docker-${{ matrix.chain }}
+      # - name: Run ts tests for ${{ matrix.chain }}
+      #   if: needs.set-condition.outputs.run_parachain_test == 'true'
+      #   timeout-minutes: 20
+      #   run: |
+      #     make test-ts-docker-${{ matrix.chain }}
 
       - name: Collect docker logs if test fails
         continue-on-error: true
@@ -621,23 +621,23 @@ jobs:
           ls -l tee-worker/docker/litentry/
           shasum tee-worker/docker/litentry/*.json
 
-      - name: Build litentry parachain docker images
-        run: |
-          cd tee-worker/docker
-          docker compose -f litentry-parachain.build.yml build
+      # - name: Build litentry parachain docker images
+      #   run: |
+      #     cd tee-worker/docker
+      #     docker compose -f litentry-parachain.build.yml build
 
-      - name: Integration Test ${{ matrix.test_name }}
-        if: needs.set-condition.outputs.run_tee_test == 'true'
-        timeout-minutes: 40
-        run: |
-          cd tee-worker/docker
-          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
+      # - name: Integration Test ${{ matrix.test_name }}
+      #   if: needs.set-condition.outputs.run_tee_test == 'true'
+      #   timeout-minutes: 40
+      #   run: |
+      #     cd tee-worker/docker
+      #     docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
 
-      - name: Stop docker containers
-        if: needs.set-condition.outputs.run_tee_test == 'true'
-        run: |
-          cd tee-worker/docker
-          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
+      # - name: Stop docker containers
+      #   if: needs.set-condition.outputs.run_tee_test == 'true'
+      #   run: |
+      #     cd tee-worker/docker
+      #     docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
 
       - name: Collect Docker Logs
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,16 +156,16 @@ jobs:
           make fmtcheck
           make taplocheck
 
-      - name: Tee-worker fmt check
-        working-directory: ./tee-worker
-        run: |
-          cargo fmt --all -- --check
-          taplo fmt --check
+      # - name: Tee-worker fmt check
+      #   working-directory: ./tee-worker
+      #   run: |
+      #     cargo fmt --all -- --check
+      #     taplo fmt --check
 
-      - name: Enclave-runtime fmt check
-        working-directory: ./tee-worker/enclave-runtime
-        run: |
-          cargo fmt --all -- --check
+      # - name: Enclave-runtime fmt check
+      #   working-directory: ./tee-worker/enclave-runtime
+      #   run: |
+      #     cargo fmt --all -- --check
 
       # - name: Tee-worker install npm deps
       #   working-directory: ./tee-worker/ts-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,6 +620,10 @@ jobs:
           ls -l docker/generated-rococo/
           ls -l tee-worker/docker/litentry/
           shasum tee-worker/docker/litentry/*.json
+          if [ $(stat -c %s docker/generated-rococo/rococo-local.json) -ne 5040588 ]; then
+            echo "unexpected rococo-local.json size"
+            exit 1
+          fi
 
       # - name: Build litentry parachain docker images
       #   run: |

--- a/docker/package.json
+++ b/docker/package.json
@@ -8,6 +8,6 @@
     "start": "node_modules/.bin/parachain-launch"
   },
   "dependencies": {
-    "@open-web3/parachain-launch": "https://github.com/Kailai-Wang/parachain-launch#use-stdbuf"
+    "@open-web3/parachain-launch": "https://github.com/Kailai-Wang/parachain-launch#use-raw-binary"
   }
 }

--- a/docker/package.json
+++ b/docker/package.json
@@ -8,6 +8,6 @@
     "start": "node_modules/.bin/parachain-launch"
   },
   "dependencies": {
-    "@open-web3/parachain-launch": "https://github.com/Kailai-Wang/parachain-launch#tmp"
+    "@open-web3/parachain-launch": "https://github.com/Kailai-Wang/parachain-launch#use-stdbuf"
   }
 }

--- a/docker/package.json
+++ b/docker/package.json
@@ -4,9 +4,10 @@
   "main": "",
   "license": "GPL-3.0",
   "scripts": {
-    "start": "node_modules/@open-web3/parachain-launch/bin/parachain-launch"
+    "build": "cd node_modules/@open-web3/parachain-launch && yarn && yarn build",
+    "start": "node_modules/.bin/parachain-launch"
   },
   "dependencies": {
-    "@open-web3/parachain-launch": "^1.4.2"
+    "@open-web3/parachain-launch": "https://github.com/Kailai-Wang/parachain-launch#tmp"
   }
 }

--- a/scripts/generate-docker-files.sh
+++ b/scripts/generate-docker-files.sh
@@ -22,6 +22,8 @@ print_divider
 
 echo "installing parachain-launch ..."
 corepack yarn install
+corepack yarn upgrade
+corepack yarn build
 print_divider
 
 # pull the polkadot image to make sure we are using the latest

--- a/tee-worker/scripts/litentry/generate_parachain_artefacts.sh
+++ b/tee-worker/scripts/litentry/generate_parachain_artefacts.sh
@@ -7,6 +7,12 @@ DESTDIR="$ROOTDIR/tee-worker/docker/litentry"
 # generate files
 cd "$ROOTDIR"
 make generate-docker-compose-rococo
+
+if [ $(stat -c %s docker/generated-rococo/rococo-local.json) -ne 5040588 ]; then
+    echo "unexpected rococo-local.json size"
+    exit 1
+fi
+
 # copy files over to `DESTDIR`
 mkdir -p "$DESTDIR"
 cp docker/generated-rococo/* "$DESTDIR/"

--- a/tee-worker/scripts/litentry/generate_parachain_artefacts.sh
+++ b/tee-worker/scripts/litentry/generate_parachain_artefacts.sh
@@ -8,11 +8,6 @@ DESTDIR="$ROOTDIR/tee-worker/docker/litentry"
 cd "$ROOTDIR"
 make generate-docker-compose-rococo
 
-if [ $(stat -c %s docker/generated-rococo/rococo-local.json) -ne 5040588 ]; then
-    echo "unexpected rococo-local.json size"
-    exit 1
-fi
-
 # copy files over to `DESTDIR`
 mkdir -p "$DESTDIR"
 cp docker/generated-rococo/* "$DESTDIR/"


### PR DESCRIPTION
### Context

The previously submitted upstream PRs(https://github.com/open-web3-stack/parachain-launch/commit/45693e2cc05b36b79ab2e96052c41bcd471c49db, https://github.com/open-web3-stack/parachain-launch/commit/eafed3cfbaf305e2b93131fd40051ee9bf7e7366) didn't solve the problem completely.


We still see truncated chain specs like:

https://github.com/litentry/litentry-parachain/actions/runs/6064157036
https://github.com/litentry/litentry-parachain/actions/runs/6063920972

I tried `stdbuf` too but it didn't work.

It's highly possible that `docker run` is doing some buffered io: https://stackoverflow.com/a/39497651/921992

As a workaround, this PR uses a [self-forked](https://github.com/open-web3-stack/parachain-launch/compare/master...Kailai-Wang:parachain-launch:use-raw-binary) `parachain-branch` where the raw binary is used instead of `docker run`. The downside is this parachain-launch version will **only work under Linux**.

For local env other than Linux, please use binary mode to launch the parachain network.

