### PR TITLE
Hotfix of tee-test dependency in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,9 +599,12 @@ jobs:
 
   tee-test:
     runs-on: ubuntu-latest
+    # we could use this if-condition on job level because `run_tee_test == false` implies
+    # rebuild_parachain == false AND rebuild_tee == false, so we've got nothing to push
     if: needs.set-condition.outputs.run_tee_test == 'true'
     needs:
       - set-condition
+      - parachain-build-dev
       - tee-build
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,9 +599,6 @@ jobs:
 
   tee-test:
     runs-on: ubuntu-latest
-    # we could use this if-condition on job level because `run_tee_test == false` implies
-    # rebuild_parachain == false AND rebuild_tee == false, so we've got nothing to push
-    if: needs.set-condition.outputs.run_tee_test == 'true'
     needs:
       - set-condition
       - parachain-build-dev
@@ -660,12 +657,14 @@ jobs:
           docker compose -f litentry-parachain.build.yml build
 
       - name: Integration Test ${{ matrix.test_name }}
+        if: needs.set-condition.outputs.run_tee_test == 'true'
         timeout-minutes: 40
         run: |
           cd tee-worker/docker
           docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
 
       - name: Stop docker containers
+        if: needs.set-condition.outputs.run_tee_test == 'true'
         run: |
           cd tee-worker/docker
           docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop


### PR DESCRIPTION
### Context

As topic, otherwise the tee-test will be launched too early:

<img width="1298" alt="image" src="https://github.com/litentry/litentry-parachain/assets/7630809/54378675-0672-4bd6-a7b1-47314ec07564">


~~I added some comments to further explain the usage in our case, because~~

~~# [3] please beware that if a job in `needs` is skipped, its dependent job will also be skipped,~~
~~# see https://github.com/actions/runner/issues/491~~

No we can't use it in job level, because if the matrix is completely skipped, the status check will be pending forever, that was why I forced it to always run:

<img width="658" alt="image" src="https://github.com/litentry/litentry-parachain/assets/7630809/0a60487d-3229-4cb6-8cb9-2a507f89957c">

