### PR TITLE
Fix typo add -> aad

### DIFF
--- a/tee-worker/ts-tests/integration-tests/common/di-utils.ts
+++ b/tee-worker/ts-tests/integration-tests/common/di-utils.ts
@@ -393,7 +393,7 @@ export const createAesRequest = async (
                     ciphertext: compactAddLength(
                         hexToU8a(encryptWithAes(u8aToHex(aesKey), hexToU8a(keyNonce), Buffer.from(top)))
                     ),
-                    add: hexToU8a('0x'),
+                    aad: hexToU8a('0x'),
                     nonce: hexToU8a(keyNonce),
                 })
                 .toU8a(),


### PR DESCRIPTION
### Context

A trivial PR thanks to bc colleagues.

Somehow we haven't got any runtime error even though it's correctly written in the definitions:
https://github.com/litentry/litentry-parachain/blob/78c79c949206acf1360b7dea7ea894c27decacbb/tee-worker/client-api/parachain-api/prepare-build/interfaces/sidechain/definitions.ts#L17

Maybe it worked because of default values.