### PR TITLE
Allow empty web3networks when linking identities

### DIFF
--- a/tee-worker/litentry/core/data-providers/src/geniidata.rs
+++ b/tee-worker/litentry/core/data-providers/src/geniidata.rs
@@ -20,15 +20,12 @@ use crate::sgx_reexport_prelude::*;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use crate::{
-	build_client,  Error as DataProviderError,
-	GLOBAL_DATA_PROVIDER_CONFIG,
-};
+use crate::{build_client, Error as DataProviderError, GLOBAL_DATA_PROVIDER_CONFIG};
 use http::header::ACCEPT;
 use http_req::response::Headers;
 use itc_rest_client::{
 	error::Error as RestClientError,
-	http_client::{HttpClient, DefaultSend},
+	http_client::{DefaultSend, HttpClient},
 	rest_client::RestClient,
 	RestGet, RestPath,
 };
@@ -82,9 +79,15 @@ impl GeniidataClient {
 	pub fn new() -> Self {
 		let mut headers = Headers::new();
 		headers.insert(ACCEPT.as_str(), "application/json");
-		headers.insert("api-key", GLOBAL_DATA_PROVIDER_CONFIG.read().unwrap().geniidata_api_key.as_str());
+		headers.insert(
+			"api-key",
+			GLOBAL_DATA_PROVIDER_CONFIG.read().unwrap().geniidata_api_key.as_str(),
+		);
 
-		let client = build_client(GLOBAL_DATA_PROVIDER_CONFIG.read().unwrap().geniidata_url.as_str(), headers);
+		let client = build_client(
+			GLOBAL_DATA_PROVIDER_CONFIG.read().unwrap().geniidata_url.as_str(),
+			headers,
+		);
 
 		GeniidataClient { client }
 	}

--- a/tee-worker/litentry/pallets/identity-management/src/mock.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/mock.rs
@@ -22,7 +22,7 @@ use frame_support::{
 };
 use frame_system as system;
 use frame_system::EnsureSignedBy;
-use litentry_primitives::{Identity, IdentityString, USER_SHIELDING_KEY_LEN};
+use litentry_primitives::{Identity, IdentityString, Web3Network, USER_SHIELDING_KEY_LEN};
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -140,7 +140,7 @@ pub fn new_test_ext(set_shielding_key: bool) -> sp_io::TestExternalities {
 				RuntimeOrigin::signed(ALICE),
 				who,
 				shielding_key.clone(),
-				vec![],
+				vec![Web3Network::Litentry],
 			);
 		}
 	});

--- a/tee-worker/litentry/pallets/identity-management/src/tests.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/tests.rs
@@ -36,7 +36,7 @@ fn set_user_shielding_key_works() {
 			RuntimeOrigin::signed(ALICE),
 			who.clone(),
 			shielding_key,
-			vec![],
+			vec![Web3Network::Litentry],
 		));
 		assert_eq!(IMT::user_shielding_keys(who.clone()), Some(shielding_key));
 		System::assert_last_event(RuntimeEvent::IMT(crate::Event::UserShieldingKeySet {
@@ -122,6 +122,29 @@ fn link_identity_with_wrong_network_fails() {
 }
 
 #[test]
+fn link_identity_with_empty_network_works() {
+	new_test_ext(true).execute_with(|| {
+		let web3networks: Vec<Web3Network> = vec![];
+		let who: Identity = BOB.into();
+		assert_ok!(IMT::link_identity(
+			RuntimeOrigin::signed(ALICE),
+			who.clone(),
+			alice_evm_identity(),
+			web3networks,
+		));
+		assert_eq!(
+			IMT::id_graphs(who.clone(), alice_evm_identity()).unwrap(),
+			IdentityContext {
+				link_block: 1,
+				web3networks: vec![Web3Network::Ethereum, Web3Network::Bsc].try_into().unwrap(),
+				status: IdentityStatus::Active
+			}
+		);
+		assert_eq!(crate::IDGraphLens::<Test>::get(&who), 2);
+	});
+}
+
+#[test]
 fn cannot_link_identity_again() {
 	new_test_ext(true).execute_with(|| {
 		let web3networks: Vec<Web3Network> = vec![Web3Network::Polkadot];
@@ -194,7 +217,7 @@ fn remove_identity_works() {
 			RuntimeOrigin::signed(ALICE),
 			who.clone(),
 			shielding_key,
-			vec![],
+			vec![Web3Network::Litentry],
 		));
 		assert_noop!(
 			IMT::remove_identity(
@@ -256,7 +279,7 @@ fn set_identity_networks_works() {
 			RuntimeOrigin::signed(ALICE),
 			who.clone(),
 			shielding_key,
-			vec![],
+			vec![Web3Network::Litentry],
 		));
 		assert_noop!(
 			IMT::remove_identity(
@@ -305,7 +328,7 @@ fn set_identity_networks_with_wrong_network_fails() {
 			RuntimeOrigin::signed(ALICE),
 			who.clone(),
 			shielding_key,
-			vec![],
+			vec![Web3Network::Litentry],
 		));
 		assert_noop!(
 			IMT::remove_identity(

--- a/tee-worker/litentry/pallets/identity-management/src/tests.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/tests.rs
@@ -18,7 +18,7 @@ use crate::{
 	mock::*, Error, Identity, IdentityContext, IdentityStatus, UserShieldingKeyType, Web3Network,
 };
 use frame_support::{assert_err, assert_noop, assert_ok, traits::Get};
-use litentry_primitives::USER_SHIELDING_KEY_LEN;
+use litentry_primitives::{all_evm_web3networks, USER_SHIELDING_KEY_LEN};
 use sp_runtime::AccountId32;
 
 pub const ALICE: AccountId32 = AccountId32::new([1u8; 32]);
@@ -136,7 +136,7 @@ fn link_identity_with_empty_network_works() {
 			IMT::id_graphs(who.clone(), alice_evm_identity()).unwrap(),
 			IdentityContext {
 				link_block: 1,
-				web3networks: vec![Web3Network::Ethereum, Web3Network::Bsc].try_into().unwrap(),
+				web3networks: all_evm_web3networks().try_into().unwrap(),
 				status: IdentityStatus::Active
 			}
 		);


### PR DESCRIPTION
### Context

This is a workaround to reduce the encoded call size.

We allow the client to pass in empty `web3networks` when linking identities and restore it to full network types internally.
Please note `set_user_shielding_key` is not affected - the client still has to provide valid network types.
