### PR TITLE
Add support for BTC account linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,6 +620,7 @@ jobs:
           - test_name: lit-ii-identity-test
           - test_name: lit-di-substrate-identity-test
           - test_name: lit-di-evm-identity-test
+          - test_name: lit-di-bitcoin-identity-test
           - test_name: lit-di-vc-test
           - test_name: lit-parentchain-nonce
           - test_name: lit-ii-batch-test

--- a/primitives/core/src/network.rs
+++ b/primitives/core/src/network.rs
@@ -69,6 +69,10 @@ pub enum Web3Network {
 	Ethereum,
 	#[codec(index = 8)]
 	Bsc,
+
+	// btc
+	#[codec(index = 9)]
+	Bitcoin,
 }
 
 // mainly used in CLI
@@ -95,6 +99,10 @@ impl Web3Network {
 	pub fn is_evm(&self) -> bool {
 		matches!(self, Self::Ethereum | Self::Bsc)
 	}
+
+	pub fn is_bitcoin(&self) -> bool {
+		matches!(self, Self::Bitcoin)
+	}
 }
 
 pub fn all_web3networks() -> Vec<Web3Network> {
@@ -107,6 +115,10 @@ pub fn all_substrate_web3networks() -> Vec<Web3Network> {
 
 pub fn all_evm_web3networks() -> Vec<Web3Network> {
 	Web3Network::iter().filter(|n| n.is_evm()).collect()
+}
+
+pub fn all_bitcoin_web3networks() -> Vec<Web3Network> {
+	Web3Network::iter().filter(|n| n.is_bitcoin()).collect()
 }
 
 #[cfg(test)]
@@ -134,6 +146,7 @@ mod tests {
 					Web3Network::SubstrateTestnet => false,
 					Web3Network::Ethereum => true,
 					Web3Network::Bsc => true,
+					Web3Network::Bitcoin => false,
 				}
 			)
 		})
@@ -154,6 +167,28 @@ mod tests {
 					Web3Network::SubstrateTestnet => true,
 					Web3Network::Ethereum => false,
 					Web3Network::Bsc => false,
+					Web3Network::Bitcoin => false,
+				}
+			)
+		})
+	}
+
+	#[test]
+	fn is_bitcoin_works() {
+		Web3Network::iter().for_each(|network| {
+			assert_eq!(
+				network.is_bitcoin(),
+				match network {
+					Web3Network::Polkadot => false,
+					Web3Network::Kusama => false,
+					Web3Network::Litentry => false,
+					Web3Network::Litmus => false,
+					Web3Network::LitentryRococo => false,
+					Web3Network::Khala => false,
+					Web3Network::SubstrateTestnet => false,
+					Web3Network::Ethereum => false,
+					Web3Network::Bsc => false,
+					Web3Network::Bitcoin => true,
 				}
 			)
 		})

--- a/scripts/launch-standalone.sh
+++ b/scripts/launch-standalone.sh
@@ -27,3 +27,5 @@ echo "Starting litentry-collator in standalone mode ..."
 $PARACHAIN_BIN --dev --unsafe-ws-external --unsafe-rpc-external \
   --port "${CollatorPort:-30333}" --ws-port "${CollatorWSPort:-9944}" --rpc-port "${CollatorRPCPort:-9933}" \
   &> "$LITENTRY_PARACHAIN_DIR/para.alice.log" &
+
+sleep 10

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
@@ -26,13 +26,26 @@ export default {
                 Github: "IdentityString",
                 Substrate: "Address32",
                 Evm: "Address20",
+                Bitcoin: "Address33",
             },
         },
         Address32: "[u8;32]",
         Address20: "[u8;20]",
+        Address33: "[u8;33]",
         IdentityString: "Vec<u8>",
         Web3Network: {
-            _enum: ["Polkadot", "Kusama", "Litentry", "Litmus", "LitentryRococo", "Khala", "SubstrateTestnet", "Ethereum", "Bsc"],
+            _enum: [
+                "Polkadot",
+                "Kusama",
+                "Litentry",
+                "Litmus",
+                "LitentryRococo",
+                "Khala",
+                "SubstrateTestnet",
+                "Ethereum",
+                "Bsc",
+                "Bitcoin",
+            ],
         },
         LitentryValidationData: {
             _enum: {
@@ -58,6 +71,7 @@ export default {
             _enum: {
                 Substrate: "Web3CommonValidationData",
                 Evm: "Web3CommonValidationData",
+                Bitcoin: "Web3CommonValidationData",
             },
         },
         Web3CommonValidationData: {

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
@@ -81,13 +81,16 @@ export default {
 
         LitentryMultiSignature: {
             _enum: {
-                Ed25519: "ed25519::Signature",
-                Sr25519: "sr25519::Signature",
-                Ecdsa: "ecdsa::Signature",
+                Ed25519: "Ed25519Signature",
+                Sr25519: "Sr25519Signature",
+                Ecdsa: "EcdsaSignature",
                 Ethereum: "EthereumSignature",
                 EthereumPrettified: "EthereumSignature",
             },
         },
+        Ed25519Signature: "([u8; 64])",
+        Sr25519Signature: "([u8; 64])",
+        EcdsaSignature: "([u8; 65])",
         EthereumSignature: "([u8; 65])",
 
         IdentityGenericEvent: {

--- a/tee-worker/core-primitives/substrate-sgx/sp-io/src/lib.rs
+++ b/tee-worker/core-primitives/substrate-sgx/sp-io/src/lib.rs
@@ -670,10 +670,8 @@ pub mod crypto {
 	) -> Result<[u8; 33], EcdsaVerifyError> {
 		let rs = libsecp256k1::Signature::parse_standard_slice(&sig[0..64])
 			.map_err(|_| EcdsaVerifyError::BadRS)?;
-		let v = libsecp256k1::RecoveryId::parse(
-			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
-		)
-		.map_err(|_| EcdsaVerifyError::BadV)?;
+		let v = libsecp256k1::RecoveryId::parse(if sig[64] > 26 { sig[64] - 27 } else { sig[64] })
+			.map_err(|_| EcdsaVerifyError::BadV)?;
 		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
 			.map_err(|_| EcdsaVerifyError::BadSignature)?;
 		Ok(pubkey.serialize_compressed())

--- a/tee-worker/core-primitives/substrate-sgx/sp-io/src/lib.rs
+++ b/tee-worker/core-primitives/substrate-sgx/sp-io/src/lib.rs
@@ -668,8 +668,15 @@ pub mod crypto {
 		sig: &[u8; 65],
 		msg: &[u8; 32],
 	) -> Result<[u8; 33], EcdsaVerifyError> {
-		warn!("crypto::secp256k1_ecdsa_recover unimplemented");
-		Ok([0; 33])
+		let rs = libsecp256k1::Signature::parse_standard_slice(&sig[0..64])
+			.map_err(|_| EcdsaVerifyError::BadRS)?;
+		let v = libsecp256k1::RecoveryId::parse(
+			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
+		)
+		.map_err(|_| EcdsaVerifyError::BadV)?;
+		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
+			.map_err(|_| EcdsaVerifyError::BadSignature)?;
+		Ok(pubkey.serialize_compressed())
 	}
 }
 

--- a/tee-worker/docker/lit-di-bitcoin-identity-test.yml
+++ b/tee-worker/docker/lit-di-bitcoin-identity-test.yml
@@ -1,7 +1,7 @@
 services:
-    lit-di-evm-identity-test:
+    lit-di-bitcoin-identity-test:
         image: litentry/litentry-cli:latest
-        container_name: litentry-di-evm-identity-test
+        container_name: litentry-di-bitcoin-identity-test
         volumes:
             - ../ts-tests:/ts-tests
             - ../client-api:/client-api

--- a/tee-worker/docker/lit-di-bitcoin-identity-test.yml
+++ b/tee-worker/docker/lit-di-bitcoin-identity-test.yml
@@ -1,0 +1,24 @@
+services:
+    lit-di-evm-identity-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-di-evm-identity-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_test.sh test-di-bitcoin-identity 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -175,6 +175,7 @@ pub fn web3_network_to_chain(network: &Web3Network) -> String {
 		Web3Network::SubstrateTestnet => "substrate_testnet".into(),
 		Web3Network::Ethereum => "ethereum".into(),
 		Web3Network::Bsc => "bsc".into(),
+		Web3Network::Bitcoin => "bitcoin".into(),
 	}
 }
 

--- a/tee-worker/litentry/primitives/src/lib.rs
+++ b/tee-worker/litentry/primitives/src/lib.rs
@@ -55,7 +55,10 @@ pub use parentchain_primitives::{
 };
 use scale_info::TypeInfo;
 use sp_core::{ecdsa, ed25519, sr25519, ByteArray};
-use sp_io::{crypto::secp256k1_ecdsa_recover, hashing::keccak_256};
+use sp_io::{
+	crypto::secp256k1_ecdsa_recover,
+	hashing::{blake2_256, keccak_256},
+};
 use sp_runtime::traits::Verify;
 use std::string::{String, ToString};
 pub use teerex_primitives::{decl_rsa_request, ShardIdentifier};
@@ -90,6 +93,7 @@ impl LitentryMultiSignature {
 				self.verify_substrate(substrate_wrap(msg).as_slice(), address)
 					|| self.verify_substrate(msg, address),
 			Identity::Evm(address) => self.verify_evm(msg, address),
+			Identity::Bitcoin(address) => self.verify_bitcoin(msg, address),
 			_ => false,
 		}
 	}
@@ -105,11 +109,10 @@ impl LitentryMultiSignature {
 				Err(()) => false,
 			},
 			(Self::Ecdsa(ref sig), who) => {
-				let m = sp_io::hashing::blake2_256(msg);
+				let m = blake2_256(msg);
 				match sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m) {
 					Ok(pubkey) =>
-						&sp_io::hashing::blake2_256(pubkey.as_ref())
-							== <dyn AsRef<[u8; 32]>>::as_ref(who),
+						&blake2_256(pubkey.as_ref()) == <dyn AsRef<[u8; 32]>>::as_ref(who),
 					_ => false,
 				}
 			},
@@ -130,6 +133,19 @@ impl LitentryMultiSignature {
 				let data = user_readable_message.as_bytes();
 				return verify_evm_signature(evm_eip191_wrap(data).as_slice(), sig, signer)
 					|| verify_evm_signature(data, sig, signer)
+			},
+			_ => false,
+		}
+	}
+
+	fn verify_bitcoin(&self, msg: &[u8], signer: &Address33) -> bool {
+		match self {
+			Self::Ecdsa(ref sig) => {
+				let m = blake2_256(msg);
+				match sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m) {
+					Ok(pubkey) => pubkey.as_ref() == signer.as_ref(),
+					_ => false,
+				}
 			},
 			_ => false,
 		}

--- a/tee-worker/litentry/primitives/src/validation_data.rs
+++ b/tee-worker/litentry/primitives/src/validation_data.rs
@@ -64,6 +64,8 @@ pub enum Web3ValidationData {
 	Substrate(Web3CommonValidationData),
 	#[codec(index = 1)]
 	Evm(Web3CommonValidationData),
+	#[codec(index = 2)]
+	Bitcoin(Web3CommonValidationData),
 }
 
 impl Web3ValidationData {
@@ -71,6 +73,7 @@ impl Web3ValidationData {
 		match self {
 			Self::Substrate(data) => &data.message,
 			Self::Evm(data) => &data.message,
+			Self::Bitcoin(data) => &data.message,
 		}
 	}
 
@@ -78,6 +81,7 @@ impl Web3ValidationData {
 		match self {
 			Self::Substrate(data) => &data.signature,
 			Self::Evm(data) => &data.signature,
+			Self::Bitcoin(data) => &data.signature,
 		}
 	}
 }

--- a/tee-worker/service/src/prometheus_metrics.rs
+++ b/tee-worker/service/src/prometheus_metrics.rs
@@ -265,6 +265,7 @@ fn handle_stf_call_request(req: RequestType, time: f64) {
 			Identity::Github(_) => "Github",
 			Identity::Substrate(_) => "Substrate",
 			Identity::Evm(_) => "Evm",
+			Identity::Bitcoin(_) => "Bitcoin",
 		},
 		RequestType::AssertionVerification(request) => match request.assertion {
 			Assertion::A1 => "A1",

--- a/tee-worker/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/tee-worker/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -330,12 +330,8 @@ where
 	TCS: PartialEq + Encode + Decode + Debug + Send + Sync + 'static,
 	G: PartialEq + Encode + Decode + Debug + Send + Sync + 'static,
 {
-	debug!("Author submit and watch AesRequest..");
-
 	let hex_encoded_params = params.parse::<Vec<String>>().map_err(|e| format!("{:?}", e))?;
-
-	info!("Got request hex: {:?}", &hex_encoded_params[0]);
-	std::println!("Got request hex: {:?}", &hex_encoded_params[0]);
+	info!("author_submitAndWatchAesRequest, request hex: {:?}", &hex_encoded_params[0]);
 
 	let request =
 		AesRequest::from_hex(&hex_encoded_params[0].clone()).map_err(|e| format!("{:?}", e))?;

--- a/tee-worker/ts-tests/integration-tests/common/common-types.ts
+++ b/tee-worker/ts-tests/integration-tests/common/common-types.ts
@@ -5,6 +5,7 @@ import { Metadata, TypeRegistry } from '@polkadot/types';
 import { Wallet } from 'ethers';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { HexString } from '@polkadot/util/types';
+import { ECPairInterface } from 'ecpair';
 
 // If there are types already defined in the client-api, please avoid redefining these types.
 // Instead, make every effort to use the types that have been generated within the client-api.
@@ -14,6 +15,9 @@ interface EthersWalletItem {
 interface SubstrateWalletItem {
     [key: string]: KeyringPair;
 }
+interface BitcoinWalletItem {
+    [key: string]: ECPairInterface;
+}
 export type IntegrationTestContext = {
     tee: WebSocketAsPromised;
     api: ApiPromise;
@@ -21,9 +25,9 @@ export type IntegrationTestContext = {
     mrEnclave: HexString;
     ethersWallet: EthersWalletItem;
     substrateWallet: SubstrateWalletItem;
+    bitcoinWallet: BitcoinWalletItem;
     sidechainMetaData: Metadata;
     sidechainRegistry: TypeRegistry;
-    web3Signers: Web3Wallets[];
     chainIdentifier: number;
     requestId: number;
 };
@@ -31,6 +35,7 @@ export type IntegrationTestContext = {
 export type Web3Wallets = {
     substrateWallet: KeyringPair;
     evmWallet: Wallet;
+    bitcoinWallet: ECPairInterface;
 };
 
 export type JsonRpcRequest = {

--- a/tee-worker/ts-tests/integration-tests/common/utils/integration-setup.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/integration-setup.ts
@@ -1,12 +1,12 @@
 import { ApiPromise } from 'parachain-api';
 import { KeyObject } from 'crypto';
 import WebSocketAsPromised from 'websocket-as-promised';
-import type { IntegrationTestContext, Web3Wallets } from '../common-types';
+import type { IntegrationTestContext } from '../common-types';
 import type { Metadata, TypeRegistry } from '@polkadot/types';
 import type { HexString } from '@polkadot/util/types';
 import { initIntegrationTestContext } from './context';
 
-export function describeLitentry(title: string, walletsNumber: number, cb: (context: IntegrationTestContext) => void) {
+export function describeLitentry(title: string, cb: (context: IntegrationTestContext) => void) {
     describe(title, function () {
         // Set timeout to 6000 seconds
         this.timeout(6000000);
@@ -18,9 +18,9 @@ export function describeLitentry(title: string, walletsNumber: number, cb: (cont
             teeShieldingKey: {} as KeyObject,
             ethersWallet: {},
             substrateWallet: {},
+            bitcoinWallet: {},
             sidechainMetaData: {} as Metadata,
             sidechainRegistry: {} as TypeRegistry,
-            web3Signers: [] as Web3Wallets[],
             // default LitentryRococo
             chainIdentifier: 42,
             requestId: 0,
@@ -29,20 +29,16 @@ export function describeLitentry(title: string, walletsNumber: number, cb: (cont
         before('Starting Litentry(parachain&tee)', async function () {
             //env url
 
-            const tmp = await initIntegrationTestContext(
-                process.env.WORKER_ENDPOINT!,
-                process.env.NODE_ENDPOINT!,
-                walletsNumber
-            );
+            const tmp = await initIntegrationTestContext(process.env.WORKER_ENDPOINT!, process.env.NODE_ENDPOINT!);
             context.mrEnclave = tmp.mrEnclave;
             context.api = tmp.api;
             context.tee = tmp.tee;
             context.teeShieldingKey = tmp.teeShieldingKey;
             context.ethersWallet = tmp.ethersWallet;
             context.substrateWallet = tmp.substrateWallet;
+            context.bitcoinWallet = tmp.bitcoinWallet;
             context.sidechainMetaData = tmp.sidechainMetaData;
             context.sidechainRegistry = tmp.sidechainRegistry;
-            context.web3Signers = tmp.web3Signers;
             context.chainIdentifier = tmp.chainIdentifier;
         });
 

--- a/tee-worker/ts-tests/integration-tests/di_bitcoin_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_bitcoin_identity.test.ts
@@ -1,0 +1,359 @@
+import { randomBytes, KeyObject } from 'crypto';
+import { step } from 'mocha-steps';
+import { assert } from 'chai';
+import { u8aToHex, bufferToU8a } from '@polkadot/util';
+import {
+    buildIdentityFromKeypair,
+    buildIdentityHelper,
+    buildValidations,
+    initIntegrationTestContext,
+    EthersSigner,
+    BitcoinSigner,
+    assertIdGraphMutationResult,
+    assertIdGraphHash,
+} from './common/utils';
+import { assertIsInSidechainBlock, assertIdGraphMutation } from './common/utils/assertion';
+import {
+    createSignedTrustedCallLinkIdentity,
+    createSignedTrustedGetterIdGraph,
+    createSignedTrustedCallDeactivateIdentity,
+    createSignedTrustedCallActivateIdentity,
+    decodeIdGraph,
+    getSidechainNonce,
+    getTeeShieldingKey,
+    sendRequestFromGetter,
+    sendRequestFromTrustedCall,
+} from './common/di-utils'; // @fixme move to a better place
+import type { IntegrationTestContext } from './common/common-types';
+import { aesKey } from './common/call';
+import { LitentryValidationData, Web3Network } from 'parachain-api';
+import { LitentryPrimitivesIdentity } from 'sidechain-api';
+import { Vec } from '@polkadot/types';
+import { subscribeToEventsWithExtHash } from './common/transactions';
+
+describe('Test Identity (bitcoin direct invocation)', function () {
+    let context: IntegrationTestContext = undefined as any;
+    let teeShieldingKey: KeyObject = undefined as any;
+    let aliceBitcoinIdentity: LitentryPrimitivesIdentity = undefined as any;
+    let aliceEvmIdentity: LitentryPrimitivesIdentity;
+
+    // Alice links:
+    // - alice's evm identity
+    const linkIdentityRequestParams: {
+        nonce: number;
+        identity: LitentryPrimitivesIdentity;
+        validation: LitentryValidationData;
+        networks: Vec<Web3Network>;
+    }[] = [];
+    this.timeout(6000000);
+
+    before(async () => {
+        context = await initIntegrationTestContext(
+            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
+            process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
+        );
+        teeShieldingKey = await getTeeShieldingKey(context);
+        aliceBitcoinIdentity = await buildIdentityHelper(
+            u8aToHex(bufferToU8a(context.bitcoinWallet.alice.publicKey)),
+            'Bitcoin',
+            context
+        );
+        aliceEvmIdentity = await buildIdentityFromKeypair(new EthersSigner(context.ethersWallet.alice), context);
+    });
+
+    step('check idGraph from sidechain storage before linking', async function () {
+        const idGraphGetter = await createSignedTrustedGetterIdGraph(
+            context.api,
+            new BitcoinSigner(context.bitcoinWallet.alice),
+            aliceBitcoinIdentity
+        );
+        const res = await sendRequestFromGetter(context, teeShieldingKey, idGraphGetter);
+        const idGraph = decodeIdGraph(context.sidechainRegistry, res.value);
+        assert.lengthOf(idGraph, 0);
+    });
+
+    step('linking identities (alice bitcoin account)', async function () {
+        let currentNonce = (await getSidechainNonce(context, teeShieldingKey, aliceBitcoinIdentity)).toNumber();
+        const getNextNonce = () => currentNonce++;
+
+        const aliceNonce = getNextNonce();
+        const [aliceEvmValidation] = await buildValidations(
+            context,
+            [aliceBitcoinIdentity],
+            [aliceEvmIdentity],
+            aliceNonce,
+            'ethereum',
+            undefined,
+            [context.ethersWallet.alice]
+        );
+        const aliceEvmNetworks = context.api.createType('Vec<Web3Network>', [
+            'Ethereum',
+            'Bsc',
+        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        linkIdentityRequestParams.push({
+            nonce: aliceNonce,
+            identity: aliceEvmIdentity,
+            validation: aliceEvmValidation,
+            networks: aliceEvmNetworks,
+        });
+
+        const identityLinkedEvents: any[] = [];
+        const idGraphHashResults: any[] = [];
+        let expectedIdGraphs: [LitentryPrimitivesIdentity, boolean][][] = [
+            [
+                [aliceBitcoinIdentity, true],
+                [aliceEvmIdentity, true],
+            ],
+        ];
+
+        for (const { nonce, identity, validation, networks } of linkIdentityRequestParams) {
+            const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
+            const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
+            const linkIdentityCall = await createSignedTrustedCallLinkIdentity(
+                context.api,
+                context.mrEnclave,
+                context.api.createType('Index', nonce),
+                new BitcoinSigner(context.bitcoinWallet.alice),
+                aliceBitcoinIdentity,
+                identity.toHex(),
+                validation.toHex(),
+                networks.toHex(),
+                context.api.createType('Option<RequestAesKey>', aesKey).toHex(),
+                requestIdentifier
+            );
+
+            const res = await sendRequestFromTrustedCall(context, teeShieldingKey, linkIdentityCall);
+            idGraphHashResults.push(
+                assertIdGraphMutationResult(context, res, 'LinkIdentityResult', expectedIdGraphs[0])
+            );
+            expectedIdGraphs = expectedIdGraphs.slice(1, expectedIdGraphs.length);
+            await assertIsInSidechainBlock('linkIdentityCall', res);
+
+            const events = (await eventsPromise).map(({ event }) => event);
+            events.forEach((event) => {
+                if (context.api.events.identityManagement.LinkIdentityFailed.is(event)) {
+                    assert.fail(JSON.stringify(event.toHuman(), null, 4));
+                }
+                if (context.api.events.identityManagement.IdentityLinked.is(event)) {
+                    identityLinkedEvents.push(event);
+                }
+            });
+        }
+
+        await assertIdGraphMutation(
+            new BitcoinSigner(context.bitcoinWallet.alice),
+            identityLinkedEvents,
+            idGraphHashResults,
+            1
+        );
+    });
+
+    step('check user sidechain storage after linking', async function () {
+        const idGraphGetter = await createSignedTrustedGetterIdGraph(
+            context.api,
+            new BitcoinSigner(context.bitcoinWallet.alice),
+            aliceBitcoinIdentity
+        );
+        const res = await sendRequestFromGetter(context, teeShieldingKey, idGraphGetter);
+
+        const idGraph = decodeIdGraph(context.sidechainRegistry, res.value);
+
+        // according to the order of linkIdentityRequestParams
+        const expectedWeb3Networks = [['Ethereum', 'Bsc']];
+        let currentIndex = 0;
+
+        for (const { identity } of linkIdentityRequestParams) {
+            const identityDump = JSON.stringify(identity.toHuman(), null, 4);
+            console.debug(`checking identity: ${identityDump}`);
+            const idGraphNode = idGraph.find(([idGraphNodeIdentity]) => idGraphNodeIdentity.eq(identity));
+            assert.isDefined(idGraphNode, `identity not found in idGraph: ${identityDump}`);
+            const [, idGraphNodeContext] = idGraphNode!;
+
+            const web3networks = idGraphNode![1].web3networks.toHuman();
+            assert.deepEqual(web3networks, expectedWeb3Networks[currentIndex]);
+
+            assert.equal(
+                idGraphNodeContext.status.toString(),
+                'Active',
+                `status should be active for identity: ${identityDump}`
+            );
+            console.debug('active ✅');
+
+            currentIndex++;
+        }
+
+        await assertIdGraphHash(context, new BitcoinSigner(context.bitcoinWallet.alice), idGraph);
+    });
+    step('deactivating identity(alice bitcoin account)', async function () {
+        let currentNonce = (await getSidechainNonce(context, teeShieldingKey, aliceBitcoinIdentity)).toNumber();
+        const getNextNonce = () => currentNonce++;
+
+        const deactivateIdentityRequestParams: {
+            nonce: number;
+            identity: LitentryPrimitivesIdentity;
+        }[] = [];
+
+        const aliceEvmNonce = getNextNonce();
+
+        deactivateIdentityRequestParams.push({
+            nonce: aliceEvmNonce,
+            identity: aliceEvmIdentity,
+        });
+
+        const identityDeactivatedEvents: any[] = [];
+        const idGraphHashResults: any[] = [];
+        let expectedIdGraphs: [LitentryPrimitivesIdentity, boolean][][] = [[[aliceEvmIdentity, false]]];
+
+        for (const { nonce, identity } of deactivateIdentityRequestParams) {
+            const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
+            const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
+            const deactivateIdentityCall = await createSignedTrustedCallDeactivateIdentity(
+                context.api,
+                context.mrEnclave,
+                context.api.createType('Index', nonce),
+                new BitcoinSigner(context.bitcoinWallet.alice),
+                aliceBitcoinIdentity,
+                identity.toHex(),
+                context.api.createType('Option<RequestAesKey>', aesKey).toHex(),
+                requestIdentifier
+            );
+
+            const res = await sendRequestFromTrustedCall(context, teeShieldingKey, deactivateIdentityCall);
+            idGraphHashResults.push(
+                assertIdGraphMutationResult(context, res, 'DeactivateIdentityResult', expectedIdGraphs[0])
+            );
+            expectedIdGraphs = expectedIdGraphs.slice(1, expectedIdGraphs.length);
+            await assertIsInSidechainBlock('deactivateIdentityCall', res);
+
+            const events = (await eventsPromise).map(({ event }) => event);
+            events.forEach((event) => {
+                if (context.api.events.identityManagement.DeactivateIdentityFailed.is(event)) {
+                    assert.fail(JSON.stringify(event.toHuman(), null, 4));
+                }
+                if (context.api.events.identityManagement.IdentityDeactivated.is(event)) {
+                    identityDeactivatedEvents.push(event);
+                }
+            });
+        }
+
+        await assertIdGraphMutation(
+            new BitcoinSigner(context.bitcoinWallet.alice),
+            identityDeactivatedEvents,
+            idGraphHashResults,
+            1
+        );
+    });
+
+    step('check idGraph from sidechain storage after deactivating', async function () {
+        const idGraphGetter = await createSignedTrustedGetterIdGraph(
+            context.api,
+            new BitcoinSigner(context.bitcoinWallet.alice),
+            aliceBitcoinIdentity
+        );
+        const res = await sendRequestFromGetter(context, teeShieldingKey, idGraphGetter);
+        const idGraph = decodeIdGraph(context.sidechainRegistry, res.value);
+
+        for (const { identity } of linkIdentityRequestParams) {
+            const identityDump = JSON.stringify(identity.toHuman(), null, 4);
+            console.debug(`checking identity: ${identityDump}`);
+            const idGraphNode = idGraph.find(([idGraphNodeIdentity]) => idGraphNodeIdentity.eq(identity));
+            assert.isDefined(idGraphNode, `identity not found in idGraph: ${identityDump}`);
+            const [, idGraphNodeContext] = idGraphNode!;
+
+            assert.equal(
+                idGraphNodeContext.status.toString(),
+                'Inactive',
+                `status should be Inactive for identity: ${identityDump}`
+            );
+            console.debug('inactive ✅');
+        }
+
+        await assertIdGraphHash(context, new BitcoinSigner(context.bitcoinWallet.alice), idGraph);
+    });
+    step('activating identity(alice bitcoin account)', async function () {
+        let currentNonce = (await getSidechainNonce(context, teeShieldingKey, aliceBitcoinIdentity)).toNumber();
+        const getNextNonce = () => currentNonce++;
+
+        const activateIdentityRequestParams: {
+            nonce: number;
+            identity: LitentryPrimitivesIdentity;
+        }[] = [];
+
+        const aliceEvmNonce = getNextNonce();
+
+        activateIdentityRequestParams.push({
+            nonce: aliceEvmNonce,
+            identity: aliceEvmIdentity,
+        });
+
+        const identityActivatedEvents: any[] = [];
+        const idGraphHashResults: any[] = [];
+        let expectedIdGraphs: [LitentryPrimitivesIdentity, boolean][][] = [[[aliceEvmIdentity, true]]];
+
+        for (const { nonce, identity } of activateIdentityRequestParams) {
+            const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
+            const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
+            const activateIdentityCall = await createSignedTrustedCallActivateIdentity(
+                context.api,
+                context.mrEnclave,
+                context.api.createType('Index', nonce),
+                new BitcoinSigner(context.bitcoinWallet.alice),
+                aliceBitcoinIdentity,
+                identity.toHex(),
+                context.api.createType('Option<RequestAesKey>', aesKey).toHex(),
+                requestIdentifier
+            );
+
+            const res = await sendRequestFromTrustedCall(context, teeShieldingKey, activateIdentityCall);
+            idGraphHashResults.push(
+                assertIdGraphMutationResult(context, res, 'ActivateIdentityResult', expectedIdGraphs[0])
+            );
+            expectedIdGraphs = expectedIdGraphs.slice(1, expectedIdGraphs.length);
+            await assertIsInSidechainBlock('activateIdentityCall', res);
+
+            const events = (await eventsPromise).map(({ event }) => event);
+            events.forEach((event) => {
+                if (context.api.events.identityManagement.ActivateIdentityFailed.is(event)) {
+                    assert.fail(JSON.stringify(event.toHuman(), null, 4));
+                }
+                if (context.api.events.identityManagement.IdentityActivated.is(event)) {
+                    identityActivatedEvents.push(event);
+                }
+            });
+        }
+
+        await assertIdGraphMutation(
+            new BitcoinSigner(context.bitcoinWallet.alice),
+            identityActivatedEvents,
+            idGraphHashResults,
+            1
+        );
+    });
+
+    step('check idGraph from sidechain storage after activating', async function () {
+        const idGraphGetter = await createSignedTrustedGetterIdGraph(
+            context.api,
+            new BitcoinSigner(context.bitcoinWallet.alice),
+            aliceBitcoinIdentity
+        );
+        const res = await sendRequestFromGetter(context, teeShieldingKey, idGraphGetter);
+        const idGraph = decodeIdGraph(context.sidechainRegistry, res.value);
+
+        for (const { identity } of linkIdentityRequestParams) {
+            const identityDump = JSON.stringify(identity.toHuman(), null, 4);
+            console.debug(`checking identity: ${identityDump}`);
+            const idGraphNode = idGraph.find(([idGraphNodeIdentity]) => idGraphNodeIdentity.eq(identity));
+            assert.isDefined(idGraphNode, `identity not found in idGraph: ${identityDump}`);
+            const [, idGraphNodeContext] = idGraphNode!;
+
+            assert.equal(
+                idGraphNodeContext.status.toString(),
+                'Active',
+                `status should be active for identity: ${identityDump}`
+            );
+            console.debug('active ✅');
+        }
+
+        await assertIdGraphHash(context, new BitcoinSigner(context.bitcoinWallet.alice), idGraph);
+    });
+});

--- a/tee-worker/ts-tests/integration-tests/di_evm_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_evm_identity.test.ts
@@ -52,8 +52,7 @@ describe('Test Identity (evm direct invocation)', function () {
     before(async () => {
         context = await initIntegrationTestContext(
             process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
-            process.env.NODE_ENDPOINT!, // @fixme evil assertion; centralize env access
-            0
+            process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);
 

--- a/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
@@ -1,7 +1,7 @@
 import { randomBytes, KeyObject } from 'crypto';
 import { step } from 'mocha-steps';
 import { assert } from 'chai';
-import { u8aToHex, u8aToString } from '@polkadot/util';
+import { u8aToHex, u8aToString, bufferToU8a } from '@polkadot/util';
 import {
     assertIdGraphMutationResult,
     assertIdGraphHash,
@@ -43,6 +43,7 @@ describe('Test Identity (direct invocation)', function () {
     // - a `mock_user` twitter
     // - alice's evm identity
     // - eve's substrate identity (as alice can't link her own substrate again)
+    // - alice's bitcoin identity
     const linkIdentityRequestParams: {
         nonce: number;
         identity: LitentryPrimitivesIdentity;
@@ -141,6 +142,31 @@ describe('Test Identity (direct invocation)', function () {
             networks: eveSubstrateNetworks,
         });
 
+        const bitcoinNonce = getNextNonce();
+        const bitcoinIdentity = await buildIdentityHelper(
+            u8aToHex(bufferToU8a(context.bitcoinWallet.alice.publicKey)),
+            'Bitcoin',
+            context
+        );
+        console.log('bitcoin id: ', bitcoinIdentity.toHuman());
+        const [bitcoinValidation] = await buildValidations(
+            context,
+            [aliceSubject],
+            [bitcoinIdentity],
+            bitcoinNonce,
+            'bitcoin',
+            undefined,
+            undefined,
+            context.bitcoinWallet.alice
+        );
+        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['Bitcoin']) as unknown as Vec<Web3Network>; // @fixme #1878
+        linkIdentityRequestParams.push({
+            nonce: bitcoinNonce,
+            identity: bitcoinIdentity,
+            validation: bitcoinValidation,
+            networks: bitcoinNetworks,
+        });
+
         const identityLinkedEvents: any[] = [];
         const idGraphHashResults: any[] = [];
         let expectedIdGraphs: [LitentryPrimitivesIdentity, boolean][][] = [
@@ -150,6 +176,7 @@ describe('Test Identity (direct invocation)', function () {
             ],
             [[evmIdentity, true]],
             [[eveSubstrateIdentity, true]],
+            [[bitcoinIdentity, true]],
         ];
 
         for (const { nonce, identity, validation, networks } of linkIdentityRequestParams) {
@@ -190,7 +217,7 @@ describe('Test Identity (direct invocation)', function () {
             new PolkadotSigner(context.substrateWallet.alice),
             identityLinkedEvents,
             idGraphHashResults,
-            3
+            4
         );
     });
 
@@ -205,7 +232,7 @@ describe('Test Identity (direct invocation)', function () {
         const idGraph = decodeIdGraph(context.sidechainRegistry, res.value);
 
         // according to the order of linkIdentityRequestParams
-        const expectedWeb3Networks = [[], ['Ethereum', 'Bsc'], ['Polkadot', 'Litentry']];
+        const expectedWeb3Networks = [[], ['Ethereum', 'Bsc'], ['Polkadot', 'Litentry'], ['Bitcoin']];
         let currentIndex = 0;
 
         for (const { identity } of linkIdentityRequestParams) {
@@ -431,12 +458,24 @@ describe('Test Identity (direct invocation)', function () {
             identity: eveSubstrateIdentity,
         });
 
+        const bitcoinNonce = getNextNonce();
+        const bitcoinIdentity = await buildIdentityHelper(
+            u8aToHex(bufferToU8a(context.bitcoinWallet.alice.publicKey)),
+            'Bitcoin',
+            context
+        );
+        deactivateIdentityRequestParams.push({
+            nonce: bitcoinNonce,
+            identity: bitcoinIdentity,
+        });
+
         const identityDeactivatedEvents: any[] = [];
         const idGraphHashResults: any[] = [];
         let expectedIdGraphs: [LitentryPrimitivesIdentity, boolean][][] = [
             [[twitterIdentity, false]],
             [[evmIdentity, false]],
             [[eveSubstrateIdentity, false]],
+            [[bitcoinIdentity, false]],
         ];
 
         for (const { nonce, identity } of deactivateIdentityRequestParams) {
@@ -474,7 +513,7 @@ describe('Test Identity (direct invocation)', function () {
             new PolkadotSigner(context.substrateWallet.alice),
             identityDeactivatedEvents,
             idGraphHashResults,
-            3
+            4
         );
     });
 
@@ -540,12 +579,24 @@ describe('Test Identity (direct invocation)', function () {
             identity: eveSubstrateIdentity,
         });
 
+        const bitcoinNonce = getNextNonce();
+        const bitcoinIdentity = await buildIdentityHelper(
+            u8aToHex(bufferToU8a(context.bitcoinWallet.alice.publicKey)),
+            'Bitcoin',
+            context
+        );
+        activateIdentityRequestParams.push({
+            nonce: bitcoinNonce,
+            identity: bitcoinIdentity,
+        });
+
         const identityActivatedEvents: any[] = [];
         const idGraphHashResults: any[] = [];
         let expectedIdGraphs: [LitentryPrimitivesIdentity, boolean][][] = [
             [[twitterIdentity, true]],
             [[evmIdentity, true]],
             [[eveSubstrateIdentity, true]],
+            [[bitcoinIdentity, true]],
         ];
 
         for (const { nonce, identity } of activateIdentityRequestParams) {
@@ -583,7 +634,7 @@ describe('Test Identity (direct invocation)', function () {
             new PolkadotSigner(context.substrateWallet.alice),
             identityActivatedEvents,
             idGraphHashResults,
-            3
+            4
         );
     });
 

--- a/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
@@ -54,8 +54,7 @@ describe('Test Identity (direct invocation)', function () {
     before(async () => {
         context = await initIntegrationTestContext(
             process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
-            process.env.NODE_ENDPOINT!, // @fixme evil assertion; centralize env access
-            0
+            process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);
         aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);

--- a/tee-worker/ts-tests/integration-tests/di_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_vc.test.ts
@@ -25,8 +25,7 @@ describe('Test Vc (direct invocation)', function () {
     before(async () => {
         context = await initIntegrationTestContext(
             process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
-            process.env.NODE_ENDPOINT!, // @fixme evil assertion; centralize env access
-            0
+            process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);
         aliceSubject = await buildIdentityFromKeypair(new PolkadotSigner(context.substrateWallet.alice), context);
@@ -74,7 +73,7 @@ describe('Test Vc (direct invocation)', function () {
             const nonce = getNextNonce();
             const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
             console.log(`request vc ${Object.keys(assertion)[0]} for Alice ... Assertion description: ${description}`);
-            const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
+            subscribeToEventsWithExtHash(requestIdentifier, context);
 
             const requestVcCall = await createSignedTrustedCallRequestVc(
                 context.api,
@@ -87,7 +86,7 @@ describe('Test Vc (direct invocation)', function () {
                 requestIdentifier
             );
 
-            const res = await sendRequestFromTrustedCall(context, teeShieldingKey, requestVcCall);
+            await sendRequestFromTrustedCall(context, teeShieldingKey, requestVcCall);
             // pending test
             this.skip();
         });

--- a/tee-worker/ts-tests/integration-tests/ii_batch.test.ts
+++ b/tee-worker/ts-tests/integration-tests/ii_batch.test.ts
@@ -15,7 +15,7 @@ import type { LitentryPrimitivesIdentity } from 'sidechain-api';
 import type { LitentryValidationData, Web3Network } from 'parachain-api';
 import { Vec } from '@polkadot/types';
 
-describeLitentry('Test Batch Utility', 0, (context) => {
+describeLitentry('Test Batch Utility', (context) => {
     let identities: LitentryPrimitivesIdentity[] = [];
     let validations: LitentryValidationData[] = [];
     let evmSigners: ethers.Wallet[] = [];

--- a/tee-worker/ts-tests/integration-tests/ii_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/ii_identity.test.ts
@@ -51,7 +51,7 @@ async function getNonce(base58mrEnclave: string, workerAddr: string, context: In
     return nonce;
 }
 
-describeLitentry('Test Identity', 0, (context) => {
+describeLitentry('Test Identity', (context) => {
     // random wrong msg
     const wrongMsg = '0x693d9131808e7a8574c7ea5eb7813bdf356223263e61fa8fe2ee8e434508bc75';
     let signatureSubstrate;

--- a/tee-worker/ts-tests/integration-tests/ii_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/ii_vc.test.ts
@@ -26,7 +26,7 @@ const allAssertions = [
 
 // It doesn't make much difference test A1 only vs test A1 - A11, one VC type is enough.
 // So only use A1 to trigger the wrong event
-describeLitentry('VC ii test', 0, async (context) => {
+describeLitentry('VC ii test', async (context) => {
     const indexList: HexString[] = [];
     step('Request VC', async () => {
         // request all vc

--- a/tee-worker/ts-tests/integration-tests/package.json
+++ b/tee-worker/ts-tests/integration-tests/package.json
@@ -11,6 +11,8 @@
         "test-di-substrate-identity:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_substrate_identity.test.ts'",
         "test-di-evm-identity:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_evm_identity.test.ts'",
         "test-di-evm-identity:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_evm_identity.test.ts'",
+        "test-di-bitcoin-identity:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_bitcoin_identity.test.ts'",
+        "test-di-bitcoin-identity:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_bitcoin_identity.test.ts'",
         "test-di-vc:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_vc.test.ts'",
         "test-di-vc:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_vc.test.ts'",
         "test-resuming-worker:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'resuming_worker.test.ts'",

--- a/tee-worker/ts-tests/integration-tests/package.json
+++ b/tee-worker/ts-tests/integration-tests/package.json
@@ -60,9 +60,11 @@
         "@typescript-eslint/parser": "^5.60.0",
         "cross-env": "^7.0.3",
         "dotenv": "^16.0.3",
+        "ecpair": "^2.0.1",
         "eslint": "^8.43.0",
         "ethers": "^5.7.2",
         "prettier": "2.8.1",
+        "tiny-secp256k1": "^2.2.0",
         "ts-node": "^10.9.1",
         "typescript": "5.0.4"
     },

--- a/tee-worker/ts-tests/pnpm-lock.yaml
+++ b/tee-worker/ts-tests/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.3.1
+      ecpair:
+        specifier: ^2.0.1
+        version: 2.1.0
       eslint:
         specifier: ^8.43.0
         version: 8.50.0
@@ -131,6 +134,9 @@ importers:
       prettier:
         specifier: 2.8.1
         version: 2.8.1
+      tiny-secp256k1:
+        specifier: ^2.2.0
+        version: 2.2.3
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@20.7.1)(typescript@5.0.4)
@@ -1405,6 +1411,12 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  /base-x@3.0.9:
+    resolution: {integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
   /bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
     dev: true
@@ -1443,6 +1455,20 @@ packages:
 
   /browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  /bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+    dependencies:
+      base-x: 3.0.9
+    dev: true
+
+  /bs58check@2.1.2:
+    resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}
+    dependencies:
+      bs58: 4.0.1
+      create-hash: 1.2.0
+      safe-buffer: 5.2.1
+    dev: true
 
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
@@ -1502,6 +1528,13 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
+  /cipher-base@1.0.4:
+    resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: true
+
   /cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
     dependencies:
@@ -1534,6 +1567,16 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  /create-hash@1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+    dependencies:
+      cipher-base: 1.0.4
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.2
+      sha.js: 2.4.11
+    dev: true
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -1631,6 +1674,15 @@ packages:
   /dotenv@16.3.1:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
     engines: {node: '>=12'}
+    dev: true
+
+  /ecpair@2.1.0:
+    resolution: {integrity: sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      randombytes: 2.1.0
+      typeforce: 1.18.0
+      wif: 2.0.6
     dev: true
 
   /elliptic@6.5.4:
@@ -2131,6 +2183,15 @@ packages:
       function-bind: 1.1.1
     dev: false
 
+  /hash-base@3.1.0:
+    resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
+    engines: {node: '>=4'}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      safe-buffer: 5.2.1
+    dev: true
+
   /hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
     dependencies:
@@ -2403,6 +2464,14 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
+  /md5.js@1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
+    dependencies:
+      hash-base: 3.1.0
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: true
+
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2668,6 +2737,15 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
+  /readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: true
+
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -2707,6 +2785,13 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+    dev: true
+
+  /ripemd160@2.0.2:
+    resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
+    dependencies:
+      hash-base: 3.1.0
+      inherits: 2.0.4
     dev: true
 
   /run-parallel@1.2.0:
@@ -2771,6 +2856,14 @@ packages:
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.0
     dev: false
+
+  /sha.js@2.4.11:
+    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+    hasBin: true
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2847,6 +2940,12 @@ packages:
       es-abstract: 1.22.2
     dev: false
 
+  /string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2871,6 +2970,13 @@ packages:
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
+  /tiny-secp256k1@2.2.3:
+    resolution: {integrity: sha512-SGcL07SxcPN2nGKHTCvRMkQLYPSoeFcvArUSCYtjVARiFAWU44cCIqYS0mYAU6nY7XfvwURuTIGo2Omt3ZQr0Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      uint8array-tools: 0.0.7
     dev: true
 
   /to-regex-range@5.0.1:
@@ -2982,6 +3088,10 @@ packages:
       is-typed-array: 1.1.12
     dev: false
 
+  /typeforce@1.18.0:
+    resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
+    dev: true
+
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
@@ -2996,6 +3106,11 @@ packages:
     dev: false
     optional: true
 
+  /uint8array-tools@0.0.7:
+    resolution: {integrity: sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -3009,6 +3124,10 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
+
+  /util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -3056,6 +3175,12 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /wif@2.0.6:
+    resolution: {integrity: sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==}
+    dependencies:
+      bs58check: 2.1.2
     dev: true
 
   /wordwrap@1.0.0:

--- a/ts-tests/tests/base-filter.test.ts
+++ b/ts-tests/tests/base-filter.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { step } from 'mocha-steps';
-import { assert } from 'chai';
 import { signAndSend, describeLitentry, loadConfig, sleep } from './utils';
 
 describeLitentry('Test Base Filter', ``, (context) => {

--- a/ts-tests/tests/evm-contract.test.ts
+++ b/ts-tests/tests/evm-contract.test.ts
@@ -2,7 +2,7 @@ import { assert, expect } from 'chai';
 import { step } from 'mocha-steps';
 
 import { signAndSend, describeLitentry, loadConfig, sleep } from './utils';
-import { evmToAddress } from '@polkadot/util-crypto'
+import { evmToAddress } from '@polkadot/util-crypto';
 import Web3 from 'web3';
 
 import { compiled } from './compile';
@@ -63,7 +63,7 @@ describeLitentry('Test EVM Module Contract', ``, (context) => {
 
         // If a substrate account using pallet_evm to trigger evm transaction,
         // it will bump 2 for nonce (one for substrate extrinsic, one for evm).
-        // +1 nonce for original substrate account, plus another 1 nonce for original substrate account's truncated evm address's mapped susbtrate account. 
+        // +1 nonce for original substrate account, plus another 1 nonce for original substrate account's truncated evm address's mapped susbtrate account.
         expect(eveCurrentNonce.toNumber()).to.equal(eveInitNonce.toNumber() + 1);
         expect(evmAccountCurrentBalance.free.toBigInt()).to.equal(
             evmAccountInitBalance.free.toBigInt() + BigInt(value)

--- a/ts-tests/tests/evm-transfer.test.ts
+++ b/ts-tests/tests/evm-transfer.test.ts
@@ -4,7 +4,7 @@ import { step } from 'mocha-steps';
 import { signAndSend, describeLitentry } from './utils';
 import { hexToU8a, u8aToHex } from '@polkadot/util';
 import { createPair, encodeAddress } from '@polkadot/keyring';
-import { evmToAddress } from '@polkadot/util-crypto'
+import { evmToAddress } from '@polkadot/util-crypto';
 import Web3 from 'web3';
 
 describeLitentry('Test EVM Module Transfer', ``, (context) => {
@@ -75,7 +75,7 @@ describeLitentry('Test EVM Module Transfer', ``, (context) => {
 
         // If a substrate account using pallet_evm to trigger evm transaction,
         // it will bump 2 for nonce (one for substrate extrinsic, one for evm).
-        // +1 nonce for original substrate account, plus another 1 nonce for original substrate account's truncated evm address's mapped susbtrate account. 
+        // +1 nonce for original substrate account, plus another 1 nonce for original substrate account's truncated evm address's mapped susbtrate account.
         expect(eveCurrentNonce.toNumber()).to.equal(eveInitNonce.toNumber() + 1);
         expect(evmAccountCurrentBalance.free.toBigInt()).to.equal(
             evmAccountInitBalance.free.toBigInt() + BigInt(value)


### PR DESCRIPTION
### Context

As topic.

The raw pubkey (`[u8; 33]`) is used as the bitcoin identity handle, thus we require that the wallet API provides such interface (to retrieve an account's pubkey).

Otherwise parachain needs to support [all 5 address formats](https://github.com/rust-bitcoin/rust-bitcoin/blob/8afa379f3946f9b7605a278b59cd103dbd5020b1/bitcoin/src/address/mod.rs#L62-L73) instead of a unified pubkey. This not only brings extra work, it also makes it inconsistent with other web3 networks (substrate/EVM) where the raw bytes are used as Identity Handle.

The message signing and verification is yet to be tested with the real wallet extension. It **might not work** as the wallet could massage the message freely. In this implementation, a standard ECDSA/SECP256k1 keypair with a recoverable signature is used.

This impl **should not** break the old `Identity` or `IDGraph` structures, or the sidechain storages - but we'll need to test it out. 