### PR TITLE
Switch the order of unittests

### DIFF
--- a/tee-worker/enclave-runtime/src/test/tests_main.rs
+++ b/tee-worker/enclave-runtime/src/test/tests_main.rs
@@ -154,8 +154,8 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		tls_ra::seal_handler::test::seal_state_works,
 		tls_ra::seal_handler::test::seal_state_fails_for_invalid_state,
 		tls_ra::seal_handler::test::unseal_seal_state_works,
-		tls_ra::tests::test_tls_ra_server_client_networking,
 		tls_ra::tests::test_state_and_key_provisioning,
+		tls_ra::tests::test_tls_ra_server_client_networking,
 		// RPC tests
 		direct_rpc_tests::get_state_request_works,
 


### PR DESCRIPTION
### Context

The PR just tries to get more information about the CI test failure of `tls_ra::tests::test_state_and_key_provisioning` by putting it before the other key provisioning test.

If the other test now fails randomly, we know it's caused by the leftover state of the previous test, if not, it's solely the problem of the unittest itself.

Related: P-336