### PR TITLE
P-216: add new vc structure independent of data provider

### DIFF
--- a/primitives/core/src/assertion.rs
+++ b/primitives/core/src/assertion.rs
@@ -20,6 +20,7 @@
 use crate::{
 	all_web3networks, AccountId, BnbDigitDomainType, BoundedWeb3Network, EVMTokenType,
 	GenericDiscordRoleType, OneBlockCourseType, VIP3MembershipCardLevel, Web3Network,
+	Web3TokenType,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
@@ -257,6 +258,9 @@ pub enum Assertion {
 
 	#[codec(index = 23)]
 	CryptoSummary,
+
+	#[codec(index = 24)]
+	TokenHoldingAmount(Web3TokenType),
 }
 
 impl Assertion {
@@ -304,6 +308,7 @@ impl Assertion {
 			Self::A1 | Self::A13(..) | Self::A20 => all_web3networks(),
 			// no web3 network is allowed
 			Self::A2(..) | Self::A3(..) | Self::A6 | Self::GenericDiscordRole(..) => vec![],
+			Self::TokenHoldingAmount(t_type) => t_type.get_supported_networks(),
 		}
 	}
 }

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -59,6 +59,9 @@ pub use generic_discord_role::*;
 mod evm_amount_holding;
 pub use evm_amount_holding::*;
 
+mod web3_token;
+pub use web3_token::*;
+
 /// Common types of parachains.
 mod types {
 	use sp_runtime::{

--- a/primitives/core/src/web3_token.rs
+++ b/primitives/core/src/web3_token.rs
@@ -1,0 +1,85 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_std::{vec, vec::Vec};
+
+use crate::Web3Network;
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, MaxEncodedLen, TypeInfo)]
+pub enum Web3TokenType {
+	#[codec(index = 0)]
+	Bnb,
+	#[codec(index = 1)]
+	Eth,
+	#[codec(index = 2)]
+	SpaceId,
+	#[codec(index = 3)]
+	Lit,
+	#[codec(index = 4)]
+	Wbtc,
+	#[codec(index = 5)]
+	Usdc,
+	#[codec(index = 6)]
+	Usdt,
+	#[codec(index = 7)]
+	Crv,
+	#[codec(index = 8)]
+	Matic,
+	#[codec(index = 9)]
+	Dydx,
+	#[codec(index = 10)]
+	Amp,
+	#[codec(index = 11)]
+	Cvx,
+	#[codec(index = 12)]
+	Tusd,
+	#[codec(index = 13)]
+	Usdd,
+	#[codec(index = 14)]
+	Gusd,
+	#[codec(index = 15)]
+	Link,
+	#[codec(index = 16)]
+	Grt,
+	#[codec(index = 17)]
+	Comp,
+	#[codec(index = 18)]
+	People,
+	#[codec(index = 19)]
+	Gtc,
+	#[codec(index = 20)]
+	Ton,
+	#[codec(index = 21)]
+	Trx,
+}
+
+impl Web3TokenType {
+	pub fn get_supported_networks(&self) -> Vec<Web3Network> {
+		match self {
+			Self::Bnb | Self::Eth | Self::SpaceId | Self::Ton | Self::Trx =>
+				vec![Web3Network::Bsc, Web3Network::Ethereum],
+			Self::Lit => vec![
+				Web3Network::Bsc,
+				Web3Network::Ethereum,
+				Web3Network::Litentry,
+				Web3Network::Litmus,
+			],
+			_ => vec![Web3Network::Ethereum],
+		}
+	}
+}

--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -6155,6 +6155,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "lc-assertion-build-v2"
+version = "0.1.0"
+dependencies = [
+ "env_logger 0.10.0",
+ "itc-rest-client",
+ "itp-ocall-api",
+ "itp-stf-primitives",
+ "itp-types",
+ "itp-utils",
+ "lc-assertion-build",
+ "lc-common",
+ "lc-credentials-v2",
+ "lc-mock-server",
+ "lc-service",
+ "lc-stf-task-sender",
+ "litentry-primitives",
+ "log 0.4.20",
+ "parity-scale-codec",
+ "sgx_tstd",
+ "thiserror 1.0.44",
+ "thiserror 1.0.9",
+]
+
+[[package]]
+name = "lc-common"
+version = "0.1.0"
+dependencies = [
+ "litentry-primitives",
+ "sgx_tstd",
+]
+
+[[package]]
 name = "lc-credentials"
 version = "0.1.0"
 dependencies = [
@@ -6180,6 +6212,24 @@ dependencies = [
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "sgx_tstd",
  "sp-core",
+ "thiserror 1.0.44",
+ "thiserror 1.0.9",
+]
+
+[[package]]
+name = "lc-credentials-v2"
+version = "0.1.0"
+dependencies = [
+ "itp-stf-primitives",
+ "itp-time-utils",
+ "itp-types",
+ "itp-utils",
+ "lc-common",
+ "lc-credentials",
+ "litentry-primitives",
+ "log 0.4.20",
+ "parity-scale-codec",
+ "sgx_tstd",
  "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
@@ -6266,6 +6316,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lc-service"
+version = "0.1.0"
+dependencies = [
+ "itp-stf-primitives",
+ "itp-time-utils",
+ "itp-types",
+ "itp-utils",
+ "lc-common",
+ "lc-data-providers",
+ "litentry-primitives",
+ "log 0.4.20",
+ "parity-scale-codec",
+ "sgx_tstd",
+ "thiserror 1.0.44",
+ "thiserror 1.0.9",
+]
+
+[[package]]
 name = "lc-stf-task-receiver"
 version = "0.1.0"
 dependencies = [
@@ -6292,6 +6360,7 @@ dependencies = [
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "lc-assertion-build",
+ "lc-assertion-build-v2",
  "lc-credentials",
  "lc-data-providers",
  "lc-identity-verification",
@@ -6349,6 +6418,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "lc-assertion-build",
+ "lc-assertion-build-v2",
  "lc-credentials",
  "lc-data-providers",
  "lc-stf-task-receiver",

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
@@ -30,7 +30,7 @@ use litentry_primitives::{
 	AchainableDate, AchainableDateInterval, AchainableDatePercent, AchainableParams,
 	AchainableToken, Assertion, BoundedWeb3Network, ContestType, EVMTokenType,
 	GenericDiscordRoleType, Identity, OneBlockCourseType, ParameterString, RequestAesKey,
-	SoraQuizType, VIP3MembershipCardLevel, Web3Network, REQUEST_AES_KEY_LEN,
+	SoraQuizType, VIP3MembershipCardLevel, Web3Network, Web3TokenType, REQUEST_AES_KEY_LEN,
 };
 use sp_core::Pair;
 
@@ -106,6 +106,8 @@ pub enum Command {
 	CryptoSummary,
 	LITStaking,
 	BRC20AmountHolder,
+	#[clap(subcommand)]
+	TokenHoldingAmount(TokenHoldingAmountCommand),
 }
 
 #[derive(Args, Debug)]
@@ -188,6 +190,32 @@ pub enum SoraQuizCommand {
 
 #[derive(Subcommand, Debug)]
 pub enum EVMAmountHoldingCommand {
+	Ton,
+	Trx,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TokenHoldingAmountCommand {
+	Bnb,
+	Eth,
+	SpaceId,
+	Lit,
+	Wbtc,
+	Usdc,
+	Usdt,
+	Crv,
+	Matic,
+	Dydx,
+	Amp,
+	Cvx,
+	Tusd,
+	Usdd,
+	Gusd,
+	Link,
+	Grt,
+	Comp,
+	People,
+	Gtc,
 	Ton,
 	Trx,
 }
@@ -480,6 +508,42 @@ impl RequestVcCommand {
 			Command::CryptoSummary => Assertion::CryptoSummary,
 			Command::LITStaking => Assertion::LITStaking,
 			Command::BRC20AmountHolder => Assertion::BRC20AmountHolder,
+			Command::TokenHoldingAmount(arg) => match arg {
+				TokenHoldingAmountCommand::Bnb => Assertion::TokenHoldingAmount(Web3TokenType::Bnb),
+				TokenHoldingAmountCommand::Eth => Assertion::TokenHoldingAmount(Web3TokenType::Eth),
+				TokenHoldingAmountCommand::SpaceId =>
+					Assertion::TokenHoldingAmount(Web3TokenType::SpaceId),
+				TokenHoldingAmountCommand::Lit => Assertion::TokenHoldingAmount(Web3TokenType::Lit),
+				TokenHoldingAmountCommand::Wbtc =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Wbtc),
+				TokenHoldingAmountCommand::Usdc =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Usdc),
+				TokenHoldingAmountCommand::Usdt =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Usdt),
+				TokenHoldingAmountCommand::Crv => Assertion::TokenHoldingAmount(Web3TokenType::Crv),
+				TokenHoldingAmountCommand::Matic =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Matic),
+				TokenHoldingAmountCommand::Dydx =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Dydx),
+				TokenHoldingAmountCommand::Amp => Assertion::TokenHoldingAmount(Web3TokenType::Amp),
+				TokenHoldingAmountCommand::Cvx => Assertion::TokenHoldingAmount(Web3TokenType::Cvx),
+				TokenHoldingAmountCommand::Tusd =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Tusd),
+				TokenHoldingAmountCommand::Usdd =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Usdd),
+				TokenHoldingAmountCommand::Gusd =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Gusd),
+				TokenHoldingAmountCommand::Link =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Link),
+				TokenHoldingAmountCommand::Grt => Assertion::TokenHoldingAmount(Web3TokenType::Grt),
+				TokenHoldingAmountCommand::Comp =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Comp),
+				TokenHoldingAmountCommand::People =>
+					Assertion::TokenHoldingAmount(Web3TokenType::People),
+				TokenHoldingAmountCommand::Gtc => Assertion::TokenHoldingAmount(Web3TokenType::Gtc),
+				TokenHoldingAmountCommand::Ton => Assertion::TokenHoldingAmount(Web3TokenType::Ton),
+				TokenHoldingAmountCommand::Trx => Assertion::TokenHoldingAmount(Web3TokenType::Trx),
+			},
 		};
 
 		let key = Self::random_aes_key();

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc_direct.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc_direct.rs
@@ -31,7 +31,7 @@ use litentry_primitives::{
 	AchainableDate, AchainableDateInterval, AchainableDatePercent, AchainableParams,
 	AchainableToken, Assertion, ContestType, EVMTokenType, GenericDiscordRoleType, Identity,
 	OneBlockCourseType, RequestAesKey, SoraQuizType, VIP3MembershipCardLevel, Web3Network,
-	REQUEST_AES_KEY_LEN,
+	Web3TokenType, REQUEST_AES_KEY_LEN,
 };
 use sp_core::Pair;
 
@@ -257,6 +257,42 @@ impl RequestVcDirectCommand {
 			Command::CryptoSummary => Assertion::CryptoSummary,
 			Command::LITStaking => Assertion::LITStaking,
 			Command::BRC20AmountHolder => Assertion::BRC20AmountHolder,
+			Command::TokenHoldingAmount(arg) => match arg {
+				TokenHoldingAmountCommand::Bnb => Assertion::TokenHoldingAmount(Web3TokenType::Bnb),
+				TokenHoldingAmountCommand::Eth => Assertion::TokenHoldingAmount(Web3TokenType::Eth),
+				TokenHoldingAmountCommand::SpaceId =>
+					Assertion::TokenHoldingAmount(Web3TokenType::SpaceId),
+				TokenHoldingAmountCommand::Lit => Assertion::TokenHoldingAmount(Web3TokenType::Lit),
+				TokenHoldingAmountCommand::Wbtc =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Wbtc),
+				TokenHoldingAmountCommand::Usdc =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Usdc),
+				TokenHoldingAmountCommand::Usdt =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Usdt),
+				TokenHoldingAmountCommand::Crv => Assertion::TokenHoldingAmount(Web3TokenType::Crv),
+				TokenHoldingAmountCommand::Matic =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Matic),
+				TokenHoldingAmountCommand::Dydx =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Dydx),
+				TokenHoldingAmountCommand::Amp => Assertion::TokenHoldingAmount(Web3TokenType::Amp),
+				TokenHoldingAmountCommand::Cvx => Assertion::TokenHoldingAmount(Web3TokenType::Cvx),
+				TokenHoldingAmountCommand::Tusd =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Tusd),
+				TokenHoldingAmountCommand::Usdd =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Usdd),
+				TokenHoldingAmountCommand::Gusd =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Gusd),
+				TokenHoldingAmountCommand::Link =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Link),
+				TokenHoldingAmountCommand::Grt => Assertion::TokenHoldingAmount(Web3TokenType::Grt),
+				TokenHoldingAmountCommand::Comp =>
+					Assertion::TokenHoldingAmount(Web3TokenType::Comp),
+				TokenHoldingAmountCommand::People =>
+					Assertion::TokenHoldingAmount(Web3TokenType::People),
+				TokenHoldingAmountCommand::Gtc => Assertion::TokenHoldingAmount(Web3TokenType::Gtc),
+				TokenHoldingAmountCommand::Ton => Assertion::TokenHoldingAmount(Web3TokenType::Ton),
+				TokenHoldingAmountCommand::Trx => Assertion::TokenHoldingAmount(Web3TokenType::Trx),
+			},
 		};
 
 		let key: [u8; 32] = Self::random_aes_key();

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/vc/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/vc/definitions.ts
@@ -31,6 +31,7 @@ export default {
                 EVMAmountHolding: "EVMTokenType",
                 BRC20AmountHolder: "Null",
                 CyptoSummary: "Null",
+                TokenHoldingAmount: "Web3TokenType",
             },
         },
         AssertionSupportedNetwork: {
@@ -144,6 +145,33 @@ export default {
         // EVMAmountHolding
         EVMTokenType: {
             _enum: ["Ton", "Trx"],
+        },
+        // Web3TokenType
+        Web3TokenType: {
+            _enum: [
+                "Bnb",
+                "Eth",
+                "SpaceId",
+                "Lit",
+                "Wbtc",
+                "Usdc",
+                "Usdt",
+                "Crv",
+                "Matic",
+                "Dydx",
+                "Amp",
+                "Cvx",
+                "Tusd",
+                "Usdd",
+                "Gusd",
+                "Link",
+                "Grt",
+                "Comp",
+                "People",
+                "Gtc",
+                "Ton",
+                "Trx",
+            ],
         },
     },
 };

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -2918,6 +2918,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "lc-assertion-build-v2"
+version = "0.1.0"
+dependencies = [
+ "itc-rest-client",
+ "itp-ocall-api",
+ "itp-stf-primitives",
+ "itp-types",
+ "itp-utils",
+ "lc-assertion-build",
+ "lc-common",
+ "lc-credentials-v2",
+ "lc-service",
+ "lc-stf-task-sender",
+ "litentry-primitives",
+ "log",
+ "parity-scale-codec",
+ "sgx_tstd",
+ "thiserror",
+]
+
+[[package]]
+name = "lc-common"
+version = "0.1.0"
+dependencies = [
+ "litentry-primitives",
+ "sgx_tstd",
+]
+
+[[package]]
 name = "lc-credentials"
 version = "0.1.0"
 dependencies = [
@@ -2940,6 +2969,23 @@ dependencies = [
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "sgx_tstd",
  "sp-core",
+ "thiserror",
+]
+
+[[package]]
+name = "lc-credentials-v2"
+version = "0.1.0"
+dependencies = [
+ "itp-stf-primitives",
+ "itp-time-utils",
+ "itp-types",
+ "itp-utils",
+ "lc-common",
+ "lc-credentials",
+ "litentry-primitives",
+ "log",
+ "parity-scale-codec",
+ "sgx_tstd",
  "thiserror",
 ]
 
@@ -2999,6 +3045,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lc-service"
+version = "0.1.0"
+dependencies = [
+ "itp-stf-primitives",
+ "itp-time-utils",
+ "itp-types",
+ "itp-utils",
+ "lc-common",
+ "lc-data-providers",
+ "litentry-primitives",
+ "log",
+ "parity-scale-codec",
+ "sgx_tstd",
+ "thiserror",
+]
+
+[[package]]
 name = "lc-stf-task-receiver"
 version = "0.1.0"
 dependencies = [
@@ -3018,6 +3081,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "lc-assertion-build",
+ "lc-assertion-build-v2",
  "lc-credentials",
  "lc-data-providers",
  "lc-identity-verification",
@@ -3070,6 +3134,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "lc-assertion-build",
+ "lc-assertion-build-v2",
  "lc-credentials",
  "lc-data-providers",
  "lc-stf-task-receiver",

--- a/tee-worker/litentry/core/assertion-build-v2/Cargo.toml
+++ b/tee-worker/litentry/core/assertion-build-v2/Cargo.toml
@@ -1,0 +1,62 @@
+[package]
+authors = ["Trust Computing GmbH <info@litentry.com>"]
+edition = "2021"
+name = "lc-assertion-build-v2"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# std dependencies
+thiserror = { version = "1.0.38", optional = true }
+
+# sgx dependencies
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
+
+# no_std dependencies
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+log = { version = "0.4", default-features = false }
+
+# internal dependencies
+itc-rest-client = { path = "../../../core/rest-client", default-features = false }
+itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features = false }
+itp-stf-primitives = { default-features = false, path = "../../../core-primitives/stf-primitives" }
+itp-types = { path = "../../../core-primitives/types", default-features = false }
+itp-utils = { path = "../../../core-primitives/utils", default-features = false }
+
+# litentry
+lc-assertion-build = { path = "../assertion-build", default-features = false }
+lc-common = { path = "../common", default-features = false }
+lc-credentials-v2 = { path = "../credentials-v2", default-features = false }
+lc-service = { path = "../service", default-features = false }
+lc-stf-task-sender = { path = "../stf-task/sender", default-features = false }
+litentry-primitives = { path = "../../primitives", default-features = false }
+
+[dev-dependencies]
+env_logger = "0.10.0"
+lc-mock-server = { path = "../mock-server" }
+
+[features]
+default = ["std"]
+sgx = [
+    "sgx_tstd",
+    "thiserror_sgx",
+    "litentry-primitives/sgx",
+    "lc-common/sgx",
+    "lc-assertion-build/sgx",
+    "lc-credentials-v2/sgx",
+    "lc-service/sgx",
+    "lc-stf-task-sender/sgx",
+]
+std = [
+    "log/std",
+    "itp-types/std",
+    "itp-utils/std",
+    "litentry-primitives/std",
+    "lc-common/std",
+    "lc-assertion-build/std",
+    "lc-credentials-v2/std",
+    "lc-service/std",
+    "lc-stf-task-sender/std",
+]

--- a/tee-worker/litentry/core/assertion-build-v2/src/lib.rs
+++ b/tee-worker/litentry/core/assertion-build-v2/src/lib.rs
@@ -1,0 +1,44 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::result_large_err)]
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+#[macro_use]
+extern crate sgx_tstd as std;
+
+// re-export module to properly feature gate sgx and regular std environment
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+pub mod sgx_reexport_prelude {
+	pub use thiserror_sgx as thiserror;
+}
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+use std::{string::String, vec::Vec};
+
+use litentry_primitives::{
+	Assertion, ErrorDetail, ErrorString, IntoErrorDetail, VCMPError as Error,
+};
+
+// TODO migration to v2 in the future
+use lc_assertion_build::{transpose_identity, Result};
+use lc_service::DataProviderConfig;
+use log::*;
+
+pub mod token_holding_amount;

--- a/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs
+++ b/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs
@@ -1,0 +1,507 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use lc_credentials_v2::{token_holding_amount::TokenHoldingAmountAssertionUpdate, Credential};
+use lc_service::web3_token::token_balance::get_token_balance;
+use lc_stf_task_sender::AssertionBuildRequest;
+use litentry_primitives::{Web3Network, Web3TokenType};
+use log::debug;
+
+use crate::*;
+
+pub fn build(
+	req: &AssertionBuildRequest,
+	token_type: Web3TokenType,
+	data_provider_config: &DataProviderConfig,
+) -> Result<Credential> {
+	debug!("token holding amount: {:?}", token_type);
+
+	let identities: Vec<(Web3Network, Vec<String>)> = transpose_identity(&req.identities);
+	let addresses = identities
+		.into_iter()
+		.flat_map(|(newtwork_type, addresses)| {
+			addresses.into_iter().map(move |address| (newtwork_type, address))
+		})
+		.collect::<Vec<(Web3Network, String)>>();
+
+	let result =
+		get_token_balance(token_type.clone(), addresses, data_provider_config).map_err(|e| {
+			Error::RequestVCFailed(
+				Assertion::TokenHoldingAmount(token_type.clone()),
+				ErrorDetail::DataProviderError(ErrorString::truncate_from(
+					format!("{e:?}").as_bytes().to_vec(),
+				)),
+			)
+		});
+
+	match result {
+		Ok(value) => match Credential::new(&req.who, &req.shard) {
+			Ok(mut credential_unsigned) => {
+				credential_unsigned.update_token_holding_amount_assertion(token_type, value);
+				Ok(credential_unsigned)
+			},
+			Err(e) => {
+				error!("Generate unsigned credential failed {:?}", e);
+				Err(Error::RequestVCFailed(
+					Assertion::TokenHoldingAmount(token_type),
+					e.into_error_detail(),
+				))
+			},
+		},
+		Err(e) => Err(e),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use itp_stf_primitives::types::ShardIdentifier;
+	use itp_types::AccountId;
+	use itp_utils::hex::decode_hex;
+	use lc_common::web3_token::{TokenAddress, TokenName};
+	use lc_credentials_v2::assertion_logic::{AssertionLogic, Op};
+	use lc_mock_server::run;
+	use litentry_primitives::{Identity, IdentityNetworkTuple};
+
+	fn crate_assertion_build_request(
+		token_type: Web3TokenType,
+		identities: Vec<IdentityNetworkTuple>,
+	) -> AssertionBuildRequest {
+		AssertionBuildRequest {
+			shard: ShardIdentifier::default(),
+			signer: AccountId::from([0; 32]),
+			who: AccountId::from([0; 32]).into(),
+			assertion: Assertion::TokenHoldingAmount(token_type),
+			identities,
+			top_hash: Default::default(),
+			parachain_block_number: 0u32,
+			sidechain_block_number: 0u32,
+			maybe_key: None,
+			should_create_id_graph: false,
+			req_ext_hash: Default::default(),
+		}
+	}
+
+	fn create_token_assertion_logic(token_type: Web3TokenType) -> Box<AssertionLogic> {
+		Box::new(AssertionLogic::Item {
+			src: "$token".into(),
+			op: Op::Equal,
+			dst: token_type.get_token_name().into(),
+		})
+	}
+
+	fn create_bsc_assertion_logic() -> Box<AssertionLogic> {
+		Box::new(AssertionLogic::Or {
+			items: vec![
+				Box::new(AssertionLogic::And {
+					items: vec![Box::new(AssertionLogic::Item {
+						src: "$network".into(),
+						op: Op::Equal,
+						dst: "bsc".into(),
+					})],
+				}),
+				Box::new(AssertionLogic::And {
+					items: vec![
+						Box::new(AssertionLogic::Item {
+							src: "$network".into(),
+							op: Op::Equal,
+							dst: "ethereum".into(),
+						}),
+						Box::new(AssertionLogic::Item {
+							src: "$address".into(),
+							op: Op::Equal,
+							dst: Web3TokenType::Bnb
+								.get_token_address(Web3Network::Ethereum)
+								.unwrap()
+								.into(),
+						}),
+					],
+				}),
+			],
+		})
+	}
+
+	fn create_eth_assertion_logic() -> Box<AssertionLogic> {
+		Box::new(AssertionLogic::Or {
+			items: vec![
+				Box::new(AssertionLogic::And {
+					items: vec![
+						Box::new(AssertionLogic::Item {
+							src: "$network".into(),
+							op: Op::Equal,
+							dst: "bsc".into(),
+						}),
+						Box::new(AssertionLogic::Item {
+							src: "$address".into(),
+							op: Op::Equal,
+							dst: Web3TokenType::Eth
+								.get_token_address(Web3Network::Bsc)
+								.unwrap()
+								.into(),
+						}),
+					],
+				}),
+				Box::new(AssertionLogic::And {
+					items: vec![Box::new(AssertionLogic::Item {
+						src: "$network".into(),
+						op: Op::Equal,
+						dst: "ethereum".into(),
+					})],
+				}),
+			],
+		})
+	}
+
+	fn create_evm_assertion_logic(token_type: Web3TokenType) -> Box<AssertionLogic> {
+		Box::new(AssertionLogic::Or {
+			items: vec![
+				Box::new(AssertionLogic::And {
+					items: vec![
+						Box::new(AssertionLogic::Item {
+							src: "$network".into(),
+							op: Op::Equal,
+							dst: "bsc".into(),
+						}),
+						Box::new(AssertionLogic::Item {
+							src: "$address".into(),
+							op: Op::Equal,
+							dst: token_type.get_token_address(Web3Network::Bsc).unwrap().into(),
+						}),
+					],
+				}),
+				Box::new(AssertionLogic::And {
+					items: vec![
+						Box::new(AssertionLogic::Item {
+							src: "$network".into(),
+							op: Op::Equal,
+							dst: "ethereum".into(),
+						}),
+						Box::new(AssertionLogic::Item {
+							src: "$address".into(),
+							op: Op::Equal,
+							dst: token_type
+								.get_token_address(Web3Network::Ethereum)
+								.unwrap()
+								.into(),
+						}),
+					],
+				}),
+			],
+		})
+	}
+
+	fn create_ethereum_assertion_logic(token_type: Web3TokenType) -> Box<AssertionLogic> {
+		Box::new(AssertionLogic::Or {
+			items: vec![Box::new(AssertionLogic::And {
+				items: vec![
+					Box::new(AssertionLogic::Item {
+						src: "$network".into(),
+						op: Op::Equal,
+						dst: "ethereum".into(),
+					}),
+					Box::new(AssertionLogic::Item {
+						src: "$address".into(),
+						op: Op::Equal,
+						dst: token_type.get_token_address(Web3Network::Ethereum).unwrap().into(),
+					}),
+				],
+			})],
+		})
+	}
+
+	fn create_lit_assertion_logic() -> Box<AssertionLogic> {
+		Box::new(AssertionLogic::Or {
+			items: vec![
+				Box::new(AssertionLogic::And {
+					items: vec![
+						Box::new(AssertionLogic::Item {
+							src: "$network".into(),
+							op: Op::Equal,
+							dst: "bsc".into(),
+						}),
+						Box::new(AssertionLogic::Item {
+							src: "$address".into(),
+							op: Op::Equal,
+							dst: Web3TokenType::Lit
+								.get_token_address(Web3Network::Bsc)
+								.unwrap()
+								.into(),
+						}),
+					],
+				}),
+				Box::new(AssertionLogic::And {
+					items: vec![
+						Box::new(AssertionLogic::Item {
+							src: "$network".into(),
+							op: Op::Equal,
+							dst: "ethereum".into(),
+						}),
+						Box::new(AssertionLogic::Item {
+							src: "$address".into(),
+							op: Op::Equal,
+							dst: Web3TokenType::Lit
+								.get_token_address(Web3Network::Ethereum)
+								.unwrap()
+								.into(),
+						}),
+					],
+				}),
+				Box::new(AssertionLogic::And {
+					items: vec![Box::new(AssertionLogic::Item {
+						src: "$network".into(),
+						op: Op::Equal,
+						dst: "litentry".into(),
+					})],
+				}),
+				Box::new(AssertionLogic::And {
+					items: vec![Box::new(AssertionLogic::Item {
+						src: "$network".into(),
+						op: Op::Equal,
+						dst: "litmus".into(),
+					})],
+				}),
+			],
+		})
+	}
+
+	fn init() -> DataProviderConfig {
+		let _ = env_logger::builder().is_test(true).try_init();
+		let url = run(0).unwrap();
+
+		let mut data_provider_config = DataProviderConfig::default();
+
+		data_provider_config.set_nodereal_api_key("d416f55179dbd0e45b1a8ed030e3".into());
+		data_provider_config.set_nodereal_api_chain_network_url(url.clone() + "/nodereal_jsonrpc/");
+		data_provider_config.set_achainable_url(url.clone());
+		data_provider_config
+	}
+
+	#[test]
+	fn build_bnb_holding_amount_works() {
+		let data_provider_config = init();
+		let address = decode_hex("0x45cdb67696802b9d01ed156b883269dbdb9c6239".as_bytes().to_vec())
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
+		let identities: Vec<IdentityNetworkTuple> =
+			vec![(Identity::Evm(address), vec![Web3Network::Bsc, Web3Network::Ethereum])];
+
+		let req = crate_assertion_build_request(Web3TokenType::Bnb, identities);
+
+		match build(&req, Web3TokenType::Bnb, &data_provider_config) {
+			Ok(credential) => {
+				log::info!("build bnb TokenHoldingAmount done");
+				assert_eq!(
+					*(credential.credential_subject.assertions.first().unwrap()),
+					AssertionLogic::And {
+						items: vec![
+							create_token_assertion_logic(Web3TokenType::Bnb),
+							create_bsc_assertion_logic(),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::GreaterEq,
+								dst: "50".into()
+							}),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::LessThan,
+								dst: "100".into()
+							})
+						]
+					}
+				);
+				assert_eq!(*(credential.credential_subject.values.first().unwrap()), true);
+			},
+			Err(e) => {
+				panic!("build bnb TokenHoldingAmount failed with error {:?}", e);
+			},
+		}
+	}
+
+	#[test]
+	fn build_eth_holding_amount_works() {
+		let data_provider_config = init();
+		let identities: Vec<IdentityNetworkTuple> =
+			vec![(Identity::Evm([0; 20].into()), vec![Web3Network::Ethereum])];
+
+		let req = crate_assertion_build_request(Web3TokenType::Eth, identities);
+
+		match build(&req, Web3TokenType::Eth, &data_provider_config) {
+			Ok(credential) => {
+				log::info!("build eth TokenHoldingAmount done");
+				assert_eq!(
+					*(credential.credential_subject.assertions.first().unwrap()),
+					AssertionLogic::And {
+						items: vec![
+							create_token_assertion_logic(Web3TokenType::Eth),
+							create_eth_assertion_logic(),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::GreaterEq,
+								dst: "1".into()
+							}),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::LessThan,
+								dst: "50".into()
+							})
+						]
+					}
+				);
+				assert_eq!(*(credential.credential_subject.values.first().unwrap()), true);
+			},
+			Err(e) => {
+				panic!("build eth TokenHoldingAmount failed with error {:?}", e);
+			},
+		}
+	}
+
+	#[test]
+	fn build_evm_holding_amount_works() {
+		let data_provider_config = init();
+		let address = decode_hex("0x75438d34c9125839c8b08d21b7f3167281659e7c".as_bytes().to_vec())
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
+		let identities: Vec<IdentityNetworkTuple> =
+			vec![(Identity::Evm(address), vec![Web3Network::Bsc, Web3Network::Ethereum])];
+
+		let req = crate_assertion_build_request(Web3TokenType::SpaceId, identities);
+
+		match build(&req, Web3TokenType::SpaceId, &data_provider_config) {
+			Ok(credential) => {
+				log::info!("build evm TokenHoldingAmount done");
+				assert_eq!(
+					*(credential.credential_subject.assertions.first().unwrap()),
+					AssertionLogic::And {
+						items: vec![
+							create_token_assertion_logic(Web3TokenType::SpaceId),
+							create_evm_assertion_logic(Web3TokenType::SpaceId),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::GreaterEq,
+								dst: "800".into()
+							}),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::LessThan,
+								dst: "1200".into()
+							})
+						]
+					}
+				);
+				assert_eq!(*(credential.credential_subject.values.first().unwrap()), true);
+			},
+			Err(e) => {
+				panic!("build evm TokenHoldingAmount failed with error {:?}", e);
+			},
+		}
+	}
+
+	#[test]
+	fn build_ethereum_holding_amount_works() {
+		let data_provider_config = init();
+		let address = decode_hex("0x75438d34c9125839c8b08d21b7f3167281659e7c".as_bytes().to_vec())
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
+		let identities: Vec<IdentityNetworkTuple> =
+			vec![(Identity::Evm(address), vec![Web3Network::Ethereum])];
+
+		let req = crate_assertion_build_request(Web3TokenType::Amp, identities);
+
+		match build(&req, Web3TokenType::Amp, &data_provider_config) {
+			Ok(credential) => {
+				log::info!("build ethereum TokenHoldingAmount done");
+				assert_eq!(
+					*(credential.credential_subject.assertions.first().unwrap()),
+					AssertionLogic::And {
+						items: vec![
+							create_token_assertion_logic(Web3TokenType::Amp),
+							create_ethereum_assertion_logic(Web3TokenType::Amp),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::GreaterEq,
+								dst: "200".into()
+							}),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::LessThan,
+								dst: "500".into()
+							})
+						]
+					}
+				);
+				assert_eq!(*(credential.credential_subject.values.first().unwrap()), true);
+			},
+			Err(e) => {
+				panic!("build ethereum TokenHoldingAmount failed with error {:?}", e);
+			},
+		}
+	}
+
+	#[test]
+	fn build_lit_holding_amount_works() {
+		let data_provider_config = init();
+		let address = decode_hex("0xba359c153ad11aa17c3122b05a4db8b46bb3191b".as_bytes().to_vec())
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
+		let identities: Vec<IdentityNetworkTuple> =
+			vec![(Identity::Evm(address), vec![Web3Network::Ethereum, Web3Network::Litentry])];
+
+		let req = crate_assertion_build_request(Web3TokenType::Lit, identities);
+
+		match build(&req, Web3TokenType::Lit, &data_provider_config) {
+			Ok(credential) => {
+				log::info!("build lit TokenHoldingAmount done");
+				assert_eq!(
+					*(credential.credential_subject.assertions.first().unwrap()),
+					AssertionLogic::And {
+						items: vec![
+							create_token_assertion_logic(Web3TokenType::Lit),
+							create_lit_assertion_logic(),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::GreaterEq,
+								dst: "1600".into()
+							}),
+							Box::new(AssertionLogic::Item {
+								src: "$holding_amount".into(),
+								op: Op::LessThan,
+								dst: "3000".into()
+							})
+						]
+					}
+				);
+				assert_eq!(*(credential.credential_subject.values.first().unwrap()), true);
+			},
+			Err(e) => {
+				panic!("build lit TokenHoldingAmount failed with error {:?}", e);
+			},
+		}
+	}
+}

--- a/tee-worker/litentry/core/assertion-build/src/nodereal/amount_holding/evm_amount_holding.rs
+++ b/tee-worker/litentry/core/assertion-build/src/nodereal/amount_holding/evm_amount_holding.rs
@@ -44,7 +44,7 @@ fn get_holding_balance(
 ) -> result::Result<f64, DataProviderError> {
 	let mut eth_client = NoderealJsonrpcClient::new(NoderealChain::Eth, data_provider_config);
 	let mut bsc_client = NoderealJsonrpcClient::new(NoderealChain::Bsc, data_provider_config);
-	let mut total_balance = 0_f64;
+	let mut total_balance = 0_u128;
 
 	let decimals = token_type.get_decimals();
 
@@ -71,7 +71,8 @@ fn get_holding_balance(
 		}
 	}
 
-	Ok(total_balance / decimals)
+	Ok((total_balance / decimals as u128) as f64
+		+ ((total_balance % decimals as u128) as f64 / decimals))
 }
 
 pub fn build(

--- a/tee-worker/litentry/core/common/Cargo.toml
+++ b/tee-worker/litentry/core/common/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+edition = "2021"
+name = "lc-common"
+version = "0.1.0"
+
+[dependencies]
+# std dependencies
+
+# sgx dependencies
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+
+# Internal dependencies
+litentry-primitives = { path = "../../primitives", default-features = false }
+
+[features]
+default = ["std"]
+sgx = [
+    "sgx_tstd",
+    "litentry-primitives/sgx",
+]
+std = [
+    "litentry-primitives/std",
+]

--- a/tee-worker/litentry/core/common/src/lib.rs
+++ b/tee-worker/litentry/core/common/src/lib.rs
@@ -1,0 +1,45 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use litentry_primitives::Web3Network;
+
+pub mod web3_token;
+
+pub fn web3_network_to_chain(network: &Web3Network) -> &'static str {
+	match network {
+		Web3Network::Polkadot => "polkadot",
+		Web3Network::Kusama => "kusama",
+		Web3Network::Litentry => "litentry",
+		Web3Network::Litmus => "litmus",
+		Web3Network::LitentryRococo => "litentry_rococo",
+		Web3Network::Khala => "khala",
+		Web3Network::Ethereum => "ethereum",
+		Web3Network::Bsc => "bsc",
+		Web3Network::BitcoinP2tr => "bitcoin_p2tr",
+		Web3Network::BitcoinP2pkh => "bitcoin_p2pkh",
+		Web3Network::BitcoinP2sh => "bitcoin_p2sh",
+		Web3Network::BitcoinP2wpkh => "bitcoin_p2wpkh",
+		Web3Network::BitcoinP2wsh => "bitcoin_p2wsh",
+	}
+}

--- a/tee-worker/litentry/core/common/src/web3_token/mod.rs
+++ b/tee-worker/litentry/core/common/src/web3_token/mod.rs
@@ -1,0 +1,206 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use litentry_primitives::Web3TokenType;
+
+use crate::Web3Network;
+
+pub trait TokenName {
+	fn get_token_name(&self) -> &'static str;
+}
+
+impl TokenName for Web3TokenType {
+	fn get_token_name(&self) -> &'static str {
+		match self {
+			Self::Bnb => "BNB",
+			Self::Eth => "ETH",
+			Self::SpaceId => "SPACE_ID",
+			Self::Lit => "LIT",
+			Self::Wbtc => "WBTC",
+			Self::Usdc => "USDC",
+			Self::Usdt => "USDT",
+			Self::Crv => "CRV",
+			Self::Matic => "MATIC",
+			Self::Dydx => "DYDX",
+			Self::Amp => "AMP",
+			Self::Cvx => "CVX",
+			Self::Tusd => "TUSD",
+			Self::Usdd => "USDD",
+			Self::Gusd => "GUSD",
+			Self::Link => "LINK",
+			Self::Grt => "GRT",
+			Self::Comp => "COMP",
+			Self::People => "PEOPLE",
+			Self::Gtc => "GTC",
+			Self::Ton => "TON",
+			Self::Trx => "TRX",
+		}
+	}
+}
+
+pub trait TokenAddress {
+	fn get_token_address(&self, network: Web3Network) -> Option<&'static str>;
+}
+
+impl TokenAddress for Web3TokenType {
+	fn get_token_address(&self, network: Web3Network) -> Option<&'static str> {
+		match (self, network) {
+			// Bnb
+			(Self::Bnb, Web3Network::Ethereum) =>
+				Some("0xb8c77482e45f1f44de1745f52c74426c631bdd52"),
+			// Eth
+			(Self::Eth, Web3Network::Bsc) => Some("0x2170ed0880ac9a755fd29b2688956bd959f933f8"),
+			// SpaceId
+			(Self::SpaceId, Web3Network::Bsc) | (Self::SpaceId, Web3Network::Ethereum) =>
+				Some("0x2dff88a56767223a5529ea5960da7a3f5f766406"),
+			// Lit
+			(Self::Lit, Web3Network::Bsc) | (Self::Lit, Web3Network::Ethereum) =>
+				Some("0xb59490ab09a0f526cc7305822ac65f2ab12f9723"),
+			// Wbtc
+			(Self::Wbtc, Web3Network::Ethereum) =>
+				Some("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"),
+			// Usdc
+			(Self::Usdc, Web3Network::Bsc) => Some("0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"),
+			(Self::Usdc, Web3Network::Ethereum) =>
+				Some("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+			// Usdt
+			(Self::Usdt, Web3Network::Bsc) => Some("0x55d398326f99059ff775485246999027b3197955"),
+			(Self::Usdt, Web3Network::Ethereum) =>
+				Some("0xdac17f958d2ee523a2206206994597c13d831ec7"),
+			// Crv
+			(Self::Crv, Web3Network::Ethereum) =>
+				Some("0xd533a949740bb3306d119cc777fa900ba034cd52"),
+			// Matic
+			(Self::Matic, Web3Network::Bsc) => Some("0xcc42724c6683b7e57334c4e856f4c9965ed682bd"),
+			(Self::Matic, Web3Network::Ethereum) =>
+				Some("0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0"),
+			// Dydx
+			(Self::Dydx, Web3Network::Ethereum) =>
+				Some("0x92d6c1e31e14520e676a687f0a93788b716beff5"),
+			// Amp
+			(Self::Amp, Web3Network::Ethereum) =>
+				Some("0xff20817765cb7f73d4bde2e66e067e58d11095c2"),
+			// Cvx
+			(Self::Cvx, Web3Network::Ethereum) =>
+				Some("0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b"),
+			// Tusd
+			(Self::Tusd, Web3Network::Bsc) => Some("0x40af3827F39D0EAcBF4A168f8D4ee67c121D11c9"),
+			(Self::Tusd, Web3Network::Ethereum) =>
+				Some("0x0000000000085d4780b73119b644ae5ecd22b376"),
+			// Usdd
+			(Self::Usdd, Web3Network::Bsc) => Some("0xd17479997f34dd9156deef8f95a52d81d265be9c"),
+			(Self::Usdd, Web3Network::Ethereum) =>
+				Some("0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6"),
+			// Gusd
+			(Self::Gusd, Web3Network::Ethereum) =>
+				Some("0x056fd409e1d7a124bd7017459dfea2f387b6d5cd"),
+			// Link
+			(Self::Link, Web3Network::Bsc) => Some("0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd"),
+			(Self::Link, Web3Network::Ethereum) =>
+				Some("0x514910771af9ca656af840dff83e8264ecf986ca"),
+			// Grt
+			(Self::Grt, Web3Network::Bsc) => Some("0x52ce071bd9b1c4b00a0b92d298c512478cad67e8"),
+			(Self::Grt, Web3Network::Ethereum) =>
+				Some("0xc944e90c64b2c07662a292be6244bdf05cda44a7"),
+			// Comp
+			(Self::Comp, Web3Network::Ethereum) =>
+				Some("0xc00e94cb662c3520282e6f5717214004a7f26888"),
+			// People
+			(Self::People, Web3Network::Ethereum) =>
+				Some("0x7a58c0be72be218b41c608b7fe7c5bb630736c71"),
+			// Gtc
+			(Self::Gtc, Web3Network::Ethereum) =>
+				Some("0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"),
+			// Ton
+			(Self::Ton, Web3Network::Bsc) => Some("0x76a797a59ba2c17726896976b7b3747bfd1d220f"),
+			(Self::Ton, Web3Network::Ethereum) =>
+				Some("0x582d872a1b094fc48f5de31d3b73f2d9be47def1"),
+			// Trx
+			(Self::Trx, Web3Network::Bsc) => Some("0xCE7de646e7208a4Ef112cb6ed5038FA6cC6b12e3"),
+			(Self::Trx, Web3Network::Ethereum) =>
+				Some("0x50327c6c5a14dcade707abad2e27eb517df87ab5"),
+			_ => None,
+		}
+	}
+}
+
+pub trait TokenDecimals {
+	fn get_decimals(&self, network: Web3Network) -> u64;
+}
+
+impl TokenDecimals for Web3TokenType {
+	fn get_decimals(&self, network: Web3Network) -> u64 {
+		let decimals = match (self, network) {
+			// Bnb
+			(Self::Bnb, Web3Network::Bsc) | (Self::Bnb, Web3Network::Ethereum) |
+			// Eth
+			(Self::Eth, Web3Network::Bsc) | (Self::Eth, Web3Network::Ethereum) |
+			// SpaceId
+			(Self::SpaceId, Web3Network::Bsc) | (Self::SpaceId, Web3Network::Ethereum) |
+			// Lit
+			(Self::Lit, Web3Network::Bsc) | (Self::Lit, Web3Network::Ethereum) |
+			// Usdc
+			(Self::Usdc, Web3Network::Bsc) |
+			// Usdt
+			(Self::Usdt, Web3Network::Bsc) |
+			// Crv
+			(Self::Crv, Web3Network::Ethereum) |
+			// Matic
+			(Self::Matic, Web3Network::Bsc) | (Self::Matic, Web3Network::Ethereum) |
+			// Dydx
+			(Self::Dydx, Web3Network::Ethereum) |
+			// Amp
+			(Self::Amp, Web3Network::Ethereum) |
+			// Cvx
+			(Self::Cvx, Web3Network::Ethereum) |
+			// Tusd
+			(Self::Tusd, Web3Network::Bsc) | (Self::Tusd, Web3Network::Ethereum) |
+			// Usdd
+			(Self::Usdd, Web3Network::Bsc) | (Self::Usdd, Web3Network::Ethereum) |
+			// Link
+			(Self::Link, Web3Network::Bsc) | (Self::Link, Web3Network::Ethereum) |
+			// Grt
+			(Self::Grt, Web3Network::Bsc) | (Self::Grt, Web3Network::Ethereum) |
+			// Comp
+			(Self::Comp, Web3Network::Ethereum) |
+			// People
+			(Self::People, Web3Network::Ethereum) |
+			// Gtc
+			(Self::Gtc, Web3Network::Ethereum) => 18,
+			// Ton
+			(Self::Ton, Web3Network::Bsc) | (Self::Ton, Web3Network::Ethereum) => 9,
+			// Wbtc
+			(Self::Wbtc, Web3Network::Bsc) | (Self::Wbtc, Web3Network::Ethereum) => 8,
+			// Usdc
+			(Self::Usdc, Web3Network::Ethereum) |
+			// Usdt
+			(Self::Usdt, Web3Network::Ethereum) |
+			// Trx
+			(Self::Trx, Web3Network::Bsc) | (Self::Trx, Web3Network::Ethereum) => 6,
+			// Gusd
+			(Self::Gusd, Web3Network::Ethereum) => 2,
+			_ => 1,
+		};
+
+		10_u64.pow(decimals)
+	}
+}

--- a/tee-worker/litentry/core/credentials-v2/Cargo.toml
+++ b/tee-worker/litentry/core/credentials-v2/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+authors = ["Trust Computing GmbH <info@litentry.com>"]
+edition = "2021"
+name = "lc-credentials-v2"
+version = "0.1.0"
+
+[dependencies]
+# std dependencies
+thiserror = { version = "1.0.38", optional = true }
+
+# sgx dependencies
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
+
+# no_std dependencies
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+log = { version = "0.4", default-features = false }
+
+# internal dependencies
+itp-stf-primitives = { default-features = false, path = "../../../core-primitives/stf-primitives" }
+itp-time-utils = { path = "../../../core-primitives/time-utils", default-features = false }
+itp-types = { path = "../../../core-primitives/types", default-features = false }
+itp-utils = { path = "../../../core-primitives/utils", default-features = false }
+
+# litentry
+lc-common = { path = "../common", default-features = false }
+lc-credentials = { path = "../credentials", default-features = false }
+litentry-primitives = { path = "../../primitives", default-features = false }
+
+[features]
+default = ["std"]
+sgx = [
+    "sgx_tstd",
+    "thiserror_sgx",
+    "litentry-primitives/sgx",
+    "itp-time-utils/sgx",
+    "lc-common/sgx",
+    "lc-credentials/sgx",
+]
+std = [
+    "log/std",
+    "thiserror",
+    "itp-types/std",
+    "itp-utils/std",
+    "litentry-primitives/std",
+    "itp-time-utils/std",
+    "lc-common/std",
+    "lc-credentials/std",
+]

--- a/tee-worker/litentry/core/credentials-v2/src/lib.rs
+++ b/tee-worker/litentry/core/credentials-v2/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+//
+// TEE Implementation of Verifiable Credentials Data Model v2.0
+// W3C Editor's Draft 07 January 2023
+// https://w3c.github.io/vc-data-model
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+#[macro_use]
+extern crate sgx_tstd as std;
+
+// re-export module to properly feature gate sgx and regular std environment
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+pub mod sgx_reexport_prelude {
+	pub use thiserror_sgx as thiserror;
+}
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+// TODO migration to v2 in the future
+pub use lc_credentials::{assertion_logic, Credential};
+
+pub mod token_holding_amount;

--- a/tee-worker/litentry/core/credentials-v2/src/token_holding_amount/mod.rs
+++ b/tee-worker/litentry/core/credentials-v2/src/token_holding_amount/mod.rs
@@ -1,0 +1,133 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use lc_common::{
+	web3_network_to_chain,
+	web3_token::{TokenAddress, TokenName},
+};
+use litentry_primitives::{Web3Network, Web3TokenType};
+
+// TODO migration to v2 in the future
+use lc_credentials::{
+	assertion_logic::{AssertionLogic, Op},
+	litentry_profile::{BalanceRange, BalanceRangeIndex},
+	Credential,
+};
+
+const TOKEN_HOLDING_AMOUNT_RANGE: [f64; 10] =
+	[0.0, 1.0, 50.0, 100.0, 200.0, 500.0, 800.0, 1200.0, 1600.0, 3000.0];
+
+const TYPE: &str = "Token Holding Amount";
+const DESCRIPTION: &str = "The amount of a particular token you are holding";
+
+struct AssertionKeys {
+	token: &'static str,
+	network: &'static str,
+	address: &'static str,
+	holding_amount: &'static str,
+}
+
+const ASSERTION_KEYS: AssertionKeys = AssertionKeys {
+	token: "$token",
+	network: "$network",
+	address: "$address",
+	holding_amount: "$holding_amount",
+};
+
+pub trait TokenHoldingAmountAssertionUpdate {
+	fn update_token_holding_amount_assertion(&mut self, token_type: Web3TokenType, amount: f64);
+}
+
+impl TokenHoldingAmountAssertionUpdate for Credential {
+	fn update_token_holding_amount_assertion(&mut self, token_type: Web3TokenType, amount: f64) {
+		self.add_subject_info(DESCRIPTION, TYPE);
+
+		update_assertion(token_type, amount, self);
+	}
+}
+
+fn update_assertion(token_type: Web3TokenType, balance: f64, credential: &mut Credential) {
+	let mut assertion = AssertionLogic::new_and();
+
+	assertion = assertion.add_item(AssertionLogic::new_item(
+		ASSERTION_KEYS.token,
+		Op::Equal,
+		token_type.get_token_name(),
+	));
+
+	let mut network_assertion: AssertionLogic = AssertionLogic::new_or();
+	for newtork in token_type.get_supported_networks() {
+		network_assertion =
+			network_assertion.add_item(create_network_assertion_logic(newtork, token_type.clone()));
+	}
+
+	assertion = assertion.add_item(network_assertion);
+
+	let index = BalanceRange::index(&TOKEN_HOLDING_AMOUNT_RANGE, balance);
+	match index {
+		Some(index) => {
+			let min = format!("{}", &TOKEN_HOLDING_AMOUNT_RANGE[index]);
+			let max = format!("{}", &TOKEN_HOLDING_AMOUNT_RANGE[index + 1]);
+			let min_item =
+				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::GreaterEq, &min);
+			let max_item =
+				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
+
+			assertion = assertion.add_item(min_item);
+			assertion = assertion.add_item(max_item);
+
+			credential.credential_subject.values.push(index != 0);
+		},
+		None => {
+			let min_item = AssertionLogic::new_item(
+				ASSERTION_KEYS.holding_amount,
+				Op::GreaterEq,
+				&format!("{}", &TOKEN_HOLDING_AMOUNT_RANGE.last().unwrap()),
+			);
+			assertion = assertion.add_item(min_item);
+
+			credential.credential_subject.values.push(true);
+		},
+	}
+
+	credential.credential_subject.assertions.push(assertion);
+}
+
+fn create_network_assertion_logic(
+	network: Web3Network,
+	token_type: Web3TokenType,
+) -> AssertionLogic {
+	let mut assertion = AssertionLogic::new_and();
+	assertion = assertion.add_item(AssertionLogic::new_item(
+		ASSERTION_KEYS.network,
+		Op::Equal,
+		web3_network_to_chain(&network),
+	));
+	if let Some(address) = token_type.get_token_address(network) {
+		assertion = assertion.add_item(AssertionLogic::new_item(
+			ASSERTION_KEYS.address,
+			Op::Equal,
+			address,
+		));
+	}
+	assertion
+}

--- a/tee-worker/litentry/core/mock-server/src/achainable.rs
+++ b/tee-worker/litentry/core/mock-server/src/achainable.rs
@@ -63,6 +63,20 @@ const RES_BODY_OK_CLASS_OF_YEAR: &str = r#"
     "runningCost": 1
 }
 "#;
+const RES_BODY_OK_HOLDING_AMOUNT: &str = r#"
+{
+	"name": "Balance over {amount}",
+	"result": true,
+	"display": [
+		{
+			"text": "Balance over 0 (Balance is 800)",
+			"result": true
+		}
+	],
+	"analyticsDisplay": [],
+	"runningCost": 1
+}
+"#;
 const RES_ERRBODY: &str = r#"Error request."#;
 
 use lc_data_providers::achainable::ReqBody;
@@ -105,6 +119,10 @@ pub(crate) fn query() -> impl Filter<Extract = impl warp::Reply, Error = warp::R
 				} else {
 					Response::builder().body(RES_BODY_FALSE.to_string())
 				}
+			}
+			// HoldingAmount
+			else if body.name == "Balance over {amount}" {
+				Response::builder().body(RES_BODY_OK_HOLDING_AMOUNT.to_string())
 			} else {
 				Response::builder().body(RES_BODY_TRUE.to_string())
 			}

--- a/tee-worker/litentry/core/mock-server/src/nodereal_jsonrpc.rs
+++ b/tee-worker/litentry/core/mock-server/src/nodereal_jsonrpc.rs
@@ -68,13 +68,28 @@ pub(crate) fn query() -> impl Filter<Extract = impl warp::Reply, Error = warp::R
 						"0x85be4e2ccc9c85be8783798b6e8a101bdac6467f" => "0x174876E800",
 						// 3000
 						"0x90d53026a47ac20609accc3f2ddc9fb9b29bb310" => "0xBB8",
-						// 800.1
-						_ => "0x320.1",
+						// 50 * 10^18
+						"0x45cdb67696802b9d01ed156b883269dbdb9c6239" => "0x2b5e3af16b1880000",
+						// 400 * 10^18
+						"0x75438d34c9125839c8b08d21b7f3167281659e7c" => "0x15af1d78b58c400000",
+						// 2199 * 10^18
+						"0xba359c153ad11aa17c3122b05a4db8b46bb3191b" => "0x7735416132dbfc0000",
+						// 800
+						_ => "0x320",
 					};
 					let body = RpcResponse {
 						jsonrpc: "2.0".into(),
 						id: Id::Number(1),
 						result: serde_json::to_value(value).unwrap(),
+					};
+					Response::builder().body(serde_json::to_string(&body).unwrap())
+				},
+				"eth_getBalance" => {
+					let body = RpcResponse {
+						jsonrpc: "2.0".into(),
+						id: Id::Number(1),
+						// 1 * 10^18
+						result: serde_json::to_value("0xde0b6b3a7640000").unwrap(),
 					};
 					Response::builder().body(serde_json::to_string(&body).unwrap())
 				},

--- a/tee-worker/litentry/core/service/Cargo.toml
+++ b/tee-worker/litentry/core/service/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+authors = ["Trust Computing GmbH <info@litentry.com>"]
+edition = "2021"
+name = "lc-service"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# std dependencies
+thiserror = { version = "1.0.38", optional = true }
+
+# sgx dependencies
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
+
+# no_std dependencies
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+log = { version = "0.4", default-features = false }
+
+# internal dependencies
+itp-stf-primitives = { default-features = false, path = "../../../core-primitives/stf-primitives" }
+itp-time-utils = { path = "../../../core-primitives/time-utils", default-features = false }
+itp-types = { path = "../../../core-primitives/types", default-features = false }
+itp-utils = { path = "../../../core-primitives/utils", default-features = false }
+
+# litentry
+lc-common = { path = "../common", default-features = false }
+lc-data-providers = { path = "../data-providers", default-features = false }
+litentry-primitives = { path = "../../primitives", default-features = false }
+
+[features]
+default = ["std"]
+sgx = [
+    "sgx_tstd",
+    "thiserror_sgx",
+    "litentry-primitives/sgx",
+    "itp-time-utils/sgx",
+    "lc-common/sgx",
+    "lc-data-providers/sgx",
+]
+std = [
+    "log/std",
+    "itp-types/std",
+    "itp-utils/std",
+    "litentry-primitives/std",
+    "itp-time-utils/std",
+    "lc-common/std",
+    "lc-data-providers/std",
+]

--- a/tee-worker/litentry/core/service/src/lib.rs
+++ b/tee-worker/litentry/core/service/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+// re-export module to properly feature gate sgx and regular std environment
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+pub mod sgx_reexport_prelude {
+	pub use thiserror_sgx as thiserror;
+}
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+use std::{string::String, vec::Vec};
+
+use litentry_primitives::{ErrorDetail as Error, IntoErrorDetail, Web3Network, Web3TokenType};
+
+pub use lc_data_providers::DataProviderConfig;
+
+pub mod web3_token;

--- a/tee-worker/litentry/core/service/src/web3_token/mod.rs
+++ b/tee-worker/litentry/core/service/src/web3_token/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+pub mod token_balance;

--- a/tee-worker/litentry/core/service/src/web3_token/token_balance/bnb_balance.rs
+++ b/tee-worker/litentry/core/service/src/web3_token/token_balance/bnb_balance.rs
@@ -1,0 +1,76 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use core::result::Result;
+
+use lc_common::web3_token::{TokenAddress, TokenDecimals};
+use lc_data_providers::nodereal_jsonrpc::{
+	EthBalance, FungibleApiList, GetTokenBalance20Param, Web3NetworkNoderealJsonrpcClient,
+};
+
+use crate::*;
+
+use super::common::calculate_balance_with_decimals;
+
+pub fn get_balance(
+	addresses: Vec<(Web3Network, String)>,
+	data_provider_config: &DataProviderConfig,
+) -> Result<f64, Error> {
+	let mut total_balance = 0_f64;
+
+	for address in addresses.iter() {
+		let network = address.0;
+
+		match network {
+			Web3Network::Bsc | Web3Network::Ethereum => {
+				let decimals = Web3TokenType::Bnb.get_decimals(network);
+				if let Some(mut client) =
+					network.create_nodereal_jsonrpc_client(data_provider_config)
+				{
+					let result = if network == Web3Network::Bsc {
+						client.get_balance(address.1.as_str())
+					} else {
+						let param = GetTokenBalance20Param {
+							contract_address: Web3TokenType::Bnb
+								.get_token_address(network)
+								.unwrap_or_default()
+								.into(),
+							address: address.1.clone(),
+							block_number: "latest".into(),
+						};
+						client.get_token_balance_20(&param)
+					};
+
+					match result {
+						Ok(balance) => {
+							total_balance += calculate_balance_with_decimals(balance, decimals);
+						},
+						Err(err) => return Err(err.into_error_detail()),
+					}
+				}
+			},
+			_ => {},
+		}
+	}
+
+	Ok(total_balance)
+}

--- a/tee-worker/litentry/core/service/src/web3_token/token_balance/common.rs
+++ b/tee-worker/litentry/core/service/src/web3_token/token_balance/common.rs
@@ -1,0 +1,89 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use core::result::Result;
+
+use lc_common::web3_token::{TokenAddress, TokenDecimals};
+use lc_data_providers::nodereal_jsonrpc::{
+	FungibleApiList, GetTokenBalance20Param, Web3NetworkNoderealJsonrpcClient,
+};
+
+use crate::*;
+
+// only support to get balance for non-native token
+pub fn get_balance_from_evm(
+	addresses: Vec<(Web3Network, String)>,
+	token_type: Web3TokenType,
+	data_provider_config: &DataProviderConfig,
+) -> Result<f64, Error> {
+	let mut total_balance = 0_f64;
+
+	for address in addresses.iter() {
+		let network = address.0;
+		let decimals = token_type.get_decimals(network);
+		let param = GetTokenBalance20Param {
+			contract_address: token_type.get_token_address(network).unwrap_or_default().into(),
+			address: address.1.clone(),
+			block_number: "latest".into(),
+		};
+
+		match network {
+			Web3Network::Bsc | Web3Network::Ethereum => {
+				if let Some(mut client) =
+					network.create_nodereal_jsonrpc_client(data_provider_config)
+				{
+					match client.get_token_balance_20(&param) {
+						Ok(balance) => {
+							total_balance += calculate_balance_with_decimals(balance, decimals);
+						},
+						Err(err) => return Err(err.into_error_detail()),
+					}
+				}
+			},
+			_ => {},
+		}
+	}
+
+	Ok(total_balance)
+}
+
+pub fn calculate_balance_with_decimals(source_balance: u128, decimals: u64) -> f64 {
+	let decimals_value = (if decimals == 0 { 1 } else { decimals }) as u128;
+	(source_balance / decimals_value) as f64
+		+ ((source_balance % decimals_value) as f64 / decimals_value as f64)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn should_calculate_balance_with_decimals_works() {
+		assert_eq!(calculate_balance_with_decimals(100, 0), 100_f64);
+
+		assert_eq!(calculate_balance_with_decimals(123, 100), 1.23_f64);
+
+		assert_eq!(calculate_balance_with_decimals(123, 1000), 0.123_f64);
+
+		assert_eq!(calculate_balance_with_decimals(0, 1000), 0_f64);
+	}
+}

--- a/tee-worker/litentry/core/service/src/web3_token/token_balance/eth_balance.rs
+++ b/tee-worker/litentry/core/service/src/web3_token/token_balance/eth_balance.rs
@@ -1,0 +1,76 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use core::result::Result;
+
+use lc_common::web3_token::{TokenAddress, TokenDecimals};
+use lc_data_providers::nodereal_jsonrpc::{
+	EthBalance, FungibleApiList, GetTokenBalance20Param, Web3NetworkNoderealJsonrpcClient,
+};
+
+use crate::*;
+
+use super::common::calculate_balance_with_decimals;
+
+pub fn get_balance(
+	addresses: Vec<(Web3Network, String)>,
+	data_provider_config: &DataProviderConfig,
+) -> Result<f64, Error> {
+	let mut total_balance = 0_f64;
+
+	for address in addresses.iter() {
+		let network = address.0;
+
+		match network {
+			Web3Network::Bsc | Web3Network::Ethereum => {
+				let decimals = Web3TokenType::Eth.get_decimals(network);
+				if let Some(mut client) =
+					network.create_nodereal_jsonrpc_client(data_provider_config)
+				{
+					let result = if network == Web3Network::Ethereum {
+						client.get_balance(address.1.as_str())
+					} else {
+						let param = GetTokenBalance20Param {
+							contract_address: Web3TokenType::Eth
+								.get_token_address(network)
+								.unwrap_or_default()
+								.into(),
+							address: address.1.clone(),
+							block_number: "latest".into(),
+						};
+						client.get_token_balance_20(&param)
+					};
+
+					match result {
+						Ok(balance) => {
+							total_balance += calculate_balance_with_decimals(balance, decimals);
+						},
+						Err(err) => return Err(err.into_error_detail()),
+					}
+				}
+			},
+			_ => {},
+		}
+	}
+
+	Ok(total_balance)
+}

--- a/tee-worker/litentry/core/service/src/web3_token/token_balance/lit_balance.rs
+++ b/tee-worker/litentry/core/service/src/web3_token/token_balance/lit_balance.rs
@@ -1,0 +1,94 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use core::result::Result;
+use std::vec;
+
+use lc_common::web3_token::{TokenAddress, TokenDecimals};
+use lc_data_providers::{
+	achainable::{AchainableClient, HoldingAmount, Params, ParamsBasicTypeWithAmountToken},
+	achainable_names::{AchainableNameAmountToken, GetAchainableName},
+	nodereal_jsonrpc::{FungibleApiList, GetTokenBalance20Param, Web3NetworkNoderealJsonrpcClient},
+};
+
+use crate::*;
+
+use super::common::calculate_balance_with_decimals;
+
+pub fn get_balance(
+	addresses: Vec<(Web3Network, String)>,
+	data_provider_config: &DataProviderConfig,
+) -> Result<f64, Error> {
+	let mut total_balance = 0_f64;
+
+	for address in addresses.iter() {
+		let network = address.0;
+		let account_address = address.1.clone();
+		match network {
+			Web3Network::Bsc | Web3Network::Ethereum => {
+				let decimals = Web3TokenType::Lit.get_decimals(network);
+				let param = GetTokenBalance20Param {
+					contract_address: Web3TokenType::Lit
+						.get_token_address(address.0)
+						.unwrap_or_default()
+						.into(),
+					address: account_address,
+					block_number: "latest".into(),
+				};
+
+				if let Some(mut client) =
+					network.create_nodereal_jsonrpc_client(data_provider_config)
+				{
+					match client.get_token_balance_20(&param) {
+						Ok(balance) => {
+							total_balance += calculate_balance_with_decimals(balance, decimals);
+						},
+						Err(err) => return Err(err.into_error_detail()),
+					}
+				}
+			},
+			Web3Network::Litentry | Web3Network::Litmus => {
+				let mut client = AchainableClient::new(&data_provider_config);
+
+				let param =
+					Params::ParamsBasicTypeWithAmountToken(ParamsBasicTypeWithAmountToken::new(
+						AchainableNameAmountToken::BalanceOverAmount.name().into(),
+						&network,
+						"0".into(),
+						None,
+					));
+				match client.holding_amount(vec![account_address], param) {
+					Ok(balance) => match balance.parse::<f64>() {
+						Ok(balance_value) => {
+							total_balance += balance_value;
+						},
+						Err(_) => return Err(Error::ParseError),
+					},
+					Err(err) => return Err(err.into_error_detail()),
+				}
+			},
+			_ => {},
+		}
+	}
+
+	Ok(total_balance)
+}

--- a/tee-worker/litentry/core/service/src/web3_token/token_balance/lit_balance.rs
+++ b/tee-worker/litentry/core/service/src/web3_token/token_balance/lit_balance.rs
@@ -67,7 +67,7 @@ pub fn get_balance(
 				}
 			},
 			Web3Network::Litentry | Web3Network::Litmus => {
-				let mut client = AchainableClient::new(&data_provider_config);
+				let mut client = AchainableClient::new(data_provider_config);
 
 				let param =
 					Params::ParamsBasicTypeWithAmountToken(ParamsBasicTypeWithAmountToken::new(

--- a/tee-worker/litentry/core/service/src/web3_token/token_balance/mod.rs
+++ b/tee-worker/litentry/core/service/src/web3_token/token_balance/mod.rs
@@ -1,0 +1,43 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+use core::result::Result;
+
+use crate::*;
+
+mod bnb_balance;
+mod common;
+mod eth_balance;
+mod lit_balance;
+
+pub fn get_token_balance(
+	token_type: Web3TokenType,
+	addresses: Vec<(Web3Network, String)>,
+	data_provider_config: &DataProviderConfig,
+) -> Result<f64, Error> {
+	match token_type {
+		Web3TokenType::Bnb => bnb_balance::get_balance(addresses, data_provider_config),
+		Web3TokenType::Eth => eth_balance::get_balance(addresses, data_provider_config),
+		Web3TokenType::Lit => lit_balance::get_balance(addresses, data_provider_config),
+		_ => common::get_balance_from_evm(addresses, token_type, data_provider_config),
+	}
+}

--- a/tee-worker/litentry/core/stf-task/receiver/Cargo.toml
+++ b/tee-worker/litentry/core/stf-task/receiver/Cargo.toml
@@ -42,6 +42,7 @@ itp-utils = { path = "../../../../core-primitives/utils", default-features = fal
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 ita-sgx-runtime = { path = "../../../../app-libs/sgx-runtime", default-features = false }
 lc-assertion-build = { path = "../../assertion-build", default-features = false }
+lc-assertion-build-v2 = { path = "../../assertion-build-v2", default-features = false }
 lc-credentials = { path = "../../credentials", default-features = false }
 lc-data-providers = { path = "../../data-providers", default-features = false }
 lc-identity-verification = { path = "../../identity-verification", default-features = false }
@@ -79,6 +80,7 @@ sgx = [
     "lc-stf-task-sender/sgx",
     "lc-identity-verification/sgx",
     "lc-assertion-build/sgx",
+    "lc-assertion-build-v2/sgx",
     "lc-credentials/sgx",
     "lc-data-providers/sgx",
 ]
@@ -98,6 +100,7 @@ std = [
     "lc-stf-task-sender/std",
     "lc-identity-verification/std",
     "lc-assertion-build/std",
+    "lc-assertion-build-v2/std",
     "ita-sgx-runtime/std",
     "frame-support/std",
     "lc-credentials/std",

--- a/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
@@ -192,6 +192,13 @@ where
 				&self.req,
 				&self.context.data_provider_config,
 			),
+
+			Assertion::TokenHoldingAmount(token_type) =>
+				lc_assertion_build_v2::token_holding_amount::build(
+					&self.req,
+					token_type,
+					&self.context.data_provider_config,
+				),
 		}?;
 
 		// post-process the credential

--- a/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/Cargo.toml
+++ b/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/Cargo.toml
@@ -38,6 +38,7 @@ itp-utils = { path = "../../../../core-primitives/utils", default-features = fal
 
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 lc-assertion-build = { path = "../../assertion-build", default-features = false }
+lc-assertion-build-v2 = { path = "../../assertion-build-v2", default-features = false }
 lc-credentials = { path = "../../credentials", default-features = false }
 lc-data-providers = { path = "../../data-providers", default-features = false }
 lc-stf-task-receiver = { path = "../../stf-task/receiver", default-features = false }
@@ -60,6 +61,7 @@ sgx = [
     "sp-core/full_crypto",
     "litentry-primitives/sgx",
     "lc-assertion-build/sgx",
+    "lc-assertion-build-v2/sgx",
     "lc-credentials/sgx",
     "lc-data-providers/sgx",
     "lc-stf-task-receiver/sgx",
@@ -79,6 +81,7 @@ std = [
     "sp-core/std",
     "litentry-primitives/std",
     "lc-assertion-build/std",
+    "lc-assertion-build-v2/std",
     "ita-sgx-runtime/std",
     "frame-support/std",
     "lc-credentials/std",

--- a/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/src/vc_handling.rs
+++ b/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/src/vc_handling.rs
@@ -168,6 +168,13 @@ where
 				&self.req,
 				&self.context.data_provider_config,
 			),
+
+			Assertion::TokenHoldingAmount(token_type) =>
+				lc_assertion_build_v2::token_holding_amount::build(
+					&self.req,
+					token_type,
+					&self.context.data_provider_config,
+				),
 		}?;
 
 		// post-process the credential

--- a/tee-worker/litentry/primitives/src/lib.rs
+++ b/tee-worker/litentry/primitives/src/lib.rs
@@ -54,7 +54,7 @@ pub use parentchain_primitives::{
 	GenericDiscordRoleType, Hash as ParentchainHash, Header as ParentchainHeader, IMPError,
 	Index as ParentchainIndex, IntoErrorDetail, OneBlockCourseType, ParameterString,
 	SchemaContentString, SchemaIdString, Signature as ParentchainSignature, SoraQuizType,
-	VCMPError, VIP3MembershipCardLevel, Web3Network, ASSERTION_FROM_DATE, MINUTES,
+	VCMPError, VIP3MembershipCardLevel, Web3Network, Web3TokenType, ASSERTION_FROM_DATE, MINUTES,
 };
 use scale_info::TypeInfo;
 use sp_core::{ecdsa, ed25519, sr25519, ByteArray};

--- a/tee-worker/service/src/prometheus_metrics.rs
+++ b/tee-worker/service/src/prometheus_metrics.rs
@@ -291,6 +291,7 @@ fn handle_stf_call_request(req: RequestType, time: f64) {
 			Assertion::EVMAmountHolding(_) => "EVMAmountHolding",
 			Assertion::BRC20AmountHolder => "BRC20AmountHolder",
 			Assertion::CryptoSummary => "CryptoSummary",
+			Assertion::TokenHoldingAmount(_) => "TokenHoldingAmount",
 		},
 	};
 	inc_stf_calls(category, label);

--- a/ts-tests/common/setup/setup-bridge.ts
+++ b/ts-tests/common/setup/setup-bridge.ts
@@ -99,7 +99,7 @@ async function deployBridgeContracts(wallet: Wallet) {
     console.log('GenericHandler: ', genericHandler.address);
     console.log('ERC20:          ', erc20.address);
 
-    await sleep(1);
+    await sleep(10);
     return { bridge, erc20Handler, erc721Handler, genericHandler, erc20 };
 }
 


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

Currently data provider is coupled in credentials and assertion-build level, which is unnecessary
This PR is to build a more generic data provider agnostic VC scanfold, taking business requirement of token holding amount VC as an example


### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


