### PR TITLE
refactor: remove substratetestnet

### DIFF
--- a/primitives/core/src/network.rs
+++ b/primitives/core/src/network.rs
@@ -70,9 +70,7 @@ pub enum Web3Network {
 	LitentryRococo,
 	#[codec(index = 5)]
 	Khala,
-	#[codec(index = 6)]
-	SubstrateTestnet, // when launched it with standalone (integritee-)node
-
+	// Index 6 used to SubstrateTestnet, So let's not break the indexing...
 	// evm
 	#[codec(index = 7)]
 	Ethereum,
@@ -109,7 +107,7 @@ impl Web3Network {
 			Self::Polkadot |
 				Self::Kusama | Self::Litentry |
 				Self::Litmus | Self::LitentryRococo |
-				Self::Khala | Self::SubstrateTestnet
+				Self::Khala
 		)
 	}
 
@@ -167,7 +165,6 @@ mod tests {
 					Web3Network::Litmus => false,
 					Web3Network::LitentryRococo => false,
 					Web3Network::Khala => false,
-					Web3Network::SubstrateTestnet => false,
 					Web3Network::Ethereum => true,
 					Web3Network::Bsc => true,
 					Web3Network::BitcoinP2tr => false,
@@ -192,7 +189,6 @@ mod tests {
 					Web3Network::Litmus => true,
 					Web3Network::LitentryRococo => true,
 					Web3Network::Khala => true,
-					Web3Network::SubstrateTestnet => true,
 					Web3Network::Ethereum => false,
 					Web3Network::Bsc => false,
 					Web3Network::BitcoinP2tr => false,
@@ -217,7 +213,6 @@ mod tests {
 					Web3Network::Litmus => false,
 					Web3Network::LitentryRococo => false,
 					Web3Network::Khala => false,
-					Web3Network::SubstrateTestnet => false,
 					Web3Network::Ethereum => false,
 					Web3Network::Bsc => false,
 					Web3Network::BitcoinP2tr => true,

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
@@ -41,7 +41,6 @@ export default {
                 "Litmus",
                 "LitentryRococo",
                 "Khala",
-                "SubstrateTestnet",
                 "Ethereum",
                 "Bsc",
                 "BitcoinP2tr",

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
@@ -41,7 +41,7 @@ export default {
                 "Litmus",
                 "LitentryRococo",
                 "Khala",
-                __Unused6: "Null",
+                "Null",
                 "Ethereum",
                 "Bsc",
                 "BitcoinP2tr",

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
@@ -41,6 +41,7 @@ export default {
                 "Litmus",
                 "LitentryRococo",
                 "Khala",
+                __Unused6: "Null",
                 "Ethereum",
                 "Bsc",
                 "BitcoinP2tr",

--- a/tee-worker/litentry/core/assertion-build/src/lib.rs
+++ b/tee-worker/litentry/core/assertion-build/src/lib.rs
@@ -177,7 +177,6 @@ fn pubkey_to_address(network: &Web3Network, pubkey: &str) -> String {
 		| Web3Network::Litmus
 		| Web3Network::LitentryRococo
 		| Web3Network::Khala
-		| Web3Network::SubstrateTestnet
 		| Web3Network::Ethereum
 		| Web3Network::Bsc => "".to_string(),
 	}

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -176,7 +176,6 @@ pub fn web3_network_to_chain(network: &Web3Network) -> String {
 		Web3Network::Litmus => "litmus".into(),
 		Web3Network::LitentryRococo => "litentry_rococo".into(),
 		Web3Network::Khala => "khala".into(),
-		Web3Network::SubstrateTestnet => "substrate_testnet".into(),
 		Web3Network::Ethereum => "ethereum".into(),
 		Web3Network::Bsc => "bsc".into(),
 		Web3Network::BitcoinP2tr => "bitcoin_p2tr".into(),


### PR DESCRIPTION
I think this PR is good for review, It's a simple PR that removes the `SubstrateTestnet` and based on @Verin1005 said, I don't have to generate types manually as it is done in the CI. 


