### PR TITLE
fix: .env.local is updated correctly

### DIFF
--- a/tee-worker/local-setup/launch.py
+++ b/tee-worker/local-setup/launch.py
@@ -132,8 +132,8 @@ def generate_env_local():
 
     with open(env_local_example_file, "r") as f:
         data = f.read()
-        data.replace(":2000", ":" + os.environ.get("TrustedWorkerPort", "2000"))
-        data.replace(":9944", ":" + os.environ.get("CollatorWSPort", "9944"))
+        data = data.replace(":2000", ":" + os.environ.get("TrustedWorkerPort", "2000"))
+        data = data.replace(":9944", ":" + os.environ.get("CollatorWSPort", "9944"))
 
     with open(env_local_file, "w") as f:
         f.write(data)


### PR DESCRIPTION
So the problem is that this line 
```
data.replace(":9944", ":" + os.environ.get("CollatorWSPort", "9944"))
``` 
does not mutate the data in place and instead returns a new string, because of which `.env.local` always has `9944` and `2000` 


