### PR TITLE
Make tee-prod build less resource intensive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,8 @@ jobs:
 
       - name: Build docker image
         if: |
-          needs.set-condition.outputs.rebuild_parachain == 'true'
+          needs.set-condition.outputs.rebuild_parachain == 'true' &&
+          needs.set-condition.outputs.push_docker == 'true'
         run: |
           ./scripts/build-docker.sh production tee-prod
           echo "============================="
@@ -456,11 +457,11 @@ jobs:
         run: |
           docker load -i litentry-parachain-dev.tar
 
-      # - name: Run ts tests for ${{ matrix.chain }}
-      #   if: needs.set-condition.outputs.run_parachain_test == 'true'
-      #   timeout-minutes: 30
-      #   run: |
-      #     make test-ts-docker-${{ matrix.chain }}
+      - name: Run ts tests for ${{ matrix.chain }}
+        if: needs.set-condition.outputs.run_parachain_test == 'true'
+        timeout-minutes: 30
+        run: |
+          make test-ts-docker-${{ matrix.chain }}
 
       - name: Collect docker logs if test fails
         continue-on-error: true
@@ -626,18 +627,18 @@ jobs:
           cd tee-worker/docker
           docker compose -f litentry-parachain.build.yml build
 
-      # - name: Integration Test ${{ matrix.test_name }}
-      #   if: needs.set-condition.outputs.run_tee_test == 'true'
-      #   timeout-minutes: 40
-      #   run: |
-      #     cd tee-worker/docker
-      #     docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
+      - name: Integration Test ${{ matrix.test_name }}
+        if: needs.set-condition.outputs.run_tee_test == 'true'
+        timeout-minutes: 40
+        run: |
+          cd tee-worker/docker
+          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
 
-      # - name: Stop docker containers
-      #   if: needs.set-condition.outputs.run_tee_test == 'true'
-      #   run: |
-      #     cd tee-worker/docker
-      #     docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
+      - name: Stop docker containers
+        if: needs.set-condition.outputs.run_tee_test == 'true'
+        run: |
+          cd tee-worker/docker
+          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
 
       - name: Collect Docker Logs
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,8 +326,7 @@ jobs:
 
       - name: Build docker image
         if: |
-          needs.set-condition.outputs.rebuild_parachain == 'true' &&
-          needs.set-condition.outputs.push_docker == 'true'
+          needs.set-condition.outputs.rebuild_parachain == 'true'
         run: |
           ./scripts/build-docker.sh production tee-prod
           echo "============================="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,11 +456,11 @@ jobs:
         run: |
           docker load -i litentry-parachain-dev.tar
 
-      - name: Run ts tests for ${{ matrix.chain }}
-        if: needs.set-condition.outputs.run_parachain_test == 'true'
-        timeout-minutes: 30
-        run: |
-          make test-ts-docker-${{ matrix.chain }}
+      # - name: Run ts tests for ${{ matrix.chain }}
+      #   if: needs.set-condition.outputs.run_parachain_test == 'true'
+      #   timeout-minutes: 30
+      #   run: |
+      #     make test-ts-docker-${{ matrix.chain }}
 
       - name: Collect docker logs if test fails
         continue-on-error: true
@@ -626,18 +626,18 @@ jobs:
           cd tee-worker/docker
           docker compose -f litentry-parachain.build.yml build
 
-      - name: Integration Test ${{ matrix.test_name }}
-        if: needs.set-condition.outputs.run_tee_test == 'true'
-        timeout-minutes: 40
-        run: |
-          cd tee-worker/docker
-          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
+      # - name: Integration Test ${{ matrix.test_name }}
+      #   if: needs.set-condition.outputs.run_tee_test == 'true'
+      #   timeout-minutes: 40
+      #   run: |
+      #     cd tee-worker/docker
+      #     docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
 
-      - name: Stop docker containers
-        if: needs.set-condition.outputs.run_tee_test == 'true'
-        run: |
-          cd tee-worker/docker
-          docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
+      # - name: Stop docker containers
+      #   if: needs.set-condition.outputs.run_tee_test == 'true'
+      #   run: |
+      #     cd tee-worker/docker
+      #     docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
 
       - name: Collect Docker Logs
         continue-on-error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,6 @@ inherits = "release"
 [profile.production]
 codegen-units = 1
 inherits = "release"
-lto = true
+lto = "thin"
 strip = "symbols"
+incremental = false


### PR DESCRIPTION
### Context

We have problems building the `tee-prod` docker image of parachain:
https://github.com/litentry/litentry-parachain/actions/runs/6173744153/job/16767091897

The error log is:
```
lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```

It's most likely CPU/RAM starvation.

This PR tries to use [thin LTO](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) to reduce the resource usage.
It looks fine in the manual test: https://github.com/litentry/litentry-parachain/actions/runs/6185784593


