### PR TITLE
Always init GLOBAL_SCHEDULED_ENCLAVE

### DIFF
--- a/bitacross-worker/README.md
+++ b/bitacross-worker/README.md
@@ -186,7 +186,7 @@ They take single argument representing raw payload bytes to sign.
 #### Example usage
 
 ```bash
-./bitacross-cli trusted -m 7ppBUcnjGir4szRHCG59p2dTnbtRwKRbLZPpR32ACjbK request-direct-call-sign-bitcoin 00
+./bitacross-cli trusted request-direct-call-sign-bitcoin 00
 ```
 
 ### Obtaining data from parachain's teebag pallet

--- a/bitacross-worker/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/bitacross-worker/core-primitives/enclave-api/ffi/src/lib.rs
@@ -30,10 +30,7 @@ extern "C" {
 		encoded_base_dir_size: u32,
 	) -> sgx_status_t;
 
-	pub fn init_enclave_sidechain_components(
-		eid: sgx_enclave_id_t,
-		retval: *mut sgx_status_t,
-	) -> sgx_status_t;
+	pub fn init_mr_enclave(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
 
 	pub fn init_direct_invocation_server(
 		eid: sgx_enclave_id_t,

--- a/bitacross-worker/core-primitives/enclave-api/src/enclave_base.rs
+++ b/bitacross-worker/core-primitives/enclave-api/src/enclave_base.rs
@@ -36,8 +36,7 @@ pub trait EnclaveBase: Send + Sync + 'static {
 		base_dir: &str,
 	) -> EnclaveResult<()>;
 
-	/// Initialize the enclave sidechain components.
-	fn init_enclave_sidechain_components(&self) -> EnclaveResult<()>;
+	fn init_mr_enclave(&self) -> EnclaveResult<()>;
 
 	/// Initialize the direct invocation RPC server.
 	fn init_direct_invocation_server(&self, rpc_server_addr: String) -> EnclaveResult<()>;
@@ -140,10 +139,9 @@ mod impl_ffi {
 			Ok(())
 		}
 
-		fn init_enclave_sidechain_components(&self) -> EnclaveResult<()> {
+		fn init_mr_enclave(&self) -> EnclaveResult<()> {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
-
-			let result = unsafe { ffi::init_enclave_sidechain_components(self.eid, &mut retval) };
+			let result = unsafe { ffi::init_mr_enclave(self.eid, &mut retval) };
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));

--- a/bitacross-worker/enclave-runtime/Enclave.edl
+++ b/bitacross-worker/enclave-runtime/Enclave.edl
@@ -45,7 +45,7 @@ enclave {
 
 		public sgx_status_t publish_wallets();
 
-		public sgx_status_t init_enclave_sidechain_components();
+		public sgx_status_t init_mr_enclave();
 
 		public sgx_status_t init_direct_invocation_server(
 			[in, size=server_addr_size] uint8_t* server_addr, uint32_t server_addr_size

--- a/bitacross-worker/enclave-runtime/src/initialization/mod.rs
+++ b/bitacross-worker/enclave-runtime/src/initialization/mod.rs
@@ -304,11 +304,13 @@ fn run_bit_across_handler() -> Result<(), Error> {
 	Ok(())
 }
 
-pub(crate) fn init_enclave_sidechain_components() -> EnclaveResult<()> {
+pub(crate) fn init_mr_enclave() -> EnclaveResult<()> {
 	// GLOBAL_SCHEDULED_ENCLAVE must be initialized after attestation_handler and enclave
 	let attestation_handler = GLOBAL_ATTESTATION_HANDLER_COMPONENT.get()?;
 	let mrenclave = attestation_handler.get_mrenclave()?;
+	println!("Initializing global scheduled enclave with mrenclave: {:?}", mrenclave);
 	GLOBAL_SCHEDULED_ENCLAVE.init(mrenclave).map_err(|e| Error::Other(e.into()))?;
+
 	Ok(())
 }
 

--- a/bitacross-worker/enclave-runtime/src/lib.rs
+++ b/bitacross-worker/enclave-runtime/src/lib.rs
@@ -387,15 +387,10 @@ pub unsafe extern "C" fn publish_wallets() -> sgx_status_t {
 	sgx_status_t::SGX_SUCCESS
 }
 
-/// Initialize sidechain enclave components.
-///
-/// Call this once at startup. Has to be called AFTER the light-client
-/// (parentchain components) have been initialized (because we need the parentchain
-/// block import dispatcher).
 #[no_mangle]
-pub unsafe extern "C" fn init_enclave_sidechain_components() -> sgx_status_t {
-	if let Err(e) = initialization::init_enclave_sidechain_components() {
-		error!("Failed to initialize sidechain components: {:?}", e);
+pub unsafe extern "C" fn init_mr_enclave() -> sgx_status_t {
+	if let Err(e) = initialization::init_mr_enclave() {
+		error!("Failed to initialize mr_enclave: {:?}", e);
 		return sgx_status_t::SGX_ERROR_UNEXPECTED
 	}
 

--- a/bitacross-worker/service/src/main_impl.rs
+++ b/bitacross-worker/service/src/main_impl.rs
@@ -530,8 +530,10 @@ fn start_worker<E, T, InitializationHandler>(
 			is_development_mode,
 		)
 	}
-	// Publish generated custiodian wallets
+	// Publish generated custodian wallets
 	enclave.publish_wallets();
+
+	enclave.init_mr_enclave().unwrap();
 
 	// ------------------------------------------------------------------------
 	// Subscribe to events and print them.

--- a/bitacross-worker/service/src/tests/mocks/enclave_api_mock.rs
+++ b/bitacross-worker/service/src/tests/mocks/enclave_api_mock.rs
@@ -37,7 +37,7 @@ impl EnclaveBase for EnclaveMock {
 		Ok(())
 	}
 
-	fn init_enclave_sidechain_components(&self) -> EnclaveResult<()> {
+	fn init_mr_enclave(&self) -> EnclaveResult<()> {
 		Ok(())
 	}
 

--- a/tee-worker/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/tee-worker/core-primitives/enclave-api/ffi/src/lib.rs
@@ -39,6 +39,8 @@ extern "C" {
 		fail_at_size: u32,
 	) -> sgx_status_t;
 
+	pub fn init_mr_enclave(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
+
 	pub fn init_direct_invocation_server(
 		eid: sgx_enclave_id_t,
 		retval: *mut sgx_status_t,

--- a/tee-worker/core-primitives/enclave-api/src/enclave_base.rs
+++ b/tee-worker/core-primitives/enclave-api/src/enclave_base.rs
@@ -42,6 +42,8 @@ pub trait EnclaveBase: Send + Sync + 'static {
 		fail_at: u64,
 	) -> EnclaveResult<()>;
 
+	fn init_mr_enclave(&self) -> EnclaveResult<()>;
+
 	/// Initialize the direct invocation RPC server.
 	fn init_direct_invocation_server(&self, rpc_server_addr: String) -> EnclaveResult<()>;
 
@@ -153,6 +155,16 @@ mod impl_ffi {
 					encoded_fail_at.len() as u32,
 				)
 			};
+
+			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+			Ok(())
+		}
+
+		fn init_mr_enclave(&self) -> EnclaveResult<()> {
+			let mut retval = sgx_status_t::SGX_SUCCESS;
+			let result = unsafe { ffi::init_mr_enclave(self.eid, &mut retval) };
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));

--- a/tee-worker/enclave-runtime/Enclave.edl
+++ b/tee-worker/enclave-runtime/Enclave.edl
@@ -48,6 +48,8 @@ enclave {
 		    [in, size=fail_at_size] uint8_t* fail_at, uint32_t fail_at_size
 		);
 
+		public sgx_status_t init_mr_enclave();
+
 		public sgx_status_t init_direct_invocation_server(
 			[in, size=server_addr_size] uint8_t* server_addr, uint32_t server_addr_size
 		);

--- a/tee-worker/enclave-runtime/src/initialization/mod.rs
+++ b/tee-worker/enclave-runtime/src/initialization/mod.rs
@@ -306,11 +306,6 @@ pub(crate) fn init_enclave_sidechain_components(
 	let top_pool_author = GLOBAL_TOP_POOL_AUTHOR_COMPONENT.get()?;
 	let state_key_repository = GLOBAL_STATE_KEY_REPOSITORY_COMPONENT.get()?;
 
-	// GLOBAL_SCHEDULED_ENCLAVE must be initialized after attestation_handler and enclave
-	let attestation_handler = GLOBAL_ATTESTATION_HANDLER_COMPONENT.get()?;
-	let mrenclave = attestation_handler.get_mrenclave()?;
-	GLOBAL_SCHEDULED_ENCLAVE.init(mrenclave).map_err(|e| Error::Other(e.into()))?;
-
 	let parentchain_block_import_dispatcher =
 		get_triggered_dispatcher_from_integritee_solo_or_parachain()?;
 
@@ -373,6 +368,16 @@ pub(crate) fn init_enclave_sidechain_components(
 		#[allow(clippy::unwrap_used)]
 		run_vc_issuance().unwrap();
 	});
+
+	Ok(())
+}
+
+pub(crate) fn init_mr_enclave() -> EnclaveResult<()> {
+	// GLOBAL_SCHEDULED_ENCLAVE must be initialized after attestation_handler and enclave
+	let attestation_handler = GLOBAL_ATTESTATION_HANDLER_COMPONENT.get()?;
+	let mrenclave = attestation_handler.get_mrenclave()?;
+	println!("Initializing global scheduled enclave with mrenclave: {:?}", mrenclave);
+	GLOBAL_SCHEDULED_ENCLAVE.init(mrenclave).map_err(|e| Error::Other(e.into()))?;
 
 	Ok(())
 }

--- a/tee-worker/enclave-runtime/src/lib.rs
+++ b/tee-worker/enclave-runtime/src/lib.rs
@@ -402,6 +402,16 @@ pub unsafe extern "C" fn init_enclave_sidechain_components(
 	sgx_status_t::SGX_SUCCESS
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn init_mr_enclave() -> sgx_status_t {
+	if let Err(e) = initialization::init_mr_enclave() {
+		error!("Failed to initialize mr_enclave: {:?}", e);
+		return sgx_status_t::SGX_ERROR_UNEXPECTED
+	}
+
+	sgx_status_t::SGX_SUCCESS
+}
+
 /// Call this once at worker startup to initialize the TOP pool and direct invocation RPC server.
 ///
 /// This function will run the RPC server on the same thread as it is called and will loop there.

--- a/tee-worker/service/src/main_impl.rs
+++ b/tee-worker/service/src/main_impl.rs
@@ -628,6 +628,8 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		)
 	}
 
+	enclave.init_mr_enclave().unwrap();
+
 	// ------------------------------------------------------------------------
 	// Subscribe to events and print them.
 	println!("*** [{:?}] Subscribing to events", ParentchainId::Litentry);

--- a/tee-worker/service/src/tests/mocks/enclave_api_mock.rs
+++ b/tee-worker/service/src/tests/mocks/enclave_api_mock.rs
@@ -44,6 +44,10 @@ impl EnclaveBase for EnclaveMock {
 		Ok(())
 	}
 
+	fn init_mr_enclave(&self) -> EnclaveResult<()> {
+		Ok(())
+	}
+
 	fn init_direct_invocation_server(&self, _rpc_server_addr: String) -> EnclaveResult<()> {
 		unreachable!()
 	}


### PR DESCRIPTION
* initializes `GLOBAL_SCHEDULED_ENCLAVE` for any worker type, previously it was initialized only in case of sidechain worker.
