### PR TITLE
feat: optimise sidechain read

### DIFF
--- a/tee-worker/core-primitives/substrate-sgx/externalities/Cargo.toml
+++ b/tee-worker/core-primitives/substrate-sgx/externalities/Cargo.toml
@@ -22,6 +22,9 @@ sp-core = { default-features = false, git = "https://github.com/paritytech/subst
 environmental = { default-features = false, path = "../environmental" }
 itp-hashing = { default-features = false, path = "../../hashing" }
 
+[dev-dependencies]
+itp-storage = { default-features = false, path = "../../storage" }
+
 [features]
 default = ["std"]
 std = [
@@ -31,6 +34,7 @@ std = [
     "log/std",
     "postcard/use-std",
     "serde/std",
+    "itp-storage/std",
     # substrate
     "sp-core/std",
 ]

--- a/tee-worker/core-primitives/substrate-sgx/externalities/src/lib.rs
+++ b/tee-worker/core-primitives/substrate-sgx/externalities/src/lib.rs
@@ -110,7 +110,7 @@ pub trait SgxExternalitiesTrait {
 	/// Get the next key in state after the given one (excluded) in lexicographic order.
 	fn next_storage_key(&self, key: &[u8]) -> Option<Vec<u8>>;
 
-	/// Iter prefix
+	/// Reads all keys and values under given prefix
 	fn iter_prefix<K: Decode + Debug, V: Decode + Debug>(
 		&self,
 		key_prefix: &[u8],

--- a/tee-worker/core-primitives/substrate-sgx/externalities/src/lib.rs
+++ b/tee-worker/core-primitives/substrate-sgx/externalities/src/lib.rs
@@ -27,7 +27,7 @@ use derive_more::{Deref, DerefMut, From, IntoIterator};
 use itp_hashing::Hash;
 use serde::{Deserialize, Serialize};
 use sp_core::{hashing::blake2_256, H256};
-use std::{collections::BTreeMap, vec, vec::Vec};
+use std::{collections::BTreeMap, fmt::Debug, vec, vec::Vec};
 
 pub use scope_limited::{set_and_run_with_externalities, with_externalities};
 
@@ -110,6 +110,12 @@ pub trait SgxExternalitiesTrait {
 	/// Get the next key in state after the given one (excluded) in lexicographic order.
 	fn next_storage_key(&self, key: &[u8]) -> Option<Vec<u8>>;
 
+	/// Iter prefix
+	fn iter_prefix<K: Decode + Debug, V: Decode + Debug>(
+		&self,
+		key_prefix: &[u8],
+	) -> Option<Vec<(K, V)>>;
+
 	/// Clears all values that match the given key prefix.
 	fn clear_prefix(&mut self, key_prefix: &[u8], maybe_limit: Option<u32>) -> u32;
 
@@ -173,6 +179,40 @@ where
 
 	fn prune_state_diff(&mut self) {
 		self.state_diff.clear();
+	}
+
+	fn iter_prefix<K: Decode + Debug, V: Decode + Debug>(
+		&self,
+		key_prefix: &[u8],
+	) -> Option<Vec<(K, V)>> {
+		// The size of the hash part in Blake2_128Concat (16 bytes for blake2_128)
+		const HASH_PART_SIZE: usize = 16;
+
+		let key_values = self
+			.state
+			.range::<[u8], _>((Bound::Included(key_prefix), Bound::Unbounded))
+			.take_while(|(k, _)| k.starts_with(key_prefix))
+			.filter_map(|(encoded_key, encoded_value)| {
+				let suffix_start = key_prefix.len() + HASH_PART_SIZE;
+				if encoded_key.len() > suffix_start {
+					let suffix = &encoded_key[suffix_start..];
+					let decoded_key = K::decode(&mut &suffix[..]).ok();
+					let decoded_value = V::decode(&mut &encoded_value[..]).ok();
+					match (decoded_key, decoded_value) {
+						(Some(key), Some(value)) => Some((key, value)),
+						_ => None,
+					}
+				} else {
+					None
+				}
+			})
+			.collect::<Vec<_>>();
+
+		if key_values.is_empty() {
+			None
+		} else {
+			Some(key_values)
+		}
 	}
 
 	fn clear_prefix(&mut self, key_prefix: &[u8], _maybe_limit: Option<u32>) -> u32 {

--- a/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/Cargo.toml
+++ b/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/Cargo.toml
@@ -38,6 +38,7 @@ itp-sgx-crypto = { path = "../../../../core-primitives/sgx/crypto", default-feat
 itp-sgx-externalities = { path = "../../../../core-primitives/substrate-sgx/externalities", default-features = false }
 itp-stf-executor = { path = "../../../../core-primitives/stf-executor", default-features = false }
 itp-stf-state-handler = { path = "../../../../core-primitives/stf-state-handler", default-features = false }
+itp-storage = { path = "../../../../core-primitives/storage", default-features = false }
 itp-top-pool-author = { path = "../../../../core-primitives/top-pool-author", default-features = false }
 
 # litentry
@@ -50,6 +51,7 @@ lc-stf-task-receiver = { path = "../../stf-task/receiver", default-features = fa
 lc-stf-task-sender = { path = "../../stf-task/sender", default-features = false }
 lc-vc-task-sender = { path = "../lc-vc-task-sender", default-features = false }
 litentry-primitives = { path = "../../../primitives", default-features = false }
+pallet-identity-management-tee = { path = "../../../pallets/identity-management", default-features = false }
 
 [features]
 default = ["std"]
@@ -75,6 +77,7 @@ sgx = [
     "lc-stf-task-sender/sgx",
     "itp-extrinsics-factory/sgx",
     "itp-node-api/sgx",
+    "itp-storage/sgx",
     "lc-vc-task-sender/sgx",
 ]
 std = [
@@ -98,5 +101,6 @@ std = [
     "lc-stf-task-sender/std",
     "itp-extrinsics-factory/std",
     "itp-node-api/std",
+    "itp-storage/std",
     "lc-vc-task-sender/std",
 ]

--- a/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/src/lib.rs
+++ b/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/src/lib.rs
@@ -23,12 +23,13 @@ mod vc_handling;
 
 use crate::vc_handling::VCRequestHandler;
 use codec::{Decode, Encode};
+use core::cmp::Ordering;
 pub use futures;
-use ita_sgx_runtime::Hash;
+use ita_sgx_runtime::{Hash, Runtime};
 use ita_stf::{
 	aes_encrypt_default, helpers::enclave_signer_account, trusted_call_result::RequestVCResult,
 	ConvertAccountId, Getter, OpaqueCall, SgxParentchainTypeConverter, TrustedCall,
-	TrustedCallSigned, TrustedOperation, H256, IMT,
+	TrustedCallSigned, TrustedOperation, H256,
 };
 use itp_extrinsics_factory::CreateExtrinsics;
 use itp_node_api::metadata::{
@@ -39,14 +40,16 @@ use itp_sgx_crypto::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
 use itp_sgx_externalities::SgxExternalitiesTrait;
 use itp_stf_executor::traits::StfEnclaveSigning;
 use itp_stf_state_handler::handle_state::HandleState;
+use itp_storage::{storage_map_key, StorageHasher};
 use itp_top_pool_author::traits::AuthorApi;
 use itp_types::parentchain::ParentchainId;
 use lc_stf_task_receiver::StfTaskContext;
 use lc_stf_task_sender::AssertionBuildRequest;
 use lc_vc_task_sender::init_vc_task_sender_storage;
 use litentry_primitives::{
-	aes_decrypt, AesOutput, IdentityNetworkTuple, RequestAesKey, ShardIdentifier,
+	aes_decrypt, AesOutput, Identity, IdentityNetworkTuple, RequestAesKey, ShardIdentifier,
 };
+use pallet_identity_management_tee::IdentityContext;
 use std::{
 	format,
 	string::{String, ToString},
@@ -137,86 +140,102 @@ where
 	if let TrustedCall::request_vc(signer, who, assertion, maybe_key, _hash) =
 		trusted_call.call.clone()
 	{
-		let (mut state, _) = context.state_handler.load_cloned(&shard).map_err(|e| {
-			format!("Received error while trying to obtain sidechain state: {:?}", e)
-		})?;
+		let key = match maybe_key {
+			Some(s) => s,
+			None => return Err("User shielding key not provided".to_string()),
+		};
+		let identities: Vec<IdentityNetworkTuple> = context
+			.state_handler
+			.execute_on_current(&shard, |state, _| {
+				let prefix_key = storage_map_key(
+					"IdentityManagement",
+					"IDGraphs",
+					&who,
+					&StorageHasher::Blake2_128Concat,
+				);
+				let mut id_graph =
+					state.iter_prefix::<Identity, IdentityContext<Runtime>>(&prefix_key).unwrap();
+				id_graph.sort_by(|a, b| {
+					let order = Ord::cmp(&a.1.link_block, &b.1.link_block);
+					if order == Ordering::Equal {
+						// Compare identities by their did formated string
+						Ord::cmp(&a.0.to_did().ok(), &b.0.to_did().ok())
+					} else {
+						order
+					}
+				});
+				let assertion_networks = assertion.clone().get_supported_web3networks();
+				let identities: Vec<IdentityNetworkTuple> = id_graph
+					.into_iter()
+					.filter(|item| item.1.is_active())
+					.map(|item| {
+						let mut networks = item.1.web3networks.to_vec();
+						networks.retain(|n| assertion_networks.contains(n));
+						(item.0, networks)
+					})
+					.collect();
 
-		state.execute_with(|| {
-			let key = match maybe_key {
+				identities
+			})
+			.map_err(|e| format!("Failed to fetch sidechain data due to: {:?}", e))?;
+
+		let signer = match signer.to_account_id() {
+			Some(s) => s,
+			None => return Err("Invalid signer account, failed to convert".to_string()),
+		};
+
+		let assertion_build: AssertionBuildRequest = AssertionBuildRequest {
+			shard,
+			signer,
+			enclave_account: enclave_signer_account(),
+			who,
+			assertion,
+			identities,
+			maybe_key,
+			top_hash: H256::zero(),
+			req_ext_hash: H256::zero(),
+		};
+
+		let vc_request_handler =
+			VCRequestHandler { req: assertion_build, context: context.clone() };
+		let response = vc_request_handler
+			.process()
+			.map_err(|e| format!("Failed to build assertion due to: {:?}", e))?;
+
+		let call_index = node_metadata_repo
+			.get_from_metadata(|m| m.vc_issued_call_indexes())
+			.unwrap()
+			.unwrap();
+		let result = aes_encrypt_default(&key, &response.vc_payload);
+		let account = SgxParentchainTypeConverter::convert(
+			match response.assertion_request.who.to_account_id() {
 				Some(s) => s,
-				None => return Err("User shielding key not provided".to_string()),
-			};
+				None => return Err("Failed to convert account".to_string()),
+			},
+		);
+		let call = OpaqueCall::from_tuple(&(
+			call_index,
+			account,
+			response.assertion_request.assertion,
+			response.vc_index,
+			response.vc_hash,
+			H256::zero(),
+		));
+		let res = RequestVCResult {
+			vc_index: response.vc_index,
+			vc_hash: response.vc_hash,
+			vc_payload: result,
+		};
+		// This internally fetches nonce from a Mutex and then updates it thereby ensuring ordering
+		let xt = extrinsic_factory
+			.create_extrinsics(&[call], None)
+			.map_err(|e| format!("Failed to construct extrinsic for parentchain: {:?}", e))?;
+		context
+			.ocall_api
+			.send_to_parentchain(xt, &ParentchainId::Litentry, false)
+			.map_err(|e| format!("Unable to send extrinsic to parentchain: {:?}", e))?;
 
-			let id_graph = IMT::get_id_graph(&who);
-			let assertion_networks = assertion.clone().get_supported_web3networks();
-			let identities: Vec<IdentityNetworkTuple> = id_graph
-				.into_iter()
-				.filter(|item| item.1.is_active())
-				.map(|item| {
-					let mut networks = item.1.web3networks.to_vec();
-					networks.retain(|n| assertion_networks.contains(n));
-					(item.0, networks)
-				})
-				.collect();
-
-			let signer = match signer.to_account_id() {
-				Some(s) => s,
-				None => return Err("Invalid signer account, failed to convert".to_string()),
-			};
-
-			let assertion_build: AssertionBuildRequest = AssertionBuildRequest {
-				shard,
-				signer,
-				enclave_account: enclave_signer_account(),
-				who: who.clone(),
-				assertion: assertion.clone(),
-				identities,
-				maybe_key,
-				top_hash: H256::zero(),
-				req_ext_hash: H256::zero(),
-			};
-
-			let vc_request_handler =
-				VCRequestHandler { req: assertion_build, context: context.clone() };
-			let response = vc_request_handler
-				.process()
-				.map_err(|e| format!("Failed to build assertion due to: {:?}", e))?;
-
-			let call_index = node_metadata_repo
-				.get_from_metadata(|m| m.vc_issued_call_indexes())
-				.unwrap()
-				.unwrap();
-			let result = aes_encrypt_default(&key, &response.vc_payload);
-			let account = SgxParentchainTypeConverter::convert(
-				match response.assertion_request.who.to_account_id() {
-					Some(s) => s,
-					None => return Err("Failed to convert account".to_string()),
-				},
-			);
-			let call = OpaqueCall::from_tuple(&(
-				call_index,
-				account,
-				response.assertion_request.assertion,
-				response.vc_index,
-				response.vc_hash,
-				H256::zero(),
-			));
-			let res = RequestVCResult {
-				vc_index: response.vc_index,
-				vc_hash: response.vc_hash,
-				vc_payload: result,
-			};
-			// This internally fetches nonce from a Mutex and then updates it thereby ensuring ordering
-			let xt = extrinsic_factory
-				.create_extrinsics(&[call], None)
-				.map_err(|e| format!("Failed to construct extrinsic for parentchain: {:?}", e))?;
-			context
-				.ocall_api
-				.send_to_parentchain(xt, &ParentchainId::Litentry, false)
-				.map_err(|e| format!("Unable to send extrinsic to parentchain: {:?}", e))?;
-
-			Ok(res.encode())
-		})
+		Ok(res.encode())
 	} else {
 		Err("Invalid Trusted Operation send to VC Request handler".to_string())
 	}

--- a/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/src/lib.rs
+++ b/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/src/lib.rs
@@ -122,7 +122,7 @@ where
 		.map_err(|e| format!("Failed to convert to UserShieldingKeyType: {:?}", e))?;
 
 	let decrypted_trusted_operation = aes_decrypt(&aes_key, &mut encrypted_trusted_call)
-		.ok_or("Failed to decrypt trusted operation".to_string())?;
+		.ok_or_else(|| "Failed to decrypt trusted operation".to_string())?;
 
 	let trusted_operation = TrustedOperation::<TrustedCallSigned, Getter>::decode(
 		&mut decrypted_trusted_operation.as_slice(),
@@ -131,12 +131,12 @@ where
 
 	let trusted_call: &TrustedCallSigned = trusted_operation
 		.to_call()
-		.ok_or("Failed to convert trusted operation to trusted call".to_string())?;
+		.ok_or_else(|| "Failed to convert trusted operation to trusted call".to_string())?;
 
 	if let TrustedCall::request_vc(signer, who, assertion, maybe_key, _hash) =
 		trusted_call.call.clone()
 	{
-		let key = maybe_key.ok_or("User shielding key not provided".to_string())?;
+		let key = maybe_key.ok_or_else(|| "User shielding key not provided".to_string())?;
 		let identities: Vec<IdentityNetworkTuple> = context
 			.state_handler
 			.execute_on_current(&shard, |state, _| {
@@ -169,7 +169,7 @@ where
 
 		let signer = signer
 			.to_account_id()
-			.ok_or("Invalid signer account, failed to convert".to_string())?;
+			.ok_or_else(|| "Invalid signer account, failed to convert".to_string())?;
 
 		let assertion_build: AssertionBuildRequest = AssertionBuildRequest {
 			shard,

--- a/tee-worker/litentry/pallets/identity-management/src/identity_context.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/identity_context.rs
@@ -16,6 +16,8 @@
 
 use crate::{BlockNumberOf, Config, Web3Network};
 use codec::{Decode, Encode};
+use core::cmp::Ordering;
+use litentry_primitives::Identity;
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
 
@@ -68,4 +70,16 @@ impl<T: Config> IdentityContext<T> {
 		web3networks.dedup();
 		web3networks
 	}
+}
+
+pub fn sort_id_graph<T: Config>(id_graph: &mut [(Identity, IdentityContext<T>)]) {
+	id_graph.sort_by(|a, b| {
+		let order = Ord::cmp(&a.1.link_block, &b.1.link_block);
+		if order == Ordering::Equal {
+			// Compare identities by their did formated string
+			Ord::cmp(&a.0.to_did().ok(), &b.0.to_did().ok())
+		} else {
+			order
+		}
+	});
 }

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -36,7 +36,6 @@ pub mod migrations;
 
 pub use pallet::*;
 pub mod identity_context;
-use core::cmp::Ordering;
 pub use identity_context::*;
 
 use frame_support::{pallet_prelude::*, sp_runtime::traits::One, traits::StorageVersion};
@@ -297,15 +296,7 @@ pub mod pallet {
 			let mut id_graph = IDGraphs::iter_prefix(who).collect::<IDGraph<T>>();
 
 			// Initial sort to ensure a deterministic order
-			id_graph.sort_by(|a, b| {
-				let order = Ord::cmp(&a.1.link_block, &b.1.link_block);
-				if order == Ordering::Equal {
-					// Compare identities by their did formated string
-					Ord::cmp(&a.0.to_did().ok(), &b.0.to_did().ok())
-				} else {
-					order
-				}
-			});
+			sort_id_graph::<T>(&mut id_graph);
 
 			id_graph
 		}


### PR DESCRIPTION
This PR removes the need to clone the entire sidechain state everytime we need to read from it, This would have been a bottleneck as the state of the sidechain grew over a period of time. 

Some notes: 
- While obtaining a value using encoded keys is simple, but performing `iter_prefix` was not as straightforward 
- I created a function `iter_prefix` and included it as part of the `Externalities` trait, It is generic and can be used in the future 
- We have the `primary key` or (prefix key), We need to iter for all the suffix keys and also obtain their original value, Since we use `Blake2_128Concat`, The hasher concatenates the original value to the hash and the structure of the key is like this : `[key2 hash][key2 value]` 
- So once we iter the suffix keys, We just need to extract the original key value that was hashed, and the value it holds and this is how we do it here:
```rust
	let suffix_start = key_prefix.len() + HASH_PART_SIZE;
	if encoded_key.len() > suffix_start {
			let suffix = &encoded_key[suffix_start..];
			let decoded_key = K::decode(&mut &suffix[..]).ok();
```