### PR TITLE
Re-register enclave after state provisioning

### DIFF
--- a/tee-worker/docker/multiworker-docker-compose.yml
+++ b/tee-worker/docker/multiworker-docker-compose.yml
@@ -208,7 +208,7 @@ services:
     entrypoint:
       "/usr/local/bin/litentry-worker --clean-reset --ws-external -M litentry-worker-2 -T wss://litentry-worker-2
       -u ws://litentry-node -U ws://litentry-worker-2 -P 2011 -w 2101 -p 9912 -h 4645 --enable-mock-server
-      run --dev --skip-ra --request-state"
+      run --dev --skip-ra"
     restart: "no"
   litentry-worker-3:
     image: litentry/litentry-worker:latest
@@ -264,7 +264,7 @@ services:
     entrypoint:
       "/usr/local/bin/litentry-worker --clean-reset --ws-external -M litentry-worker-3 -T wss://litentry-worker-3
       -u ws://litentry-node -U ws://litentry-worker-3 -P 2011 -w 2101 -p 9912 -h 4645 --enable-mock-server
-      run --dev --skip-ra --request-state"
+      run --dev --skip-ra"
     restart: "no"
 volumes:
   ? relaychain-alice

--- a/tee-worker/scripts/launch_local_worker.sh
+++ b/tee-worker/scripts/launch_local_worker.sh
@@ -36,7 +36,6 @@ UNTRUSTED_WORKER_PORT="3000"
 
 F_CLEAN=""
 FSUBCMD_DEV=""
-FSUBCMD_REQ_STATE=""
 
 WAIT_INTERVAL_SECONDS=10
 WAIT_ROUNDS=20
@@ -87,10 +86,6 @@ for ((i = 0; i < ${WORKER_NUM}; i++)); do
 	echo ""
 	echo "--------------------setup worker(${worker_name})----------------------------------------"
 
-	if ((i > 0)); then
-		FSUBCMD_REQ_STATE="--request-state"
-	fi
-
 	if ((i == 0)); then
 		MOCK_SERVER="--enable-mock-server"
 	fi
@@ -128,7 +123,7 @@ for ((i = 0; i < ${WORKER_NUM}; i++)); do
 --untrusted-external-address ws://${WORKER_ENDPOINT} \
 --untrusted-http-port ${untrusted_http_port} \
 --untrusted-worker-port ${untrusted_worker_port} \
-run --skip-ra ${FSUBCMD_DEV} ${FSUBCMD_REQ_STATE}"
+run --skip-ra ${FSUBCMD_DEV}"
 
 	echo "${worker_name} command: ${launch_command}"
 	eval "${launch_command}" > "${ROOTDIR}"/log/${worker_name}.log 2>&1 &

--- a/tee-worker/service/src/cli.yml
+++ b/tee-worker/service/src/cli.yml
@@ -151,17 +151,14 @@ subcommands:
                     long: dev
                     short: d
                     help: Set this flag if running in development mode to bootstrap enclave account on parentchain via //Alice.
-              - request-state:
-                    long: request-state
-                    short: r
-                    help: Run the worker and request key and state provisioning from another worker.
-              - marblerun-url:
+              - shielding-target:
                     required: false
-                    long: marblerun-url
-                    help: Set the URL for prometheus metrics. Probably put some meaningful description
+                    long: shielding-target
+                    short: s
+                    help: set parentchain target for shielding / unshielding. only relevant for primary worker upon first start for shard. can't be changed later for a shard
                     takes_value: true
     - request-state:
-          about: (Deprecated - TODO) join a shard by requesting key provisioning from another worker
+          about: (DEPRECATED) join a shard by requesting key provisioning from another worker
           args:
               - shard:
                     long: shard

--- a/tee-worker/ts-tests/worker/resuming_worker.test.ts
+++ b/tee-worker/ts-tests/worker/resuming_worker.test.ts
@@ -24,7 +24,6 @@ type WorkerConfig = {
     trustedWorkerPort: number;
     untrustedWorkerPort: number;
     enableMockServer: boolean;
-    requestStateOnLaunch: boolean;
 };
 
 const workerConfig: Record<'worker0' | 'worker1', WorkerConfig> = {
@@ -35,7 +34,6 @@ const workerConfig: Record<'worker0' | 'worker1', WorkerConfig> = {
         trustedWorkerPort: 2000,
         untrustedWorkerPort: 3000,
         enableMockServer: true,
-        requestStateOnLaunch: false,
     },
     worker1: {
         name: 'worker1',
@@ -44,7 +42,6 @@ const workerConfig: Record<'worker0' | 'worker1', WorkerConfig> = {
         trustedWorkerPort: 2001,
         untrustedWorkerPort: 3001,
         enableMockServer: false,
-        requestStateOnLaunch: true,
     },
 } as const;
 
@@ -78,7 +75,6 @@ function generateWorkerCommandArguments(
         `run`,
         `--skip-ra`,
         `--dev`,
-        ...(isLaunch && workerParams.requestStateOnLaunch ? ['--request-state'] : []),
     ].join(' ');
 }
 


### PR DESCRIPTION
### Context

As topic.

In #2571 the state provisioning happens after the worker is started, thus we need to re-register the enclave, otherwise the registry will contain the old data.

Please also note: following upstream `request-state` arg is removed, the subcommand is still there but marked as "DEPRECATED" too.