### PR TITLE
chore: inheriting proxy env vars from host when building with docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 # global args that are used across multiple stages
 ARG PROFILE
-ARG HTTP_PROXY
 
 # ==========================
 # stage 1: build
@@ -8,10 +7,6 @@ ARG HTTP_PROXY
 # our host is based on bullseye/sid (ubuntu 20)
 # ==========================
 FROM rust:bullseye as builder
-ENV HTTP_PROXY=$HTTP_PROXY
-ENV HTTPS_PROXY=$HTTP_PROXY
-ENV http_proxy=$HTTP_PROXY
-ENV https_proxy=$HTTP_PROXY
 
 WORKDIR /litentry
 COPY . /litentry
@@ -27,10 +22,6 @@ RUN cargo build --locked --profile $PROFILE $BUILD_ARGS
 # stage 2: packaging
 # ==========================
 FROM ubuntu:20.04
-ENV HTTP_PROXY=$HTTP_PROXY
-ENV HTTPS_PROXY=$HTTP_PROXY
-ENV http_proxy=$HTTP_PROXY
-ENV https_proxy=$HTTP_PROXY
 LABEL maintainer="Trust Computing GmbH <info@litentry.com>"
 
 ARG PROFILE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 # global args that are used across multiple stages
 ARG PROFILE
+ARG HTTP_PROXY
 
 # ==========================
 # stage 1: build
@@ -7,6 +8,10 @@ ARG PROFILE
 # our host is based on bullseye/sid (ubuntu 20)
 # ==========================
 FROM rust:bullseye as builder
+ENV HTTP_PROXY=$HTTP_PROXY
+ENV HTTPS_PROXY=$HTTP_PROXY
+ENV http_proxy=$HTTP_PROXY
+ENV https_proxy=$HTTP_PROXY
 
 WORKDIR /litentry
 COPY . /litentry
@@ -22,6 +27,10 @@ RUN cargo build --locked --profile $PROFILE $BUILD_ARGS
 # stage 2: packaging
 # ==========================
 FROM ubuntu:20.04
+ENV HTTP_PROXY=$HTTP_PROXY
+ENV HTTPS_PROXY=$HTTP_PROXY
+ENV http_proxy=$HTTP_PROXY
+ENV https_proxy=$HTTP_PROXY
 LABEL maintainer="Trust Computing GmbH <info@litentry.com>"
 
 ARG PROFILE
@@ -35,9 +44,9 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /litentry litentry && \
 	mkdir -p /data /litentry/.local/share && \
 	chown -R litentry:litentry /data && \
 	ln -s /data /litentry/.local/share/litentry-collator && \
-# unclutter and minimize the attack surface
+	# unclutter and minimize the attack surface
 	rm -rf /usr/bin /usr/sbin && \
-# check if executable works in this container
+	# check if executable works in this container
 	/usr/local/bin/litentry-collator --version
 
 USER litentry

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -44,6 +44,7 @@ echo "ARGS: $ARGS"
 
 GITUSER=litentry
 GITREPO=litentry-parachain
+PROXY="${HTTP_PROXY//localhost/host.docker.internal}"
 
 # Build the image
 echo "------------------------------------------------------------"
@@ -51,7 +52,10 @@ echo "Building ${GITUSER}/${GITREPO}:${TAG} docker image ..."
 docker build ${NOCACHE_FLAG} --pull -f ./docker/Dockerfile \
     --build-arg PROFILE="$PROFILE" \
     --build-arg BUILD_ARGS="$ARGS" \
-    --build-arg HTTP_PROXY="${HTTP_PROXY//localhost/host.docker.internal}" \
+    --build-arg HTTP_PROXY="$PROXY" \
+    --build-arg HTTPS_PROXY="$PROXY" \
+    --build-arg http_proxy="$PROXY" \
+    --build-arg https_proxy="$PROXY" \
     --add-host=host.docker.internal:host-gateway \
     --network host \
     -t ${GITUSER}/${GITREPO}:${TAG} .

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -51,6 +51,9 @@ echo "Building ${GITUSER}/${GITREPO}:${TAG} docker image ..."
 docker build ${NOCACHE_FLAG} --pull -f ./docker/Dockerfile \
     --build-arg PROFILE="$PROFILE" \
     --build-arg BUILD_ARGS="$ARGS" \
+    --build-arg HTTP_PROXY="${HTTP_PROXY//localhost/host.docker.internal}" \
+    --add-host=host.docker.internal:host-gateway \
+    --network host \
     -t ${GITUSER}/${GITREPO}:${TAG} .
 
 # Tag it with latest if no tag parameter was provided


### PR DESCRIPTION
Modified the build script to pass `HTTP_PROXY` environment variables from the host machine to the build container, so that developers under GFW would use their custom proxy to build the project.