### PR TITLE
update geniidata query limit to i32::MAX

### DIFF
--- a/tee-worker/litentry/core/data-providers/src/geniidata.rs
+++ b/tee-worker/litentry/core/data-providers/src/geniidata.rs
@@ -71,6 +71,9 @@ impl RestPath<String> for GeniidataResponse {
 	}
 }
 
+// According to https://geniidata.readme.io/reference/get-brc20-tick-list-copy, the maximum limit is i32::MAX
+const GENIIDATA_QUERY_LIMIT: &str = "2147483647";
+
 pub struct GeniidataClient {
 	client: RestClient<HttpClient<SendWithCertificateVerification>>,
 }
@@ -95,7 +98,8 @@ impl GeniidataClient {
 	) -> Result<Vec<ResponseItem>, DataProviderError> {
 		let mut all_items: Vec<ResponseItem> = Vec::new();
 		for address in addresses {
-			let query = vec![("limit", "20"), ("offset", "0"), ("address", &address)];
+			let query =
+				vec![("limit", GENIIDATA_QUERY_LIMIT), ("offset", "0"), ("address", &address)];
 			let response = self
 				.client
 				.get_with::<String, GeniidataResponse>("".to_string(), query.as_slice())


### PR DESCRIPTION
Currently, the query limit is `20`, As a result, not all data can be obtained. According to the documentation, the maximum limit that can be set is `i32:: MAX`.
Based on the `offset` field here, it may be more appropriate to make a paging request in the future, but we also need to consider the issue of apikey request restrictions.
