### PR TITLE
P-62 Connect the worker to litentry-rococo parachain

### DIFF
--- a/tee-worker/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/tee-worker/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -65,10 +65,11 @@ use std::{
 
 pub const DEV_HOSTNAME: &str = "api.trustedservices.intel.com";
 
+// Litentry TODO: use `dev` for production temporary. Will switch to dcap later.
 #[cfg(feature = "production")]
-pub const SIGRL_SUFFIX: &str = "/sgx/attestation/v4/sigrl/";
+pub const SIGRL_SUFFIX: &str = "/sgx/dev/attestation/v4/sigrl/";
 #[cfg(feature = "production")]
-pub const REPORT_SUFFIX: &str = "/sgx/attestation/v4/report";
+pub const REPORT_SUFFIX: &str = "/sgx/dev/attestation/v4/report";
 
 #[cfg(not(feature = "production"))]
 pub const SIGRL_SUFFIX: &str = "/sgx/dev/attestation/v4/sigrl/";

--- a/tee-worker/enclave-runtime/src/attestation.rs
+++ b/tee-worker/enclave-runtime/src/attestation.rs
@@ -362,30 +362,10 @@ fn generate_ias_ra_extrinsic_internal(
 	let attestation_handler = GLOBAL_ATTESTATION_HANDLER_COMPONENT.get()?;
 	let cert_der = attestation_handler.generate_ias_ra_cert(skip_ra)?;
 
-	if !skip_ra {
-		generate_ias_ra_extrinsic_from_der_cert_internal(url, &cert_der)
-	} else {
-		generate_ias_skip_ra_extrinsic_from_der_cert_internal(url, &cert_der)
-	}
+	generate_ias_ra_extrinsic_from_der_cert_internal(url, &cert_der)
 }
 
 pub fn generate_ias_ra_extrinsic_from_der_cert_internal(
-	url: String,
-	cert_der: &[u8],
-) -> EnclaveResult<OpaqueExtrinsic> {
-	let node_metadata_repo = get_node_metadata_repository_from_integritee_solo_or_parachain()?;
-
-	info!("    [Enclave] Compose register enclave call");
-	let call_ids = node_metadata_repo
-		.get_from_metadata(|m| m.register_enclave_call_indexes())?
-		.map_err(MetadataProviderError::MetadataError)?;
-
-	let call = OpaqueCall::from_tuple(&(call_ids, cert_der, Some(url), SgxAttestationMethod::Ias));
-
-	create_extrinsics(call)
-}
-
-pub fn generate_ias_skip_ra_extrinsic_from_der_cert_internal(
 	url: String,
 	cert_der: &[u8],
 ) -> EnclaveResult<OpaqueExtrinsic> {

--- a/tee-worker/local-setup/rococo_one_worker.json
+++ b/tee-worker/local-setup/rococo_one_worker.json
@@ -1,0 +1,29 @@
+{
+  "workers": [
+    {
+      "source": "bin",
+      "flags": [
+        "--clean-reset",
+        "--ws-external",
+        "-P",
+        "2000",
+        "-w",
+        "2001",
+        "-r",
+        "3443",
+        "-h",
+        "4545",
+        "-u",
+        "wss://rpc.rococo-parachain.litentry.io",
+        "-p",
+        "443",
+        "--running-mode",
+        "mock",
+        "--parentchain-start-block",
+        "3299860"
+      ],
+      "subcommand_flags": [
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- bug fix: compose teerex::register_enclave extrinsics; 
- use intel 'dev' server for attestation temporarily; 
- add one example config file


