### PR TITLE
Retrieve mrenclave automatically in cli

### DIFF
--- a/tee-worker/cli/src/benchmark/mod.rs
+++ b/tee-worker/cli/src/benchmark/mod.rs
@@ -118,10 +118,10 @@ impl BenchmarkCommand {
 			self.random_wait_before_transaction_min_ms,
 			self.random_wait_before_transaction_max_ms,
 		);
-		let store = LocalKeystore::open(get_keystore_path(trusted_args), None).unwrap();
-		let funding_account_keys = get_pair_from_str(trusted_args, &self.funding_account);
+		let store = LocalKeystore::open(get_keystore_path(trusted_args, cli), None).unwrap();
+		let funding_account_keys = get_pair_from_str(trusted_args, &self.funding_account, cli);
 
-		let (mrenclave, shard) = get_identifiers(trusted_args);
+		let (mrenclave, shard) = get_identifiers(trusted_args, cli);
 
 		// Get shielding pubkey.
 		let worker_api_direct = get_worker_api_direct(cli);
@@ -142,7 +142,7 @@ impl BenchmarkCommand {
 
 			// Create new account to use.
 			let a: sr25519::AppPair = store.generate().unwrap();
-			let account = get_pair_from_str(trusted_args, a.public().to_string().as_str());
+			let account = get_pair_from_str(trusted_args, a.public().to_string().as_str(), cli);
 			let initial_balance = 10000000;
 
 			let funding_identity = funding_account_keys.public().into();
@@ -194,7 +194,7 @@ impl BenchmarkCommand {
 					// Create new account.
 					let account_keys: sr25519::AppPair = store.generate().unwrap();
 					let new_account =
-						get_pair_from_str(trusted_args, account_keys.public().to_string().as_str());
+						get_pair_from_str(trusted_args, account_keys.public().to_string().as_str(), cli);
 
 
 					println!("  Transfer amount: {}", EXISTENTIAL_DEPOSIT);

--- a/tee-worker/cli/src/command_utils.rs
+++ b/tee-worker/cli/src/command_utils.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::Cli;
-use base58::FromBase58;
+use base58::{FromBase58, ToBase58};
 use itc_rpc_client::direct_client::{DirectApi, DirectClient as DirectWorkerApi};
 use itp_node_api::api_client::{ParentchainApi, WsRpcClient};
 use litentry_primitives::{ParentchainAccountId as AccountId, ParentchainSignature as Signature};
@@ -84,4 +84,8 @@ pub(crate) fn mrenclave_from_base58(src: &str) -> [u8; 32] {
 	let mut mrenclave = [0u8; 32];
 	mrenclave.copy_from_slice(&src.from_base58().expect("mrenclave has to be base58 encoded"));
 	mrenclave
+}
+
+pub(crate) fn mrenclave_to_base58(src: &[u8]) -> String {
+	src.to_base58()
 }

--- a/tee-worker/cli/src/evm/commands/evm_call.rs
+++ b/tee-worker/cli/src/evm/commands/evm_call.rs
@@ -61,7 +61,7 @@ impl EvmCallCommands {
 
 		let function_hash = array_bytes::hex2bytes(&self.function).unwrap();
 
-		let (mrenclave, shard) = get_identifiers(trusted_args);
+		let (mrenclave, shard) = get_identifiers(trusted_args, cli);
 		let nonce = get_layer_two_nonce!(sender, cli, trusted_args);
 		let evm_nonce = get_layer_two_evm_nonce!(sender, cli, trusted_args);
 

--- a/tee-worker/cli/src/evm/commands/evm_call.rs
+++ b/tee-worker/cli/src/evm/commands/evm_call.rs
@@ -44,7 +44,7 @@ pub struct EvmCallCommands {
 
 impl EvmCallCommands {
 	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
-		let sender = get_pair_from_str(trusted_args, &self.from);
+		let sender = get_pair_from_str(trusted_args, &self.from, cli);
 		let sender_acc: AccountId = sender.public().into();
 
 		info!("senders ss58 is {}", sender.public().to_ss58check());

--- a/tee-worker/cli/src/evm/commands/evm_create.rs
+++ b/tee-worker/cli/src/evm/commands/evm_create.rs
@@ -45,7 +45,7 @@ pub struct EvmCreateCommands {
 
 impl EvmCreateCommands {
 	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
-		let from = get_pair_from_str(trusted_args, &self.from);
+		let from = get_pair_from_str(trusted_args, &self.from, cli);
 		let from_acc: AccountId = from.public().into();
 		println!("from ss58 is {}", from.public().to_ss58check());
 

--- a/tee-worker/cli/src/evm/commands/evm_create.rs
+++ b/tee-worker/cli/src/evm/commands/evm_create.rs
@@ -54,7 +54,7 @@ impl EvmCreateCommands {
 			.copy_from_slice((<[u8; 32]>::from(from_acc.clone())).get(0..20).unwrap());
 		let sender_evm_acc: H160 = sender_evm_acc_slice.into();
 
-		let (mrenclave, shard) = get_identifiers(trusted_args);
+		let (mrenclave, shard) = get_identifiers(trusted_args, cli);
 
 		let sender_evm_substrate_addr =
 			HashedAddressMapping::<BlakeTwo256>::into_account_id(sender_evm_acc);

--- a/tee-worker/cli/src/evm/commands/evm_read.rs
+++ b/tee-worker/cli/src/evm/commands/evm_read.rs
@@ -37,7 +37,7 @@ pub struct EvmReadCommands {
 
 impl EvmReadCommands {
 	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
-		let sender = get_pair_from_str(trusted_args, &self.from);
+		let sender = get_pair_from_str(trusted_args, &self.from, cli);
 		let sender_acc: AccountId = sender.public().into();
 
 		info!("senders ss58 is {}", sender.public().to_ss58check());

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/id_graph.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/id_graph.rs
@@ -40,7 +40,7 @@ pub struct IDGraphCommand {
 
 impl IDGraphCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
-		let alice = get_pair_from_str(trusted_cli, "//Alice");
+		let alice = get_pair_from_str(trusted_cli, "//Alice", cli);
 		let id: Identity = Identity::from_did(self.did.as_str()).unwrap();
 
 		let top: TrustedOperation =

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/id_graph_stats.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/id_graph_stats.rs
@@ -34,7 +34,7 @@ pub struct IDGraphStats {
 
 impl IDGraphStats {
 	pub(crate) fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
-		let who = get_pair_from_str(trusted_cli, &self.account);
+		let who = get_pair_from_str(trusted_cli, &self.account, cli);
 		let top: TrustedOperation = TrustedGetter::id_graph_stats(who.public().into())
 			.sign(&KeyPair::Sr25519(Box::new(who)))
 			.into();

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/link_identity.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/link_identity.rs
@@ -58,13 +58,13 @@ pub struct LinkIdentityCommand {
 
 impl LinkIdentityCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
-		let alice = get_pair_from_str(trusted_cli, "//Alice");
+		let alice = get_pair_from_str(trusted_cli, "//Alice", cli);
 		let src_id: Identity = Identity::from_did(self.src_did.as_str()).unwrap();
 		let dst_id: Identity = Identity::from_did(self.dst_did.as_str()).unwrap();
 		let networks: Vec<Web3Network> =
 			self.networks.iter().map(|n| n.as_str().try_into().unwrap()).collect();
 
-		let (mrenclave, shard) = get_identifiers(trusted_cli);
+		let (mrenclave, shard) = get_identifiers(trusted_cli, cli);
 		let nonce = get_layer_two_nonce!(alice, cli, trusted_cli);
 
 		let top: TrustedOperation = TrustedCall::link_identity_callback(

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
@@ -219,10 +219,10 @@ pub struct TokenArg {
 
 impl RequestVcCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
-		let alice = get_pair_from_str(trusted_cli, "//Alice");
+		let alice = get_pair_from_str(trusted_cli, "//Alice", cli);
 		let id: Identity = Identity::from_did(self.did.as_str()).unwrap();
 
-		let (mrenclave, shard) = get_identifiers(trusted_cli);
+		let (mrenclave, shard) = get_identifiers(trusted_cli, cli);
 		let nonce = get_layer_two_nonce!(alice, cli, trusted_cli);
 
 		let assertion = match &self.command {

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/send_erroneous_parentchain_call.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/send_erroneous_parentchain_call.rs
@@ -32,9 +32,9 @@ pub struct SendErroneousParentchainCallCommand {}
 
 impl SendErroneousParentchainCallCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
-		let root = get_pair_from_str(trusted_cli, "//Alice");
+		let root = get_pair_from_str(trusted_cli, "//Alice", cli);
 
-		let (mrenclave, shard) = get_identifiers(trusted_cli);
+		let (mrenclave, shard) = get_identifiers(trusted_cli, cli);
 		let nonce = get_layer_two_nonce!(root, cli, trusted_cli);
 
 		let top: TrustedOperation =

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/set_user_shielding_key.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/set_user_shielding_key.rs
@@ -38,10 +38,10 @@ pub struct SetUserShieldingKeyCommand {
 
 impl SetUserShieldingKeyCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
-		let alice = get_pair_from_str(trusted_cli, "//Alice");
+		let alice = get_pair_from_str(trusted_cli, "//Alice", cli);
 		let id: Identity = Identity::from_did(self.did.as_str()).unwrap();
 
-		let (mrenclave, shard) = get_identifiers(trusted_cli);
+		let (mrenclave, shard) = get_identifiers(trusted_cli, cli);
 		let nonce = get_layer_two_nonce!(alice, cli, trusted_cli);
 
 		let mut key = UserShieldingKeyType::default();

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/user_shielding_key.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/user_shielding_key.rs
@@ -32,7 +32,7 @@ pub struct UserShieldingKeyCommand {
 
 impl UserShieldingKeyCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
-		let alice = get_pair_from_str(trusted_cli, "//Alice");
+		let alice = get_pair_from_str(trusted_cli, "//Alice", cli);
 		let id: Identity = Identity::from_did(self.did.as_str()).unwrap();
 
 		let top: TrustedOperation = TrustedGetter::user_shielding_key(id)

--- a/tee-worker/cli/src/trusted_base_cli/commands/nonce.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/nonce.rs
@@ -32,8 +32,8 @@ pub struct NonceCommand {
 
 impl NonceCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
-		let (_mrenclave, shard) = get_identifiers(trusted_cli);
-		let who = get_pair_from_str(trusted_cli, &self.account);
+		let (_mrenclave, shard) = get_identifiers(trusted_cli, cli);
+		let who = get_pair_from_str(trusted_cli, &self.account, cli);
 		let worker_api_direct = get_worker_api_direct(cli);
 		let nonce_ret = worker_api_direct.get_next_nonce(&shard, &(who.public().into()));
 		let nonce = nonce_ret.expect("get nonce error!");

--- a/tee-worker/cli/src/trusted_base_cli/commands/set_balance.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/set_balance.rs
@@ -41,13 +41,13 @@ pub struct SetBalanceCommand {
 
 impl SetBalanceCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
-		let who = get_pair_from_str(trusted_args, &self.account);
-		let signer = get_pair_from_str(trusted_args, "//Alice");
+		let who = get_pair_from_str(trusted_args, &self.account, cli);
+		let signer = get_pair_from_str(trusted_args, "//Alice", cli);
 		info!("account ss58 is {}", who.public().to_ss58check());
 
 		println!("send trusted call set-balance({}, {})", who.public(), self.amount);
 
-		let (mrenclave, shard) = get_identifiers(trusted_args);
+		let (mrenclave, shard) = get_identifiers(trusted_args, cli);
 		let nonce = get_layer_two_nonce!(signer, cli, trusted_args);
 		let top: TrustedOperation = TrustedCall::balance_set_balance(
 			signer.public().into(),

--- a/tee-worker/cli/src/trusted_base_cli/commands/transfer.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/transfer.rs
@@ -44,12 +44,12 @@ pub struct TransferCommand {
 
 impl TransferCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
-		let from = get_pair_from_str(trusted_args, &self.from);
+		let from = get_pair_from_str(trusted_args, &self.from, cli);
 		let to = get_accountid_from_str(&self.to);
 		info!("from ss58 is {}", from.public().to_ss58check());
 		info!("to ss58 is {}", to.to_ss58check());
 
-		let (mrenclave, shard) = get_identifiers(trusted_args);
+		let (mrenclave, shard) = get_identifiers(trusted_args, cli);
 		let nonce = get_layer_two_nonce!(from, cli, trusted_args);
 		println!(
 			"send trusted call transfer from {} to {}: {}, nonce: {}",

--- a/tee-worker/cli/src/trusted_base_cli/commands/unshield_funds.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/unshield_funds.rs
@@ -44,7 +44,7 @@ pub struct UnshieldFundsCommand {
 
 impl UnshieldFundsCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
-		let from = get_pair_from_str(trusted_args, &self.from);
+		let from = get_pair_from_str(trusted_args, &self.from, cli);
 		let to = get_accountid_from_str(&self.to);
 		println!("from ss58 is {}", from.public().to_ss58check());
 		println!("to   ss58 is {}", to.to_ss58check());
@@ -56,7 +56,7 @@ impl UnshieldFundsCommand {
 			self.amount
 		);
 
-		let (mrenclave, shard) = get_identifiers(trusted_args);
+		let (mrenclave, shard) = get_identifiers(trusted_args, cli);
 		let nonce = get_layer_two_nonce!(from, cli, trusted_args);
 		let top: TrustedOperation =
 			TrustedCall::balance_unshield(from.public().into(), to, self.amount, shard)

--- a/tee-worker/cli/src/trusted_base_cli/mod.rs
+++ b/tee-worker/cli/src/trusted_base_cli/mod.rs
@@ -88,8 +88,8 @@ pub enum TrustedBaseCommand {
 impl TrustedBaseCommand {
 	pub fn run(&self, cli: &Cli, trusted_cli: &TrustedCli) -> CliResult {
 		match self {
-			TrustedBaseCommand::NewAccount => new_account(trusted_cli),
-			TrustedBaseCommand::ListAccounts => list_accounts(trusted_cli),
+			TrustedBaseCommand::NewAccount => new_account(trusted_cli, cli),
+			TrustedBaseCommand::ListAccounts => list_accounts(trusted_cli, cli),
 			TrustedBaseCommand::Transfer(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::SetBalance(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::Balance(cmd) => cmd.run(cli, trusted_cli),
@@ -106,8 +106,8 @@ impl TrustedBaseCommand {
 	}
 }
 
-fn new_account(trusted_args: &TrustedCli) -> CliResult {
-	let store = LocalKeystore::open(get_keystore_path(trusted_args), None).unwrap();
+fn new_account(trusted_args: &TrustedCli, cli: &Cli) -> CliResult {
+	let store = LocalKeystore::open(get_keystore_path(trusted_args, cli), None).unwrap();
 	let key: sr25519::AppPair = store.generate().unwrap();
 	drop(store);
 	info!("new account {}", key.public().to_ss58check());
@@ -117,8 +117,8 @@ fn new_account(trusted_args: &TrustedCli) -> CliResult {
 	Ok(CliResultOk::PubKeysBase58 { pubkeys_sr25519: Some(vec![key_str]), pubkeys_ed25519: None })
 }
 
-fn list_accounts(trusted_args: &TrustedCli) -> CliResult {
-	let store = LocalKeystore::open(get_keystore_path(trusted_args), None).unwrap();
+fn list_accounts(trusted_args: &TrustedCli, cli: &Cli) -> CliResult {
+	let store = LocalKeystore::open(get_keystore_path(trusted_args, cli), None).unwrap();
 	info!("sr25519 keys:");
 	for pubkey in store.public_keys::<sr25519::AppPublic>().unwrap().into_iter() {
 		println!("{}", pubkey.to_ss58check());

--- a/tee-worker/cli/src/trusted_cli.rs
+++ b/tee-worker/cli/src/trusted_cli.rs
@@ -25,7 +25,7 @@ use crate::trusted_base_cli::TrustedBaseCommand;
 pub struct TrustedCli {
 	/// targeted worker MRENCLAVE
 	#[clap(short, long)]
-	pub(crate) mrenclave: String,
+	pub(crate) mrenclave: Option<String>,
 
 	/// shard identifier
 	#[clap(short, long)]

--- a/tee-worker/cli/src/trusted_command_utils.rs
+++ b/tee-worker/cli/src/trusted_command_utils.rs
@@ -70,7 +70,7 @@ const TRUSTED_KEYSTORE_PATH: &str = "my_trusted_keystore";
 
 pub(crate) fn get_balance(cli: &Cli, trusted_args: &TrustedCli, arg_who: &str) -> Option<u128> {
 	debug!("arg_who = {:?}", arg_who);
-	let who = get_pair_from_str(trusted_args, arg_who);
+	let who = get_pair_from_str(trusted_args, arg_who, cli);
 	let top: TrustedOperation = TrustedGetter::free_balance(who.public().into())
 		.sign(&KeyPair::Sr25519(Box::new(who)))
 		.into();
@@ -90,13 +90,20 @@ pub(crate) fn decode_balance(maybe_encoded_balance: Option<Vec<u8>>) -> Option<B
 	})
 }
 
-pub(crate) fn get_keystore_path(trusted_args: &TrustedCli) -> PathBuf {
-	let (_mrenclave, shard) = get_identifiers(trusted_args);
+pub(crate) fn get_keystore_path(trusted_args: &TrustedCli, cli: &Cli) -> PathBuf {
+	let (_mrenclave, shard) = get_identifiers(trusted_args, cli);
 	PathBuf::from(&format!("{}/{}", TRUSTED_KEYSTORE_PATH, shard.encode().to_base58()))
 }
 
-pub(crate) fn get_identifiers(trusted_args: &TrustedCli) -> ([u8; 32], ShardIdentifier) {
-	let mrenclave = mrenclave_from_base58(&trusted_args.mrenclave);
+pub(crate) fn get_identifiers(trusted_args: &TrustedCli, cli: &Cli) -> ([u8; 32], ShardIdentifier) {
+	let mrenclave = if let Some(mrenclave) = &trusted_args.mrenclave {
+		mrenclave_from_base58(mrenclave)
+	} else {
+		let direct_api = get_worker_api_direct(cli);
+		direct_api
+			.get_state_mrenclave()
+			.expect("Unable to retrieve MRENCLAVE from endpoint")
+	};
 	let shard = match &trusted_args.shard {
 		Some(val) =>
 			ShardIdentifier::from_slice(&val.from_base58().expect("shard has to be base58 encoded")),
@@ -119,14 +126,18 @@ pub(crate) fn get_accountid_from_str(account: &str) -> AccountId {
 
 // TODO this function is ALMOST redundant with client::main
 // get a pair either form keyring (well known keys) or from the store
-pub(crate) fn get_pair_from_str(trusted_args: &TrustedCli, account: &str) -> sr25519_core::Pair {
+pub(crate) fn get_pair_from_str(
+	trusted_args: &TrustedCli,
+	account: &str,
+	cli: &Cli,
+) -> sr25519_core::Pair {
 	info!("getting pair for {}", account);
 	match &account[..2] {
 		"//" => sr25519_core::Pair::from_string(account, None).unwrap(),
 		_ => {
 			info!("fetching from keystore at {}", &TRUSTED_KEYSTORE_PATH);
 			// open store without password protection
-			let store = LocalKeystore::open(get_keystore_path(trusted_args), None)
+			let store = LocalKeystore::open(get_keystore_path(trusted_args, cli), None)
 				.expect("store should exist");
 			info!("store opened");
 			let _pair = store

--- a/tee-worker/cli/src/trusted_command_utils.rs
+++ b/tee-worker/cli/src/trusted_command_utils.rs
@@ -159,7 +159,7 @@ pub(crate) fn get_pending_trusted_calls_for(
 	trusted_args: &TrustedCli,
 	who: &AccountId,
 ) -> Vec<TrustedOperation> {
-	let shard = read_shard(trusted_args).unwrap();
+	let shard = read_shard(trusted_args, cli).unwrap();
 	let direct_api = get_worker_api_direct(cli);
 	let rpc_method = "author_pendingTrustedCallsFor".to_owned();
 	let jsonrpc_call: String = RpcRequest::compose_jsonrpc_call(

--- a/tee-worker/cli/src/trusted_operation.rs
+++ b/tee-worker/cli/src/trusted_operation.rs
@@ -72,7 +72,7 @@ pub(crate) fn execute_getter_from_cli_args(
 	trusted_args: &TrustedCli,
 	getter: &Getter,
 ) -> TrustedOpResult {
-	let shard = read_shard(trusted_args).unwrap();
+	let shard = read_shard(trusted_args, cli).unwrap();
 	Ok(get_worker_api_direct(cli).get_state(shard, getter))
 }
 
@@ -85,7 +85,7 @@ fn send_request(
 	let encryption_key = get_shielding_key(cli).unwrap();
 	let call_encrypted = encryption_key.encrypt(&trusted_operation.encode()).unwrap();
 
-	let shard = read_shard(trusted_args).unwrap();
+	let shard = read_shard(trusted_args, cli).unwrap();
 
 	let arg_signer = &trusted_args.xt_signer;
 	let signer = get_pair_from_str(arg_signer);
@@ -161,15 +161,31 @@ fn check_if_received_event_exceeds_expected(
 	Ok(())
 }
 
-pub fn read_shard(trusted_args: &TrustedCli) -> StdResult<ShardIdentifier, codec::Error> {
+pub fn read_shard(
+	trusted_args: &TrustedCli,
+	cli: &Cli,
+) -> StdResult<ShardIdentifier, codec::Error> {
 	match &trusted_args.shard {
 		Some(s) => match s.from_base58() {
 			Ok(s) => ShardIdentifier::decode(&mut &s[..]),
 			_ => panic!("shard argument must be base58 encoded"),
 		},
-		None => match trusted_args.mrenclave.clone().unwrap().from_base58() {
-			Ok(s) => ShardIdentifier::decode(&mut &s[..]),
-			_ => panic!("mrenclave argument must be base58 encoded"),
+		None => match trusted_args.mrenclave.clone() {
+			Some(mrenclave) =>
+				if let Ok(s) = mrenclave.from_base58() {
+					ShardIdentifier::decode(&mut &s[..])
+				} else {
+					panic!("Mrenclave argument must be base58 encoded")
+				},
+			None => {
+				// Fetch mrenclave from worker
+				let direct_api = get_worker_api_direct(cli);
+				if let Ok(s) = direct_api.get_state_mrenclave() {
+					ShardIdentifier::decode(&mut &s[..])
+				} else {
+					panic!("Unable to fetch MRENCLAVE from worker endpoint");
+				}
+			},
 		},
 	}
 }
@@ -181,7 +197,7 @@ fn send_direct_request(
 	operation_call: &TrustedOperation,
 ) -> TrustedOpResult {
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let shard = read_shard(trusted_args).unwrap();
+	let shard = read_shard(trusted_args, cli).unwrap();
 	let jsonrpc_call: String = get_json_request(shard, operation_call, encryption_key);
 
 	debug!("get direct api");

--- a/tee-worker/cli/src/trusted_operation.rs
+++ b/tee-worker/cli/src/trusted_operation.rs
@@ -167,7 +167,7 @@ pub fn read_shard(trusted_args: &TrustedCli) -> StdResult<ShardIdentifier, codec
 			Ok(s) => ShardIdentifier::decode(&mut &s[..]),
 			_ => panic!("shard argument must be base58 encoded"),
 		},
-		None => match trusted_args.mrenclave.from_base58() {
+		None => match trusted_args.mrenclave.clone().unwrap().from_base58() {
 			Ok(s) => ShardIdentifier::decode(&mut &s[..]),
 			_ => panic!("mrenclave argument must be base58 encoded"),
 		},


### PR DESCRIPTION
Some notes: 
1. I've first made the `Mrenclave` as an `Option<String>` in the Cli arguments 
2. In order to retrieve the `Mrenclave` from a running worker, I'm creating the `DirectApi` client and using it to retrieve the MRENCLAVE 
3. In order to initialise `DirectApi` client, We need `Cli` arguments, So I've updated most functions to include this argument 

TODO: 
- [ ] Perform E2E test for all commands with MRENCLAVE provided and without MRENCLAVE 

