### PR TITLE
fix: remove fees for TEE callback extrinsics

### DIFF
--- a/pallets/teebag/src/lib.rs
+++ b/pallets/teebag/src/lib.rs
@@ -528,7 +528,7 @@ pub mod pallet {
 		pub fn post_opaque_task(origin: OriginFor<T>, request: RsaRequest) -> DispatchResult {
 			let _ = ensure_signed(origin)?;
 			Self::deposit_event(Event::OpaqueTaskPosted { shard: request.shard });
-			Ok(().into())
+			Ok(())
 		}
 
 		#[pallet::call_index(21)]

--- a/pallets/teebag/src/lib.rs
+++ b/pallets/teebag/src/lib.rs
@@ -525,10 +525,13 @@ pub mod pallet {
 
 		#[pallet::call_index(20)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::Yes))]
-		pub fn post_opaque_task(origin: OriginFor<T>, request: RsaRequest) -> DispatchResult {
+		pub fn post_opaque_task(
+			origin: OriginFor<T>,
+			request: RsaRequest,
+		) -> DispatchResultWithPostInfo {
 			let _ = ensure_signed(origin)?;
 			Self::deposit_event(Event::OpaqueTaskPosted { shard: request.shard });
-			Ok(())
+			Ok(Pays::No.into())
 		}
 
 		#[pallet::call_index(21)]
@@ -549,7 +552,7 @@ pub mod pallet {
 				block_hash,
 				task_merkle_root,
 			});
-			Ok(().into())
+			Ok(Pays::No.into())
 		}
 
 		#[pallet::call_index(22)]
@@ -590,7 +593,7 @@ pub mod pallet {
 					"Ignore block confirmation from non primary enclave identifier: {:?}, primary: {:?}",
 					sender, primary_enclave_identifier
 				);
-				return Ok(().into())
+				return Ok(Pays::No.into())
 			}
 
 			let block_number = confirmation.block_number;
@@ -612,7 +615,7 @@ pub mod pallet {
 			);
 
 			Self::finalize_block(sender, shard, confirmation);
-			Ok(().into())
+			Ok(Pays::No.into())
 		}
 	}
 }

--- a/pallets/teebag/src/lib.rs
+++ b/pallets/teebag/src/lib.rs
@@ -525,13 +525,10 @@ pub mod pallet {
 
 		#[pallet::call_index(20)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::Yes))]
-		pub fn post_opaque_task(
-			origin: OriginFor<T>,
-			request: RsaRequest,
-		) -> DispatchResultWithPostInfo {
+		pub fn post_opaque_task(origin: OriginFor<T>, request: RsaRequest) -> DispatchResult {
 			let _ = ensure_signed(origin)?;
 			Self::deposit_event(Event::OpaqueTaskPosted { shard: request.shard });
-			Ok(Pays::No.into())
+			Ok(().into())
 		}
 
 		#[pallet::call_index(21)]

--- a/pallets/teebag/src/lib.rs
+++ b/pallets/teebag/src/lib.rs
@@ -270,7 +270,7 @@ pub mod pallet {
 		///
 		/// Weights should be 2 DB writes: 1 for mode and 1 for event
 		#[pallet::call_index(0)]
-		#[pallet::weight((2 * T::DbWeight::get().write, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((2 * T::DbWeight::get().write, DispatchClass::Normal))]
 		pub fn set_admin(
 			origin: OriginFor<T>,
 			new_admin: T::AccountId,
@@ -285,7 +285,7 @@ pub mod pallet {
 		///
 		/// Weights should be 2 DB writes: 1 for mode and 1 for event
 		#[pallet::call_index(1)]
-		#[pallet::weight((2 * T::DbWeight::get().write, DispatchClass::Normal, Pays::Yes))]
+		#[pallet::weight((2 * T::DbWeight::get().write, DispatchClass::Normal))]
 		pub fn set_mode(
 			origin: OriginFor<T>,
 			new_mode: OperationalMode,
@@ -297,7 +297,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(2)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn force_add_enclave(
 			origin: OriginFor<T>,
 			who: T::AccountId,
@@ -309,7 +309,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(3)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn force_remove_enclave(
 			origin: OriginFor<T>,
 			who: T::AccountId,
@@ -320,7 +320,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(4)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn force_remove_enclave_by_mrenclave(
 			origin: OriginFor<T>,
 			mrenclave: MrEnclave,
@@ -345,7 +345,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(5)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn force_remove_enclave_by_worker_type(
 			origin: OriginFor<T>,
 			worker_type: WorkerType,
@@ -371,7 +371,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(6)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn set_scheduled_enclave(
 			origin: OriginFor<T>,
 			worker_type: WorkerType,
@@ -385,11 +385,11 @@ pub mod pallet {
 				sidechain_block_number,
 				mrenclave,
 			});
-			Ok(().into())
+			Ok(Pays::No.into())
 		}
 
 		#[pallet::call_index(7)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn remove_scheduled_enclave(
 			origin: OriginFor<T>,
 			worker_type: WorkerType,
@@ -405,11 +405,11 @@ pub mod pallet {
 				worker_type,
 				sidechain_block_number,
 			});
-			Ok(().into())
+			Ok(Pays::No.into())
 		}
 
 		#[pallet::call_index(8)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::Yes))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn register_enclave(
 			origin: OriginFor<T>,
 			worker_type: WorkerType,
@@ -480,7 +480,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(9)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::Yes))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn unregister_enclave(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			Self::remove_enclave(&sender)?;
@@ -488,7 +488,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(10)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn register_quoting_enclave(
 			origin: OriginFor<T>,
 			enclave_identity: Vec<u8>,
@@ -500,11 +500,11 @@ pub mod pallet {
 			let quoting_enclave =
 				Self::verify_quoting_enclave(enclave_identity, signature, certificate_chain)?;
 			<QuotingEnclaveRegistry<T>>::put(quoting_enclave);
-			Ok(().into())
+			Ok(Pays::No.into())
 		}
 
 		#[pallet::call_index(11)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn register_tcb_info(
 			origin: OriginFor<T>,
 			tcb_info: Vec<u8>,
@@ -516,7 +516,7 @@ pub mod pallet {
 			let (fmspc, on_chain_info) =
 				Self::verify_tcb_info(tcb_info, signature, certificate_chain)?;
 			TcbInfo::<T>::insert(fmspc, on_chain_info);
-			Ok(().into())
+			Ok(Pays::No.into())
 		}
 
 		// ===============================================================================
@@ -524,7 +524,7 @@ pub mod pallet {
 		// ===============================================================================
 
 		#[pallet::call_index(20)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::Yes))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn post_opaque_task(origin: OriginFor<T>, request: RsaRequest) -> DispatchResult {
 			let _ = ensure_signed(origin)?;
 			Self::deposit_event(Event::OpaqueTaskPosted { shard: request.shard });
@@ -532,7 +532,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(21)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn parentchain_block_processed(
 			origin: OriginFor<T>,
 			block_hash: H256,
@@ -553,7 +553,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(22)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal, Pays::No))]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn sidechain_block_imported(
 			origin: OriginFor<T>,
 			shard: ShardIdentifier,


### PR DESCRIPTION
~This is a straightforward PR. We observed an `out of balance` for TEE-worker in one of our latest deployment. I went through three pallets namely `teebag` , `identity-management` and `vc-management`. I found two extrinsics in `teebag` that are not feeless and most likely the reason why we observed an `out of balance`. However I'm confused about `post-opaque-task` extrinsic, Are we actively using it or is there an update to it?~
[UPDATE] 
_One thing we can improve is:
prefer returning Pays::No over weight macro, as the latter will waive the fee even for failed extrinsic (which can be spammed)
see https://substrate.stackexchange.com/questions/3964/feeless-transactions-unsigned-vs-signed-extension__ 

I checked the extrinsics called by the Worker, only two in `teebag` use the weight macro
