### PR TITLE
fix: add block numbers and assertion text

### DIFF
--- a/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/src/vc_handling.rs
+++ b/tee-worker/litentry/core/vc-issuance/lc-vc-task-receiver/src/vc_handling.rs
@@ -194,8 +194,13 @@ where
 			)
 		})?;
 
+		credential.parachain_block_number = self.req.parachain_block_number;
+		credential.sidechain_block_number = self.req.sidechain_block_number;
+
 		credential.credential_subject.endpoint =
 			self.context.data_provider_config.credential_endpoint.to_string();
+
+		credential.credential_subject.assertion_text = format!("{:?}", self.req.assertion);
 
 		credential.issuer.id =
 			Identity::Substrate(enclave_account.into()).to_did().map_err(|e| {


### PR DESCRIPTION
I think the issue describes, It's a three line fix, The code to query the block numbers was already present, thanks to @Kailai-Wang 

Here's a VC I generated via CLI
```json
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://w3id.org/security/suites/ed25519-2020/v1"
  ],
  "id": "0x51b437e2ec7a90eb365b6c986d588cf1ce9bb4cdfac7bf8ee547b16f1f64dcba",
  "type": [
    "VerifiableCredential"
  ],
  "credentialSubject": {
    "id": "did:litentry:substrate:0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48",
    "description": "Gets the range of number of transactions a user has made for a specific token on all supported networks (invalid transactions are also counted)",
    "type": "EVM/Substrate Transaction Count",
    "assertionText": "A8(BoundedVec([Litentry, Litmus], 128))",
    "assertions": [
      {
        "and": [
          {
            "src": "$total_txs",
            "op": ">=",
            "dst": "50"
          },
          {
            "src": "$total_txs",
            "op": "<",
            "dst": "100"
          },
          {
            "or": [
              {
                "src": "$network",
                "op": "==",
                "dst": "Litentry"
              },
              {
                "src": "$network",
                "op": "==",
                "dst": "Litmus"
              }
            ]
          }
        ]
      }
    ],
    "values": [
      true
    ],
    "endpoint": "http://localhost:9933"
  },
  "issuer": {
    "id": "did:litentry:substrate:0x0f9193547c5eecfa8ba77ff219bcddea9987e5a15e7da6f3e3ac61562ed722fe",
    "name": "Litentry TEE Worker",
    "mrenclave": "7qp7QsiEmUxhFm36jd5PfDGPJM96bPrDQ8VZeLTgR3Qu"
  },
  "issuanceDate": "2024-02-12T14:16:55.905146419+00:00",
  "parachainBlockNumber": 13,
  "sidechainBlockNumber": 15,
  "proof": {
    "created": "2024-02-12T14:16:55.905858661+00:00",
    "type": "Ed25519Signature2020",
    "proofPurpose": "assertionMethod",
    "proofValue": "84c4116cfaa9a7ceb8e7e12d25c055aee9fe80d79b0eed3140105a6b8d9b8838c637217388fb8a2444b47f20783f1a092cfc1b49267c4a77b75d43c039f24c0e",
    "verificationMethod": "0x0f9193547c5eecfa8ba77ff219bcddea9987e5a15e7da6f3e3ac61562ed722fe"
  }
}
```