### PR TITLE
fix: change nft holder credentials type name to 'Generic NFT Holder'

### DIFF
--- a/tee-worker/litentry/core/credentials-v2/src/nft_holder/mod.rs
+++ b/tee-worker/litentry/core/credentials-v2/src/nft_holder/mod.rs
@@ -32,7 +32,7 @@ use lc_credentials::{
 	Credential,
 };
 
-const TYPE: &str = "NFT Holder";
+const TYPE: &str = "Generic NFT Holder";
 const DESCRIPTION: &str = "You are a holder of a certain kind of NFT";
 
 struct AssertionKeys {


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

There is existing VC type being NFT Holder, although parachain doesn't have such unique constraints, FE does assume so, hence changing the VC type of the newly published one.


### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


