### PR TITLE
Add `link_identity_short` workaround

### DIFF
--- a/tee-worker/litentry/core/data-providers/src/geniidata.rs
+++ b/tee-worker/litentry/core/data-providers/src/geniidata.rs
@@ -29,7 +29,6 @@ use itc_rest_client::{
 	rest_client::RestClient,
 	RestGet, RestPath,
 };
-use litentry_primitives::ErrorDetail;
 use serde::{Deserialize, Serialize};
 use std::{
 	format, str,

--- a/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
@@ -117,8 +117,6 @@ where
 
 			Assertion::BRC20AmountHolder =>
 				lc_assertion_build::brc20::amount_holder::build(&self.req),
-
-			_ => unimplemented!(),
 		}?;
 
 		// post-process the credential

--- a/tee-worker/ts-tests/parachain-api/prepare-build/interfaces/identity/definitions.ts
+++ b/tee-worker/ts-tests/parachain-api/prepare-build/interfaces/identity/definitions.ts
@@ -59,6 +59,9 @@ export default {
                 request_vc: "(LitentryIdentity, LitentryIdentity, Assertion, H256)",
                 set_identity_networks:
                     "(LitentryIdentity, LitentryIdentity, LitentryIdentity, Vec<Web3Network>)",
+                link_identity_short:
+                    "(LitentryIdentity, LitentryIdentity, LitentryValidationData, Vec<Web3Network>, UserShieldingKeyNonceType, H256)",
+
             },
         },
         UserShieldingKeyType: "[u8; 32]",


### PR DESCRIPTION
### Context

As topic.

```
	// a hotfix to work around the "too long encoded call size" problem
	// it's similiar to `link_identity`, but with reduced parameters:
	// - the first identity is the prime identity, whose signature is required
	// - the second identity is the to-be-linked identity
	// in this sense, it can only be called via DI
```

