### PR TITLE
P-508 Avoid using as sometype

### DIFF
--- a/tee-worker/ts-tests/integration-tests/common/di-utils.ts
+++ b/tee-worker/ts-tests/integration-tests/common/di-utils.ts
@@ -11,7 +11,6 @@ import { createPublicKey, KeyObject } from 'crypto';
 import WebSocketAsPromised from 'websocket-as-promised';
 import { H256, Index } from '@polkadot/types/interfaces';
 import { blake2AsHex } from '@polkadot/util-crypto';
-import type { PalletIdentityManagementTeeIdentityContext } from 'sidechain-api';
 import { createJsonRpcRequest, nextRequestId } from './helpers';
 
 // Send the request to worker ws
@@ -35,7 +34,7 @@ async function sendRequest(
             const parsed = JSON.parse(data);
             if (parsed.id === request.id) {
                 const result = parsed.result;
-                const res: WorkerRpcReturnValue = api.createType('WorkerRpcReturnValue', result) as any;
+                const res = api.createType('WorkerRpcReturnValue', result);
 
                 console.log('Got response: ' + JSON.stringify(res.toHuman()));
 
@@ -105,7 +104,7 @@ export const createSignedTrustedCall = async (
         call: call,
         index: nonce,
         signature: signature,
-    }) as unknown as TrustedCallSigned;
+    });
 };
 
 export const createSignedTrustedGetter = async (
@@ -265,7 +264,7 @@ export async function createSignedTrustedGetterIdGraph(
         signer,
         primeIdentity.toHuman()
     );
-    return parachainApi.createType('Getter', { trusted: getterSigned }) as unknown as Getter; // @fixme 1878;
+    return parachainApi.createType('Getter', { trusted: getterSigned });
 }
 
 export const getSidechainNonce = async (
@@ -274,7 +273,7 @@ export const getSidechainNonce = async (
     primeIdentity: CorePrimitivesIdentity
 ): Promise<Index> => {
     const getterPublic = createPublicGetter(context.api, ['nonce', '(LitentryIdentity)'], primeIdentity.toHuman());
-    const getter = context.api.createType('Getter', { public: getterPublic }) as unknown as Getter; // @fixme 1878
+    const getter = context.api.createType('Getter', { public: getterPublic });
     const res = await sendRequestFromGetter(context, teeShieldingKey, getter);
     const nonce = context.api.createType('Option<Bytes>', hexToU8a(res.value.toHex())).unwrap();
     return context.api.createType('Index', nonce);
@@ -290,7 +289,7 @@ export const getIdGraphHash = async (
         ['id_graph_hash', '(LitentryIdentity)'],
         primeIdentity.toHuman()
     );
-    const getter = context.api.createType('Getter', { public: getterPublic }) as unknown as Getter; // @fixme 1878
+    const getter = context.api.createType('Getter', { public: getterPublic });
     const res = await sendRequestFromGetter(context, teeShieldingKey, getter);
     const hash = context.api.createType('Option<Bytes>', hexToU8a(res.value.toHex())).unwrap();
     return context.api.createType('H256', hash);
@@ -407,7 +406,7 @@ export function decodeIdGraph(sidechainRegistry: TypeRegistry, value: Bytes) {
     return sidechainRegistry.createType(
         'Vec<(CorePrimitivesIdentity, PalletIdentityManagementTeeIdentityContext)>',
         idgraphBytes.unwrap()
-    ) as unknown as [CorePrimitivesIdentity, PalletIdentityManagementTeeIdentityContext][];
+    );
 }
 
 export function getTopHash(parachainApi: ApiPromise, call: TrustedCallSigned) {

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -4,7 +4,6 @@ import Ajv from 'ajv';
 import { assert } from 'chai';
 import * as ed from '@noble/ed25519';
 import { parseIdGraph } from './identity-helper';
-import type { PalletIdentityManagementTeeError } from 'sidechain-api';
 import { CorePrimitivesIdentity } from 'parachain-api';
 import type { IntegrationTestContext } from '../common-types';
 import { getIdGraphHash } from '../di-utils';
@@ -12,44 +11,13 @@ import type { HexString } from '@polkadot/util/types';
 import { jsonSchema } from './vc-helper';
 import { aesKey } from '../call';
 import colors from 'colors';
-import { CorePrimitivesErrorErrorDetail, FrameSystemEventRecord, WorkerRpcReturnValue, StfError } from 'parachain-api';
+import { WorkerRpcReturnValue, StfError } from 'parachain-api';
 import { Bytes } from '@polkadot/types-codec';
 import { Signer, decryptWithAes } from './crypto';
 import { blake2AsHex } from '@polkadot/util-crypto';
 import { PalletIdentityManagementTeeIdentityContext } from 'sidechain-api';
 import { KeyObject } from 'crypto';
 import * as base58 from 'micro-base58';
-
-export async function assertFailedEvent(
-    context: IntegrationTestContext,
-    events: FrameSystemEventRecord[],
-    eventType: 'LinkIdentityFailed' | 'DeactivateIdentityFailed',
-    expectedEvent: CorePrimitivesErrorErrorDetail['type'] | PalletIdentityManagementTeeError['type']
-) {
-    const failedType = context.api.events.identityManagement[eventType];
-    const isFailed = failedType.is.bind(failedType);
-    type EventLike = Parameters<typeof isFailed>[0];
-    const ievents: EventLike[] = events.map(({ event }) => event);
-    const failedEvent = ievents.filter(isFailed);
-    /* 
-      @fix Why this type don't work?????? https://github.com/litentry/litentry-parachain/issues/1917
-    */
-    const eventData = failedEvent[0].data[1] as CorePrimitivesErrorErrorDetail;
-    assert.lengthOf(failedEvent, 1);
-    if (eventData.isStfError) {
-        assert.equal(
-            eventData.asStfError.toHuman(),
-            expectedEvent,
-            `check event detail is ${expectedEvent}, but is ${eventData.asStfError.toHuman()}`
-        );
-    } else {
-        assert.equal(
-            eventData.type,
-            expectedEvent,
-            `check event detail is  ${expectedEvent}, but is ${eventData.type}`
-        );
-    }
-}
 
 export function assertIdGraph(
     actual: [CorePrimitivesIdentity, PalletIdentityManagementTeeIdentityContext][],

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -1,25 +1,18 @@
-import { ApiPromise } from '@polkadot/api';
 import { Event } from '@polkadot/types/interfaces';
 import { hexToU8a, u8aToHex } from '@polkadot/util';
 import Ajv from 'ajv';
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 import * as ed from '@noble/ed25519';
 import { parseIdGraph } from './identity-helper';
 import type { PalletIdentityManagementTeeError } from 'sidechain-api';
-import { PalletTeebagEnclave, CorePrimitivesIdentity } from 'parachain-api';
+import { CorePrimitivesIdentity } from 'parachain-api';
 import type { IntegrationTestContext } from '../common-types';
 import { getIdGraphHash } from '../di-utils';
 import type { HexString } from '@polkadot/util/types';
 import { jsonSchema } from './vc-helper';
 import { aesKey } from '../call';
 import colors from 'colors';
-import {
-    CorePrimitivesErrorErrorDetail,
-    FrameSystemEventRecord,
-    WorkerRpcReturnValue,
-    RequestVCResult,
-    StfError,
-} from 'parachain-api';
+import { CorePrimitivesErrorErrorDetail, FrameSystemEventRecord, WorkerRpcReturnValue, StfError } from 'parachain-api';
 import { Bytes } from '@polkadot/types-codec';
 import { Signer, decryptWithAes } from './crypto';
 import { blake2AsHex } from '@polkadot/util-crypto';
@@ -162,7 +155,7 @@ export function assertWorkerError(
     check: (returnValue: StfError) => void,
     returnValue: WorkerRpcReturnValue
 ) {
-    const errValueDecoded = context.api.createType('StfError', returnValue.value) as unknown as StfError;
+    const errValueDecoded = context.api.createType('StfError', returnValue.value);
     check(errValueDecoded);
 }
 
@@ -180,7 +173,7 @@ export async function assertIdGraphMutationResult(
         | 'SetIdentityNetworksResult',
     expectedIdGraph: [CorePrimitivesIdentity, boolean][]
 ): Promise<HexString> {
-    const decodedResult = context.api.createType(resultType, returnValue.value) as any;
+    const decodedResult = context.api.createType(resultType, returnValue.value);
     assert.isNotNull(decodedResult.mutated_id_graph);
     const idGraph = parseIdGraph(context.sidechainRegistry, decodedResult.mutated_id_graph, aesKey);
     assertIdGraph(idGraph, expectedIdGraph);
@@ -205,7 +198,7 @@ export async function assertIdGraphMutationResult(
 */
 
 export async function assertVc(context: IntegrationTestContext, subject: CorePrimitivesIdentity, data: Bytes) {
-    const results = context.api.createType('RequestVCResult', data) as unknown as RequestVCResult;
+    const results = context.api.createType('RequestVCResult', data);
     // step 1
     // decryptWithAes function added 0x prefix
     const vcPayload = results.vc_payload;

--- a/tee-worker/ts-tests/integration-tests/common/utils/identity-helper.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/identity-helper.ts
@@ -4,7 +4,7 @@ import type { IntegrationTestContext } from '../common-types';
 import { AesOutput } from 'parachain-api';
 import { decryptWithAes, encryptWithTeeShieldingKey, Signer } from './crypto';
 import { ethers } from 'ethers';
-import type { TypeRegistry } from '@polkadot/types';
+import type { Bytes, TypeRegistry, Vec } from '@polkadot/types';
 import type { PalletIdentityManagementTeeIdentityContext } from 'sidechain-api';
 import type { LitentryValidationData, Web3Network, CorePrimitivesIdentity } from 'parachain-api';
 import type { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types';
@@ -35,7 +35,7 @@ export async function buildIdentityHelper(
     const identity = {
         [type]: address,
     };
-    return context.api.createType('CorePrimitivesIdentity', identity) as unknown as CorePrimitivesIdentity;
+    return context.api.createType('CorePrimitivesIdentity', identity);
 }
 
 export async function buildIdentityFromKeypair(
@@ -64,7 +64,7 @@ export async function buildIdentityFromKeypair(
         [type]: address,
     };
 
-    return context.api.createType('CorePrimitivesIdentity', identity) as unknown as CorePrimitivesIdentity;
+    return context.api.createType('CorePrimitivesIdentity', identity);
 }
 
 // If multiple transactions are built from multiple accounts, pass the signers as an array.
@@ -77,7 +77,7 @@ export async function buildIdentityTxs(
     identities: CorePrimitivesIdentity[],
     method: 'linkIdentity' | 'deactivateIdentity' | 'activateIdentity',
     validations?: LitentryValidationData[],
-    web3networks?: Web3Network[][]
+    web3networks?: (Bytes | Vec<Web3Network>)[]
 ): Promise<any[]> {
     const txs: {
         tx: SubmittableExtrinsic<ApiTypes>;
@@ -138,7 +138,7 @@ export function parseIdGraph(
         sidechainRegistry.createType(
             'Vec<(CorePrimitivesIdentity, PalletIdentityManagementTeeIdentityContext)>',
             decryptedIdGraph
-        ) as unknown as [CorePrimitivesIdentity, PalletIdentityManagementTeeIdentityContext][];
+        );
 
     return idGraph;
 }
@@ -182,10 +182,7 @@ export async function buildValidations(
 
             evmValidationData!.Web3Validation.Evm.signature.Ethereum = evmSignature;
             console.log('evmValidationData', evmValidationData);
-            const encodedVerifyIdentityValidation = context.api.createType(
-                'LitentryValidationData',
-                evmValidationData
-            ) as unknown as LitentryValidationData;
+            const encodedVerifyIdentityValidation = context.api.createType('LitentryValidationData', evmValidationData);
 
             validations.push(encodedVerifyIdentityValidation);
         } else if (network === 'substrate') {
@@ -207,7 +204,7 @@ export async function buildValidations(
             const encodedVerifyIdentityValidation: LitentryValidationData = context.api.createType(
                 'LitentryValidationData',
                 substrateValidationData
-            ) as unknown as LitentryValidationData;
+            );
             validations.push(encodedVerifyIdentityValidation);
         } else if (network === 'bitcoin') {
             const bitcoinValidationData = {
@@ -233,7 +230,7 @@ export async function buildValidations(
             const encodedVerifyIdentityValidation: LitentryValidationData = context.api.createType(
                 'LitentryValidationData',
                 bitcoinValidationData
-            ) as unknown as LitentryValidationData;
+            );
             validations.push(encodedVerifyIdentityValidation);
         } else if (network === 'bitcoinPrettified') {
             const bitcoinValidationData = {
@@ -258,7 +255,7 @@ export async function buildValidations(
             const encodedVerifyIdentityValidation: LitentryValidationData = context.api.createType(
                 'LitentryValidationData',
                 bitcoinValidationData
-            ) as unknown as LitentryValidationData;
+            );
             validations.push(encodedVerifyIdentityValidation);
         } else if (network === 'twitter') {
             console.log('post verification msg to twitter: ', msg);
@@ -273,7 +270,7 @@ export async function buildValidations(
             const encodedVerifyIdentityValidation = context.api.createType(
                 'LitentryValidationData',
                 twitterValidationData
-            ) as unknown as LitentryValidationData;
+            );
             validations.push(encodedVerifyIdentityValidation);
         }
     }

--- a/tee-worker/ts-tests/integration-tests/common/utils/storage.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/storage.ts
@@ -105,9 +105,6 @@ export async function checkIdGraph(
 
     const request = createJsonRpcRequest('state_getStorage', [base58mrEnclave, storageKey], nextRequestId(context));
     const resp = await sendRequest(context.tee, request, context.api);
-    const idGraph = context.sidechainRegistry.createType(
-        'PalletIdentityManagementTeeIdentityContext',
-        resp.value
-    ) as unknown as PalletIdentityManagementTeeIdentityContext;
+    const idGraph = context.sidechainRegistry.createType('PalletIdentityManagementTeeIdentityContext', resp.value);
     return idGraph;
 }

--- a/tee-worker/ts-tests/integration-tests/data-provider.test.ts
+++ b/tee-worker/ts-tests/integration-tests/data-provider.test.ts
@@ -104,7 +104,7 @@ describe('Test Vc (direct invocation)', function () {
         const res = await sendRequestFromTrustedCall(context, teeShieldingKey, requestVcCall);
         await assertIsInSidechainBlock(`${Object.keys(assertion)[0]} requestVcCall`, res);
 
-        const vcResults = context.api.createType('RequestVCResult', res.value) as unknown as RequestVCResult;
+        const vcResults = context.api.createType('RequestVCResult', res.value);
         const decryptVcPayload = decryptWithAes(aesKey, vcResults.vc_payload, 'utf-8').replace('0x', '');
         const vcPayloadJson = JSON.parse(decryptVcPayload);
         console.log('vcPayload: ', vcPayloadJson);

--- a/tee-worker/ts-tests/integration-tests/di_bitcoin_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_bitcoin_identity.test.ts
@@ -103,7 +103,7 @@ describe('Test Identity (bitcoin direct invocation)', function () {
             undefined,
             [context.ethersWallet.alice]
         );
-        const aliceEvmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
+        const aliceEvmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']);
         linkIdentityRequestParams.push({
             nonce: aliceEvmNonce,
             identity: aliceEvmIdentity,
@@ -123,7 +123,7 @@ describe('Test Identity (bitcoin direct invocation)', function () {
             undefined,
             context.bitcoinWallet.bob
         );
-        const bobBitcoinNetowrks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']); // @fixme #1878
+        const bobBitcoinNetowrks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']);
         linkIdentityRequestParams.push({
             nonce: bobBitcoinNonce,
             identity: bobBitcoinIdentity,

--- a/tee-worker/ts-tests/integration-tests/di_bitcoin_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_bitcoin_identity.test.ts
@@ -27,7 +27,7 @@ import {
 import type { IntegrationTestContext } from './common/common-types';
 import { aesKey } from './common/call';
 import { LitentryValidationData, Web3Network, CorePrimitivesIdentity } from 'parachain-api';
-import { Vec } from '@polkadot/types';
+import { Bytes, Vec } from '@polkadot/types';
 import { subscribeToEventsWithExtHash } from './common/transactions';
 
 describe('Test Identity (bitcoin direct invocation)', function () {
@@ -44,7 +44,7 @@ describe('Test Identity (bitcoin direct invocation)', function () {
         nonce: number;
         identity: CorePrimitivesIdentity;
         validation: LitentryValidationData;
-        networks: Vec<Web3Network>;
+        networks: Bytes | Vec<Web3Network>;
     }[] = [];
 
     const deactivateIdentityRequestParams: {
@@ -103,10 +103,7 @@ describe('Test Identity (bitcoin direct invocation)', function () {
             undefined,
             [context.ethersWallet.alice]
         );
-        const aliceEvmNetworks = context.api.createType('Vec<Web3Network>', [
-            'Ethereum',
-            'Bsc',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const aliceEvmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: aliceEvmNonce,
             identity: aliceEvmIdentity,
@@ -126,9 +123,7 @@ describe('Test Identity (bitcoin direct invocation)', function () {
             undefined,
             context.bitcoinWallet.bob
         );
-        const bobBitcoinNetowrks = context.api.createType('Vec<Web3Network>', [
-            'BitcoinP2tr',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const bobBitcoinNetowrks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: bobBitcoinNonce,
             identity: bobBitcoinIdentity,

--- a/tee-worker/ts-tests/integration-tests/di_evm_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_evm_identity.test.ts
@@ -85,7 +85,7 @@ describe('Test Identity (evm direct invocation)', function () {
             undefined,
             [context.ethersWallet.bob]
         );
-        const bobEvmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
+        const bobEvmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']);
         linkIdentityRequestParams.push({
             nonce: bobEvmNonce,
             identity: bobEvmIdentity,
@@ -107,7 +107,7 @@ describe('Test Identity (evm direct invocation)', function () {
             'substrate',
             context.substrateWallet.eve
         );
-        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Litentry', 'Khala']); // @fixme #1878
+        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Litentry', 'Khala']);
         linkIdentityRequestParams.push({
             nonce: eveSubstrateNonce,
             identity: eveSubstrateIdentity,

--- a/tee-worker/ts-tests/integration-tests/di_evm_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_evm_identity.test.ts
@@ -26,7 +26,7 @@ import {
 import type { IntegrationTestContext } from './common/common-types';
 import { aesKey } from './common/call';
 import { LitentryValidationData, Web3Network, CorePrimitivesIdentity } from 'parachain-api';
-import { Vec } from '@polkadot/types';
+import { Vec, Bytes } from '@polkadot/types';
 import { subscribeToEventsWithExtHash } from './common/transactions';
 
 describe('Test Identity (evm direct invocation)', function () {
@@ -43,7 +43,7 @@ describe('Test Identity (evm direct invocation)', function () {
         nonce: number;
         identity: CorePrimitivesIdentity;
         validation: LitentryValidationData;
-        networks: Vec<Web3Network>;
+        networks: Bytes | Vec<Web3Network>;
     }[] = [];
     this.timeout(6000000);
 
@@ -85,10 +85,7 @@ describe('Test Identity (evm direct invocation)', function () {
             undefined,
             [context.ethersWallet.bob]
         );
-        const bobEvmNetworks = context.api.createType('Vec<Web3Network>', [
-            'Ethereum',
-            'Bsc',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const bobEvmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: bobEvmNonce,
             identity: bobEvmIdentity,
@@ -110,10 +107,7 @@ describe('Test Identity (evm direct invocation)', function () {
             'substrate',
             context.substrateWallet.eve
         );
-        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', [
-            'Litentry',
-            'Khala',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Litentry', 'Khala']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: eveSubstrateNonce,
             identity: eveSubstrateIdentity,

--- a/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
@@ -12,7 +12,7 @@ import {
     initIntegrationTestContext,
     PolkadotSigner,
 } from './common/utils';
-import { assertFailedEvent, assertIsInSidechainBlock, assertIdGraphMutationEvent } from './common/utils/assertion';
+import { assertIsInSidechainBlock, assertIdGraphMutationEvent } from './common/utils/assertion';
 import {
     createSignedTrustedCallLinkIdentity,
     createSignedTrustedGetterIdGraph,
@@ -89,7 +89,7 @@ describe('Test Identity (direct invocation)', function () {
             twitterNonce,
             'twitter'
         );
-        const twitterNetworks = context.api.createType('Vec<Web3Network>', []); // @fixme #1878
+        const twitterNetworks = context.api.createType('Vec<Web3Network>', []);
         linkIdentityRequestParams.push({
             nonce: twitterNonce,
             identity: twitterIdentity,
@@ -108,7 +108,7 @@ describe('Test Identity (direct invocation)', function () {
             undefined,
             [context.ethersWallet.alice]
         );
-        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
+        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']);
         linkIdentityRequestParams.push({
             nonce: evmNonce,
             identity: evmIdentity,
@@ -130,7 +130,7 @@ describe('Test Identity (direct invocation)', function () {
             'substrate',
             context.substrateWallet.eve
         );
-        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Polkadot', 'Litentry']); // @fixme #1878
+        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Polkadot', 'Litentry']);
         linkIdentityRequestParams.push({
             nonce: eveSubstrateNonce,
             identity: eveSubstrateIdentity,
@@ -155,7 +155,7 @@ describe('Test Identity (direct invocation)', function () {
             undefined,
             context.bitcoinWallet.alice
         );
-        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']); // @fixme #1878
+        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']);
         linkIdentityRequestParams.push({
             nonce: bitcoinNonce,
             identity: bitcoinIdentity,
@@ -317,7 +317,7 @@ describe('Test Identity (direct invocation)', function () {
             res
         );
         const events = await eventsPromise;
-        await assertFailedEvent(context, events, 'LinkIdentityFailed', 'InvalidIdentity');
+        assert.lengthOf(events, 1);
     });
 
     step('linking identity with wrong signature', async function () {
@@ -376,7 +376,7 @@ describe('Test Identity (direct invocation)', function () {
         );
         const events = await eventsPromise;
 
-        await assertFailedEvent(context, events, 'LinkIdentityFailed', 'UnexpectedMessage');
+        assert.lengthOf(events, 1);
     });
 
     step('linking already linked identity', async function () {
@@ -425,7 +425,7 @@ describe('Test Identity (direct invocation)', function () {
             res
         );
         const events = await eventsPromise;
-        await assertFailedEvent(context, events, 'LinkIdentityFailed', 'IdentityAlreadyLinked');
+        assert.lengthOf(events, 1);
     });
 
     step('deactivating linked identities', async function () {

--- a/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
@@ -28,7 +28,7 @@ import {
 import type { IntegrationTestContext } from './common/common-types';
 import { aesKey } from './common/call';
 import { LitentryValidationData, Web3Network, CorePrimitivesIdentity } from 'parachain-api';
-import { Vec } from '@polkadot/types';
+import { Vec, Bytes } from '@polkadot/types';
 import { ethers } from 'ethers';
 import type { HexString } from '@polkadot/util/types';
 import { subscribeToEventsWithExtHash } from './common/transactions';
@@ -47,7 +47,7 @@ describe('Test Identity (direct invocation)', function () {
         nonce: number;
         identity: CorePrimitivesIdentity;
         validation: LitentryValidationData;
-        networks: Vec<Web3Network>;
+        networks: Bytes | Vec<Web3Network>;
     }[] = [];
     this.timeout(6000000);
 
@@ -89,7 +89,7 @@ describe('Test Identity (direct invocation)', function () {
             twitterNonce,
             'twitter'
         );
-        const twitterNetworks = context.api.createType('Vec<Web3Network>', []) as unknown as Vec<Web3Network>; // @fixme #1878
+        const twitterNetworks = context.api.createType('Vec<Web3Network>', []); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: twitterNonce,
             identity: twitterIdentity,
@@ -108,10 +108,7 @@ describe('Test Identity (direct invocation)', function () {
             undefined,
             [context.ethersWallet.alice]
         );
-        const evmNetworks = context.api.createType('Vec<Web3Network>', [
-            'Ethereum',
-            'Bsc',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: evmNonce,
             identity: evmIdentity,
@@ -133,10 +130,7 @@ describe('Test Identity (direct invocation)', function () {
             'substrate',
             context.substrateWallet.eve
         );
-        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', [
-            'Polkadot',
-            'Litentry',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Polkadot', 'Litentry']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: eveSubstrateNonce,
             identity: eveSubstrateIdentity,
@@ -161,9 +155,7 @@ describe('Test Identity (direct invocation)', function () {
             undefined,
             context.bitcoinWallet.alice
         );
-        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', [
-            'BitcoinP2tr',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: bitcoinNonce,
             identity: bitcoinIdentity,

--- a/tee-worker/ts-tests/integration-tests/di_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_vc.test.ts
@@ -18,7 +18,7 @@ import { CorePrimitivesIdentity } from 'parachain-api';
 import { subscribeToEventsWithExtHash } from './common/transactions';
 import { defaultAssertions, unconfiguredAssertions } from './common/utils/vc-helper';
 import { LitentryValidationData, Web3Network } from 'parachain-api';
-import { Vec } from '@polkadot/types';
+import { Vec, Bytes } from '@polkadot/types';
 
 describe('Test Vc (direct invocation)', function () {
     let context: IntegrationTestContext = undefined as any;
@@ -35,7 +35,7 @@ describe('Test Vc (direct invocation)', function () {
         nonce: number;
         identity: CorePrimitivesIdentity;
         validation: LitentryValidationData;
-        networks: Vec<Web3Network>;
+        networks: Bytes | Vec<Web3Network>;
     }[] = [];
     this.timeout(6000000);
 
@@ -64,7 +64,7 @@ describe('Test Vc (direct invocation)', function () {
             twitterNonce,
             'twitter'
         );
-        const twitterNetworks = context.api.createType('Vec<Web3Network>', []) as unknown as Vec<Web3Network>; // @fixme #1878
+        const twitterNetworks = context.api.createType('Vec<Web3Network>', []); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: twitterNonce,
             identity: twitterIdentity,
@@ -83,10 +83,7 @@ describe('Test Vc (direct invocation)', function () {
             undefined,
             [context.ethersWallet.alice]
         );
-        const evmNetworks = context.api.createType('Vec<Web3Network>', [
-            'Ethereum',
-            'Bsc',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: evmNonce,
             identity: evmIdentity,
@@ -111,9 +108,7 @@ describe('Test Vc (direct invocation)', function () {
             undefined,
             context.bitcoinWallet.alice
         );
-        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', [
-            'BitcoinP2tr',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: bitcoinNonce,
             identity: bitcoinIdentity,

--- a/tee-worker/ts-tests/integration-tests/di_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_vc.test.ts
@@ -64,7 +64,7 @@ describe('Test Vc (direct invocation)', function () {
             twitterNonce,
             'twitter'
         );
-        const twitterNetworks = context.api.createType('Vec<Web3Network>', []); // @fixme #1878
+        const twitterNetworks = context.api.createType('Vec<Web3Network>', []);
         linkIdentityRequestParams.push({
             nonce: twitterNonce,
             identity: twitterIdentity,
@@ -83,7 +83,7 @@ describe('Test Vc (direct invocation)', function () {
             undefined,
             [context.ethersWallet.alice]
         );
-        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
+        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']);
         linkIdentityRequestParams.push({
             nonce: evmNonce,
             identity: evmIdentity,
@@ -108,7 +108,7 @@ describe('Test Vc (direct invocation)', function () {
             undefined,
             context.bitcoinWallet.alice
         );
-        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']); // @fixme #1878
+        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']);
         linkIdentityRequestParams.push({
             nonce: bitcoinNonce,
             identity: bitcoinIdentity,

--- a/tee-worker/ts-tests/integration-tests/dr_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/dr_vc.test.ts
@@ -18,7 +18,7 @@ import { CorePrimitivesIdentity } from 'parachain-api';
 import { subscribeToEventsWithExtHash } from './common/transactions';
 import { defaultAssertions, unconfiguredAssertions } from './common/utils/vc-helper';
 import { LitentryValidationData, Web3Network } from 'parachain-api';
-import { Vec } from '@polkadot/types';
+import { Vec, Bytes } from '@polkadot/types';
 
 describe('Test Vc (direct request)', function () {
     let context: IntegrationTestContext = undefined as any;
@@ -35,7 +35,7 @@ describe('Test Vc (direct request)', function () {
         nonce: number;
         identity: CorePrimitivesIdentity;
         validation: LitentryValidationData;
-        networks: Vec<Web3Network>;
+        networks: Bytes | Vec<Web3Network>;
     }[] = [];
     this.timeout(6000000);
 
@@ -64,7 +64,7 @@ describe('Test Vc (direct request)', function () {
             twitterNonce,
             'twitter'
         );
-        const twitterNetworks = context.api.createType('Vec<Web3Network>', []) as unknown as Vec<Web3Network>; // @fixme #1878
+        const twitterNetworks = context.api.createType('Vec<Web3Network>', []); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: twitterNonce,
             identity: twitterIdentity,
@@ -83,10 +83,7 @@ describe('Test Vc (direct request)', function () {
             undefined,
             [context.ethersWallet.alice]
         );
-        const evmNetworks = context.api.createType('Vec<Web3Network>', [
-            'Ethereum',
-            'Bsc',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: evmNonce,
             identity: evmIdentity,
@@ -111,9 +108,7 @@ describe('Test Vc (direct request)', function () {
             undefined,
             context.bitcoinWallet.alice
         );
-        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', [
-            'BitcoinP2tr',
-        ]) as unknown as Vec<Web3Network>; // @fixme #1878
+        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']); // @fixme #1878
         linkIdentityRequestParams.push({
             nonce: bitcoinNonce,
             identity: bitcoinIdentity,

--- a/tee-worker/ts-tests/integration-tests/dr_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/dr_vc.test.ts
@@ -64,7 +64,7 @@ describe('Test Vc (direct request)', function () {
             twitterNonce,
             'twitter'
         );
-        const twitterNetworks = context.api.createType('Vec<Web3Network>', []); // @fixme #1878
+        const twitterNetworks = context.api.createType('Vec<Web3Network>', []);
         linkIdentityRequestParams.push({
             nonce: twitterNonce,
             identity: twitterIdentity,
@@ -83,7 +83,7 @@ describe('Test Vc (direct request)', function () {
             undefined,
             [context.ethersWallet.alice]
         );
-        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']); // @fixme #1878
+        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']);
         linkIdentityRequestParams.push({
             nonce: evmNonce,
             identity: evmIdentity,
@@ -108,7 +108,7 @@ describe('Test Vc (direct request)', function () {
             undefined,
             context.bitcoinWallet.alice
         );
-        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']); // @fixme #1878
+        const bitcoinNetworks = context.api.createType('Vec<Web3Network>', ['BitcoinP2tr']);
         linkIdentityRequestParams.push({
             nonce: bitcoinNonce,
             identity: bitcoinIdentity,

--- a/tee-worker/ts-tests/integration-tests/ii_batch.test.ts
+++ b/tee-worker/ts-tests/integration-tests/ii_batch.test.ts
@@ -12,13 +12,13 @@ import { sendTxsWithUtility } from './common/transactions';
 import { generateWeb3Wallets, assertIdGraphMutationEvent, assertIdentityDeactivated } from './common/utils';
 import { ethers } from 'ethers';
 import type { LitentryValidationData, Web3Network, CorePrimitivesIdentity } from 'parachain-api';
-import { Vec } from '@polkadot/types';
+import { Vec, Bytes } from '@polkadot/types';
 
 describeLitentry('Test Batch Utility', (context) => {
     let identities: CorePrimitivesIdentity[] = [];
     let validations: LitentryValidationData[] = [];
     let evmSigners: ethers.Wallet[] = [];
-    const we3networks: Web3Network[][] = [];
+    const web3networks: (Bytes | Vec<Web3Network>)[] = [];
     const signerIdentities: CorePrimitivesIdentity[] = [];
 
     step('generate web3 wallets', async function () {
@@ -39,7 +39,7 @@ describeLitentry('Test Batch Utility', (context) => {
             const signer = evmSigners[index];
             const evmIdentity = await buildIdentityHelper(signer.address, 'Evm', context);
             identities.push(evmIdentity);
-            we3networks.push(defaultNetworks as unknown as Vec<Web3Network>); // @fixme #1878
+            web3networks.push(defaultNetworks);
             signerIdentities.push(aliceSubstrateIdentity);
         }
 
@@ -60,7 +60,7 @@ describeLitentry('Test Batch Utility', (context) => {
             identities,
             'linkIdentity',
             validations,
-            we3networks
+            web3networks
         );
         const events = await sendTxsWithUtility(context, context.substrateWallet.alice, txs, 'identityManagement', [
             'IdentityLinked',

--- a/tee-worker/ts-tests/integration-tests/ii_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/ii_identity.test.ts
@@ -24,6 +24,7 @@ import { sendRequest } from './common/call';
 import * as base58 from 'micro-base58';
 import { decodeRpcBytesAsString } from './common/call';
 import { createJsonRpcRequest, nextRequestId } from './common/helpers';
+import { Bytes, Vec } from '@polkadot/types';
 
 async function getEnclaveSignerPublicKey(context: IntegrationTestContext): Promise<string> {
     const request = createJsonRpcRequest('author_getEnclaveSignerAccount', [], nextRequestId(context));
@@ -58,7 +59,7 @@ describeLitentry('Test Identity', (context) => {
     let charlieIdentities: CorePrimitivesIdentity[] = [];
     let eveValidations: LitentryValidationData[] = [];
     let bobValidations: LitentryValidationData[] = [];
-    let web3networks: Web3Network[][] = [];
+    let web3networks: (Bytes | Vec<Web3Network>)[] = [];
     let base58mrEnclave: string;
     let workerAddress: string;
     let identityLinkedEvents;
@@ -127,12 +128,9 @@ describeLitentry('Test Identity', (context) => {
 
         eveValidations = [...evmValidations, ...eveSubstrateValidations, ...twitterValidations];
 
-        const twitterNetworks = context.api.createType('Vec<Web3Network>', []) as unknown as Web3Network[];
-        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']) as unknown as Web3Network[];
-        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', [
-            'Litentry',
-            'Polkadot',
-        ]) as unknown as Web3Network[];
+        const twitterNetworks = context.api.createType('Vec<Web3Network>', []);
+        const evmNetworks = context.api.createType('Vec<Web3Network>', ['Ethereum', 'Bsc']);
+        const eveSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Litentry', 'Polkadot']);
 
         web3networks = [evmNetworks, eveSubstrateNetworks, twitterNetworks];
 
@@ -194,13 +192,10 @@ describeLitentry('Test Identity', (context) => {
         const bobSubstrateValidation = context.api.createType(
             'LitentryValidationData',
             substrateExtensionValidationData
-        ) as unknown as LitentryValidationData;
+        );
         bobValidations = [bobSubstrateValidation];
 
-        const bobSubstrateNetworks = context.api.createType('Vec<Web3Network>', [
-            'Litentry',
-            'Polkadot',
-        ]) as unknown as Web3Network[];
+        const bobSubstrateNetworks = context.api.createType('Vec<Web3Network>', ['Litentry', 'Polkadot']);
 
         const bobTxs = await buildIdentityTxs(
             context,
@@ -290,10 +285,7 @@ describeLitentry('Test Identity', (context) => {
                 },
             },
         };
-        const evmValidationData: LitentryValidationData = context.api.createType(
-            'LitentryValidationData',
-            validation
-        ) as unknown as LitentryValidationData;
+        const evmValidationData: LitentryValidationData = context.api.createType('LitentryValidationData', validation);
         const aliceTxs = await buildIdentityTxs(
             context,
             context.substrateWallet.alice,

--- a/tee-worker/ts-tests/stress/src/litentry-api.ts
+++ b/tee-worker/ts-tests/stress/src/litentry-api.ts
@@ -107,7 +107,7 @@ export async function buildValidation(
                           },
                       },
                   },
-    }) as unknown as LitentryValidationData;
+    });
 }
 
 export async function buildIdentityFromWallet(
@@ -119,7 +119,7 @@ export async function buildIdentityFromWallet(
             Evm: wallet.wallet.address,
         };
 
-        return api.createType('CorePrimitivesIdentity', identity) as unknown as CorePrimitivesIdentity;
+        return api.createType('CorePrimitivesIdentity', identity);
     }
 
     const { keyringPair } = wallet;
@@ -143,7 +143,7 @@ export async function buildIdentityFromWallet(
         [type]: address,
     };
 
-    return api.createType('CorePrimitivesIdentity', identity) as unknown as CorePrimitivesIdentity;
+    return api.createType('CorePrimitivesIdentity', identity);
 }
 
 export function decodeRpcBytesAsString(value: Bytes): string {
@@ -221,7 +221,7 @@ const createPublicGetter = (
     const [variant, argType] = publicGetter;
     const getter = parachainApi.createType('PublicGetter', {
         [variant]: parachainApi.createType(argType, params),
-    }) as unknown as PublicGetter;
+    });
 
     return getter;
 };
@@ -257,7 +257,7 @@ export function createSignedTrustedGetterUserShieldingKey(
         signer,
         subject.toHuman()
     );
-    return parachainApi.createType('Getter', { trusted: getterSigned }) as unknown as Getter;
+    return parachainApi.createType('Getter', { trusted: getterSigned });
 }
 
 const sendRequestFromGetter = async (
@@ -332,7 +332,7 @@ export const getSidechainNonce = async (
     log: WritableStream<string>
 ): Promise<Index> => {
     const getterPublic = createPublicGetter(parachainApi, ['nonce', '(LitentryIdentity)'], subject.toHuman());
-    const getter = parachainApi.createType('Getter', { public: getterPublic }) as unknown as Getter;
+    const getter = parachainApi.createType('Getter', { public: getterPublic });
     const nonce = await sendRequestFromGetter(teeWorker, parachainApi, mrenclave, teeShieldingKey, getter, log);
     const nonceValue = decodeNonce(nonce.value.toHex());
     return parachainApi.createType('Index', nonceValue) as Index;
@@ -403,7 +403,7 @@ const createSignedTrustedCall = async (
         call: call,
         index: nonce,
         signature: signature,
-    }) as unknown as TrustedCallSigned;
+    });
 };
 
 export const subscribeToEventsWithExtHash = async (


### PR DESCRIPTION
### Context

- Remove `as sometype` for `api.createType`.
- Checked the usage of `toHuman()`, currently `toHuman()` is mostly used for for final assertions of content, there is no usage of `toHuman() as sometype`.

The clien-api has been properly configured for TypeScript types. Whether it's `parachain-ap`i or `sidechain-api`, as long as the import is correct, api.createType can correctly create types without the need for `as sometype.`

also resolved https://github.com/litentry/litentry-parachain/pull/2502#discussion_r1495017714, this is an unnecessary method, just remove it; we already have assertions in place [here](https://github.com/litentry/litentry-parachain/blob/dev/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts#L316).


