### PR TITLE
Extend bitcoin networks to all address types

### DIFF
--- a/primitives/core/src/network.rs
+++ b/primitives/core/src/network.rs
@@ -70,9 +70,17 @@ pub enum Web3Network {
 	#[codec(index = 8)]
 	Bsc,
 
-	// btc
+	// btc, see https://github.com/rust-bitcoin/rust-bitcoin/blob/9ea3e29d61569479b7b4618c8ae1992612f3d01a/bitcoin/src/address/mod.rs#L64-L75
 	#[codec(index = 9)]
-	Bitcoin,
+	BitcoinP2tr,
+	#[codec(index = 10)]
+	BitcoinP2pkh,
+	#[codec(index = 11)]
+	BitcoinP2sh,
+	#[codec(index = 12)]
+	BitcoinP2wpkh,
+	#[codec(index = 13)]
+	BitcoinP2wsh,
 }
 
 // mainly used in CLI
@@ -101,7 +109,14 @@ impl Web3Network {
 	}
 
 	pub fn is_bitcoin(&self) -> bool {
-		matches!(self, Self::Bitcoin)
+		matches!(
+			self,
+			Self::BitcoinP2tr |
+				Self::BitcoinP2pkh |
+				Self::BitcoinP2sh |
+				Self::BitcoinP2wpkh |
+				Self::BitcoinP2wsh
+		)
 	}
 }
 
@@ -146,7 +161,11 @@ mod tests {
 					Web3Network::SubstrateTestnet => false,
 					Web3Network::Ethereum => true,
 					Web3Network::Bsc => true,
-					Web3Network::Bitcoin => false,
+					Web3Network::BitcoinP2tr => false,
+					Web3Network::BitcoinP2pkh => false,
+					Web3Network::BitcoinP2sh => false,
+					Web3Network::BitcoinP2wpkh => false,
+					Web3Network::BitcoinP2wsh => false,
 				}
 			)
 		})
@@ -167,7 +186,11 @@ mod tests {
 					Web3Network::SubstrateTestnet => true,
 					Web3Network::Ethereum => false,
 					Web3Network::Bsc => false,
-					Web3Network::Bitcoin => false,
+					Web3Network::BitcoinP2tr => false,
+					Web3Network::BitcoinP2pkh => false,
+					Web3Network::BitcoinP2sh => false,
+					Web3Network::BitcoinP2wpkh => false,
+					Web3Network::BitcoinP2wsh => false,
 				}
 			)
 		})
@@ -188,7 +211,11 @@ mod tests {
 					Web3Network::SubstrateTestnet => false,
 					Web3Network::Ethereum => false,
 					Web3Network::Bsc => false,
-					Web3Network::Bitcoin => true,
+					Web3Network::BitcoinP2tr => true,
+					Web3Network::BitcoinP2pkh => true,
+					Web3Network::BitcoinP2sh => true,
+					Web3Network::BitcoinP2wpkh => true,
+					Web3Network::BitcoinP2wsh => true,
 				}
 			)
 		})

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
@@ -44,7 +44,11 @@ export default {
                 "SubstrateTestnet",
                 "Ethereum",
                 "Bsc",
-                "Bitcoin",
+                "BitcoinP2tr",
+                "BitcoinP2pkh",
+                "BitcoinP2sh",
+                "BitcoinP2wpkh",
+                "BitcoinP2wsh",
             ],
         },
         LitentryValidationData: {

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -179,7 +179,11 @@ pub fn web3_network_to_chain(network: &Web3Network) -> String {
 		Web3Network::SubstrateTestnet => "substrate_testnet".into(),
 		Web3Network::Ethereum => "ethereum".into(),
 		Web3Network::Bsc => "bsc".into(),
-		Web3Network::Bitcoin => "bitcoin".into(),
+		Web3Network::BitcoinP2tr => "bitcoin_p2tr".into(),
+		Web3Network::BitcoinP2pkh => "bitcoin_p2pkh".into(),
+		Web3Network::BitcoinP2sh => "bitcoin_p2sh".into(),
+		Web3Network::BitcoinP2wpkh => "bitcoin_p2wpkh".into(),
+		Web3Network::BitcoinP2wsh => "bitcoin_p2wsh".into(),
 	}
 }
 

--- a/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
@@ -162,7 +162,9 @@ describe('Test Identity (direct invocation)', function () {
             undefined,
             context.bitcoinWallet.alice
         );
-        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['Bitcoin']) as unknown as Vec<Web3Network>; // @fixme #1878
+        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', [
+            'BitcoinP2tr',
+        ]) as unknown as Vec<Web3Network>; // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: bitcoinNonce,
             identity: bitcoinIdentity,
@@ -242,7 +244,7 @@ describe('Test Identity (direct invocation)', function () {
         const idGraph = decodeIdGraph(context.sidechainRegistry, res.value);
 
         // according to the order of linkIdentityRequestParams
-        const expectedWeb3Networks = [[], ['Ethereum', 'Bsc'], ['Polkadot', 'Litentry'], ['Bitcoin']];
+        const expectedWeb3Networks = [[], ['Ethereum', 'Bsc'], ['Polkadot', 'Litentry'], ['BitcoinP2tr']];
         let currentIndex = 0;
 
         for (const { identity } of linkIdentityRequestParams) {


### PR DESCRIPTION
### Context

As topic.

Theoretically the client only needs to rename `Bitcoin` to `BitcoinP2tr` and that's all