### PR TITLE
chore: introducing fast-check feature

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -142,3 +142,11 @@ try-runtime = [
 tee-dev = [
     "rococo-parachain-runtime/tee-dev",
 ]
+
+# bypasses wasm builds for cargo checks
+# for IDE only, DO NOT ENABLE ON RELEASE
+fast-check = [
+    "litentry-parachain-runtime/fast-check",
+    "litmus-parachain-runtime/fast-check",
+    "rococo-parachain-runtime/fast-check",
+]

--- a/runtime/litentry/Cargo.toml
+++ b/runtime/litentry/Cargo.toml
@@ -107,6 +107,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 
 [features]
 default = ["std"]
+fast-check = []
 fast-runtime = []
 runtime-benchmarks = [
     "cumulus-pallet-session-benchmarking/runtime-benchmarks",

--- a/runtime/litentry/build.rs
+++ b/runtime/litentry/build.rs
@@ -17,6 +17,9 @@
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
+	if cfg!(feature = "fast-check") {
+		return
+	}
 	WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()

--- a/runtime/litentry/src/lib.rs
+++ b/runtime/litentry/src/lib.rs
@@ -72,7 +72,11 @@ use xcm_config::{XcmConfig, XcmOriginToTransactDispatchOrigin};
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
+#[cfg(not(feature = "fast-check"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
+#[cfg(feature = "fast-check")]
+pub const WASM_BINARY: Option<&[u8]> = None;
 
 pub mod asset_config;
 pub mod constants;

--- a/runtime/litmus/Cargo.toml
+++ b/runtime/litmus/Cargo.toml
@@ -113,6 +113,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 
 [features]
 default = ["std"]
+fast-check = []
 fast-runtime = []
 runtime-benchmarks = [
     "cumulus-pallet-session-benchmarking/runtime-benchmarks",
@@ -122,9 +123,7 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "pallet-asset-manager/runtime-benchmarks",
     "pallet-balances/runtime-benchmarks",
-    "pallet-bounties/runtime-benchmarks",
-    # This module returned an error when ran the benchmark, temporarily chose to comment it out
-    #  "pallet-collator-selection/runtime-benchmarks",
+    "pallet-bounties/runtime-benchmarks",                     # This module returned an error when ran the benchmark, temporarily chose to comment it out  #  "pallet-collator-selection/runtime-benchmarks",
     "pallet-collective/runtime-benchmarks",
     "pallet-democracy/runtime-benchmarks",
     "pallet-identity/runtime-benchmarks",

--- a/runtime/litmus/build.rs
+++ b/runtime/litmus/build.rs
@@ -17,6 +17,9 @@
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
+	if cfg!(feature = "fast-check") {
+		return
+	}
 	WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -82,7 +82,11 @@ use xcm_config::{XcmConfig, XcmOriginToTransactDispatchOrigin};
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
+#[cfg(not(feature = "fast-check"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
+#[cfg(feature = "fast-check")]
+pub const WASM_BINARY: Option<&[u8]> = None;
 
 pub mod asset_config;
 pub mod constants;

--- a/runtime/rococo/Cargo.toml
+++ b/runtime/rococo/Cargo.toml
@@ -128,6 +128,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 
 [features]
 default = ["std"]
+fast-check = []
 fast-runtime = []
 runtime-benchmarks = [
     "cumulus-pallet-session-benchmarking/runtime-benchmarks",

--- a/runtime/rococo/build.rs
+++ b/runtime/rococo/build.rs
@@ -17,6 +17,9 @@
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
+	if cfg!(feature = "fast-check") {
+		return
+	}
 	WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -90,7 +90,11 @@ use pallet_evm::{
 };
 // Make the WASM binary available.
 #[cfg(feature = "std")]
+#[cfg(not(feature = "fast-check"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
+#[cfg(feature = "fast-check")]
+pub const WASM_BINARY: Option<&[u8]> = None;
 
 pub mod asset_config;
 pub mod constants;


### PR DESCRIPTION
The current build scripts of the wasm(runtime) projects runs wasm builds unconditionally, which makes `cargo check`(which is called by rust-analyzer on save to perform compilation checks) extremely slow.
I added a feature switch to disable these scripts when `cargo check` is called by rust-analyzer.

This feature is never used on build, just for rust-analyzer only, with the following config:
`.vscode/settings.json` :

```
{
    "rust-analyzer.check.features": [
        "fast-check"
    ]
}
```