### PR TITLE
fix evm build

### DIFF
--- a/tee-worker/app-libs/stf/src/evm_helpers.rs
+++ b/tee-worker/app-libs/stf/src/evm_helpers.rs
@@ -15,8 +15,9 @@
 
 */
 use crate::helpers::{get_storage_double_map, get_storage_map};
+use itp_stf_primitives::types::Nonce;
 use itp_storage::StorageHasher;
-use itp_types::{AccountId, Nonce};
+use itp_types::AccountId;
 use sha3::{Digest, Keccak256};
 use sp_core::{H160, H256};
 use std::prelude::v1::*;

--- a/tee-worker/cli/src/evm/commands/evm_call.rs
+++ b/tee-worker/cli/src/evm/commands/evm_call.rs
@@ -22,7 +22,6 @@ use crate::{
 	trusted_operation::perform_trusted_operation,
 	Cli, CliResult, CliResultOk,
 };
-use codec::Decode;
 use ita_stf::{Index, TrustedCall, TrustedGetter};
 use itp_stf_primitives::{
 	traits::TrustedCallSigning,

--- a/tee-worker/cli/src/evm/commands/evm_create.rs
+++ b/tee-worker/cli/src/evm/commands/evm_create.rs
@@ -22,7 +22,6 @@ use crate::{
 	trusted_operation::perform_trusted_operation,
 	Cli, CliResult, CliResultOk,
 };
-use codec::Decode;
 use ita_stf::{evm_helpers::evm_create_address, Index, TrustedCall, TrustedGetter};
 use itp_stf_primitives::{
 	traits::TrustedCallSigning,

--- a/tee-worker/cli/src/evm/commands/evm_read.rs
+++ b/tee-worker/cli/src/evm/commands/evm_read.rs
@@ -19,7 +19,6 @@ use crate::{
 	trusted_cli::TrustedCli, trusted_command_utils::get_pair_from_str,
 	trusted_operation::perform_trusted_operation, Cli, CliResult, CliResultOk,
 };
-use codec::Decode;
 use ita_stf::{Getter, TrustedCallSigned, TrustedGetter};
 use itp_stf_primitives::types::{KeyPair, TrustedOperation};
 use itp_types::AccountId;
@@ -53,7 +52,7 @@ impl EvmReadCommands {
 			H160::from_slice(&array_bytes::hex2bytes(&self.execution_address).unwrap());
 
 		let top = TrustedOperation::<TrustedCallSigned, Getter>::get(Getter::trusted(
-			TrustedGetter::evm_account_storages(sender_acc, execution_address, H256::zero())
+			TrustedGetter::evm_account_storages(sender_acc.into(), execution_address, H256::zero())
 				.sign(&KeyPair::Sr25519(Box::new(sender))),
 		));
 		let hash = perform_trusted_operation::<H256>(cli, trusted_args, &top)?;


### PR DESCRIPTION
Our evm build broke recently.
I noticed it because I run `scripts/pre-commit.sh` before each push.
