### PR TITLE
Refactor the way we run ts tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -701,7 +701,6 @@ jobs:
           - test_name: lit-di-vc-test
           - test_name: lit-parentchain-nonce
           - test_name: lit-ii-batch-test
-          - test_name: lit-test-stress-script
     steps:
       - uses: actions/checkout@v4
 

--- a/tee-worker/cli/lit_ts_integration_test.sh
+++ b/tee-worker/cli/lit_ts_integration_test.sh
@@ -68,4 +68,4 @@ pnpm run build
 
 cd /ts-tests
 pnpm install
-pnpm --filter integration-tests run $TEST:staging
+NODE_ENV=staging pnpm --filter integration-tests run $TEST

--- a/tee-worker/cli/lit_ts_worker_test.sh
+++ b/tee-worker/cli/lit_ts_worker_test.sh
@@ -22,4 +22,4 @@ echo "Using node endpoint: $NODE_ENDPOINT"
 
 cd /ts-tests
 pnpm install
-pnpm --filter worker run $TEST:staging
+NODE_ENV=staging pnpm --filter worker run $TEST

--- a/tee-worker/docker/lit-data-provider-test.yml
+++ b/tee-worker/docker/lit-data-provider-test.yml
@@ -17,7 +17,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-data-provider 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh data-provider.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-di-bitcoin-identity-test.yml
+++ b/tee-worker/docker/lit-di-bitcoin-identity-test.yml
@@ -17,7 +17,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-di-bitcoin-identity 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_bitcoin_identity.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-di-evm-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-evm-identity-multiworker-test.yml
@@ -21,7 +21,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-di-evm-identity 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_evm_identity.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-di-evm-identity-test.yml
+++ b/tee-worker/docker/lit-di-evm-identity-test.yml
@@ -17,7 +17,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-di-evm-identity 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_evm_identity.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-di-substrate-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-substrate-identity-multiworker-test.yml
@@ -21,7 +21,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-di-substrate-identity 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_substrate_identity.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-di-substrate-identity-test.yml
+++ b/tee-worker/docker/lit-di-substrate-identity-test.yml
@@ -17,7 +17,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-di-substrate-identity 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_substrate_identity.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-di-vc-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-vc-multiworker-test.yml
@@ -21,7 +21,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-di-vc 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_vc.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-di-vc-test.yml
+++ b/tee-worker/docker/lit-di-vc-test.yml
@@ -17,7 +17,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-di-vc 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_vc.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-ii-batch-test-multiworker.yml
+++ b/tee-worker/docker/lit-ii-batch-test-multiworker.yml
@@ -21,7 +21,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-ii-batch 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh ii_batch.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-ii-batch-test.yml
+++ b/tee-worker/docker/lit-ii-batch-test.yml
@@ -17,7 +17,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-ii-batch 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh ii_batch.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-ii-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-ii-identity-multiworker-test.yml
@@ -21,7 +21,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-ii-identity 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh ii_identity.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-ii-identity-test.yml
+++ b/tee-worker/docker/lit-ii-identity-test.yml
@@ -17,7 +17,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-ii-identity 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh ii_identity.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-ii-vc-multiworker-test.yml
+++ b/tee-worker/docker/lit-ii-vc-multiworker-test.yml
@@ -21,7 +21,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-ii-vc 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh ii_vc.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-ii-vc-test.yml
+++ b/tee-worker/docker/lit-ii-vc-test.yml
@@ -17,7 +17,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-ii-vc 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh ii_vc.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/docker/lit-resume-worker.yml
+++ b/tee-worker/docker/lit-resume-worker.yml
@@ -15,7 +15,7 @@ services:
                 condition: service_healthy
         networks:
             - litentry-test-network
-        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_worker_test.sh test-resuming-worker 2>&1' "
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_worker_test.sh resuming_worker.test.ts 2>&1' "
         restart: "no"
 networks:
     litentry-test-network:

--- a/tee-worker/ts-tests/README.md
+++ b/tee-worker/ts-tests/README.md
@@ -33,14 +33,14 @@ pnpm install
 pnpm --filter integration-tests run test your-testfile.test.ts
 ```
 
-II identity test: `pnpm --filter integration-tests run ii_identity.test.ts`
+II identity test: `pnpm --filter integration-tests run test ii_identity.test.ts`
 
-II vc test: `pnpm --filter integration-tests run ii_vc.test.ts`
+II vc test: `pnpm --filter integration-tests run test ii_vc.test.ts`
 
-II batch identity test: `pnpm --filter integration-tests run ii_batch.test.ts`
+II batch identity test: `pnpm --filter integration-tests run test ii_batch.test.ts`
 
-Direct invocation substrate identity test: `pnpm --filter integration-tests run di_substrate_identity.test.ts`
+Direct invocation substrate identity test: `pnpm --filter integration-tests run test di_substrate_identity.test.ts`
 
-Direct invocation evm identity test: `pnpm --filter integration-tests run di_evm_identity.test.ts`
+Direct invocation evm identity test: `pnpm --filter integration-tests run test di_evm_identity.test.ts`
 
-Direct invocation vc test: `pnpm --filter integration-tests run di_vc.test.ts`
+Direct invocation vc test: `pnpm --filter integration-tests run test di_vc.test.ts`

--- a/tee-worker/ts-tests/README.md
+++ b/tee-worker/ts-tests/README.md
@@ -29,14 +29,18 @@ pnpm install
 
 ## Usage(ts-tests folder)
 
-II identity test: `pnpm --filter integration-tests run test-ii-identity:local`
+```
+pnpm --filter integration-tests run test your-testfile.test.ts
+```
 
-II vc test: `pnpm --filter integration-tests run test-ii-vc:local`
+II identity test: `pnpm --filter integration-tests run ii_identity.test.ts`
 
-II batch identity test: `pnpm --filter integration-tests run test-ii-batch:local`
+II vc test: `pnpm --filter integration-tests run ii_vc.test.ts`
 
-Direct invocation substrate identity test: `pnpm --filter integration-tests run test-di-substrate-identity:local`
+II batch identity test: `pnpm --filter integration-tests run ii_batch.test.ts`
 
-Direct invocation evm identity test: `pnpm --filter integration-tests run test-di-evm-identity:local`
+Direct invocation substrate identity test: `pnpm --filter integration-tests run di_substrate_identity.test.ts`
 
-Direct invocation vc test: `pnpm --filter integration-tests run test-di-vc:local`
+Direct invocation evm identity test: `pnpm --filter integration-tests run di_evm_identity.test.ts`
+
+Direct invocation vc test: `pnpm --filter integration-tests run di_vc.test.ts`

--- a/tee-worker/ts-tests/integration-tests/common/config.js
+++ b/tee-worker/ts-tests/integration-tests/common/config.js
@@ -1,4 +1,4 @@
 import dotenv from 'dotenv';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
-dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
+dotenv.config({ path: `.env.${process.env.NODE_ENV || 'local'}` });

--- a/tee-worker/ts-tests/integration-tests/package.json
+++ b/tee-worker/ts-tests/integration-tests/package.json
@@ -3,24 +3,10 @@
     "license": "ISC",
     "type": "module",
     "scripts": {
-        "check-format": "pnpm exec prettier --check .",
-        "format": "pnpm exec prettier --write .",
-        "test-ii-identity:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'ii_identity.test.ts'",
-        "test-ii-identity:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm --loader=ts-node/esm 'ii_identity.test.ts'",
-        "test-di-substrate-identity:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_substrate_identity.test.ts'",
-        "test-di-substrate-identity:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_substrate_identity.test.ts'",
-        "test-di-evm-identity:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_evm_identity.test.ts'",
-        "test-di-evm-identity:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_evm_identity.test.ts'",
-        "test-di-bitcoin-identity:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_bitcoin_identity.test.ts'",
-        "test-di-bitcoin-identity:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_bitcoin_identity.test.ts'",
-        "test-di-vc:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_vc.test.ts'",
-        "test-di-vc:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'di_vc.test.ts'",
-        "test-ii-vc:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'ii_vc.test.ts'",
-        "test-ii-vc:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'ii_vc.test.ts'",
-        "test-ii-batch:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'ii_batch.test.ts'",
-        "test-ii-batch:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'ii_batch.test.ts'",
-        "test-data-provider:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'data-provider.test.ts'",
-        "test-data-provider:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'data-provider.test.ts'"
+        "check-format": "prettier --check .",
+        "format": "prettier --write .",
+        "pretest": "eslint .",
+        "test": "mocha --exit --sort -r ts-node/register --loader=ts-node/esm"
     },
     "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/tee-worker/ts-tests/stress/package.json
+++ b/tee-worker/ts-tests/stress/package.json
@@ -3,11 +3,10 @@
     "license": "ISC",
     "type": "module",
     "scripts": {
-        "format": "pnpm exec prettier --write .",
-        "check-format": "pnpm exec prettier --check .",
-        "run-script": "NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm exec ts-node bin/stress.ts",
-        "test-stress-script:local": "pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'test/test.ts'",
-        "test-stress-script:staging": "pnpm exec cross-env NODE_ENV=staging mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'test/test.ts'"
+        "format": "prettier --write .",
+        "check-format": "prettier --check .",
+        "run-script": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node bin/stress.ts",
+        "test": "mocha --exit --sort -r ts-node/register --loader=ts-node/esm"
     },
     "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/tee-worker/ts-tests/worker/package.json
+++ b/tee-worker/ts-tests/worker/package.json
@@ -3,10 +3,9 @@
     "license": "ISC",
     "type": "module",
     "scripts": {
-        "format": "pnpm exec prettier --write .",
-        "check-format": "pnpm exec prettier --check .",
-        "test-resuming-worker:staging": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=staging mocha --trace-warnings --full-trace --exit --sort -r ts-node/register --loader=ts-node/esm 'resuming_worker.test.ts'",
-        "test-resuming-worker:local": "pnpm exec eslint . && pnpm exec cross-env NODE_ENV=local mocha --exit --sort -r ts-node/register --loader=ts-node/esm 'resuming_worker.test.ts'"
+        "format": "prettier --write .",
+        "check-format": "prettier --check .",
+        "test": "mocha --trace-warnings --full-trace --exit --sort -r ts-node/register --loader=ts-node/esm"
     },
     "dependencies": {
         "chai": "^4.3.6",


### PR DESCRIPTION
### Context
This PR tends to simplify running integration tests with one `pnpm test` command
ref: https://github.com/litentry/litentry-parachain/pull/2431#discussion_r1469815073

### How (Optional)

with new implementation we just have to know filename or use regexp
```
// within ./ts-tests/integration-tests
pnpm test your-filename.test.ts

// within ./ts-tests/
pnpm --filter integration-tests run test di_vc.test.ts
```

In case we want to introduce more integration tests, instead of remembering a package script name we just have to use filename instead

```
// before
entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh test-data-provider 2>&1' "

//after
entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh data-provider.test.ts 2>&1' "
```



