### PR TITLE
include only one variant in compiled code

### DIFF
--- a/primitives/core/macros/src/lib.rs
+++ b/primitives/core/macros/src/lib.rs
@@ -17,19 +17,23 @@
 
 #[macro_export]
 macro_rules! if_production_or {
-	($prod_variant:expr, $non_prod_variant:expr) => {
-		if cfg!(feature = "production") {
-			$prod_variant
-		} else {
+	($prod_variant:expr, $non_prod_variant:expr) => {{
+		#[cfg(not(feature = "production"))]
+		{
 			$non_prod_variant
 		}
-	};
+		#[cfg(feature = "production")]
+		{
+			$prod_variant
+		}
+	}};
 }
 
 #[macro_export]
 macro_rules! if_not_production {
 	($expression:expr) => {
-		if cfg!(not(feature = "production")) {
+		#[cfg(not(feature = "production"))]
+		{
 			$expression
 		}
 	};


### PR DESCRIPTION
After this change only one expression will be present in compiled code, also there will be no if statement anymore. 

Previous version was failing in this case:
```
#[cfg(feature = "production")]
fn print_prod() {
	info!("Prod")
}

#[cfg(not(feature = "production"))]
fn print_dev() {
	info!("Dev")
}

if_production_or!(
	print_prod(),
	print_dev()
);
```

```
105 |         print_dev()
    |         ^^^^^^^^^ not found in this scope
```