### PR TITLE
Add `pallet-teerex` tests to CI with all feature combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,7 +549,9 @@ jobs:
         run: |
           rustup show
           cargo test --locked --release -p core-primitives --lib
-          # test pallet-teerex separately
+          # test pallet-teerex separately, with all feature combinations
+          cargo test --locked --release -p pallet-teerex --lib
+          cargo test --locked --release -p pallet-teerex --lib --features=skip-ias-check
           cargo test --locked --release -p pallet-teerex --lib --features=skip-scheduled-enclave-check
           cargo test --locked --release -p pallet-teerex --lib --features=skip-ias-check,skip-scheduled-enclave-check
           # no `skip-ias-check` feature

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,6 +552,7 @@ jobs:
           cargo hack test --feature-powerset --features=default --locked --release -p pallet-teerex --lib
 
       - name: Run all unittests
+        run: |
           cargo test --locked --release -p core-primitives --lib
           # no `skip-ias-check` feature
           cargo test --locked --release -p pallet-* --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,6 +549,9 @@ jobs:
         run: |
           rustup show
           cargo test --locked --release -p core-primitives --lib
+          # test pallet-teerex separately
+          cargo test --locked --release -p pallet-teerex --lib --features=skip-scheduled-enclave-check
+          cargo test --locked --release -p pallet-teerex --lib --features=skip-ias-check,skip-scheduled-enclave-check
           # no `skip-ias-check` feature
           cargo test --locked --release -p pallet-* --lib
           # with `skip-ias-check` feature only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,15 +545,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run unittests
+      - name: Run pallet-teerex unittests
         run: |
           rustup show
+          cargo +stable install cargo-hack --locked
+          cargo hack test --feature-powerset --features=default --locked --release -p pallet-teerex --lib
+
+      - name: Run all unittests
           cargo test --locked --release -p core-primitives --lib
-          # test pallet-teerex separately, with all feature combinations
-          cargo test --locked --release -p pallet-teerex --lib
-          cargo test --locked --release -p pallet-teerex --lib --features=skip-ias-check
-          cargo test --locked --release -p pallet-teerex --lib --features=skip-scheduled-enclave-check
-          cargo test --locked --release -p pallet-teerex --lib --features=skip-ias-check,skip-scheduled-enclave-check
           # no `skip-ias-check` feature
           cargo test --locked --release -p pallet-* --lib
           # with `skip-ias-check` feature only

--- a/pallets/teerex/src/tests/mod.rs
+++ b/pallets/teerex/src/tests/mod.rs
@@ -16,5 +16,5 @@
 */
 #[cfg(feature = "skip-ias-check")]
 mod skip_ias_check_tests;
-#[cfg(not(feature = "skip-ias-check"))]
+#[cfg(all(not(feature = "skip-ias-check"), feature = "skip-scheduled-enclave-check"))]
 mod test_cases;

--- a/pallets/teerex/src/tests/skip_ias_check_tests.rs
+++ b/pallets/teerex/src/tests/skip_ias_check_tests.rs
@@ -111,7 +111,7 @@ fn register_enclave_with_empty_url_inserts_default() {
 fn register_enclave_with_scheduled_enclave_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Teerex::update_scheduled_enclave(
-			RuntimeOrigin::root(),
+			RuntimeOrigin::signed(AccountKeyring::Alice.to_account_id()),
 			0u64,
 			Default::default(),
 		));

--- a/pallets/teerex/src/tests/skip_ias_check_tests.rs
+++ b/pallets/teerex/src/tests/skip_ias_check_tests.rs
@@ -112,7 +112,7 @@ fn register_enclave_with_scheduled_enclave_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Teerex::update_scheduled_enclave(
 			RuntimeOrigin::root(),
-			0u32,
+			0u64,
 			Default::default(),
 		));
 		assert_ok!(Teerex::register_enclave(


### PR DESCRIPTION
### Context

fixes #2139 

A minor PR - that's the only compilation error that I found. The fact that the tests fail for some features is known.

It's also known behavior that when using wildcards(`pallet-*`) the features will be consolidated, so it might behave differently from using concrete `pallet-teerex`.
