### PR TITLE
Bump download-artifact version

### DIFF
--- a/.github/workflows/build-docker-with-args.yml
+++ b/.github/workflows/build-docker-with-args.yml
@@ -5,24 +5,24 @@ on:
     inputs:
       ref:
         description: The commit SHA or tag for checking out code
-        default: ''
+        default: ""
         required: false
       cargo_profile:
         type: choice
         description: which profile to use in cargo
         options:
-        - release
-        - production
+          - release
+          - production
       docker_tag:
         description: The tag for the built docker image
         required: true
       args:
         description: Args to pass to `cargo build`, e.g. --features=runtime-benchmarks
-        default: ''
+        default: ""
         required: false
 
 env:
-    DOCKER_BUILDKIT: 1
+  DOCKER_BUILDKIT: 1
 
 jobs:
   ## build docker image of client binary with args ##
@@ -56,7 +56,7 @@ jobs:
           docker cp $(docker create --rm litentry/litentry-parachain:${{ github.event.inputs.docker_tag }}):/usr/local/bin/litentry-collator .
 
       - name: Upload the client binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: litentry-collator
           path: |

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -7,12 +7,12 @@ on:
         type: choice
         description: The chain whose runtime-wasm is built
         options:
-        - litmus
-        - litentry
-        - rococo
+          - litmus
+          - litentry
+          - rococo
       ref:
         description: The commit SHA or tag for checking out code
-        default: ''
+        default: ""
         required: false
 
 env:
@@ -50,7 +50,7 @@ jobs:
           cp ${{ steps.srtool_build.outputs.wasm_compressed }} ${{ github.event.inputs.chain }}-parachain-runtime.compact.compressed.wasm
 
       - name: Upload wasm artefacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.inputs.chain }}-parachain-runtime
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
 
       - name: Cache worker-cache
         if: needs.set-condition.outputs.rebuild_tee == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             worker-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
           docker save litentry/litentry-parachain:latest | gzip > litentry-parachain-dev.tar.gz
 
       - name: Upload docker image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: litentry-parachain-dev
           path: litentry-parachain-dev.tar.gz
@@ -463,7 +463,7 @@ jobs:
         run: docker save litentry/litentry-worker:latest litentry/litentry-cli:latest | gzip > litentry-tee.tar.gz
 
       - name: Upload docker images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: litentry-tee
           path: litentry-tee.tar.gz
@@ -513,7 +513,7 @@ jobs:
           dest: docker-logs
 
       - name: Upload docker logs if test fails
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.chain }}-ts-tests-docker-logs
@@ -522,7 +522,7 @@ jobs:
           retention-days: 3
 
       - name: Archive logs if test fails
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.chain }}-ts-tests-artifact
@@ -682,7 +682,7 @@ jobs:
           dest: docker-logs
 
       - name: Upload docker logs if test fails
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.test_name }}-docker-logs
@@ -765,7 +765,7 @@ jobs:
           dest: docker-logs
 
       - name: Upload docker logs if test fails
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.test_name }}-docker-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       # Checks to see if any files in the PR/commit match one of the listed file types.
       # We can use this filter to decide whether or not to build docker images
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: .github/file-filter.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: litentry-parachain-dev
 
@@ -632,11 +632,11 @@ jobs:
         run: |
           docker pull parity/polkadot
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: litentry-parachain-dev
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: litentry-tee
 
@@ -715,11 +715,11 @@ jobs:
         run: |
           docker pull parity/polkadot
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: litentry-parachain-dev
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: litentry-tee
 
@@ -795,11 +795,11 @@ jobs:
       - tee-single-worker-test
     if: ${{ !failure() && needs.set-condition.outputs.push_docker == 'true' }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: litentry-parachain-dev
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: litentry-tee
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Checks to see if any files in the PR/commit match one of the listed file types.
       # We can use this filter to decide whether or not to build docker images
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: .github/file-filter.yml
@@ -63,4 +63,3 @@ jobs:
         with:
           fail_ci_if_error: false
           verbose: true
-

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -417,7 +417,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download all artefacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Generate release notes
         run: |

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -108,7 +108,7 @@ jobs:
           cp ${{ steps.srtool_build.outputs.wasm_compressed }} ${{ matrix.chain }}-parachain-runtime.compact.compressed.wasm
 
       - name: Upload wasm artefacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain }}-parachain-runtime
           path: |
@@ -158,7 +158,7 @@ jobs:
           docker cp $(docker create --rm litentry/litentry-parachain:$PARACHAIN_DOCKER_TAG):/usr/local/bin/litentry-collator .
 
       - name: Upload the client binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: litentry-collator
           if-no-files-found: ignore
@@ -277,7 +277,7 @@ jobs:
           echo "worker_sha1sum=$WORKER_SHA1SUM" >> $GITHUB_OUTPUT
 
       - name: Upload artefacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: litentry-tee
           path: ./tee-worker/enclave_release/*
@@ -316,7 +316,7 @@ jobs:
           make test-ts-docker-${{ matrix.chain }}
 
       - name: Archive logs if test fails
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: ${{ matrix.chain }}-ts-tests-artifacts

--- a/.github/workflows/release-ts-api-package.yml
+++ b/.github/workflows/release-ts-api-package.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs-lit-ts-api-package-build
           path: logs

--- a/.github/workflows/simulate-runtime-upgrade.yml
+++ b/.github/workflows/simulate-runtime-upgrade.yml
@@ -62,7 +62,7 @@ jobs:
           dest: docker-logs
 
       - name: Upload docker logs if test fails
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.chain }}-docker-logs

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron


### PR DESCRIPTION
### Context

we got several warnings within CI processes which related to Node16 version within:
- `actions/download-artifact@v3`
- `actions/upload-artifact@v3`
- `dorny/paths-filter@v2`

As a solution we just bump the version