### PR TITLE
Use ethereum/client-go:v1.13.14 tag

### DIFF
--- a/.github/file-filter.yml
+++ b/.github/file-filter.yml
@@ -11,10 +11,14 @@ parachain_src: &parachain_src
   - 'Cargo.lock'
   - 'Cargo.toml'
   - 'rust-toolchain.toml'
+  - 'scripts/build-docker.sh'
 
 parachain_test: &parachain_test
   - 'ts-tests/**'
   - 'docker/**'
+  - 'scripts/build-bridge-docker.sh'
+  - 'scripts/launch-local-docker.sh'
+  - 'scripts/launch-local-bridge-docker.sh'
 
 coverage_src: &coverage_src
   - *parachain_src

--- a/scripts/launch-local-bridge-docker.sh
+++ b/scripts/launch-local-bridge-docker.sh
@@ -19,7 +19,15 @@ echo "copy binary:chainbridge to ${LITENTRY_PARACHAIN_DIR}"
 echo "------------------------------------------------------------"
 
 docker rm -f geth &>/dev/null
+
+# use the last stable release v1.13.14
+# the `latest` image introduces the geth-1.14 unstable version which emits an error when starting the network:
+# ```
+#  Fatal: Failed to register the Ethereum service: only PoS networks are supported, please transition old ones with Geth v1.13.x
+# ```
+#
+# TODO - make it work with latest image
 docker run -d --rm --entrypoint 'sh' --name 'geth' \
     -u "$(id -u)":"$(id -g)" -v ${ROOTDIR}/scripts/geth:/data/ -p 8546:8546 -p 8545:8545 \
-    ethereum/client-go:latest /data/run_geth.sh docker /data
+    ethereum/client-go:v1.13.14 /data/run_geth.sh docker /data
 echo "runing geth...(container name: geth)"


### PR DESCRIPTION
### Context

As topic - see the comments in the script.
It seems that latest image introduced a compatibility issue


