### PR TITLE
broadcast TOPs submited by stf tasks

### DIFF
--- a/tee-worker/litentry/core/stf-task/receiver/src/lib.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/lib.rs
@@ -55,7 +55,12 @@ use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{RsaRequest, ShardIdentifier, H256};
 use lc_stf_task_sender::{stf_task_sender, RequestType};
 use log::{debug, error, info};
-use std::{boxed::Box, format, string::String, sync::Arc};
+use std::{
+	boxed::Box,
+	format,
+	string::{String, ToString},
+	sync::Arc,
+};
 use threadpool::ThreadPool;
 
 #[cfg(test)]
@@ -161,9 +166,10 @@ where
 			encrypted_trusted_call.len(),
 			top.encode().len()
 		);
-		executor::block_on(
-			self.author_api.watch_top(RsaRequest::new(*shard, encrypted_trusted_call)),
-		)
+		executor::block_on(self.author_api.watch_and_broadcast_top(
+			RsaRequest::new(*shard, encrypted_trusted_call),
+			"author_submitAndWatchBroadcastedRsaRequest".to_string(),
+		))
 		.map_err(|e| {
 			Error::OtherError(format!("error submitting trusted call to top pool: {:?}", e))
 		})?;


### PR DESCRIPTION
During the last round of [refactor](https://github.com/litentry/litentry-parachain/pull/2211/commits/f77057c4911046cde8ae157349230536f654e510) in Top Pool Sync PR I forgot to apply this change to StfTask, so callbacks are not broadcasted to other peers. I caught this during asserting TOP's block time execution for single and multiworker setup.