### PR TITLE
Add back `SubstrateTestnet` enum

### DIFF
--- a/primitives/core/src/network.rs
+++ b/primitives/core/src/network.rs
@@ -70,7 +70,9 @@ pub enum Web3Network {
 	LitentryRococo,
 	#[codec(index = 5)]
 	Khala,
-	// Index 6 used to SubstrateTestnet, So let's not break the indexing...
+	#[codec(index = 6)]
+	SubstrateTestnet, // when launched it with standalone (integritee-)node
+
 	// evm
 	#[codec(index = 7)]
 	Ethereum,
@@ -107,7 +109,7 @@ impl Web3Network {
 			Self::Polkadot |
 				Self::Kusama | Self::Litentry |
 				Self::Litmus | Self::LitentryRococo |
-				Self::Khala
+				Self::Khala | Self::SubstrateTestnet
 		)
 	}
 
@@ -165,6 +167,7 @@ mod tests {
 					Web3Network::Litmus => false,
 					Web3Network::LitentryRococo => false,
 					Web3Network::Khala => false,
+					Web3Network::SubstrateTestnet => false,
 					Web3Network::Ethereum => true,
 					Web3Network::Bsc => true,
 					Web3Network::BitcoinP2tr => false,
@@ -189,6 +192,7 @@ mod tests {
 					Web3Network::Litmus => true,
 					Web3Network::LitentryRococo => true,
 					Web3Network::Khala => true,
+					Web3Network::SubstrateTestnet => true,
 					Web3Network::Ethereum => false,
 					Web3Network::Bsc => false,
 					Web3Network::BitcoinP2tr => false,
@@ -213,6 +217,7 @@ mod tests {
 					Web3Network::Litmus => false,
 					Web3Network::LitentryRococo => false,
 					Web3Network::Khala => false,
+					Web3Network::SubstrateTestnet => false,
 					Web3Network::Ethereum => false,
 					Web3Network::Bsc => false,
 					Web3Network::BitcoinP2tr => true,

--- a/primitives/core/src/network.rs
+++ b/primitives/core/src/network.rs
@@ -71,7 +71,7 @@ pub enum Web3Network {
 	#[codec(index = 5)]
 	Khala,
 	#[codec(index = 6)]
-	SubstrateTestnet, // when launched it with standalone (integritee-)node
+	SubstrateTestnet,
 
 	// evm
 	#[codec(index = 7)]

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/identity/definitions.ts
@@ -41,7 +41,7 @@ export default {
                 "Litmus",
                 "LitentryRococo",
                 "Khala",
-                "Null",
+                "SubstrateTestnet",
                 "Ethereum",
                 "Bsc",
                 "BitcoinP2tr",

--- a/tee-worker/litentry/core/assertion-build/src/lib.rs
+++ b/tee-worker/litentry/core/assertion-build/src/lib.rs
@@ -177,6 +177,7 @@ fn pubkey_to_address(network: &Web3Network, pubkey: &str) -> String {
 		| Web3Network::Litmus
 		| Web3Network::LitentryRococo
 		| Web3Network::Khala
+		| Web3Network::SubstrateTestnet
 		| Web3Network::Ethereum
 		| Web3Network::Bsc => "".to_string(),
 	}

--- a/tee-worker/litentry/core/common/src/lib.rs
+++ b/tee-worker/litentry/core/common/src/lib.rs
@@ -34,6 +34,7 @@ pub fn web3_network_to_chain(network: &Web3Network) -> &'static str {
 		Web3Network::Litmus => "litmus",
 		Web3Network::LitentryRococo => "litentry_rococo",
 		Web3Network::Khala => "khala",
+		Web3Network::SubstrateTestnet => "substrate_testnet",
 		Web3Network::Ethereum => "ethereum",
 		Web3Network::Bsc => "bsc",
 		Web3Network::BitcoinP2tr => "bitcoin_p2tr",

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -176,6 +176,7 @@ pub fn web3_network_to_chain(network: &Web3Network) -> String {
 		Web3Network::Litmus => "litmus".into(),
 		Web3Network::LitentryRococo => "litentry_rococo".into(),
 		Web3Network::Khala => "khala".into(),
+		Web3Network::SubstrateTestnet => "substrate_testnet".into(),
 		Web3Network::Ethereum => "ethereum".into(),
 		Web3Network::Bsc => "bsc".into(),
 		Web3Network::BitcoinP2tr => "bitcoin_p2tr".into(),


### PR DESCRIPTION
### Context

Basically to revert https://github.com/litentry/litentry-parachain/pull/2399

The old PR itself is fine, but it causes problems when migrating data from staging workers. The IDGraph on staging-workers is created when user shielding key is set, where prime identity is added to the IDGraph with _all_ available substrate networks, including `SubstrateTestnet`.

We have removed this field in `dev` code.  As a consequence, when decoding the state from staging workers using `dev` branch, the prime identity will be dismissed if it has `SubstrateTestnet` in `web3networks`. That's why the prime identity is missing for some IDGraphs.

Btw the prime identity is the last element in the IDGraph of staging workers, we would get empty IDGraph if it was the first one (the case in `dev`).

Can you please update the client-SDK accordingly? @jonalvarezz 
Not that urgent tho, as `__Unused6`works fine too :D

If we want to remove it on `dev` branch as well, we have to do a worker runtime upgrade with **state migration**