### PR TITLE
Add missing bitcoin match arm

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/a20.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a20.rs
@@ -48,6 +48,10 @@ impl RestPath<String> for EarlyBirdResponse {
 }
 
 pub fn build(req: &AssertionBuildRequest) -> Result<Credential> {
+	// Note: it's not perfectly implemented here
+	//       it only attests if the main address meets the criteria, but we should have implemented
+	//       the supported web3networks and attested the linked identities.
+	//       However, this VC is probably too old to change
 	let who = match req.who {
 		Identity::Substrate(account) => account_id_to_string(&account),
 		Identity::Evm(account) => account_id_to_string(&account),

--- a/tee-worker/litentry/core/assertion-build/src/a20.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a20.rs
@@ -51,6 +51,7 @@ pub fn build(req: &AssertionBuildRequest) -> Result<Credential> {
 	let who = match req.who {
 		Identity::Substrate(account) => account_id_to_string(&account),
 		Identity::Evm(account) => account_id_to_string(&account),
+		Identity::Bitcoin(account) => account_id_to_string(&account),
 		_ => unreachable!(),
 	};
 	debug!("Assertion A20 build, who: {:?}", who);

--- a/tee-worker/litentry/core/assertion-build/src/lib.rs
+++ b/tee-worker/litentry/core/assertion-build/src/lib.rs
@@ -97,6 +97,11 @@ pub fn transpose_identity(
 					addresses.push((address, n));
 					networks_set.insert(n);
 				},
+				Identity::Bitcoin(address) => {
+					let address = account_id_to_string(address.as_ref());
+					addresses.push((address, n));
+					networks_set.insert(n);
+				},
 				_ => {},
 			};
 		});

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -42,7 +42,8 @@ use frame_support::{pallet_prelude::*, sp_runtime::traits::One, traits::StorageV
 use frame_system::pallet_prelude::*;
 
 pub use litentry_primitives::{
-	all_evm_web3networks, all_substrate_web3networks, Identity, ParentchainBlockNumber, Web3Network,
+	all_bitcoin_web3networks, all_evm_web3networks, all_substrate_web3networks, Identity,
+	ParentchainBlockNumber, Web3Network,
 };
 use sp_core::{blake2_256, H256};
 use sp_std::{vec, vec::Vec};
@@ -158,6 +159,7 @@ pub mod pallet {
 				let prime_identity_web3networks = match who {
 					Identity::Substrate(_) => all_substrate_web3networks(),
 					Identity::Evm(_) => all_evm_web3networks(),
+					Identity::Bitcoin(_) => all_bitcoin_web3networks(),
 					_ => vec![],
 				};
 				let context = <IdentityContext<T>>::new(

--- a/tee-worker/litentry/primitives/src/lib.rs
+++ b/tee-worker/litentry/primitives/src/lib.rs
@@ -44,7 +44,7 @@ use itp_sgx_crypto::ShieldingCryptoDecrypt;
 use itp_utils::hex::hex_encode;
 use log::error;
 pub use parentchain_primitives::{
-	all_evm_web3networks, all_substrate_web3networks, all_web3networks,
+	all_bitcoin_web3networks, all_evm_web3networks, all_substrate_web3networks, all_web3networks,
 	AccountId as ParentchainAccountId, AchainableAmount, AchainableAmountHolding,
 	AchainableAmountToken, AchainableAmounts, AchainableBasic, AchainableBetweenPercents,
 	AchainableClassOfYear, AchainableDate, AchainableDateInterval, AchainableDatePercent,


### PR DESCRIPTION
### Context

As topic, found this bug when implementing P-363

Question to `a20`: why did it even work without `get_supported_web3networks` implementation for A20? (so no identity should participate in a20 calculation actually