### PR TITLE
Bump docker/login-action to v3

### DIFF
--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -30,7 +30,7 @@ on:
         required: true
 
 env:
-  INSTANCE_ID: ${{ secrets.BENCHMARK_INSTANCE_ID }}  # remote AWS host to run benchmarking
+  INSTANCE_ID: ${{ secrets.BENCHMARK_INSTANCE_ID }} # remote AWS host to run benchmarking
   BENCHMARK_SSH_USER: ${{ secrets.BENCHMARK_SSH_USER }}
   BENCHMARK_SSH_KEYPATH: ${{ secrets.BENCHMARK_SSH_KEYPATH }}
   DOCKER_BUILDKIT: 1
@@ -66,7 +66,7 @@ jobs:
           ./scripts/build-docker.sh production runtime-benchmarks --features=runtime-benchmarks
 
       - name: Dockerhub login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/build-docker-with-args.yml
+++ b/.github/workflows/build-docker-with-args.yml
@@ -42,7 +42,7 @@ jobs:
           docker images
 
       - name: Dockerhub login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,7 +881,7 @@ jobs:
           docker load < litentry-tee.tar.gz
 
       - name: Dockerhub login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION

### Context

We observed node16 within GHA actions again https://github.com/litentry/litentry-parachain/actions/runs/7967753339 and this PR is tend to fix it


