### PR TITLE
Fix: change sidehcain metadata update path

### DIFF
--- a/tee-worker/client-api/sidechain-api/package.json
+++ b/tee-worker/client-api/sidechain-api/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/src/index.js",
 	"scripts": {
 		"clean": "rm -rf dist build node_modules",
-		"update-metadata": "../../bin/litentry-cli print-sgx-metadata-raw > build/litentry-sidechain-metadata.json",
+		"update-metadata": "../../bin/litentry-cli print-sgx-metadata-raw > prepare-build/litentry-sidechain-metadata.json",
 		"prepare-dir": "mkdir -p build && cp -rf prepare-build/* build",
 		"generate-from-defs": "pnpm exec node --experimental-specifier-resolution=node --loader ts-node/esm node_modules/@polkadot/typegen/scripts/polkadot-types-from-defs.mjs --package sidechain-api/interfaces --input build/interfaces --endpoint build/litentry-sidechain-metadata.json",
 		"generate-from-chain": "pnpm exec node --experimental-specifier-resolution=node --loader ts-node/esm node_modules/@polkadot/typegen/scripts/polkadot-types-from-chain.mjs --package sidechain-api/interfaces --output build/interfaces --endpoint build/litentry-sidechain-metadata.json --strict",


### PR DESCRIPTION
### Context
When I was testing this [action](https://github.com/litentry/litentry-parachain/actions/runs/6649339905/job/18067796042), I noticed that the sidechain metadata I obtained was consistently different from what's local. Upon inspecting the code, I discovered that the update path being used is incorrect. The correct path should be `prepare-build`, as updating to `build` would be overwritten. Unfortunately, this incorrect path has been in place for three months, rendering the sidechain metadata updates over the past three months completely ineffective in `sidechain-api`.


