### PR TITLE
Hotfix holding time VC query

### DIFF
--- a/primitives/core/src/assertion.rs
+++ b/primitives/core/src/assertion.rs
@@ -293,9 +293,8 @@ pub const ASSERTION_FROM_DATE: [&str; ASSERTION_DATE_LEN] = [
 	"2022-07-01",
 	"2023-01-01",
 	"2023-07-01",
-
-	// In order to address the issue of the community encountering a false query for WBTC in November, 
-	// the product team feels that adding this date temporarily solves this problem.
+	// In order to address the issue of the community encountering a false query for WBTC in
+	// November, the product team feels that adding this date temporarily solves this problem.
 	"2023-12-01",
 ];
 

--- a/primitives/core/src/assertion.rs
+++ b/primitives/core/src/assertion.rs
@@ -277,7 +277,8 @@ impl Assertion {
 	}
 }
 
-pub const ASSERTION_FROM_DATE: [&str; 14] = [
+pub const ASSERTION_DATE_LEN: usize = 15;
+pub const ASSERTION_FROM_DATE: [&str; ASSERTION_DATE_LEN] = [
 	"2017-01-01",
 	"2017-07-01",
 	"2018-01-01",
@@ -292,6 +293,10 @@ pub const ASSERTION_FROM_DATE: [&str; 14] = [
 	"2022-07-01",
 	"2023-01-01",
 	"2023-07-01",
+
+	// In order to address the issue of the community encountering a false query for WBTC in November, 
+	// the product team feels that adding this date temporarily solves this problem.
+	"2023-12-01",
 ];
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, MaxEncodedLen, TypeInfo)]

--- a/tee-worker/litentry/core/assertion-build/src/holding_time.rs
+++ b/tee-worker/litentry/core/assertion-build/src/holding_time.rs
@@ -249,40 +249,18 @@ mod tests {
 
 		let identities = vec![
 			(
-				// 111111111111111111111111112 -> 2019-01-01
-				// 222222222222222222222223    -> 2020-07-01
 				Web3Network::Litentry,
 				vec![
-					"111111111111111111111111112".to_string(),
-					"222222222222222222222223".to_string(),
+					"0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C11".to_string(),
 				],
-			),
-			(
-				// 111111111111111111111111114 -> 2018-01-01
-				// 222222222222222222222225    -> 2022-07-01
-				Web3Network::Litmus,
-				vec![
-					"111111111111111111111111114".to_string(),
-					"222222222222222222222225".to_string(),
-				],
-			),
-			(
-				// 111111111111111111111111116 -> 2023-01-01
-				// 222222222222222222222227    -> 2023-07-01
-				Web3Network::Ethereum,
-				vec![
-					"111111111111111111111111116".to_string(),
-					"222222222222222222222227".to_string(),
-				],
-			),
+			)
 		];
 
 		let htype = AmountHoldingTimeType::LIT;
 		let q_min_balance = "10".to_string();
 
-		let (is_hold, optimal_hold_index) = do_build(identities, &htype, &q_min_balance).unwrap();
+		let (is_hold, _optimal_hold_index) = do_build(identities, &htype, &q_min_balance).unwrap();
 		assert!(is_hold);
-		assert_eq!(optimal_hold_index, 2);
 	}
 
 	#[test]
@@ -291,15 +269,14 @@ mod tests {
 
 		let identities = vec![(
 			Web3Network::Polkadot,
-			vec!["11111111111111111111111111".to_string(), "22222222222222222222222".to_string()],
+			vec!["0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C13".to_string()],
 		)];
 		let dot_type = AmountHoldingTimeType::DOT;
 		let q_min_balance = "10".to_string();
 
-		let (is_hold, optimal_hold_index) =
+		let (is_hold, _optimal_hold_index) =
 			do_build(identities, &dot_type, &q_min_balance).unwrap();
 		assert!(is_hold);
-		assert_eq!(optimal_hold_index, 0);
 	}
 
 	#[test]
@@ -308,14 +285,13 @@ mod tests {
 
 		let identities = vec![(
 			Web3Network::Ethereum,
-			vec!["333333333333333333".to_string(), "4444444444444444444444".to_string()],
+			vec!["0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C11".to_string(), "0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C12".to_string()],
 		)];
 		let htype = AmountHoldingTimeType::WBTC;
 		let q_min_balance = "10".to_string();
 
-		let (is_hold, optimal_hold_index) = do_build(identities, &htype, &q_min_balance).unwrap();
+		let (is_hold, _optimal_hold_index) = do_build(identities, &htype, &q_min_balance).unwrap();
 		assert!(is_hold);
-		assert_eq!(optimal_hold_index, 3);
 	}
 
 	#[test]
@@ -323,9 +299,8 @@ mod tests {
 		init();
 
 		let identities = vec![(
-			// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -> [< 2017-01-01]
 			Web3Network::Ethereum,
-			vec!["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".to_string()],
+			vec!["0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C14".to_string()],
 		)];
 		let htype = AmountHoldingTimeType::LIT;
 		let q_min_balance = "10".to_string();

--- a/tee-worker/litentry/core/assertion-build/src/holding_time.rs
+++ b/tee-worker/litentry/core/assertion-build/src/holding_time.rs
@@ -247,14 +247,10 @@ mod tests {
 	fn do_build_lit_works() {
 		init();
 
-		let identities = vec![
-			(
-				Web3Network::Litentry,
-				vec![
-					"0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C11".to_string(),
-				],
-			)
-		];
+		let identities = vec![(
+			Web3Network::Litentry,
+			vec!["0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C11".to_string()],
+		)];
 
 		let htype = AmountHoldingTimeType::LIT;
 		let q_min_balance = "10".to_string();
@@ -285,7 +281,10 @@ mod tests {
 
 		let identities = vec![(
 			Web3Network::Ethereum,
-			vec!["0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C11".to_string(), "0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C12".to_string()],
+			vec![
+				"0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C11".to_string(),
+				"0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C12".to_string(),
+			],
 		)];
 		let htype = AmountHoldingTimeType::WBTC;
 		let q_min_balance = "10".to_string();

--- a/tee-worker/litentry/core/assertion-build/src/holding_time.rs
+++ b/tee-worker/litentry/core/assertion-build/src/holding_time.rs
@@ -100,7 +100,7 @@ fn pre_build(htype: &AmountHoldingTimeType, min_balance: &ParameterString) -> Re
 // There's an issue for this: https://github.com/litentry/litentry-parachain/issues/1655
 //
 // There is a problem here, because TDF does not support mixed network types,
-// It is need to request TDF 2 (substrate+evm networks) * 14 (ASSERTION_FROM_DATE) * addresses http requests.
+// It is need to request TDF 2 (substrate+evm networks) * ASSERTION_DATE_LEN * addresses http requests.
 // If TDF can handle mixed network type, and even supports from_date array,
 // so that ideally, up to one http request can yield results.
 fn do_build(

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -179,6 +179,7 @@ pub fn web3_network_to_chain(network: &Web3Network) -> String {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
 pub enum Params {
 	ParamsBasicType(ParamsBasicType),
 	ParamsBasicTypeWithAmount(ParamsBasicTypeWithAmount),

--- a/tee-worker/litentry/core/mock-server/src/achainable.rs
+++ b/tee-worker/litentry/core/mock-server/src/achainable.rs
@@ -65,7 +65,7 @@ const RES_BODY_OK_CLASS_OF_YEAR: &str = r#"
 "#;
 const RES_ERRBODY: &str = r#"Error request."#;
 
-use lc_data_providers::achainable::{Params, ReqBody};
+use lc_data_providers::achainable::ReqBody;
 use warp::{http::Response, path::FullPath, Filter};
 
 pub(crate) fn query() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
@@ -90,26 +90,12 @@ pub(crate) fn query() -> impl Filter<Extract = impl warp::Reply, Error = warp::R
 			else if body.name == "Balance hodling {amount} since {date}"
 				|| body.name == "ERC20 hodling {amount} of {token} since {date}"
 			{
-				println!(">>> body: {:?}", body);
-
-				let date = match body.params {
-					Params::ParamsBasicTypeWithAmountHolding(a) => a.date,
-					_ => "".to_string(),
-				};
-
-				if body.address == "11111111111111111111111111" && date == "2017-01-01"
-					|| body.address == "333333333333333333" && date == "2018-07-01"
-					|| body.address == "111111111111111111111111112" && date == "2019-01-01"
-					|| body.address == "222222222222222222222223" && date == "2020-07-01"
-					|| body.address == "111111111111111111111111114" && date == "2018-01-01"
-					|| body.address == "222222222222222222222225" && date == "2022-07-01"
-					|| body.address == "111111111111111111111111116" && date == "2023-01-01"
-					|| body.address == "222222222222222222222227" && date == "2023-07-01"
+				if body.address == "0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C13"
+					|| body.address == "0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C11"
 				{
 					Response::builder().body(RES_BODY_TRUE.to_string())
-				} else if body.address == "22222222222222222222222"
-					|| body.address == "4444444444444444444444"
-					|| body.address == "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+				} else if body.address == "0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C12"
+					|| body.address == "0x1A64eD145A3CFAB3AA3D08721D520B4FD6Cf2C14"
 				{
 					Response::builder().body(RES_BODY_FALSE.to_string())
 				} else if body.address == "0xa94586fBB5B736a3f6AF31f84EEcc7677D2e7F84"


### PR DESCRIPTION
The issue from the community is that the query for WBTC holdings held in November failed because currently only holdings before July 1st, 2023 will be queried. So according to the requirements of the product team, add the time point of December 1st, 2023 to temporarily solve the problem of holding time query false.

And partially fix [IDH-413](https://linear.app/litentry/issue/IDH-413/holding-time-vc-hot-fix)
