### PR TITLE
wait 1 sec before querying state in ts tests

### DIFF
--- a/tee-worker/ts-tests/integration-tests/common/di-utils.ts
+++ b/tee-worker/ts-tests/integration-tests/common/di-utils.ts
@@ -5,7 +5,7 @@ import { TypeRegistry } from '@polkadot/types';
 import { Bytes } from '@polkadot/types-codec';
 import { IntegrationTestContext, JsonRpcRequest } from './common-types';
 import { WorkerRpcReturnValue, TrustedCallSigned, Getter } from 'parachain-api';
-import { encryptWithTeeShieldingKey, Signer, encryptWithAes } from './utils';
+import { encryptWithTeeShieldingKey, Signer, encryptWithAes, sleep } from './utils';
 import { aesKey, decodeRpcBytesAsString, keyNonce } from './call';
 import { createPublicKey, KeyObject } from 'crypto';
 import WebSocketAsPromised from 'websocket-as-promised';
@@ -336,6 +336,9 @@ export const sendRequestFromGetter = async (
     //            this is what `state_executeGetter` expects in rust
     const requestParam = await createRsaRequest(context.api, context.mrEnclave, teeShieldingKey, true, getter.toU8a());
     const request = createJsonRpcRequest('state_executeGetter', [u8aToHex(requestParam)], nextRequestId(context));
+    // in multiworker setup in some cases state might not be immediately propagated to other nodes so we wait 1 sec
+    // hopefully we will query correct state
+    await sleep(1);
     return sendRequest(context.tee, request, context.api);
 };
 


### PR DESCRIPTION
In multiworker setup trusted calls can be executed by any node. After execution state change needs to be propagated across the network - there is small time window which may lead to querying old state (through different worker rpc endpoint).

This PR adds 1 sec wait time to ensure that state is propagated across the network before sending getter.

Failed job example: https://github.com/litentry/litentry-parachain/actions/runs/7260485814/job/19781501628