### PR TITLE
Use `sign_prehash_recoverable` for ETH signing

### DIFF
--- a/bitacross-worker/Cargo.lock
+++ b/bitacross-worker/Cargo.lock
@@ -5801,6 +5801,7 @@ version = "0.1.0"
 dependencies = [
  "bc-relayer-registry",
  "core-primitives",
+ "hex 0.4.3",
  "itp-sgx-crypto",
  "itp-stf-primitives",
  "k256",

--- a/bitacross-worker/app-libs/stf/src/test_genesis.rs
+++ b/bitacross-worker/app-libs/stf/src/test_genesis.rs
@@ -56,7 +56,7 @@ pub fn test_genesis_setup(state: &mut impl SgxExternalitiesTrait) {
 	set_sudo_account(state, &ALICE_ENCODED);
 	trace!("Set new sudo account: {:?}", &ALICE_ENCODED);
 
-	let mut endowees: Vec<(AccountId32, Balance)> = vec![
+	let endowees: Vec<(AccountId32, Balance)> = vec![
 		(endowed_account().public().into(), ENDOWED_ACC_FUNDS),
 		(second_endowed_account().public().into(), SECOND_ENDOWED_ACC_FUNDS),
 		(ALICE_ENCODED.into(), ALICE_FUNDS),

--- a/bitacross-worker/bitacross/core/bc-task-receiver/src/lib.rs
+++ b/bitacross-worker/bitacross/core/bc-task-receiver/src/lib.rs
@@ -183,9 +183,9 @@ where
 			context.bitcoin_key_repository.deref(),
 		)
 		.map(|r| aes_encrypt_default(&aes_key, &r).encode()),
-		DirectCall::SignEthereum(signer, aes_key, payload) => sign_ethereum::handle(
+		DirectCall::SignEthereum(signer, aes_key, msg) => sign_ethereum::handle(
 			signer,
-			payload,
+			msg,
 			context.relayer_registry_lookup.deref(),
 			context.ethereum_key_repository.deref(),
 		)

--- a/bitacross-worker/cli/src/trusted_base_cli/commands/bitacross/direct_call_sign_ethereum.rs
+++ b/bitacross-worker/cli/src/trusted_base_cli/commands/bitacross/direct_call_sign_ethereum.rs
@@ -23,7 +23,7 @@ use crate::{
 use itp_rpc::{RpcResponse, RpcReturnValue};
 use itp_stf_primitives::types::KeyPair;
 use itp_utils::FromHexPrefixed;
-use lc_direct_call::DirectCall;
+use lc_direct_call::{DirectCall, PrehashedEthereumMessage};
 use sp_core::Pair;
 
 #[derive(Parser)]
@@ -36,8 +36,10 @@ impl RequestDirectCallSignEthereumCommand {
 		let alice = get_pair_from_str(trusted_cli, "//Alice", cli);
 		let (mrenclave, shard) = get_identifiers(trusted_cli, cli);
 		let key: [u8; 32] = random_aes_key();
+		let msg: PrehashedEthereumMessage =
+			self.payload.clone().try_into().expect("Unable to convert payload to [u8; 32]");
 
-		let dc = DirectCall::SignEthereum(alice.public().into(), key, self.payload.clone()).sign(
+		let dc = DirectCall::SignEthereum(alice.public().into(), key, msg).sign(
 			&KeyPair::Sr25519(Box::new(alice)),
 			&mrenclave,
 			&shard,

--- a/bitacross-worker/core-primitives/sgx/crypto/Cargo.toml
+++ b/bitacross-worker/core-primitives/sgx/crypto/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 aes = { version = "0.6.0" }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.5" }
-k256 = { version = "0.13.3", default-features = false, features = ["ecdsa-core", "schnorr"] }
+k256 = { version = "0.13.3", default-features = false, features = ["ecdsa-core", "schnorr", "alloc"] }
 log = { version = "0.4", default-features = false }
 ofb = { version = "0.4.0" }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }

--- a/bitacross-worker/enclave-runtime/Cargo.lock
+++ b/bitacross-worker/enclave-runtime/Cargo.lock
@@ -249,6 +249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bc-relayer-registry"
 version = "0.1.0"
 dependencies = [
@@ -854,6 +860,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -888,6 +895,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.7",
  "group",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -3146,6 +3154,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.8",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "postcard"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,6 +3706,7 @@ dependencies = [
  "base16ct",
  "der 0.7.8",
  "generic-array 0.14.7",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -4490,6 +4509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.8",
+]
+
+[[package]]
 name = "ss58-registry"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5038,7 +5067,7 @@ dependencies = [
  "const-oid",
  "der 0.6.1",
  "flagset",
- "spki",
+ "spki 0.6.0",
 ]
 
 [[package]]

--- a/bitacross-worker/enclave-runtime/Cargo.lock
+++ b/bitacross-worker/enclave-runtime/Cargo.lock
@@ -5100,8 +5100,3 @@ dependencies = [
  "quote 1.0.33",
  "syn 2.0.37",
 ]
-
-[[patch.unused]]
-name = "getrandom"
-version = "0.2.3"
-source = "git+https://github.com/integritee-network/getrandom-sgx?branch=update-v2.3#0a4af01fe1df0e6200192e7a709fd18da413466e"

--- a/bitacross-worker/enclave-runtime/Cargo.toml
+++ b/bitacross-worker/enclave-runtime/Cargo.toml
@@ -146,7 +146,6 @@ itp-sgx-temp-dir = { version = "0.1", default-features = false, optional = true,
 
 [patch.crates-io]
 env_logger = { git = "https://github.com/integritee-network/env_logger-sgx" }
-getrandom = { git = "https://github.com/integritee-network/getrandom-sgx", branch = "update-v2.3" }
 log = { git = "https://github.com/integritee-network/log-sgx" }
 
 [patch."https://github.com/mesalock-linux/log-sgx"]

--- a/bitacross-worker/litentry/core/direct-call/Cargo.toml
+++ b/bitacross-worker/litentry/core/direct-call/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false, features = ["full_crypto"] }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 
 # internal dependencies
@@ -22,6 +22,7 @@ sgx_tstd = { git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "m
 [dev-dependencies]
 k256 = { version = "0.13.3", features = ["ecdsa-core", "schnorr"] }
 rand = { version = "0.7" }
+hex = { version = "0.4" }
 
 [features]
 default = ["std"]

--- a/bitacross-worker/litentry/core/direct-call/Cargo.toml
+++ b/bitacross-worker/litentry/core/direct-call/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false, features = ["full_crypto"] }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42", default-features = false }
 
 # internal dependencies

--- a/bitacross-worker/litentry/core/direct-call/src/handler/sign_ethereum.rs
+++ b/bitacross-worker/litentry/core/direct-call/src/handler/sign_ethereum.rs
@@ -2,6 +2,7 @@ use bc_relayer_registry::RelayerRegistryLookup;
 use itp_sgx_crypto::{ecdsa::Pair, key_repository::AccessKey};
 use parentchain_primitives::Identity;
 use std::{
+	format,
 	string::{String, ToString},
 	vec::Vec,
 };
@@ -11,10 +12,11 @@ pub fn handle<RRL: RelayerRegistryLookup, EKR: AccessKey<KeyType = Pair>>(
 	payload: Vec<u8>,
 	relayer_registry: &RRL,
 	key_repository: &EKR,
-) -> Result<[u8; 64], String> {
+) -> Result<[u8; 65], String> {
 	if relayer_registry.contains_key(signer) {
-		let key = key_repository.retrieve_key().unwrap();
-		Ok(key.sign(&payload).unwrap())
+		let key = key_repository.retrieve_key().map_err(|e| format!("{}", e))?;
+		let sig = key.sign(&payload).map_err(|e| format!("{}", e))?;
+		Ok(sig)
 	} else {
 		Err("Unauthorized: Signer is not a valid relayer".to_string())
 	}
@@ -24,8 +26,8 @@ pub fn handle<RRL: RelayerRegistryLookup, EKR: AccessKey<KeyType = Pair>>(
 pub mod test {
 	use crate::handler::sign_ethereum::handle;
 	use bc_relayer_registry::{RelayerRegistry, RelayerRegistryUpdater};
-	use itp_sgx_crypto::mocks::KeyRepositoryMock;
-	use k256::elliptic_curve::rand_core;
+	use itp_sgx_crypto::{ecdsa::Pair as EcdsaPair, mocks::KeyRepositoryMock};
+	use k256::{ecdsa::SigningKey, elliptic_curve::rand_core};
 	use parentchain_primitives::Identity;
 	use sp_core::{sr25519, Pair};
 
@@ -37,8 +39,8 @@ pub mod test {
 		let relayer_account = Identity::Substrate(alice_key_pair.public().into());
 		relayer_registry.update(relayer_account.clone()).unwrap();
 
-		let private = k256::ecdsa::SigningKey::random(&mut rand_core::OsRng);
-		let signing_key = itp_sgx_crypto::ecdsa::Pair::new(private);
+		let private = SigningKey::random(&mut rand_core::OsRng);
+		let signing_key = EcdsaPair::new(private);
 
 		let key_repository = KeyRepositoryMock::new(signing_key);
 
@@ -56,31 +58,32 @@ pub mod test {
 		let alice_key_pair = sr25519::Pair::from_string("//Alice", None).unwrap();
 		let non_relayer_account = Identity::Substrate(alice_key_pair.public().into());
 
-		let private = k256::ecdsa::SigningKey::random(&mut rand_core::OsRng);
-		let signing_key = itp_sgx_crypto::ecdsa::Pair::new(private);
+		let private = SigningKey::random(&mut rand_core::OsRng);
+		let signing_key = EcdsaPair::new(private);
 
 		let key_repository = KeyRepositoryMock::new(signing_key);
 
 		//when
 		let result = handle(non_relayer_account, vec![], &relayer_registry, &key_repository);
 
+		println!("res is {:?}", result);
 		//then
 		assert!(result.is_err())
 	}
 
 	#[test]
 	pub fn sign_ethereum_works() {
+		// test vector from bc team, verified with sp_core::ecdsa::Pair::sign_prehashed
 		let private_key =
 			hex::decode("038a5c907573ea7f61a7dcce5ebb2e233a6e9376e5a6f077729bd732d6cab620")
 				.unwrap();
-		let key_pair = sp_core::ecdsa::Pair::from_seed_slice(&private_key).unwrap();
+		let key_pair = EcdsaPair::from_bytes(&private_key).unwrap();
 		let payload =
 			hex::decode("3b08e117290fdd2617ea0e457a8eeebe373c456ecd3f6dc6dc4089380f486516")
 				.unwrap();
-		let result = key_pair.sign_prehashed(&payload.try_into().unwrap());
-		let ref_result: &[u8] = result.as_ref();
+		let result = key_pair.sign(&payload).unwrap();
 		let expected_result = hex::decode("e733e8e3cd4f90d8fc10c2f8eeb7183623451b8e1d55b5ab6c4724c5428264955289fac3da7ce2095e12f19b4eb157c55be5c58a09ac8ae3358af0b7ec266a7201").unwrap();
 
-		assert!(ref_result == &expected_result)
+		assert_eq!(&result, expected_result.as_slice())
 	}
 }

--- a/bitacross-worker/litentry/core/direct-call/src/handler/sign_ethereum.rs
+++ b/bitacross-worker/litentry/core/direct-call/src/handler/sign_ethereum.rs
@@ -48,7 +48,6 @@ pub mod test {
 		let result =
 			handle(relayer_account, Default::default(), &relayer_registry, &key_repository);
 
-		println!("result is {:?}", result);
 		//then
 		assert!(result.is_ok())
 	}

--- a/bitacross-worker/litentry/core/direct-call/src/handler/sign_ethereum.rs
+++ b/bitacross-worker/litentry/core/direct-call/src/handler/sign_ethereum.rs
@@ -6,11 +6,11 @@ use std::{
 	vec::Vec,
 };
 
-pub fn handle<RRL: RelayerRegistryLookup, BKR: AccessKey<KeyType = Pair>>(
+pub fn handle<RRL: RelayerRegistryLookup, EKR: AccessKey<KeyType = Pair>>(
 	signer: Identity,
 	payload: Vec<u8>,
 	relayer_registry: &RRL,
-	key_repository: &BKR,
+	key_repository: &EKR,
 ) -> Result<[u8; 64], String> {
 	if relayer_registry.contains_key(signer) {
 		let key = key_repository.retrieve_key().unwrap();
@@ -66,5 +66,21 @@ pub mod test {
 
 		//then
 		assert!(result.is_err())
+	}
+
+	#[test]
+	pub fn sign_ethereum_works() {
+		let private_key =
+			hex::decode("038a5c907573ea7f61a7dcce5ebb2e233a6e9376e5a6f077729bd732d6cab620")
+				.unwrap();
+		let key_pair = sp_core::ecdsa::Pair::from_seed_slice(&private_key).unwrap();
+		let payload =
+			hex::decode("3b08e117290fdd2617ea0e457a8eeebe373c456ecd3f6dc6dc4089380f486516")
+				.unwrap();
+		let result = key_pair.sign_prehashed(&payload.try_into().unwrap());
+		let ref_result: &[u8] = result.as_ref();
+		let expected_result = hex::decode("e733e8e3cd4f90d8fc10c2f8eeb7183623451b8e1d55b5ab6c4724c5428264955289fac3da7ce2095e12f19b4eb157c55be5c58a09ac8ae3358af0b7ec266a7201").unwrap();
+
+		assert!(ref_result == &expected_result)
 	}
 }

--- a/bitacross-worker/litentry/core/direct-call/src/lib.rs
+++ b/bitacross-worker/litentry/core/direct-call/src/lib.rs
@@ -28,6 +28,8 @@ use std::vec::Vec;
 
 pub mod handler;
 
+pub type PrehashedEthereumMessage = [u8; 32];
+
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 pub struct DirectCallSigned {
 	pub call: DirectCall,
@@ -47,7 +49,7 @@ impl DirectCallSigned {
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 pub enum DirectCall {
 	SignBitcoin(Identity, RequestAesKey, Vec<u8>),
-	SignEthereum(Identity, RequestAesKey, Vec<u8>),
+	SignEthereum(Identity, RequestAesKey, PrehashedEthereumMessage),
 }
 
 impl DirectCall {


### PR DESCRIPTION
### Context

Using the test vector from colleagues.

The DirectCall interface is adapted to enforce `[u8; 32]` type too.