### PR TITLE
fix: double encoding

### DIFF
--- a/tee-worker/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/tee-worker/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -132,7 +132,7 @@ where
 				Ok(Ok(response)) => {
 					let json_value = RpcReturnValue {
 						do_watch: false,
-						value: response.encode(),
+						value: response,
 						status: DirectRequestStatus::Ok,
 					};
 					Ok(json!(json_value.to_hex()))


### PR DESCRIPTION
This is a simple PR - It removes double encoding, The RPC handler does not need to encode the payload again as it receives the encoded payload already. 


