### PR TITLE
Fix empty web3network for assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6485,11 +6485,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
- "num_enum_derive 0.7.1",
+ "num_enum_derive 0.7.2",
 ]
 
 [[package]]
@@ -6506,9 +6506,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7219,7 +7219,7 @@ dependencies = [
  "frame-system",
  "hex-literal 0.4.1",
  "log",
- "num_enum 0.7.1",
+ "num_enum 0.7.2",
  "pallet-balances",
  "pallet-bridge",
  "pallet-bridge-transfer",
@@ -7274,7 +7274,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "num_enum 0.7.1",
+ "num_enum 0.7.2",
  "pallet-balances",
  "pallet-evm",
  "pallet-parachain-staking",
@@ -9725,7 +9725,7 @@ dependencies = [
  "hex-literal 0.4.1",
  "impl-trait-for-tuples",
  "log",
- "num_enum 0.7.1",
+ "num_enum 0.7.2",
  "pallet-evm",
  "parity-scale-codec",
  "precompile-utils-macro",
@@ -9742,7 +9742,7 @@ dependencies = [
 name = "precompile-utils-macro"
 version = "0.9.17"
 dependencies = [
- "num_enum 0.7.1",
+ "num_enum 0.7.2",
  "proc-macro2",
  "quote",
  "sha3",
@@ -12282,18 +12282,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12302,9 +12302,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
 dependencies = [
  "itoa",
  "ryu",

--- a/pallets/teerex/sgx-verify/Cargo.toml
+++ b/pallets/teerex/sgx-verify/Cargo.toml
@@ -16,7 +16,7 @@ der = { default-features = false, version = "0.6.0" }
 hex = { default-features = false, version = "0.4.3", features = ["alloc"] }
 ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-serde = { default-features = false, version = "1.0.193", features = ["derive"] }
+serde = { default-features = false, version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3", rev = "da923ed", package = "rustls-webpki", default-features = false, features = ["alloc", "ring"] }
 x509-cert = { default-features = false, version = "0.1.0", features = ["alloc"] }

--- a/precompiles/bridge-transfer/Cargo.toml
+++ b/precompiles/bridge-transfer/Cargo.toml
@@ -6,7 +6,7 @@ version = '0.9.17'
 
 [dependencies]
 log = { version = "0.4", default-features = false }
-num_enum = { version = "0.7.1", default-features = false }
+num_enum = { version = "0.7.2", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 rustc-hex = { version = "2.0.1", default-features = false }
 

--- a/precompiles/parachain-staking/Cargo.toml
+++ b/precompiles/parachain-staking/Cargo.toml
@@ -6,7 +6,7 @@ version = '0.9.17'
 
 [dependencies]
 log = { version = "0.4", default-features = false }
-num_enum = { version = "0.7.1", default-features = false }
+num_enum = { version = "0.7.2", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 rustc-hex = { version = "2.0.1", default-features = false }
 

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -9,7 +9,7 @@ version = '0.9.17'
 evm = { git = "https://github.com/rust-blockchain/evm", rev = "b7b82c7e1fc57b7449d6dfa6826600de37cc1e65", default-features = false, optional = true }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4", default-features = false }
-num_enum = { version = "0.7.1", default-features = false }
+num_enum = { version = "0.7.2", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 similar-asserts = { version = "1.5.0", optional = true }
 

--- a/precompiles/utils/macro/Cargo.toml
+++ b/precompiles/utils/macro/Cargo.toml
@@ -12,7 +12,7 @@ name = "tests"
 path = "tests/tests.rs"
 
 [dependencies]
-num_enum = { version = "0.7.1", default-features = false }
+num_enum = { version = "0.7.2", default-features = false }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 sha3 = { version = "0.10", default-features = false }

--- a/primitives/core/src/assertion.rs
+++ b/primitives/core/src/assertion.rs
@@ -271,8 +271,6 @@ impl Assertion {
 	// the broader `Web3Network` (see network.rs)
 	pub fn get_supported_web3networks(&self) -> Vec<Web3Network> {
 		match self {
-			// A1, any web3 network is allowed
-			Self::A1 => all_web3networks(),
 			// LIT holder, not including `LitentryRococo` as it's not supported by any data provider
 			Self::A4(..) => vec![Web3Network::Litentry, Web3Network::Litmus, Web3Network::Ethereum],
 			// DOT holder
@@ -299,13 +297,13 @@ impl Assertion {
 				vec![Web3Network::Ethereum, Web3Network::Bsc],
 			// BRC20 Holder
 			Self::BRC20AmountHolder => vec![Web3Network::BitcoinP2tr],
-			// we don't care about any specific web3 network
-			Self::A2(..) |
-			Self::A3(..) |
-			Self::A6 |
-			Self::A13(..) |
-			Self::A20 |
-			Self::GenericDiscordRole(..) => vec![],
+			//
+			// general rules
+			//
+			// any web3 network is allowed
+			Self::A1 | Self::A20 | Self::A13(..) => all_web3networks(),
+			// no web3 network is allowed
+			Self::A2(..) | Self::A3(..) | Self::A6 | Self::GenericDiscordRole(..) => vec![],
 		}
 	}
 }

--- a/primitives/core/src/assertion.rs
+++ b/primitives/core/src/assertion.rs
@@ -301,7 +301,7 @@ impl Assertion {
 			// general rules
 			//
 			// any web3 network is allowed
-			Self::A1 | Self::A20 | Self::A13(..) => all_web3networks(),
+			Self::A1 | Self::A13(..) | Self::A20 => all_web3networks(),
 			// no web3 network is allowed
 			Self::A2(..) | Self::A3(..) | Self::A6 | Self::GenericDiscordRole(..) => vec![],
 		}

--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -8195,11 +8195,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
- "num_enum_derive 0.7.1",
+ "num_enum_derive 0.7.2",
 ]
 
 [[package]]
@@ -8216,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8868,7 +8868,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log 0.4.20",
- "num_enum 0.7.1",
+ "num_enum 0.7.2",
  "pallet-bridge",
  "pallet-bridge-transfer",
  "pallet-evm 6.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.42)",
@@ -8917,7 +8917,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log 0.4.20",
- "num_enum 0.7.1",
+ "num_enum 0.7.2",
  "pallet-evm 6.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.42)",
  "pallet-parachain-staking",
  "parity-scale-codec",
@@ -10191,7 +10191,7 @@ dependencies = [
  "frame-system",
  "impl-trait-for-tuples",
  "log 0.4.20",
- "num_enum 0.7.1",
+ "num_enum 0.7.2",
  "pallet-evm 6.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.42)",
  "parity-scale-codec",
  "precompile-utils-macro",
@@ -10207,7 +10207,7 @@ dependencies = [
 name = "precompile-utils-macro"
 version = "0.9.17"
 dependencies = [
- "num_enum 0.7.1",
+ "num_enum 0.7.2",
  "proc-macro2",
  "quote",
  "sha3",


### PR DESCRIPTION
### Context

As topic.

For `A13` and `A20` we should allow any web3network instead of none.
This PR updates some crates too