### PR TITLE
Use node18 base image as runner

### DIFF
--- a/tee-worker/build.Dockerfile
+++ b/tee-worker/build.Dockerfile
@@ -95,15 +95,10 @@ RUN --mount=type=cache,id=cargo-registry-cache,target=/opt/rust/registry/cache,s
 
 ### Base Runner Stage
 ##################################################
-FROM ubuntu:22.04 AS runner
+FROM node:18-bookworm-slim AS runner
 
-RUN apt update && apt install -y libssl-dev iproute2 curl
-
-## ts-tests
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash
-RUN apt-get install -y nodejs jq
-RUN corepack enable
-RUN corepack prepare yarn@3.6.1 --activate
+RUN apt update && apt install -y libssl-dev iproute2 jq
+RUN corepack enable && corepack prepare yarn@3.6.1 --activate
 
 ### Deployed CLI client
 ##################################################

--- a/tee-worker/build.Dockerfile
+++ b/tee-worker/build.Dockerfile
@@ -97,7 +97,7 @@ RUN --mount=type=cache,id=cargo-registry-cache,target=/opt/rust/registry/cache,s
 ##################################################
 FROM node:18-bookworm-slim AS runner
 
-RUN apt update && apt install -y libssl-dev iproute2 jq
+RUN apt update && apt install -y libssl-dev iproute2 jq curl
 RUN corepack enable && corepack prepare yarn@3.6.1 --activate
 
 ### Deployed CLI client


### PR DESCRIPTION
### Context

`node:18-bookworm-slim` is chosen for a compact runner image.

solves #2148 

