### PR TITLE
fix(request_vc_inner): remove duplicated String encoding

### DIFF
--- a/tee-worker/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/tee-worker/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -349,11 +349,11 @@ async fn request_vc_inner(params: Params) -> Result<RpcReturnValue, String> {
 			Ok(RpcReturnValue { do_watch: false, value: response, status: DirectRequestStatus::Ok }),
 		Ok(Err(e)) => {
 			log::error!("Received error in jsonresponse: {:?} ", e);
-			Err(compute_hex_encoded_return_error(&e))
+			Err(e)
 		},
 		Err(_) => {
 			// This case will only happen if the sender has been dropped
-			Err(compute_hex_encoded_return_error("The sender has been dropped"))
+			Err("The sender has been dropped".to_string())
 		},
 	}
 }


### PR DESCRIPTION
### Context

There is a duplicated encoding to Error strings on `request_vc_inner` which led to the issue described in [P-529](https://linear.app/litentry/issue/P-529/direct-response-of-request-vc-has-wrong-encoded-error-responses):

See:
* https://github.com/litentry/litentry-parachain/blob/2f4107c17ce5442eb5eb964fdcc966754a131618/tee-worker/sidechain/rpc-handler/src/direct_top_pool_api.rs#L130, and
* https://github.com/litentry/litentry-parachain/blob/37f5d74bdcc36a4d4c93ce3471dea1a10259dd3e/tee-worker/sidechain/rpc-handler/src/direct_top_pool_api.rs#L352


### Testing Evidences

`RcpReturnValue` response after the change: 
```
{value: '0x504e6f20656c696769626c65206964656e74697479', do_watch: false, status: 'Error'}
```

Decoding `0x504e6f20656c696769626c65206964656e74697479` gives `No eligible identity`



