### PR TITLE
Split direct request and invocation VC tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,6 +699,7 @@ jobs:
           - test_name: lit-di-evm-identity-test
           - test_name: lit-di-bitcoin-identity-test
           - test_name: lit-di-vc-test
+          - test_name: lit-dr-vc-test
           - test_name: lit-parentchain-nonce
           - test_name: lit-ii-batch-test
     steps:
@@ -780,6 +781,7 @@ jobs:
           - test_name: lit-di-evm-identity-multiworker-test
           - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-di-vc-multiworker-test
+          - test_name: lit-dr-vc-multiworker-test
           - test_name: lit-ii-batch-test-multiworker
           - test_name: lit-ii-identity-multiworker-test
           - test_name: lit-ii-vc-multiworker-test

--- a/tee-worker/docker/lit-dr-vc-multiworker-test.yml
+++ b/tee-worker/docker/lit-dr-vc-multiworker-test.yml
@@ -1,0 +1,28 @@
+services:
+    lit-di-vc-multiworker-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-di-vc-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh dr_vc.test.ts 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/lit-dr-vc-multiworker-test.yml
+++ b/tee-worker/docker/lit-dr-vc-multiworker-test.yml
@@ -1,7 +1,7 @@
 services:
-    lit-di-vc-multiworker-test:
+    lit-dr-vc-multiworker-test:
         image: litentry/litentry-cli:latest
-        container_name: litentry-di-vc-test
+        container_name: litentry-dr-vc-test
         volumes:
             - ../ts-tests:/ts-tests
             - ../client-api:/client-api

--- a/tee-worker/docker/lit-dr-vc-test.yml
+++ b/tee-worker/docker/lit-dr-vc-test.yml
@@ -1,0 +1,24 @@
+services:
+    lit-di-vc-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-di-vc-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh dr_vc.test.ts 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/lit-dr-vc-test.yml
+++ b/tee-worker/docker/lit-dr-vc-test.yml
@@ -1,7 +1,7 @@
 services:
-    lit-di-vc-test:
+    lit-dr-vc-test:
         image: litentry/litentry-cli:latest
-        container_name: litentry-di-vc-test
+        container_name: litentry-dr-vc-test
         volumes:
             - ../ts-tests:/ts-tests
             - ../client-api:/client-api

--- a/tee-worker/ts-tests/integration-tests/dr_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/dr_vc.test.ts
@@ -20,7 +20,7 @@ import { defaultAssertions, unconfiguredAssertions } from './common/utils/vc-hel
 import { LitentryValidationData, Web3Network } from 'parachain-api';
 import { Vec } from '@polkadot/types';
 
-describe('Test Vc (direct invocation)', function () {
+describe('Test Vc (direct request)', function () {
     let context: IntegrationTestContext = undefined as any;
     let teeShieldingKey: KeyObject = undefined as any;
     let aliceSubstrateIdentity: CorePrimitivesIdentity = undefined as any;
@@ -142,12 +142,14 @@ describe('Test Vc (direct invocation)', function () {
     });
 
     defaultAssertions.forEach(({ description, assertion }) => {
-        step(`request vc ${Object.keys(assertion)[0]} (alice)`, async function () {
+        step(`request vc direct ${Object.keys(assertion)[0]} (alice)`, async function () {
             let currentNonce = (await getSidechainNonce(context, teeShieldingKey, aliceSubstrateIdentity)).toNumber();
             const getNextNonce = () => currentNonce++;
             const nonce = getNextNonce();
             const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
-            console.log(`request vc ${Object.keys(assertion)[0]} for Alice ... Assertion description: ${description}`);
+            console.log(
+                `request vc direct ${Object.keys(assertion)[0]} for Alice ... Assertion description: ${description}`
+            );
             const eventsPromise = subscribeToEventsWithExtHash(requestIdentifier, context);
 
             const requestVcCall = await createSignedTrustedCallRequestVc(
@@ -161,8 +163,8 @@ describe('Test Vc (direct invocation)', function () {
                 requestIdentifier
             );
 
-            const res = await sendRequestFromTrustedCall(context, teeShieldingKey, requestVcCall);
-            await assertIsInSidechainBlock(`${Object.keys(assertion)[0]} requestVcCall`, res);
+            const isVcDirect = true;
+            const res = await sendRequestFromTrustedCall(context, teeShieldingKey, requestVcCall, isVcDirect);
             const events = await eventsPromise;
             const vcIssuedEvents = events
                 .map(({ event }) => event)
@@ -176,7 +178,6 @@ describe('Test Vc (direct invocation)', function () {
             await assertVc(context, aliceSubstrateIdentity, res.value);
         });
     });
-
     unconfiguredAssertions.forEach(({ description, assertion }) => {
         it(`request vc ${Object.keys(assertion)[0]} (alice)`, async function () {
             let currentNonce = (await getSidechainNonce(context, teeShieldingKey, aliceSubstrateIdentity)).toNumber();


### PR DESCRIPTION
### Context

during Slack conversation we decided to split Direct Invocation and Direct Request flows for testing VC. This PR just duplicates `di_vc.test.ts` logic as `dr_vc.test.ts` and includes the last one to CI 

