### PR TITLE
change level of hash creation log

### DIFF
--- a/tee-worker/core-primitives/top-pool-author/src/api.rs
+++ b/tee-worker/core-primitives/top-pool-author/src/api.rs
@@ -130,7 +130,7 @@ where
 	}
 
 	fn hash_and_length(&self, ex: &StfTrustedOperation) -> (ExtrinsicHash<Self>, usize) {
-		debug!("[Pool] creating hash of {:?}", ex);
+		trace!("[Pool] creating hash of {:?}", ex);
 		ex.using_encoded(|x| (<<Block::Header as HeaderT>::Hashing as HashT>::hash(x), x.len()))
 	}
 


### PR DESCRIPTION
Changes log level of hash creation entry.

With `debug` log level trusted operations were logged multiple times after submission
```
^[[0m^[[38;5;8m[^[[0m2023-09-04T13:13:29Z ^[[0m^[[34mDEBUG^[[0m itp_top_pool_author::api^[[0m^[[38;5;8m]^[[0m [Pool] creating hash of direct_call(TrustedCallSigned { call: link_identity(Substrate(Address32([144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156, 168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34])), Substrate(Address32([144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156, 168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34])), Substrate(Address32([142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72])), Web3(Substrate(Web3CommonValidationData { message: BoundedVec([104, 230, 232, 67, 25, 45, 49, 153, 89, 180, 106, 37, 161, 30, 135, 94, 190, 247, 208, 68, 77, 81, 26, 88, 65, 253, 101, 253, 57, 227, 72, 117], 64), signature: Sr25519() })), [Litentry, Polkadot], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], 0x4629a2ece196d5f6d98b81d5bc0bd6260558a437ad47a3591d7fcaccb04c464d), nonce: 0, signature: Sr25519() })
^[[0m^[[38;5;8m[^[[0m2023-09-04T13:13:29Z ^[[0m^[[34mDEBUG^[[0m itp_top_pool_author::author^[[0m^[[38;5;8m]^[[0m Submitting trusted call to TOP pool: link_identity(Substrate(Address32([144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156, 168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34])), Substrate(Address32([144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156, 168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34])), Substrate(Address32([142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72])), Web3(Substrate(Web3CommonValidationData { message: BoundedVec([104, 230, 232, 67, 25, 45, 49, 153, 89, 180, 106, 37, 161, 30, 135, 94, 190, 247, 208, 68, 77, 81, 26, 88, 65, 253, 101, 253, 57, 227, 72, 117], 64), signature: Sr25519() })), [Litentry, Polkadot], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], 0x4629a2ece196d5f6d98b81d5bc0bd6260558a437ad47a3591d7fcaccb04c464d), TOP hash: 0xb111fcfcb7db31057b8addc78b410ce93324b5785aa05505cc5a9393c5296d7d
^[[0m^[[38;5;8m[^[[0m2023-09-04T13:13:29Z ^[[0m^[[34mDEBUG^[[0m itp_top_pool_author::api^[[0m^[[38;5;8m]^[[0m [Pool] creating hash of direct_call(TrustedCallSigned { call: link_identity(Substrate(Address32([144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156, 168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34])), Substrate(Address32([144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156, 168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34])), Substrate(Address32([142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72])), Web3(Substrate(Web3CommonValidationData { message: BoundedVec([104, 230, 232, 67, 25, 45, 49, 153, 89, 180, 106, 37, 161, 30, 135, 94, 190, 247, 208, 68, 77, 81, 26, 88, 65, 253, 101, 253, 57, 227, 72, 117], 64), signature: Sr25519() })), [Litentry, Polkadot], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], 0x4629a2ece196d5f6d98b81d5bc0bd6260558a437ad47a3591d7fcaccb04c464d), nonce: 0, signature: Sr25519() })
```
After the change this should be reduced to:

```
^[[0m^[[38;5;8m[^[[0m2023-09-04T13:13:29Z ^[[0m^[[34mDEBUG^[[0m itp_top_pool_author::author^[[0m^[[38;5;8m]^[[0m Submitting trusted call to TOP pool: link_identity(Substrate(Address32([144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156, 168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34])), Substrate(Address32([144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156, 168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34])), Substrate(Address32([142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72])), Web3(Substrate(Web3CommonValidationData { message: BoundedVec([104, 230, 232, 67, 25, 45, 49, 153, 89, 180, 106, 37, 161, 30, 135, 94, 190, 247, 208, 68, 77, 81, 26, 88, 65, 253, 101, 253, 57, 227, 72, 117], 64), signature: Sr25519() })), [Litentry, Polkadot], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], 0x4629a2ece196d5f6d98b81d5bc0bd6260558a437ad47a3591d7fcaccb04c464d), TOP hash: 0xb111fcfcb7db31057b8addc78b410ce93324b5785aa05505cc5a9393c5296d7d
```



related #2040 