### PR TITLE
Run tests in multiworker setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,7 +700,6 @@ jobs:
           - test_name: lit-di-evm-identity-multiworker-test
           - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-di-vc-multiworker-test
-          - test_name: lit-id-graph-stats-multiworker
           - test_name: lit-ii-batch-test-multiworker
           - test_name: lit-ii-identity-multiworker-test
           - test_name: lit-ii-vc-multiworker-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -743,14 +743,14 @@ jobs:
           cd tee-worker/docker
           docker compose -f litentry-parachain.build.yml build
 
-      - name: Integration single worker test ${{ matrix.test_name }}
+      - name: Integration multi worker test ${{ matrix.test_name }}
         if: needs.set-condition.outputs.run_tee_test == 'true'
         timeout-minutes: 40
         run: |
           cd tee-worker/docker
           docker compose -f multiworker-docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
 
-      - name: Stop integration single worker docker containers
+      - name: Stop integration multi worker docker containers
         if: needs.set-condition.outputs.run_tee_test == 'true'
         run: |
           cd tee-worker/docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - test_name: lit-di-evm-identity-multiworker-test
           - test_name: lit-di-substrate-identity-multiworker-test
+          - test_name: lit-di-vc-multiworker-test
+          - test_name: lit-id-graph-stats-multiworker
+          - test_name: lit-ii-batch-test-multiworker
+          - test_name: lit-ii-identity-multiworker-test
+          - test_name: lit-ii-vc-multiworker-test
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,7 +597,7 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.3
 
-  tee-test:
+  tee-single-worker-test:
     runs-on: ubuntu-latest
     needs:
       - set-condition
@@ -656,18 +656,95 @@ jobs:
           cd tee-worker/docker
           docker compose -f litentry-parachain.build.yml build
 
-      - name: Integration Test ${{ matrix.test_name }}
+      - name: Integration single worker test ${{ matrix.test_name }}
         if: needs.set-condition.outputs.run_tee_test == 'true'
         timeout-minutes: 40
         run: |
           cd tee-worker/docker
           docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
 
-      - name: Stop docker containers
+      - name: Stop integration single worker docker containers
         if: needs.set-condition.outputs.run_tee_test == 'true'
         run: |
           cd tee-worker/docker
           docker compose -f docker-compose.yml -f ${{ matrix.test_name }}.yml stop
+
+      - name: Collect docker logs if test fails
+        continue-on-error: true
+        uses: jwalton/gh-docker-logs@v2
+        if: failure()
+        with:
+          tail: all
+          dest: docker-logs
+
+      - name: Upload docker logs if test fails
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ${{ matrix.test_name }}-docker-logs
+          path: docker-logs
+          if-no-files-found: ignore
+          retention-days: 3
+
+  tee-multi-worker-test:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs:
+      - set-condition
+      - parachain-build-dev
+      - tee-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test_name: lit-di-substrate-identity-multiworker-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull polkadot image
+        run: |
+          docker pull parity/polkadot
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: litentry-parachain-dev
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: litentry-tee
+
+      - name: Load docker image
+        run: |
+          docker load < litentry-parachain-dev.tar.gz
+          docker load < litentry-tee.tar.gz
+          docker images
+
+      - name: Enable corepack and pnpm
+        run: corepack enable && corepack enable pnpm
+
+      - name: Generate parachain artefacts
+        run: |
+          ./tee-worker/scripts/litentry/generate_parachain_artefacts.sh
+          ls -l docker/generated-rococo/
+          ls -l tee-worker/docker/litentry/
+
+      - name: Build litentry parachain docker images
+        run: |
+          cd tee-worker/docker
+          docker compose -f litentry-parachain.build.yml build
+
+      - name: Integration single worker test ${{ matrix.test_name }}
+        if: needs.set-condition.outputs.run_tee_test == 'true'
+        timeout-minutes: 40
+        run: |
+          cd tee-worker/docker
+          docker compose -f multiworker-docker-compose.yml -f ${{ matrix.test_name }}.yml up --no-build --exit-code-from ${{ matrix.test_name }} ${{ matrix.test_name }}
+
+      - name: Stop integration single worker docker containers
+        if: needs.set-condition.outputs.run_tee_test == 'true'
+        run: |
+          cd tee-worker/docker
+          docker compose -f multiworker-docker-compose.yml -f ${{ matrix.test_name }}.yml stop
 
       - name: Collect docker logs if test fails
         continue-on-error: true
@@ -691,7 +768,7 @@ jobs:
   #
   # Only try to push docker image when
   #   - parachain-ts-test passes
-  #   - tee-test passes
+  #   - tee-single-worker-test passes
   #   - set-condition.outputs.push_docker is `true`
   # Whether the parachain or tee-worker image will actually be pushed still depends on if a new image was built/rebuilt.
   # This is important not to overwrite any other jobs where a rebuild **was** triggered.
@@ -705,7 +782,7 @@ jobs:
     needs:
       - set-condition
       - parachain-ts-test
-      - tee-test
+      - tee-single-worker-test
     if: ${{ !failure() && needs.set-condition.outputs.push_docker == 'true' }}
     steps:
       - uses: actions/download-artifact@v3

--- a/tee-worker/docker/lit-di-evm-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-evm-identity-multiworker-test.yml
@@ -1,0 +1,28 @@
+services:
+    lit-di-evm-identity-multiworker-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-di-evm-identity-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-di-evm-identity 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/lit-di-substrate-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-substrate-identity-multiworker-test.yml
@@ -1,5 +1,5 @@
 services:
-    lit-di-substrate-identity-test:
+    lit-di-substrate-identity-multiworker-test:
         image: litentry/litentry-cli:latest
         container_name: litentry-di-substrate-identity-test
         volumes:

--- a/tee-worker/docker/lit-di-substrate-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-substrate-identity-multiworker-test.yml
@@ -1,0 +1,28 @@
+services:
+    lit-di-substrate-identity-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-di-substrate-identity-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-di-substrate-identity 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/lit-di-vc-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-vc-multiworker-test.yml
@@ -1,0 +1,28 @@
+services:
+    lit-di-vc-multiworker-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-di-vc-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-di-vc 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/lit-id-graph-stats-multiworker.yml
+++ b/tee-worker/docker/lit-id-graph-stats-multiworker.yml
@@ -8,15 +8,15 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-      depends_on:
-        litentry-node:
-          condition: service_healthy
-        litentry-worker-1:
-          condition: service_healthy
-        litentry-worker-2:
-          condition: service_healthy
-        litentry-worker-3:
-          condition: service_healthy
+    depends_on:
+      litentry-node:
+        condition: service_healthy
+      litentry-worker-1:
+        condition: service_healthy
+      litentry-worker-2:
+        condition: service_healthy
+      litentry-worker-3:
+        condition: service_healthy
     networks:
       - litentry-test-network
     entrypoint:

--- a/tee-worker/docker/lit-id-graph-stats-multiworker.yml
+++ b/tee-worker/docker/lit-id-graph-stats-multiworker.yml
@@ -1,0 +1,28 @@
+services:
+  lit-id-graph-stats-multiworker:
+    image: litentry/litentry-cli:latest
+    container_name: litentry-id-graph-stats
+    volumes:
+      - ../cli:/usr/local/worker-cli
+    build:
+      context: ..
+      dockerfile: build.Dockerfile
+      target: deployed-client
+      depends_on:
+        litentry-node:
+          condition: service_healthy
+        litentry-worker-1:
+          condition: service_healthy
+        litentry-worker-2:
+          condition: service_healthy
+        litentry-worker-3:
+          condition: service_healthy
+    networks:
+      - litentry-test-network
+    entrypoint:
+      "/usr/local/worker-cli/lit_id_graph_stats.sh -p 9912 -u ws://litentry-node
+      -V wss://litentry-worker-1 -A 2011 -W wss://litentry-worker-2 -B 2012 -C /usr/local/bin/litentry-cli 2>&1"
+    restart: "no"
+networks:
+  litentry-test-network:
+    driver: bridge

--- a/tee-worker/docker/lit-ii-batch-test-multiworker.yml
+++ b/tee-worker/docker/lit-ii-batch-test-multiworker.yml
@@ -1,0 +1,28 @@
+services:
+    lit-ii-batch-test-multiworker:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-ii-batch-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-ii-batch 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/lit-ii-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-ii-identity-multiworker-test.yml
@@ -1,0 +1,28 @@
+services:
+    lit-ii-identity-multiworker-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-ii-identity-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-ii-identity 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/lit-ii-vc-multiworker-test.yml
+++ b/tee-worker/docker/lit-ii-vc-multiworker-test.yml
@@ -1,0 +1,28 @@
+services:
+    lit-ii-vc-multiworker-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-ii-vc-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-ii-vc 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/multiworker-docker-compose.yml
+++ b/tee-worker/docker/multiworker-docker-compose.yml
@@ -1,0 +1,220 @@
+services:
+  relaychain-alice:
+    image: docker_relaychain-alice:latest
+    networks:
+      - litentry-test-network
+    ports:
+      - 9946:9944
+      - 9936:9933
+      - 30336:30333
+    volumes:
+      - relaychain-alice:/data
+    build:
+      context: litentry
+      dockerfile: relaychain.Dockerfile
+    command:
+      - --base-path=/data
+      - --chain=/app/rococo-local.json
+      - --validator
+      - --ws-external
+      - --rpc-external
+      - --rpc-cors=all
+      - --name=alice
+      - --alice
+      - --rpc-methods=unsafe
+      - --execution=wasm
+    environment:
+      RUST_LOG: parachain::candidate-backing=trace,parachain::candidate-selection=trace,parachain::pvf=trace,parachain::collator-protocol=trace,parachain::provisioner=trace
+    ulimits:
+      &a1
+      nofile:
+        soft: 65536
+        hard: 65536
+  relaychain-bob:
+    image: docker_relaychain-bob:latest
+    networks:
+      - litentry-test-network
+    ports:
+      - 9947:9944
+      - 9937:9933
+      - 30337:30333
+    volumes:
+      - relaychain-bob:/data
+    build:
+      context: litentry
+      dockerfile: relaychain.Dockerfile
+    command:
+      - --base-path=/data
+      - --chain=/app/rococo-local.json
+      - --validator
+      - --ws-external
+      - --rpc-external
+      - --rpc-cors=all
+      - --name=bob
+      - --bob
+      - --rpc-methods=unsafe
+      - --execution=wasm
+    environment:
+      RUST_LOG: parachain::candidate-backing=trace,parachain::candidate-selection=trace,parachain::pvf=trace,parachain::collator-protocol=trace,parachain::provisioner=trace
+    ulimits: *a1
+  litentry-node:
+    image: docker_litentry-node:latest
+    container_name: litentry-node
+    networks:
+      - litentry-test-network
+    ports:
+      # TODO: maybe not use 9912 as port
+      - 9944:9912
+      - 9933:9933
+      - 30333:30333
+    volumes:
+      - parachain-2106-0:/data
+    build:
+      context: litentry
+      dockerfile: parachain-2106.Dockerfile
+    depends_on: ['relaychain-alice', 'relaychain-bob']
+    healthcheck:
+      test: ["CMD", "nc", "-z", "litentry-node", "9912"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    command:
+      - --base-path=/data
+      - --chain=/app/rococo-dev-2106.json
+      - --ws-external
+      - --rpc-external
+      - --rpc-cors=all
+      - --name=parachain-2106-0
+      - --ws-port=9912
+      - --collator
+      - --rpc-methods=unsafe
+      - --force-authoring
+      - --execution=wasm
+      - --alice
+      - --node-key=e998e728d8bf5bff6670c5e2b20455f6de1742b7ca564057680c9781cf037dd1
+      - --listen-addr=/ip4/0.0.0.0/tcp/30333
+      - --
+      - --chain=/app/rococo-local.json
+      - --execution=wasm
+    environment:
+      RUST_LOG: sc_basic_authorship=trace,cumulus-consensus=trace,cumulus-collator=trace,collator_protocol=trace,collation_generation=trace,aura=debug
+    ulimits: *a1
+  litentry-worker-1:
+    image: litentry/litentry-worker:latest
+    container_name: litentry-worker-1
+    build:
+      context: ${PWD}/..
+      dockerfile: build.Dockerfile
+      target: deployed-worker
+    depends_on:
+      litentry-node:
+        condition: service_healthy
+    devices:
+      - "${SGX_PROVISION:-/dev/null}:/dev/sgx/provision"
+      - "${SGX_ENCLAVE:-/dev/null}:/dev/sgx/enclave"
+    volumes:
+      - "${AESMD:-/dev/null}:/var/run/aesmd"
+      - "${SGX_QCNL:-/dev/null}:/etc/sgx_default_qcnl.conf"
+    environment:
+      - RUST_LOG=info,litentry_worker=debug,ws=warn,sp_io=error,substrate_api_client=warn,itc_parentchain_light_client=info,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=debug,ita_stf=debug,its_rpc_handler=warn,itc_rpc_client=warn,its_consensus_common=debug,its_state=warn,its_consensus_aura=warn,aura*=warn,its_consensus_slots=warn,itp_attestation_handler=debug,http_req=debug,lc_mock_server=warn,itc_rest_client=debug,lc_credentials=debug,lc_identity_verification=debug,lc_stf_task_receiver=debug,lc_stf_task_sender=debug,lc_data_providers=debug,itp_top_pool=debug,itc_parentchain_indirect_calls_executor=debug,
+      - TWITTER_OFFICIAL_URL=http://localhost:19527
+      - TWITTER_LITENTRY_URL=http://localhost:19527
+      - TWITTER_AUTH_TOKEN_V2=
+      - DISCORD_OFFICIAL_URL=http://localhost:19527
+      - DISCORD_LITENTRY_URL=http://localhost:19527
+      - DISCORD_AUTH_TOKEN=
+      - ACHAINABLE_URL=http://localhost:19527
+      - ACHAINABLE_AUTH_KEY=
+      - CREDENTIAL_ENDPOINT=http://localhost:9933
+      - ONEBLOCK_NOTION_KEY=ABCDEFGHIJKLMNOPQRSTUVWXYZ
+      - ONEBLOCK_NOTION_URL=https://abc.com
+      - SORA_QUIZ_MASTER_ID=SORA_QUIZ_MASTER_ID
+      - SORA_QUIZ_ATTENDEE_ID=SORA_QUIZ_ATTENDEE_ID
+      - NODEREAL_API_KEY=NODEREAL_API_KEY
+      - NODEREAL_API_URL=https://open-platform.nodereal.io/
+      - CONTEST_LEGEND_DISCORD_ROLE_ID=CONTEST_LEGEND_DISCORD_ROLE_ID
+      - CONTEST_POPULARITY_DISCORD_ROLE_ID=CONTEST_POPULARITY_DISCORD_ROLE_ID
+      - CONTEST_PARTICIPANT_DISCORD_ROLE_ID=CONTEST_PARTICIPANT_DISCORD_ROLE_ID
+    networks:
+      - litentry-test-network
+    healthcheck:
+      test: curl -s -f http://litentry-worker-1:4645/is_initialized || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    entrypoint:
+      "/usr/local/bin/litentry-worker --clean-reset --ws-external -M litentry-worker-1 -T wss://litentry-worker-1
+      -u ws://litentry-node -U ws://litentry-worker-1 -P 2011 -w 2101 -p 9912 -h 4645 --enable-mock-server --running-mode mock
+      run --dev --skip-ra"
+    restart: "no"
+  litentry-worker-2:
+    image: litentry/litentry-worker:latest
+    container_name: litentry-worker-2
+    build:
+      context: ${PWD}/..
+      dockerfile: build.Dockerfile
+      target: deployed-worker
+    depends_on:
+      litentry-node:
+        condition: service_healthy
+      litentry-worker-1:
+        condition: service_healthy
+    devices:
+      - "${SGX_PROVISION:-/dev/null}:/dev/sgx/provision"
+      - "${SGX_ENCLAVE:-/dev/null}:/dev/sgx/enclave"
+    volumes:
+      - "${AESMD:-/dev/null}:/var/run/aesmd"
+      - "${SGX_QCNL:-/dev/null}:/etc/sgx_default_qcnl.conf"
+    environment:
+      - RUST_LOG=info,litentry_worker=debug,ws=warn,sp_io=error,substrate_api_client=warn,itc_parentchain_light_client=info,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=debug,ita_stf=debug,its_rpc_handler=warn,itc_rpc_client=warn,its_consensus_common=debug,its_state=warn,its_consensus_aura=warn,aura*=warn,its_consensus_slots=warn,itp_attestation_handler=debug,http_req=debug,lc_mock_server=warn,itc_rest_client=debug,lc_credentials=debug,lc_identity_verification=debug,lc_stf_task_receiver=debug,lc_stf_task_sender=debug,lc_data_providers=debug,itp_top_pool=debug,itc_parentchain_indirect_calls_executor=debug,
+    networks:
+      - litentry-test-network
+    healthcheck:
+      test: curl -s -f http://litentry-worker-2:4645/is_initialized || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    entrypoint:
+      "/usr/local/bin/litentry-worker --clean-reset --ws-external -M litentry-worker-2 -T wss://litentry-worker-2
+      -u ws://litentry-node -U ws://litentry-worker-2 -P 2011 -w 2101 -p 9912 -h 4645 --enable-mock-server --running-mode mock
+      run --dev --skip-ra --request-state"
+    restart: "no"
+  litentry-worker-3:
+    image: litentry/litentry-worker:latest
+    container_name: litentry-worker-3
+    build:
+      context: ${PWD}/..
+      dockerfile: build.Dockerfile
+      target: deployed-worker
+    depends_on:
+      litentry-node:
+        condition: service_healthy
+      litentry-worker-2:
+        condition: service_healthy
+    devices:
+      - "${SGX_PROVISION:-/dev/null}:/dev/sgx/provision"
+      - "${SGX_ENCLAVE:-/dev/null}:/dev/sgx/enclave"
+    volumes:
+      - "${AESMD:-/dev/null}:/var/run/aesmd"
+      - "${SGX_QCNL:-/dev/null}:/etc/sgx_default_qcnl.conf"
+    environment:
+      - RUST_LOG=info,litentry_worker=debug,ws=warn,sp_io=error,substrate_api_client=warn,itc_parentchain_light_client=info,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=debug,ita_stf=debug,its_rpc_handler=warn,itc_rpc_client=warn,its_consensus_common=debug,its_state=warn,its_consensus_aura=warn,aura*=warn,its_consensus_slots=warn,itp_attestation_handler=debug,http_req=debug,lc_mock_server=warn,itc_rest_client=debug,lc_credentials=debug,lc_identity_verification=debug,lc_stf_task_receiver=debug,lc_stf_task_sender=debug,lc_data_providers=debug,itp_top_pool=debug,itc_parentchain_indirect_calls_executor=debug,
+    networks:
+      - litentry-test-network
+    healthcheck:
+      test: curl -s -f http://litentry-worker-3:4645/is_initialized || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    entrypoint:
+      "/usr/local/bin/litentry-worker --clean-reset --ws-external -M litentry-worker-3 -T wss://litentry-worker-3
+      -u ws://litentry-node -U ws://litentry-worker-3 -P 2011 -w 2101 -p 9912 -h 4645 --enable-mock-server --running-mode mock
+      run --dev --skip-ra --request-state"
+    restart: "no"
+volumes:
+  ? relaychain-alice
+  ? relaychain-bob
+  ? parachain-2106-0
+networks:
+  litentry-test-network:
+    driver: bridge


### PR DESCRIPTION
This PR adds GHA job to run tests in multiworker setup. 
Let's run it for a while with `continue-on-error: true` to not fail pipelines.
Later we can remove this rule or and remove single worker tests or keep them both.
