### PR TITLE
Fix positional args in request-vc CLI

### DIFF
--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
@@ -74,7 +74,7 @@ pub struct RequestVcCommand {
 }
 
 // see `assertion.rs`
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum Command {
 	A1,
 	A2(A2Arg),
@@ -101,12 +101,12 @@ pub enum Command {
 	EVMAmountHolding(EVMAmountHoldingCommand),
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct A2Arg {
 	pub guild_id: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct A3Arg {
 	pub guild_id: String,
 	pub channel_id: String,
@@ -114,30 +114,30 @@ pub struct A3Arg {
 }
 
 // used in A4/A7/A10/A11
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct HolderArg {
 	pub minimum_amount: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct A8Arg {
 	#[clap(num_args = 0.., value_delimiter = ',')]
 	pub networks: Vec<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct A13Arg {
 	pub account: String,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum OneblockCommand {
 	Completion,
 	Outstanding,
 	Participation,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum AchainableCommand {
 	AmountHolding(AmountHoldingArg),
 	AmountToken(AmountTokenArg),
@@ -152,7 +152,7 @@ pub enum AchainableCommand {
 	Token(TokenArg),
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum GenericDiscordRoleCommand {
 	#[clap(subcommand)]
 	Contest(ContestCommand),
@@ -160,33 +160,33 @@ pub enum GenericDiscordRoleCommand {
 	SoraQuiz(SoraQuizCommand),
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum VIP3MembershipCardLevelCommand {
 	Gold,
 	Silver,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum ContestCommand {
 	Legend,
 	Popularity,
 	Participant,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum SoraQuizCommand {
 	Attendee,
 	Master,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub enum EVMAmountHoldingCommand {
 	Ton,
 	Trx,
 }
 
 // I haven't found a good way to use common args for subcommands
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct AmountHoldingArg {
 	pub name: String,
 	pub chain: String,
@@ -195,22 +195,27 @@ pub struct AmountHoldingArg {
 	pub token: Option<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct AmountTokenArg {
 	pub name: String,
+	#[clap(
+		num_args = 1..,
+		required(true),
+		value_delimiter(','),
+	)]
 	pub chain: Vec<String>,
 	pub amount: String,
 	pub token: Option<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct AmountArg {
 	pub name: String,
 	pub chain: String,
 	pub amount: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct AmountsArg {
 	pub name: String,
 	pub chain: String,
@@ -218,13 +223,13 @@ pub struct AmountsArg {
 	pub amount2: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct BasicArg {
 	pub name: String,
 	pub chain: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct BetweenPercentsArg {
 	pub name: String,
 	pub chain: String,
@@ -232,13 +237,13 @@ pub struct BetweenPercentsArg {
 	pub less_than_or_equal_to: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct ClassOfYearArg {
 	pub name: String,
 	pub chain: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct DateIntervalArg {
 	pub name: String,
 	pub chain: String,
@@ -246,7 +251,7 @@ pub struct DateIntervalArg {
 	pub end_date: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct DatePercentArg {
 	pub name: String,
 	pub chain: String,
@@ -255,14 +260,14 @@ pub struct DatePercentArg {
 	pub percent: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct DateArg {
 	pub name: String,
 	pub chain: String,
 	pub date: String,
 }
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct TokenArg {
 	pub name: String,
 	pub chain: String,
@@ -278,6 +283,8 @@ impl RequestVcCommand {
 		let (mrenclave, shard) = get_identifiers(trusted_cli, cli);
 		let nonce = get_layer_two_nonce!(alice, cli, trusted_cli);
 		println!(">>>nonce: {}", nonce);
+
+		println!(">>>command: {:#?}", self.command);
 
 		let assertion = match &self.command {
 			Command::A1 => Assertion::A1,

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
@@ -50,6 +50,9 @@ use sp_core::Pair;
 //
 // ./bin/litentry-cli trusted -d request-vc \
 //   did:litentry:substrate:0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48 vip3-membership-card gold
+//
+// ./bin/litentry-cli trusted -d request-vc \
+//   did:litentry:substrate:0x52a6c52dc82940a36fefd1474cc0778517bb1a56b7bda0e308b6c19152dd7510 achainable amount-token test-name -c=bsc,ethereum 1 token-value
 
 pub fn to_para_str(s: &str) -> ParameterString {
 	ParameterString::truncate_from(s.as_bytes().to_vec())
@@ -195,13 +198,20 @@ pub struct AmountHoldingArg {
 	pub token: Option<String>,
 }
 
+// positional args (to vec) + required arg + optional arg is a nightmare combination for clap parser,
+// additionally, only the last positional argument, or second to last positional argument may be set to `.num_args()`
+//
+// the best bet is to use a flag explicitly, be sure to use euqal form for `chain`, e.g.:
+// -- name -c=bsc,ethereum 10
+// -- name -c=bsc,ethereum 10 token
 #[derive(Args, Debug)]
 pub struct AmountTokenArg {
 	pub name: String,
 	#[clap(
+		short, long,
 		num_args = 1..,
-		required(true),
-		value_delimiter(','),
+		required = true,
+		value_delimiter = ',',
 	)]
 	pub chain: Vec<String>,
 	pub amount: String,


### PR DESCRIPTION
### Context

This PR tries to fix the positional args problem in request-vc `amount-token` CLI. The root cause is the terrifying combination of "positional args" with `num_args` + required arg + optional arg, which causes a big problem in clap parser.

The best solution I've found so far is to use the flag explicitly, but with the "equals" form, see the comment and example in the code.

Minimal repro-case:
```
use clap::Parser;

#[derive(Parser, Debug)]
struct Cli {
    #[clap(
        num_args = 1..,
        value_delimiter(','),
        required(true),
    )]
    chain: Vec<String>,
    amount: String,
    token: Option<String>,
}

fn main() {
    let cli = Cli::parse();
    println!("cli: {:#?}", cli);
}
```

Good luck with these trial runs:
```
cargo run -- op1,op2 3
cargo run -- op1,op2 3 token
cargo run -- op1 op2 3 token
```

See how it behaves differently without the optional `token`.
Even with the flag the space form won't work:
```
cargo run -- -c op2 op3 3
cargo run -- -c op2 op3 3 token
```