### PR TITLE
skip DCAP setting when feature disabled.

### DIFF
--- a/tee-worker/service/src/main_impl.rs
+++ b/tee-worker/service/src/main_impl.rs
@@ -160,6 +160,7 @@ pub(crate) fn main() {
 		enclave_metrics_receiver,
 	)));
 
+	#[cfg(feature = "dcap")]
 	let quoting_enclave_target_info = match enclave.qe_get_target_info() {
 		Ok(target_info) => Some(target_info),
 		Err(e) => {
@@ -167,6 +168,7 @@ pub(crate) fn main() {
 			None
 		},
 	};
+	#[cfg(feature = "dcap")]
 	let quote_size = match enclave.qe_get_quote_size() {
 		Ok(size) => Some(size),
 		Err(e) => {
@@ -174,6 +176,11 @@ pub(crate) fn main() {
 			None
 		},
 	};
+
+	#[cfg(not(feature = "dcap"))]
+	let quoting_enclave_target_info = None;
+	#[cfg(not(feature = "dcap"))]
+	let quote_size = None;
 
 	let data_provider_config = get_data_provider_config(&config);
 


### PR DESCRIPTION
as title. 
a minor PR. Otherwise `qe_get_target_info` will take a long time to fail.


