### PR TITLE
Fix TMPDIR usage

### DIFF
--- a/scripts/benchmark-weight-remote.sh
+++ b/scripts/benchmark-weight-remote.sh
@@ -17,13 +17,19 @@ function usage() {
 
 [ $# -ne 3 ] && (usage; exit 1)
 
+# setup TMPDIR
+export TMPDIR=$(mktemp -d)
+cleanup() {
+  echo "removing $1 ..."
+  rm -rf "$1"
+}
+trap 'cleanup $TMPDIR' INT TERM EXIT
+
 # pull docker image
 docker pull litentry/litentry-parachain:runtime-benchmarks
 
 # clone the repo
-TMPDIR=/tmp
 cd "$TMPDIR"
-[ -d litentry-parachain ] && rm -rf litentry-parachain
 git clone https://github.com/litentry/litentry-parachain
 cd litentry-parachain
 git checkout "$2"

--- a/scripts/clean-local-binary.sh
+++ b/scripts/clean-local-binary.sh
@@ -2,9 +2,9 @@
 
 # no `set -e` here as we allow commands to fail in this script
 
-TMPDIR=${TMPDIR:-"/tmp/parachain_dev*"}
+LITENTRY_PARACHAIN_DIR=${LITENTRY_PARACHAIN_DIR:?}
 
-# for f in $(ls $TMPDIR/*.pid 2>/dev/null); do
+# for f in $(ls $LITENTRY_PARACHAIN_DIR/*.pid 2>/dev/null); do
 #   echo "Killing $f ..."
 #   kill -9 $(cat "$f")
 # done
@@ -14,6 +14,6 @@ TMPDIR=${TMPDIR:-"/tmp/parachain_dev*"}
 killall polkadot
 killall litentry-collator
 
-rm -rf "$TMPDIR"
+rm -rf "$LITENTRY_PARACHAIN_DIR"
 
 echo "cleaned up."

--- a/scripts/clean-local-docker.sh
+++ b/scripts/clean-local-docker.sh
@@ -8,7 +8,7 @@ function usage() {
 
 [ $# -ne 1 ] && (usage; exit 1)
 
-TMPDIR=${TMPDIR:-"/tmp/parachain_dev*"}
+LITENTRY_PARACHAIN_DIR=${LITENTRY_PARACHAIN_DIR:?}
 CHAIN=$1
 
 ROOTDIR=$(git rev-parse --show-toplevel)
@@ -39,7 +39,7 @@ echo "remove generated images..."
 IMG=$(docker images --filter=reference="generated-$CHAIN*" --format "{{.Repository}}:{{.Tag}}")
 [ -z "$IMG" ] || docker rmi -f $IMG
 
-rm -rf "$TMPDIR"
+rm -rf "$LITENTRY_PARACHAIN_DIR"
 rm -rf "$ROOTDIR/ts-tests/bridge/bob.json"
 rm -rf "$ROOTDIR/ts-tests/bridge/data/"
 

--- a/scripts/fork-parachain-and-launch.sh
+++ b/scripts/fork-parachain-and-launch.sh
@@ -8,14 +8,13 @@ set -eo pipefail
 # - use this chain spec to launch a local parachain network
 
 ROOTDIR=$(git rev-parse --show-toplevel)
-TMPDIR=$(mktemp -d /tmp/XXXXXX)
 
+# setup TMPDIR
+export TMPDIR=$(mktemp -d)
 cleanup() {
   echo "removing $1 ..."
   rm -rf "$1"
-  exit
 }
-
 trap 'cleanup $TMPDIR' INT TERM EXIT
 
 FORK_OFF_SUBSTRATE_REPO="https://github.com/litentry/fork-off-substrate.git"
@@ -66,7 +65,6 @@ case "$ORIG_CHAIN" in
     exit 1 ;;
 esac
 
-echo "TMPDIR is $TMPDIR"
 cd "$TMPDIR"
 git clone "$FORK_OFF_SUBSTRATE_REPO"
 cd fork-off-substrate

--- a/scripts/geth/run_geth.sh
+++ b/scripts/geth/run_geth.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-TMPDIR=${TMPDIR:-"/tmp/parachain_dev"}
-[ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
+LITENTRY_PARACHAIN_DIR=${LITENTRY_PARACHAIN_DIR:?}
+[ -d "$LITENTRY_PARACHAIN_DIR" ] || mkdir -p "$LITENTRY_PARACHAIN_DIR"
 
 DOCKER='local'
 
@@ -19,9 +19,9 @@ GETH_BIN="geth"
 if ! geth version &>/dev/null; then
     echo "geth could not be found..download now"
     url="https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.10.21-67109427.tar.gz"
-    GETH_BIN="$TMPDIR/geth"
-    wget -O "$TMPDIR/geth.tar.gz" -q "$url"
-    tar -xf "$TMPDIR/geth.tar.gz" --strip-components 1 -C "$TMPDIR"
+    GETH_BIN="$LITENTRY_PARACHAIN_DIR/geth"
+    wget -O "$LITENTRY_PARACHAIN_DIR/geth.tar.gz" -q "$url"
+    tar -xf "$LITENTRY_PARACHAIN_DIR/geth.tar.gz" --strip-components 1 -C "$LITENTRY_PARACHAIN_DIR"
     chmod a+x "$GETH_BIN"
 fi
 

--- a/scripts/launch-local-binary.sh
+++ b/scripts/launch-local-binary.sh
@@ -25,10 +25,9 @@ CHAIN=$1
 POLKADOT_BIN="$2"
 PARACHAIN_BIN="$3"
 
-# Check if TMPDIR is already set
-TMPDIR=${TMPDIR:-"/tmp/parachain_dev"}
+LITENTRY_PARACHAIN_DIR=${LITENTRY_PARACHAIN_DIR:?}
 
-[ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
+[ -d "$LITENTRY_PARACHAIN_DIR" ] || mkdir -p "$LITENTRY_PARACHAIN_DIR"
 ROOTDIR=$(git rev-parse --show-toplevel)
 
 cd "$ROOTDIR"
@@ -48,7 +47,7 @@ if [ -z "$POLKADOT_BIN" ]; then
   # polkadot could publish release which has no binary
   #
   url="https://github.com/paritytech/polkadot/releases/download/v0.9.39/polkadot"
-  POLKADOT_BIN="$TMPDIR/polkadot"
+  POLKADOT_BIN="$LITENTRY_PARACHAIN_DIR/polkadot"
   wget -O "$POLKADOT_BIN" -q "$url"
   chmod a+x "$POLKADOT_BIN"
 fi
@@ -77,7 +76,7 @@ if ! "$PARACHAIN_BIN" --version &> /dev/null; then
   exit 1
 fi
 
-cd "$TMPDIR"
+cd "$LITENTRY_PARACHAIN_DIR"
 
 echo "starting dev network with binaries ..."
 
@@ -118,7 +117,7 @@ else
     echo "NODE_ENV=${NODE_ENV}" > .env
 fi
 pnpm install
-pnpm run register-parathread 2>&1 | tee "$TMPDIR/register-parathread.log"
+pnpm run register-parathread 2>&1 | tee "$LITENTRY_PARACHAIN_DIR/register-parathread.log"
 print_divider
 
 echo "upgrade parathread to parachain now ..."
@@ -131,9 +130,9 @@ else
     echo "NODE_ENV=${NODE_ENV}" > .env
 fi
 pnpm install
-pnpm run upgrade-parathread 2>&1 | tee "$TMPDIR/upgrade-parathread.log"
+pnpm run upgrade-parathread 2>&1 | tee "$LITENTRY_PARACHAIN_DIR/upgrade-parathread.log"
 print_divider
 
-echo "done. please check $TMPDIR for generated files if need"
+echo "done. please check $LITENTRY_PARACHAIN_DIR for generated files if need"
 
 print_divider

--- a/scripts/launch-local-bridge-binary.sh
+++ b/scripts/launch-local-bridge-binary.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-TMPDIR=${TMPDIR:-"/tmp/parachain_dev"}
-[ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
+LITENTRY_PARACHAIN_DIR=${LITENTRY_PARACHAIN_DIR:?}
+[ -d "$LITENTRY_PARACHAIN_DIR" ] || mkdir -p "$LITENTRY_PARACHAIN_DIR"
 
 ROOTDIR=$(git rev-parse --show-toplevel)
 
 GOPATH=${HOME}/go go install github.com/litentry/ChainBridge/cmd/chainbridge@dev
 
-cp ${HOME}/go/bin/chainbridge $TMPDIR/chainbridge
+cp ${HOME}/go/bin/chainbridge $LITENTRY_PARACHAIN_DIR/chainbridge
 
 ${ROOTDIR}/scripts/geth/run_geth.sh
 

--- a/scripts/launch-local-bridge-docker.sh
+++ b/scripts/launch-local-bridge-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-TMPDIR=${TMPDIR:-"/tmp/parachain_dev"}
-[ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
+LITENTRY_PARACHAIN_DIR=${LITENTRY_PARACHAIN_DIR:?}
+[ -d "$LITENTRY_PARACHAIN_DIR" ] || mkdir -p "$LITENTRY_PARACHAIN_DIR"
 
 ROOTDIR=$(git rev-parse --show-toplevel)
 
@@ -13,8 +13,8 @@ fi
 echo "------------------------------------------------------------"
 
 docker run -d --rm --name chainbridge litentry/chainbridge bash -c 'ls /go/bin/ && sleep 5'
-docker cp chainbridge:/go/bin/chainbridge ${TMPDIR}/
-echo "copy binary:chainbridge to ${TMPDIR}"
+docker cp chainbridge:/go/bin/chainbridge ${LITENTRY_PARACHAIN_DIR}/
+echo "copy binary:chainbridge to ${LITENTRY_PARACHAIN_DIR}"
 
 echo "------------------------------------------------------------"
 

--- a/scripts/run-ts-test.sh
+++ b/scripts/run-ts-test.sh
@@ -21,18 +21,17 @@ fi
 ROOTDIR=$(git rev-parse --show-toplevel)
 cd "$ROOTDIR/ts-tests"
 
-TMPDIR=${TMPDIR:-"/tmp/parachain_dev"}
-
-[ -d "$TMPDIR" ] || mkdir -p "$TMPDIR"
+LITENTRY_PARACHAIN_DIR=${LITENTRY_PARACHAIN_DIR:?}
+[ -d "$LITENTRY_PARACHAIN_DIR" ] || mkdir -p "$LITENTRY_PARACHAIN_DIR"
 
 [ -f .env ] || echo "NODE_ENV=ci" >.env
 pnpm install
-pnpm run test-filter 2>&1 | tee "$TMPDIR/parachain_ci_test.log"
+pnpm run test-filter 2>&1 | tee "$LITENTRY_PARACHAIN_DIR/parachain_ci_test.log"
 if $bridge; then
-    pnpm run test-bridge 2>&1 | tee -a "$TMPDIR/parachain_ci_test.log"
+    pnpm run test-bridge 2>&1 | tee -a "$LITENTRY_PARACHAIN_DIR/parachain_ci_test.log"
 fi
 
 if $evm; then
-    pnpm run test-evm-transfer 2>&1 | tee "$TMPDIR/parachain_ci_test.log"
-    pnpm run test-evm-contract 2>&1 | tee "$TMPDIR/parachain_ci_test.log"
+    pnpm run test-evm-transfer 2>&1 | tee "$LITENTRY_PARACHAIN_DIR/parachain_ci_test.log"
+    pnpm run test-evm-contract 2>&1 | tee "$LITENTRY_PARACHAIN_DIR/parachain_ci_test.log"
 fi

--- a/tee-worker/local-setup/launch.py
+++ b/tee-worker/local-setup/launch.py
@@ -198,13 +198,13 @@ def main(processes, config_path, parachain_type, log_config_path, offset, parach
     # Litentry
     print("Starting litentry parachain in background ...")
     if parachain_type == "local-docker":
-        os.environ['TMPDIR'] = parachain_dir
+        os.environ['LITENTRY_PARACHAIN_DIR'] = parachain_dir
         setup_environment(offset, config, parachain_dir)
         # TODO: use Popen and copy the stdout also to node.log
         run(["./scripts/litentry/start_parachain.sh"], check=True)
     elif parachain_type == "local-binary":
         # Export Parachain Directory as Global Variable
-        os.environ['TMPDIR'] = parachain_dir
+        os.environ['LITENTRY_PARACHAIN_DIR'] = parachain_dir
         setup_environment(offset, config, parachain_dir)
         run(["../scripts/launch-local-binary.sh", "rococo"], check=True)
     elif parachain_type == "remote":


### PR DESCRIPTION
### Context

Addressing the temp directory issues reported by @AlseinX.
Our scripts have been overloading the system variable `TMPDIR`; this had worked until now, but it's clashing with `pnpm` since the latter relies on `os.tmpdir()` working properly.

### Fix

- Use a specific name for the variable that designates the installation directory.
  - Drive-by: make sure the directory is actually set (i.e. no defaults)
- In the few cases where `TMPDIR` is actually intended to be the catch-all temporary location, set up its creation and cleanup

### TODO

- [x] Make sure CI passes (some steps may fail if they're relying on the default value rather than setting the variable)
