### PR TITLE
Fix: Add worker tag input

### DIFF
--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -25,9 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set env variables
-        run: echo "RELEASE_IMAGE_VERSION=${{ inputs.worker-tag }}" >> "$GITHUB_ENV"
-
       - name: Pull litentry image optionally
         run: |
           docker pull parity/polkadot

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -13,7 +13,7 @@ on:
           required: true
           default: 'latest'
         release-tag:
-          description: 'Ts api release tag'
+          description: 'Client-api release tag'
           required: true
           default: 'latest'
 env:
@@ -55,37 +55,37 @@ jobs:
           cd tee-worker/docker
           docker compose -f docker-compose.yml -f lit-ts-api-package-build.yml up --no-build --exit-code-from lit-ts-api-package-build lit-ts-api-package-build
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          registry-url: https://npm.pkg.github.com/
+      # - name: Use Node.js
+      #   uses: actions/setup-node@v3
+      #   with:
+      #     node-version: 18
+      #     registry-url: https://npm.pkg.github.com/
 
-      - name: Setup npm config
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=\${{ secrets.RELEASE_TS_API_PACKAGE_TOKEN }}" > .npmrc
-          npm config set @litentry:registry https://npm.pkg.github.com
+      # - name: Setup npm config
+      #   run: |
+      #     echo "//npm.pkg.github.com/:_authToken=\${{ secrets.RELEASE_TS_API_PACKAGE_TOKEN }}" > .npmrc
+      #     npm config set @litentry:registry https://npm.pkg.github.com
 
-      - name: Publish parachain API and sidechain API
-        working-directory: ./tee-worker/client-api
-        run: |
-          apis=("parachain-api" "sidechain-api")
-          for api in "${apis[@]}"; do
-            cd "$api"
+      # - name: Publish parachain API and sidechain API
+      #   working-directory: ./tee-worker/client-api
+      #   run: |
+      #     apis=("parachain-api" "sidechain-api")
+      #     for api in "${apis[@]}"; do
+      #       cd "$api"
 
-            # Check if dist and build files exist
-            if [ -d "dist" ] && [ -d "build" ]; then
-              echo "$api dist and build files exist."
-            else
-              echo "$api dist and build files do not exist. Publishing failed."
-              exit 1
-            fi
+      #       # Check if dist and build files exist
+      #       if [ -d "dist" ] && [ -d "build" ]; then
+      #         echo "$api dist and build files exist."
+      #       else
+      #         echo "$api dist and build files do not exist. Publishing failed."
+      #         exit 1
+      #       fi
 
-            npm publish --tag ${{ inputs.release-tag }}
+      #       npm publish --tag ${{ inputs.release-tag }}
 
-            echo "------------------------$api published------------------------"
-            cd ..
-          done
+      #       echo "------------------------$api published------------------------"
+      #       cd ..
+      #     done
 
       - name: Stop docker containers
         run: |

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -69,26 +69,26 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=\${{ secrets.RELEASE_TS_API_PACKAGE_TOKEN }}" > .npmrc
           npm config set @litentry:registry https://npm.pkg.github.com
 
-      # - name: Publish parachain API and sidechain API
-      #   working-directory: ./tee-worker/client-api
-      #   run: |
-      #     apis=("parachain-api" "sidechain-api")
-      #     for api in "${apis[@]}"; do
-      #       cd "$api"
+      - name: Publish parachain API and sidechain API
+        working-directory: ./tee-worker/client-api
+        run: |
+          apis=("parachain-api" "sidechain-api")
+          for api in "${apis[@]}"; do
+            cd "$api"
 
-      #       # Check if dist and build files exist
-      #       if [ -d "dist" ] && [ -d "build" ]; then
-      #         echo "$api dist and build files exist."
-      #       else
-      #         echo "$api dist and build files do not exist. Publishing failed."
-      #         exit 1
-      #       fi
+            # Check if dist and build files exist
+            if [ -d "dist" ] && [ -d "build" ]; then
+              echo "$api dist and build files exist."
+            else
+              echo "$api dist and build files do not exist. Publishing failed."
+              exit 1
+            fi
 
-      #       npm publish --tag ${{ inputs.release-tag }}
+            npm publish --tag ${{ inputs.release-tag }}
 
-      #       echo "------------------------$api published------------------------"
-      #       cd ..
-      #     done
+            echo "------------------------$api published------------------------"
+            cd ..
+          done
 
       - name: Stop docker containers
         run: |

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Re-tag docker image
         run: |
           docker tag litentry/litentry-worker:${{ inputs.worker-tag }} litentry/litentry-worker:latest
-          docker tag litentry/litentry-cli:${{ inputs.worker-tag }} litentry/litentry-worker:latest
-          docker tag litentry/litentry-parachain:${{ inputs.parachain-tag }} litentry/litentry-worker:latest
+          docker tag litentry/litentry-cli:${{ inputs.worker-tag }} litentry/litentry-cli:latest
+          docker tag litentry/litentry-parachain:${{ inputs.parachain-tag }} litentry/litentry-parachain:latest
 
       - run: docker images --all
 

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           docker tag litentry/litentry-worker:${{ inputs.worker-tag }} litentry/litentry-worker:latest
           docker tag litentry/litentry-cli:${{ inputs.worker-tag }} litentry/litentry-worker:latest
-          docker tag litentry/litentry-parachain:${{ inputs.worker-tag }} litentry/litentry-worker:latest
+          docker tag litentry/litentry-parachain:${{ inputs.parachain-tag }} litentry/litentry-worker:latest
 
       - run: docker images --all
 

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -35,6 +35,12 @@ jobs:
           docker pull litentry/litentry-cli:${{ inputs.worker-tag }}
           docker pull litentry/litentry-parachain:${{ inputs.parachain-tag }}
 
+      - name: Re-tag docker image
+        run: |
+          docker tag litentry/litentry-worker:${{ inputs.worker-tag }} litentry/litentry-worker:latest
+          docker tag litentry/litentry-cli:${{ inputs.worker-tag }} litentry/litentry-worker:latest
+          docker tag litentry/litentry-parachain:${{ inputs.worker-tag }} litentry/litentry-worker:latest
+
       - run: docker images --all
 
       - name: Enable corepack and pnpm
@@ -66,26 +72,26 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=\${{ secrets.RELEASE_TS_API_PACKAGE_TOKEN }}" > .npmrc
           npm config set @litentry:registry https://npm.pkg.github.com
 
-      - name: Publish parachain API and sidechain API
-        working-directory: ./tee-worker/client-api
-        run: |
-          apis=("parachain-api" "sidechain-api")
-          for api in "${apis[@]}"; do
-            cd "$api"
+      # - name: Publish parachain API and sidechain API
+      #   working-directory: ./tee-worker/client-api
+      #   run: |
+      #     apis=("parachain-api" "sidechain-api")
+      #     for api in "${apis[@]}"; do
+      #       cd "$api"
 
-            # Check if dist and build files exist
-            if [ -d "dist" ] && [ -d "build" ]; then
-              echo "$api dist and build files exist."
-            else
-              echo "$api dist and build files do not exist. Publishing failed."
-              exit 1
-            fi
+      #       # Check if dist and build files exist
+      #       if [ -d "dist" ] && [ -d "build" ]; then
+      #         echo "$api dist and build files exist."
+      #       else
+      #         echo "$api dist and build files do not exist. Publishing failed."
+      #         exit 1
+      #       fi
 
-            npm publish --tag ${{ inputs.release-tag }}
+      #       npm publish --tag ${{ inputs.release-tag }}
 
-            echo "------------------------$api published------------------------"
-            cd ..
-          done
+      #       echo "------------------------$api published------------------------"
+      #       cd ..
+      #     done
 
       - name: Stop docker containers
         run: |

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -26,13 +26,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set env variables
-        run: echo "RELEASE_IMAGE_VERSION=${{ inputs.parachain-tag }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_IMAGE_VERSION=${{ inputs.worker-tag }}" >> "$GITHUB_ENV"
 
       - name: Pull litentry image optionally
         run: |
           docker pull parity/polkadot
           docker pull litentry/litentry-worker:${{ inputs.worker-tag }}
-          docker pull litentry/litentry-cli:${{ inputs.parachain-tag }}
+          docker pull litentry/litentry-cli:${{ inputs.worker-tag }}
           docker pull litentry/litentry-parachain:${{ inputs.parachain-tag }}
 
       - run: docker images --all

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -55,37 +55,37 @@ jobs:
           cd tee-worker/docker
           docker compose -f docker-compose.yml -f lit-ts-api-package-build.yml up --no-build --exit-code-from lit-ts-api-package-build lit-ts-api-package-build
 
-      # - name: Use Node.js
-      #   uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 18
-      #     registry-url: https://npm.pkg.github.com/
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://npm.pkg.github.com/
 
-      # - name: Setup npm config
-      #   run: |
-      #     echo "//npm.pkg.github.com/:_authToken=\${{ secrets.RELEASE_TS_API_PACKAGE_TOKEN }}" > .npmrc
-      #     npm config set @litentry:registry https://npm.pkg.github.com
+      - name: Setup npm config
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=\${{ secrets.RELEASE_TS_API_PACKAGE_TOKEN }}" > .npmrc
+          npm config set @litentry:registry https://npm.pkg.github.com
 
-      # - name: Publish parachain API and sidechain API
-      #   working-directory: ./tee-worker/client-api
-      #   run: |
-      #     apis=("parachain-api" "sidechain-api")
-      #     for api in "${apis[@]}"; do
-      #       cd "$api"
+      - name: Publish parachain API and sidechain API
+        working-directory: ./tee-worker/client-api
+        run: |
+          apis=("parachain-api" "sidechain-api")
+          for api in "${apis[@]}"; do
+            cd "$api"
 
-      #       # Check if dist and build files exist
-      #       if [ -d "dist" ] && [ -d "build" ]; then
-      #         echo "$api dist and build files exist."
-      #       else
-      #         echo "$api dist and build files do not exist. Publishing failed."
-      #         exit 1
-      #       fi
+            # Check if dist and build files exist
+            if [ -d "dist" ] && [ -d "build" ]; then
+              echo "$api dist and build files exist."
+            else
+              echo "$api dist and build files do not exist. Publishing failed."
+              exit 1
+            fi
 
-      #       npm publish --tag ${{ inputs.release-tag }}
+            npm publish --tag ${{ inputs.release-tag }}
 
-      #       echo "------------------------$api published------------------------"
-      #       cd ..
-      #     done
+            echo "------------------------$api published------------------------"
+            cd ..
+          done
 
       - name: Stop docker containers
         run: |

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -4,8 +4,16 @@ name: Release Ts API Package
 on:
   workflow_dispatch:
       inputs:
-        tag:
-          description: 'Release docker image tag'
+        parachain-tag:
+          description: 'Parachain docker image tag'
+          required: true
+          default: 'latest'
+        worker-tag:
+          description: 'Worker docker image tag'
+          required: true
+          default: 'latest'
+        release-tag:
+          description: 'Ts api release tag'
           required: true
           default: 'latest'
 env:
@@ -18,14 +26,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set env variables
-        run: echo "RELEASE_IMAGE_VERSION=${{ inputs.tag }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_IMAGE_VERSION=${{ inputs.parachain-tag }}" >> "$GITHUB_ENV"
 
       - name: Pull litentry image optionally
         run: |
           docker pull parity/polkadot
-          docker pull litentry/litentry-worker:${{ inputs.tag }}
-          docker pull litentry/litentry-cli:${{ inputs.tag }}
-          docker pull litentry/litentry-parachain:${{ inputs.tag }}
+          docker pull litentry/litentry-worker:${{ inputs.worker-tag }}
+          docker pull litentry/litentry-cli:${{ inputs.parachain-tag }}
+          docker pull litentry/litentry-parachain:${{ inputs.parachain-tag }}
 
       - run: docker images --all
 
@@ -73,7 +81,7 @@ jobs:
               exit 1
             fi
 
-            npm publish --tag ${{ inputs.tag }}
+            npm publish --tag ${{ inputs.release-tag }}
 
             echo "------------------------$api published------------------------"
             cd ..

--- a/tee-worker/docker/lit-ts-api-package-build.yml
+++ b/tee-worker/docker/lit-ts-api-package-build.yml
@@ -1,6 +1,6 @@
 services:
     lit-ts-api-package-build:
-        image: litentry/litentry-cli:${RELEASE_IMAGE_VERSION:-latest}
+        image: litentry/litentry-cli:latest
         container_name: litentry-lit-ts-api-package-build
         volumes:
             - ../client-api:/client-api


### PR DESCRIPTION
### Context

Previously, when using Docker images, the worker and parachain used the same tag consistently. It's necessary to separate them now, as otherwise, errors similar to those discussed in [Slack](https://litentry.slack.com/archives/C05328L0GAF/p1701704472234529) will occur.


