### PR TITLE
Compiling non-prod code only when explicitly specified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,14 +265,14 @@ jobs:
         working-directory: ./tee-worker
         run: |
           echo "::group::cargo clippy all"
-          cargo clippy --release -- -D warnings
+          cargo clippy --release --features development -- -D warnings
           echo "::endgroup::"
           echo "::group::cargo clippy sidechain"
-          cargo clippy --release --features sidechain -- -D warnings
+          cargo clippy --release --features sidechain,development -- -D warnings
           echo "::endgroup::"
           echo "::group::cargo clippy offchain-worker"
           cargo clean --profile release
-          cargo clippy --release --features offchain-worker -- -D warnings
+          cargo clippy --release --features offchain-worker,development -- -D warnings
           echo "::endgroup::"
 
       - name: Clean up disk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Pallet unittests
         working-directory: ./tee-worker
         run: |
-          cargo test --release -p pallet-* --lib
+          cargo test --release -p pallet-* --lib --features development
 
       - name: Tee-worker clippy
         working-directory: ./tee-worker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,14 +290,14 @@ jobs:
         working-directory: ./tee-worker/enclave-runtime
         run: |
           echo "::group::cargo clippy all"
-          cargo clippy --release -- -D warnings
+          cargo clippy --release --features development -- -D warnings
           echo "::endgroup::"
           echo "::group::cargo clippy sidechain"
-          cargo clippy --release --features sidechain -- -D warnings
+          cargo clippy --release --features sidechain, development -- -D warnings
           echo "::endgroup::"
           echo "::group::cargo clippy offchain-worker"
           cargo clean --profile release
-          cargo clippy --release --features offchain-worker -- -D warnings
+          cargo clippy --release --features offchain-worker, development -- -D warnings
           echo "::endgroup::"
 
       - name: Fail early

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,11 +293,11 @@ jobs:
           cargo clippy --release --features development -- -D warnings
           echo "::endgroup::"
           echo "::group::cargo clippy sidechain"
-          cargo clippy --release --features sidechain, development -- -D warnings
+          cargo clippy --release --features sidechain,development -- -D warnings
           echo "::endgroup::"
           echo "::group::cargo clippy offchain-worker"
           cargo clean --profile release
-          cargo clippy --release --features offchain-worker, development -- -D warnings
+          cargo clippy --release --features offchain-worker,development -- -D warnings
           echo "::endgroup::"
 
       - name: Fail early
@@ -379,7 +379,7 @@ jobs:
         if: needs.set-condition.outputs.rebuild_parachain == 'true'
         run: |
           echo "::group::build docker image"
-          ./scripts/build-docker.sh release latest --features=fast-runtime
+          ./scripts/build-docker.sh release latest --features=fast-runtime,development
           echo "::endgroup::"
           echo "::group::docker images"
           docker images --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           fi
           if [ "${{ github.event.inputs.rebuild-bitacross-docker }}" = "true" ] || [ "${{ steps.filter.outputs.bitacross_src }}" = "true" ]; then
             rebuild_bitacross=true
-          fi          
+          fi
           if [ "${{ github.event.inputs.push-docker }}" = "true" ]; then
             push_docker=true
           elif [ "${{ github.event_name }}" = 'push' ] && [ "${{ github.ref }}" = 'refs/heads/dev' ]; then
@@ -133,7 +133,7 @@ jobs:
           fi
           if [ "${{ steps.filter.outputs.bitacross_test }}" = "true" ] || [ "$rebuild_parachain" = "true" ] || [ "$rebuild_bitacross" = "true" ]; then
             run_bitacross_test=true
-          fi          
+          fi
           echo "rebuild_parachain=$rebuild_parachain" | tee -a $GITHUB_OUTPUT
           echo "rebuild_tee=$rebuild_tee" | tee -a $GITHUB_OUTPUT
           echo "rebuild_bitacross=$rebuild_bitacross" | tee -a $GITHUB_OUTPUT
@@ -153,7 +153,7 @@ jobs:
       - name: Install pre-built taplo
         run: |
           mkdir -p $HOME/.local/bin
-          wget -q https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-linux-x86_64.gz                    
+          wget -q https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-linux-x86_64.gz
           gzip -d taplo-linux-x86_64.gz
           cp taplo-linux-x86_64 $HOME/.local/bin/taplo
           chmod a+x $HOME/.local/bin/taplo

--- a/bitacross-worker/Makefile
+++ b/bitacross-worker/Makefile
@@ -83,6 +83,7 @@ else
 	SGX_SIGN_KEY = "enclave-runtime/Enclave_private.pem"
 	SGX_SIGN_PASSFILE = ""
 	WORKER_FEATURES := --features=default,development,link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
+	ADDITIONAL_FEATURES := development
 endif
 
 CLIENT_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)

--- a/bitacross-worker/Makefile
+++ b/bitacross-worker/Makefile
@@ -76,7 +76,7 @@ ifeq ($(SGX_PRODUCTION), 1)
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.production.xml"
 	SGX_SIGN_KEY = $(SGX_COMMERCIAL_KEY)
 	SGX_SIGN_PASSFILE = $(SGX_PASSFILE)
-	WORKER_FEATURES := --features=production,link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
+	WORKER_FEATURES := --features=link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
 else
 	SGX_ENCLAVE_MODE = "Development Mode"
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.xml"

--- a/bitacross-worker/Makefile
+++ b/bitacross-worker/Makefile
@@ -82,7 +82,7 @@ else
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.xml"
 	SGX_SIGN_KEY = "enclave-runtime/Enclave_private.pem"
 	SGX_SIGN_PASSFILE = ""
-	WORKER_FEATURES := --features=default,link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
+	WORKER_FEATURES := --features=default,development,link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
 endif
 
 CLIENT_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)

--- a/bitacross-worker/app-libs/stf/Cargo.toml
+++ b/bitacross-worker/app-libs/stf/Cargo.toml
@@ -87,3 +87,6 @@ test = []
 production = [
     "litentry-macros/production",
 ]
+development = [
+    "litentry-macros/development",
+]

--- a/bitacross-worker/app-libs/stf/Cargo.toml
+++ b/bitacross-worker/app-libs/stf/Cargo.toml
@@ -84,9 +84,6 @@ std = [
     "litentry-primitives/std",
 ]
 test = []
-production = [
-    "litentry-macros/production",
-]
 development = [
     "litentry-macros/development",
 ]

--- a/bitacross-worker/app-libs/stf/src/getter.rs
+++ b/bitacross-worker/app-libs/stf/src/getter.rs
@@ -31,7 +31,7 @@ use sp_runtime::transaction_validity::{
 	TransactionValidityError, UnknownTransaction, ValidTransaction,
 };
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 use crate::helpers::ALICE_ACCOUNTID32;
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]

--- a/bitacross-worker/app-libs/stf/src/getter.rs
+++ b/bitacross-worker/app-libs/stf/src/getter.rs
@@ -20,7 +20,7 @@ use ita_sgx_runtime::System;
 use itp_stf_interface::ExecuteGetter;
 use itp_stf_primitives::{traits::GetterAuthorization, types::KeyPair};
 use itp_utils::stringify::account_id_to_string;
-use litentry_macros::if_production_or;
+use litentry_macros::if_development_or;
 use litentry_primitives::{Identity, LitentryMultiSignature};
 use log::*;
 use sp_std::vec;
@@ -130,17 +130,17 @@ impl TrustedGetterSigned {
 
 	pub fn verify_signature(&self) -> bool {
 		// in non-prod, we accept signature from Alice too
-		if_production_or!(
-			{
-				self.signature
-					.verify(self.getter.encode().as_slice(), self.getter.sender_identity())
-			},
+		if_development_or!(
 			{
 				self.signature
 					.verify(self.getter.encode().as_slice(), self.getter.sender_identity())
 					|| self
 						.signature
 						.verify(self.getter.encode().as_slice(), &ALICE_ACCOUNTID32.into())
+			},
+			{
+				self.signature
+					.verify(self.getter.encode().as_slice(), self.getter.sender_identity())
 			}
 		)
 	}

--- a/bitacross-worker/app-libs/stf/src/helpers.rs
+++ b/bitacross-worker/app-libs/stf/src/helpers.rs
@@ -28,7 +28,7 @@ use itp_utils::stringify::account_id_to_string;
 use log::*;
 use std::prelude::v1::*;
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 pub use non_prod::*;
 
 pub fn get_storage_value<V: Decode>(
@@ -167,7 +167,7 @@ pub fn shard_creation_info() -> ShardCreationInfo {
 	}
 }
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 mod non_prod {
 	use super::*;
 	use hex_literal::hex;

--- a/bitacross-worker/bitacross/core/bc-relayer-registry/Cargo.toml
+++ b/bitacross-worker/bitacross/core/bc-relayer-registry/Cargo.toml
@@ -29,8 +29,7 @@ base64 = { version = "0.13", features = ["alloc"] }
 
 [features]
 default = ["std"]
-production = [
-]
+development = []
 sgx = [
     "sgx_tstd",
     "thiserror-sgx",

--- a/bitacross-worker/bitacross/core/bc-task-receiver/Cargo.toml
+++ b/bitacross-worker/bitacross/core/bc-task-receiver/Cargo.toml
@@ -73,5 +73,4 @@ std = [
     "itp-stf-state-handler/std",
     "thiserror",
 ]
-production = [
-]
+development = []

--- a/bitacross-worker/cli/Cargo.toml
+++ b/bitacross-worker/cli/Cargo.toml
@@ -55,6 +55,6 @@ litentry-primitives = { path = "../litentry/primitives" }
 [features]
 default = []
 offchain-worker = []
-production = []
+development = []
 # dcap feature flag is not used in this crate, but for easier build purposes only it present here as well
 dcap = []

--- a/bitacross-worker/core-primitives/attestation-handler/Cargo.toml
+++ b/bitacross-worker/core-primitives/attestation-handler/Cargo.toml
@@ -99,4 +99,4 @@ sgx = [
     "httparse/mesalock_sgx",
 ]
 test = []
-production = []
+development = []

--- a/bitacross-worker/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/bitacross-worker/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -71,9 +71,9 @@ pub const SIGRL_SUFFIX: &str = "/sgx/dev/attestation/v4/sigrl/";
 #[cfg(feature = "production")]
 pub const REPORT_SUFFIX: &str = "/sgx/dev/attestation/v4/report";
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 pub const SIGRL_SUFFIX: &str = "/sgx/dev/attestation/v4/sigrl/";
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 pub const REPORT_SUFFIX: &str = "/sgx/dev/attestation/v4/report";
 
 /// Trait to provide an abstraction to the attestation logic

--- a/bitacross-worker/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/bitacross-worker/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -66,9 +66,9 @@ use std::{
 pub const DEV_HOSTNAME: &str = "api.trustedservices.intel.com";
 
 // Litentry TODO: use `dev` for production temporary. Will switch to dcap later.
-#[cfg(feature = "production")]
+#[cfg(not(feature = "development"))]
 pub const SIGRL_SUFFIX: &str = "/sgx/dev/attestation/v4/sigrl/";
-#[cfg(feature = "production")]
+#[cfg(not(feature = "development"))]
 pub const REPORT_SUFFIX: &str = "/sgx/dev/attestation/v4/report";
 
 #[cfg(feature = "development")]

--- a/bitacross-worker/core-primitives/settings/Cargo.toml
+++ b/bitacross-worker/core-primitives/settings/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 [dependencies]
 
 [features]
-production = [
-]
+development = []
 offchain-worker = []

--- a/bitacross-worker/core-primitives/settings/src/lib.rs
+++ b/bitacross-worker/core-primitives/settings/src/lib.rs
@@ -52,9 +52,9 @@ pub mod files {
 	#[cfg(feature = "production")]
 	pub static RA_API_KEY_FILE: &str = "key_production.txt";
 
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	pub static RA_SPID_FILE: &str = "spid.txt";
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	pub static RA_API_KEY_FILE: &str = "key.txt";
 
 	pub const SPID_MIN_LENGTH: usize = 32;

--- a/bitacross-worker/core-primitives/settings/src/lib.rs
+++ b/bitacross-worker/core-primitives/settings/src/lib.rs
@@ -47,9 +47,9 @@ pub mod files {
 	// used by worker and enclave
 	pub const SHARDS_PATH: &str = "shards";
 
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	pub static RA_SPID_FILE: &str = "spid_production.txt";
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	pub static RA_API_KEY_FILE: &str = "key_production.txt";
 
 	#[cfg(feature = "development")]

--- a/bitacross-worker/enclave-runtime/Cargo.toml
+++ b/bitacross-worker/enclave-runtime/Cargo.toml
@@ -22,6 +22,9 @@ production = [
     "litentry-macros/production",
     "bc-task-receiver/production",
 ]
+development = [
+    "litentry-macros/development",
+]
 offchain-worker = [
     "itp-settings/offchain-worker",
     "itp-top-pool-author/offchain-worker",

--- a/bitacross-worker/enclave-runtime/Cargo.toml
+++ b/bitacross-worker/enclave-runtime/Cargo.toml
@@ -14,16 +14,13 @@ crate-type = ["staticlib"]
 
 [features]
 default = []
-production = [
-    "ita-stf/production",
-    "itp-settings/production",
-    "itp-attestation-handler/production",
-    "litentry-primitives/production",
-    "litentry-macros/production",
-    "bc-task-receiver/production",
-]
 development = [
+    "ita-stf/development",
+    "itp-settings/development",
+    "itp-attestation-handler/development",
+    "litentry-primitives/development",
     "litentry-macros/development",
+    "bc-task-receiver/development",
 ]
 offchain-worker = [
     "itp-settings/offchain-worker",

--- a/bitacross-worker/enclave-runtime/Makefile
+++ b/bitacross-worker/enclave-runtime/Makefile
@@ -43,7 +43,7 @@ else
 endif
 
 ifeq ($(SGX_PRODUCTION), 1)
-	ENCLAVE_FEATURES = --features=production,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+	ENCLAVE_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 else
 	ENCLAVE_FEATURES = --features=test,development,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 endif

--- a/bitacross-worker/enclave-runtime/Makefile
+++ b/bitacross-worker/enclave-runtime/Makefile
@@ -36,7 +36,7 @@ RUSTFLAGS :="-C target-feature=+avx2"
 
 ifeq ($(SGX_DEBUG), 1)
 	OUTPUT_PATH := debug
-	CARGO_TARGET := 
+	CARGO_TARGET :=
 else
 	OUTPUT_PATH := release
 	CARGO_TARGET := --release
@@ -45,7 +45,7 @@ endif
 ifeq ($(SGX_PRODUCTION), 1)
 	ENCLAVE_FEATURES = --features=production,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 else
-	ENCLAVE_FEATURES = --features=test,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+	ENCLAVE_FEATURES = --features=test,development,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 endif
 
 .PHONY: all

--- a/bitacross-worker/enclave-runtime/src/lib.rs
+++ b/bitacross-worker/enclave-runtime/src/lib.rs
@@ -60,6 +60,7 @@ use crate::{
 };
 use codec::Decode;
 use core::ffi::c_int;
+#[cfg(feature = "development")]
 use initialization::global_components::{
 	GLOBAL_BITCOIN_KEY_REPOSITORY_COMPONENT, GLOBAL_ETHEREUM_KEY_REPOSITORY_COMPONENT,
 };
@@ -71,7 +72,9 @@ use itc_parentchain::{
 use itp_component_container::ComponentGetter;
 use itp_node_api::metadata::NodeMetadata;
 use itp_nonce_cache::{MutateNonce, Nonce};
-use itp_sgx_crypto::key_repository::{AccessKey, AccessPubkey};
+#[cfg(feature = "development")]
+use itp_sgx_crypto::key_repository::AccessKey;
+use itp_sgx_crypto::key_repository::AccessPubkey;
 use itp_storage::{StorageProof, StorageProofChecker};
 use itp_types::{ShardIdentifier, SignedBlock};
 use itp_utils::write_slice_and_whitespace_pad;
@@ -249,6 +252,7 @@ pub unsafe extern "C" fn get_ecc_signing_pubkey(pubkey: *mut u8, pubkey_size: u3
 }
 
 #[no_mangle]
+#[cfg_attr(not(feature = "development"), allow(unused_variables))]
 pub unsafe extern "C" fn get_bitcoin_wallet_pair(pair: *mut u8, pair_size: u32) -> sgx_status_t {
 	if_development_or!(
 		{
@@ -278,7 +282,8 @@ pub unsafe extern "C" fn get_bitcoin_wallet_pair(pair: *mut u8, pair_size: u32) 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn get_ethereum_wallet_pair(_pair: *mut u8, _pair_size: u32) -> sgx_status_t {
+#[cfg_attr(not(feature = "development"), allow(unused_variables))]
+pub unsafe extern "C" fn get_ethereum_wallet_pair(pair: *mut u8, pair_size: u32) -> sgx_status_t {
 	if_development_or!(
 		{
 			let ethereum_key_repository = match GLOBAL_ETHEREUM_KEY_REPOSITORY_COMPONENT.get() {

--- a/bitacross-worker/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/bitacross-worker/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -50,7 +50,7 @@ use itp_types::{DirectRequestStatus, RsaRequest, ShardIdentifier, H256};
 use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use jsonrpc_core::{serde_json::json, IoHandler, Params, Value};
 use lc_scheduled_enclave::{ScheduledEnclaveUpdater, GLOBAL_SCHEDULED_ENCLAVE};
-use litentry_macros::if_not_production;
+use litentry_macros::if_development;
 use litentry_primitives::{AesRequest, DecryptableRequest};
 use log::debug;
 use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
@@ -311,7 +311,7 @@ where
 		Ok(json!(json_value))
 	});
 
-	if_not_production!({
+	if_development!({
 		use itp_types::{MrEnclave, SidechainBlockNumber};
 		// state_setScheduledEnclave, params: sidechainBlockNumber, hex encoded mrenclave
 		io.add_sync_method("state_setScheduledEnclave", move |params: Params| {

--- a/bitacross-worker/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/bitacross-worker/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -49,6 +49,7 @@ use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{DirectRequestStatus, RsaRequest, ShardIdentifier, H256};
 use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use jsonrpc_core::{serde_json::json, IoHandler, Params, Value};
+#[cfg(feature = "development")]
 use lc_scheduled_enclave::{ScheduledEnclaveUpdater, GLOBAL_SCHEDULED_ENCLAVE};
 use litentry_macros::if_development;
 use litentry_primitives::{AesRequest, DecryptableRequest};

--- a/bitacross-worker/litentry/core/direct-call/Cargo.toml
+++ b/bitacross-worker/litentry/core/direct-call/Cargo.toml
@@ -26,8 +26,8 @@ hex = { version = "0.4" }
 
 [features]
 default = ["std"]
-production = [
-    "parentchain-primitives/production",
+development = [
+    "parentchain-primitives/development",
 ]
 sgx = [
     "sgx_tstd",

--- a/bitacross-worker/litentry/primitives/Cargo.toml
+++ b/bitacross-worker/litentry/primitives/Cargo.toml
@@ -34,8 +34,8 @@ base64 = { version = "0.13", features = ["alloc"] }
 
 [features]
 default = ["std"]
-production = [
-    "parentchain-primitives/production",
+development = [
+    "parentchain-primitives/development",
 ]
 sgx = [
     "sgx_tstd",

--- a/bitacross-worker/service/Cargo.toml
+++ b/bitacross-worker/service/Cargo.toml
@@ -73,10 +73,10 @@ litentry-primitives = { path = "../litentry/primitives" }
 [features]
 default = []
 offchain-worker = ["itp-settings/offchain-worker"]
-production = [
-    "itp-settings/production",
-    "litentry-macros/production",
-    "litentry-primitives/production",
+development = [
+    "itp-settings/development",
+    "litentry-macros/development",
+    "litentry-primitives/development",
 ]
 dcap = []
 attesteer = ["dcap"]

--- a/bitacross-worker/service/src/enclave/api.rs
+++ b/bitacross-worker/service/src/enclave/api.rs
@@ -72,7 +72,7 @@ pub fn enclave_init(config: &Config) -> EnclaveResult<Enclave> {
 
 	// Step 2: call sgx_create_enclave to initialize an enclave instance
 	// Debug Support: 1 = debug mode, 0 = not debug mode
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	let debug = 1;
 	#[cfg(feature = "production")]
 	let debug = 0;

--- a/bitacross-worker/service/src/enclave/api.rs
+++ b/bitacross-worker/service/src/enclave/api.rs
@@ -74,7 +74,7 @@ pub fn enclave_init(config: &Config) -> EnclaveResult<Enclave> {
 	// Debug Support: 1 = debug mode, 0 = not debug mode
 	#[cfg(feature = "development")]
 	let debug = 1;
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	let debug = 0;
 
 	let mut misc_attr =

--- a/bitacross-worker/service/src/main_impl.rs
+++ b/bitacross-worker/service/src/main_impl.rs
@@ -83,7 +83,7 @@ pub(crate) fn main() {
 
 	// log this information, don't println because some python scripts for GA rely on the
 	// stdout from the service
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	info!("*** Starting service in SGX production mode");
 	#[cfg(feature = "development")]
 	info!("*** Starting service in SGX debug mode");
@@ -310,7 +310,7 @@ fn start_worker<E, T, InitializationHandler>(
 	println!("  DCAP is enabled");
 	#[cfg(not(feature = "dcap"))]
 	println!("  DCAP is disabled");
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	println!("  Production Mode is enabled");
 	#[cfg(feature = "development")]
 	println!("  Production Mode is disabled");

--- a/bitacross-worker/service/src/main_impl.rs
+++ b/bitacross-worker/service/src/main_impl.rs
@@ -85,7 +85,7 @@ pub(crate) fn main() {
 	// stdout from the service
 	#[cfg(feature = "production")]
 	info!("*** Starting service in SGX production mode");
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	info!("*** Starting service in SGX debug mode");
 
 	let mut lockfile = PathBuf::from(config.data_dir());
@@ -312,7 +312,7 @@ fn start_worker<E, T, InitializationHandler>(
 	println!("  DCAP is disabled");
 	#[cfg(feature = "production")]
 	println!("  Production Mode is enabled");
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	println!("  Production Mode is disabled");
 
 	info!("starting worker on shard {}", shard.encode().to_base58());

--- a/bitacross-worker/service/src/main_impl.rs
+++ b/bitacross-worker/service/src/main_impl.rs
@@ -37,7 +37,6 @@ use itp_node_api::{
 	metadata::NodeMetadata,
 	node_api_factory::{CreateNodeApi, NodeApiFactory},
 };
-use litentry_macros::if_production_or;
 use litentry_primitives::{Enclave as TeebagEnclave, ShardIdentifier, WorkerType};
 use log::*;
 use regex::Regex;

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -43,3 +43,6 @@ std = [
 production = [
     "litentry-macros/production",
 ]
+development = [
+    "litentry-macros/development",
+]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -40,9 +40,6 @@ std = [
     "pallet-evm/std",
     "litentry-hex-utils/std",
 ]
-production = [
-    "litentry-macros/production",
-]
 development = [
     "litentry-macros/development",
 ]

--- a/primitives/core/macros/Cargo.toml
+++ b/primitives/core/macros/Cargo.toml
@@ -6,5 +6,4 @@ version = "0.9.12"
 edition = "2021"
 
 [features]
-production = []
 development = []

--- a/primitives/core/macros/Cargo.toml
+++ b/primitives/core/macros/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [features]
 production = []
+development = []

--- a/primitives/core/macros/src/lib.rs
+++ b/primitives/core/macros/src/lib.rs
@@ -16,30 +16,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_export]
-macro_rules! if_production_or {
-	($prod_variant:expr, $non_prod_variant:expr) => {{
-		#[cfg(not(feature = "production"))]
-		{
-			$non_prod_variant
-		}
-		#[cfg(feature = "production")]
-		{
-			$prod_variant
-		}
-	}};
-}
-
-#[macro_export]
-macro_rules! if_not_production {
-	($expression:expr) => {
-		#[cfg(not(feature = "production"))]
-		{
-			$expression
-		}
-	};
-}
-
-#[macro_export]
 macro_rules! if_development_or {
 	($dev_variant:expr, $non_dev_variant:expr) => {{
 		#[cfg(not(feature = "development"))]

--- a/primitives/core/macros/src/lib.rs
+++ b/primitives/core/macros/src/lib.rs
@@ -38,3 +38,27 @@ macro_rules! if_not_production {
 		}
 	};
 }
+
+#[macro_export]
+macro_rules! if_development_or {
+	($dev_variant:expr, $non_dev_variant:expr) => {{
+		#[cfg(not(feature = "development"))]
+		{
+			$non_dev_variant
+		}
+		#[cfg(feature = "development")]
+		{
+			$dev_variant
+		}
+	}};
+}
+
+#[macro_export]
+macro_rules! if_development {
+	($expression:expr) => {
+		#[cfg(feature = "development")]
+		{
+			$expression
+		}
+	};
+}

--- a/primitives/core/src/identity.rs
+++ b/primitives/core/src/identity.rs
@@ -27,7 +27,7 @@ use alloc::{format, str, string::String};
 use base58::{FromBase58, ToBase58};
 use core::fmt::{Debug, Formatter};
 use litentry_hex_utils::{decode_hex, hex_encode};
-use litentry_macros::if_production_or;
+use litentry_macros::if_development_or;
 use pallet_evm::{AddressMapping, HashedAddressMapping as GenericHashedAddressMapping};
 use parity_scale_codec::{Decode, Encode, Error, Input, MaxEncodedLen};
 use scale_info::{meta_type, Type, TypeDefSequence, TypeInfo};
@@ -88,9 +88,9 @@ impl IdentityString {
 
 impl Debug for IdentityString {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-		if_production_or!(
-			f.debug_struct("IdentityString").finish(),
-			f.debug_struct("IdentityString").field("inner", &self.inner).finish()
+		if_development_or!(
+			f.debug_struct("IdentityString").field("inner", &self.inner).finish(),
+			f.debug_struct("IdentityString").finish()
 		)
 	}
 }
@@ -127,9 +127,9 @@ impl<'a> TryFrom<&'a [u8]> for Address20 {
 
 impl Debug for Address20 {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-		if_production_or!(
-			f.debug_tuple("Address20").finish(),
-			f.debug_tuple("Address20").field(&self.0).finish()
+		if_development_or!(
+			f.debug_tuple("Address20").field(&self.0).finish(),
+			f.debug_tuple("Address20").finish()
 		)
 	}
 }
@@ -197,9 +197,9 @@ impl From<ed25519::Public> for Address32 {
 
 impl Debug for Address32 {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-		if_production_or!(
-			f.debug_tuple("Address32").finish(),
-			f.debug_tuple("Address32").field(&self.0).finish()
+		if_development_or!(
+			f.debug_tuple("Address32").field(&self.0).finish(),
+			f.debug_tuple("Address32").finish()
 		)
 	}
 }
@@ -259,9 +259,9 @@ impl From<ecdsa::Public> for Address33 {
 
 impl Debug for Address33 {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-		if_production_or!(
-			f.debug_tuple("Address33").finish(),
-			f.debug_tuple("Address33").field(&self.0).finish()
+		if_development_or!(
+			f.debug_tuple("Address33").field(&self.0).finish(),
+			f.debug_tuple("Address33").finish()
 		)
 	}
 }

--- a/tee-worker/Makefile
+++ b/tee-worker/Makefile
@@ -83,6 +83,7 @@ else
 	SGX_SIGN_KEY = "enclave-runtime/Enclave_private.pem"
 	SGX_SIGN_PASSFILE = ""
 	WORKER_FEATURES := --features=default,development,link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
+	ADDITIONAL_FEATURES := development
 endif
 
 CLIENT_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)

--- a/tee-worker/Makefile
+++ b/tee-worker/Makefile
@@ -76,7 +76,7 @@ ifeq ($(SGX_PRODUCTION), 1)
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.production.xml"
 	SGX_SIGN_KEY = $(SGX_COMMERCIAL_KEY)
 	SGX_SIGN_PASSFILE = $(SGX_PASSFILE)
-	WORKER_FEATURES := --features=production,link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
+	WORKER_FEATURES := --features=link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
 else
 	SGX_ENCLAVE_MODE = "Development Mode"
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.xml"

--- a/tee-worker/Makefile
+++ b/tee-worker/Makefile
@@ -82,7 +82,7 @@ else
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.xml"
 	SGX_SIGN_KEY = "enclave-runtime/Enclave_private.pem"
 	SGX_SIGN_PASSFILE = ""
-	WORKER_FEATURES := --features=default,link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
+	WORKER_FEATURES := --features=default,development,link-binary,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
 endif
 
 CLIENT_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)

--- a/tee-worker/app-libs/sgx-runtime/Cargo.toml
+++ b/tee-worker/app-libs/sgx-runtime/Cargo.toml
@@ -39,6 +39,9 @@ pallet-parentchain = { path = "../../../pallets/parentchain", default-features =
 default = ["std"]
 # Compile the sgx-runtime with evm support.
 evm = ["pallet-evm"]
+development = [
+    "pallet-imt/development",
+]
 std = [
     "codec/std",
     "scale-info/std",

--- a/tee-worker/app-libs/stf/Cargo.toml
+++ b/tee-worker/app-libs/stf/Cargo.toml
@@ -94,3 +94,6 @@ test = []
 production = [
     "litentry-macros/production",
 ]
+development = [
+    "litentry-macros/development",
+]

--- a/tee-worker/app-libs/stf/Cargo.toml
+++ b/tee-worker/app-libs/stf/Cargo.toml
@@ -91,9 +91,6 @@ std = [
     "itp-node-api-metadata-provider/std",
 ]
 test = []
-production = [
-    "litentry-macros/production",
-]
 development = [
     "litentry-macros/development",
 ]

--- a/tee-worker/app-libs/stf/Cargo.toml
+++ b/tee-worker/app-libs/stf/Cargo.toml
@@ -93,4 +93,5 @@ std = [
 test = []
 development = [
     "litentry-macros/development",
+    "ita-sgx-runtime/development",
 ]

--- a/tee-worker/app-libs/stf/src/getter.rs
+++ b/tee-worker/app-libs/stf/src/getter.rs
@@ -40,7 +40,7 @@ use sp_runtime::transaction_validity::{
 	TransactionValidityError, UnknownTransaction, ValidTransaction,
 };
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 use crate::helpers::ALICE_ACCOUNTID32;
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]

--- a/tee-worker/app-libs/stf/src/getter.rs
+++ b/tee-worker/app-libs/stf/src/getter.rs
@@ -20,7 +20,7 @@ use ita_sgx_runtime::{IdentityManagement, System};
 use itp_stf_interface::ExecuteGetter;
 use itp_stf_primitives::{traits::GetterAuthorization, types::KeyPair};
 use itp_utils::stringify::account_id_to_string;
-use litentry_macros::if_production_or;
+use litentry_macros::if_development_or;
 use litentry_primitives::{Identity, LitentryMultiSignature};
 use log::*;
 use sp_core::blake2_256;
@@ -162,16 +162,16 @@ impl TrustedGetterSigned {
 	pub fn verify_signature(&self) -> bool {
 		let payload = self.getter.encode();
 		// in non-prod, we accept signature from Alice too
-		if_production_or!(
-			{
-				self.signature.verify(&payload, self.getter.sender_identity())
-					|| self.signature.verify(&blake2_256(&payload), self.getter.sender_identity())
-			},
+		if_development_or!(
 			{
 				self.signature.verify(&payload, self.getter.sender_identity())
 					|| self.signature.verify(&blake2_256(&payload), self.getter.sender_identity())
 					|| self.signature.verify(&payload, &ALICE_ACCOUNTID32.into())
 					|| self.signature.verify(&blake2_256(&payload), &ALICE_ACCOUNTID32.into())
+			},
+			{
+				self.signature.verify(&payload, self.getter.sender_identity())
+					|| self.signature.verify(&blake2_256(&payload), self.getter.sender_identity())
 			}
 		)
 	}

--- a/tee-worker/app-libs/stf/src/helpers.rs
+++ b/tee-worker/app-libs/stf/src/helpers.rs
@@ -31,7 +31,7 @@ use log::*;
 use sp_core::blake2_256;
 use std::prelude::v1::*;
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 pub use non_prod::*;
 
 pub fn get_storage_value<V: Decode>(
@@ -206,7 +206,7 @@ pub fn shard_creation_info() -> ShardCreationInfo {
 	}
 }
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 mod non_prod {
 	use super::*;
 	use hex_literal::hex;

--- a/tee-worker/app-libs/stf/src/trusted_call.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call.rs
@@ -23,7 +23,7 @@ use std::vec::Vec;
 
 #[cfg(feature = "evm")]
 use crate::evm_helpers::{create_code_hash, evm_create2_address, evm_create_address};
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 use crate::helpers::ensure_enclave_signer_or_alice;
 use crate::{
 	helpers::{enclave_signer_account, ensure_enclave_signer_account, ensure_self, shard_vault},
@@ -118,7 +118,7 @@ pub enum TrustedCall {
 		Option<RequestAesKey>,
 		H256,
 	),
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	#[codec(index = 5)]
 	remove_identity(Identity, Identity, Vec<Identity>),
 	#[codec(index = 6)]
@@ -237,7 +237,7 @@ impl TrustedCall {
 			Self::handle_vcmp_error(sender_identity, ..) => sender_identity,
 			Self::send_erroneous_parentchain_call(sender_identity) => sender_identity,
 			Self::maybe_create_id_graph(sender_identity, ..) => sender_identity,
-			#[cfg(not(feature = "production"))]
+			#[cfg(feature = "development")]
 			Self::remove_identity(sender_identity, ..) => sender_identity,
 			Self::request_batch_vc(sender_identity, ..) => sender_identity,
 		}
@@ -734,7 +734,7 @@ where
 					Ok(TrustedCallResult::Streamed)
 				}
 			},
-			#[cfg(not(feature = "production"))]
+			#[cfg(feature = "development")]
 			TrustedCall::remove_identity(signer, who, identities) => {
 				debug!("remove_identity, who: {}", account_id_to_string(&who));
 

--- a/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
@@ -44,7 +44,7 @@ use lc_stf_task_sender::{
 	stf_task_sender::{SendStfRequest, StfRequestSender},
 	AssertionBuildRequest, RequestType, Web2IdentityVerificationRequest,
 };
-use litentry_macros::if_production_or;
+use litentry_macros::if_development_or;
 use litentry_primitives::{
 	Assertion, ErrorDetail, Identity, RequestAesKey, ValidationData, Web3Network,
 };
@@ -160,14 +160,14 @@ impl TrustedCallSigned {
 		match assertion {
 			// the signer will be checked inside A13, as we don't seem to have access to ocall_api here
 			Assertion::A13(_) => (),
-			_ => if_production_or!(
-				ensure!(
-					ensure_enclave_signer_or_self(&signer, who.to_account_id()),
-					StfError::RequestVCFailed(assertion, ErrorDetail::UnauthorizedSigner)
-				),
+			_ => if_development_or!(
 				ensure!(
 					ensure_enclave_signer_or_self(&signer, who.to_account_id())
 						|| ensure_alice(&signer),
+					StfError::RequestVCFailed(assertion, ErrorDetail::UnauthorizedSigner)
+				),
+				ensure!(
+					ensure_enclave_signer_or_self(&signer, who.to_account_id()),
 					StfError::RequestVCFailed(assertion, ErrorDetail::UnauthorizedSigner)
 				)
 			),
@@ -228,18 +228,18 @@ impl TrustedCallSigned {
 		identity: Identity,
 		web3networks: Vec<Web3Network>,
 	) -> StfResult<()> {
-		if_production_or!(
-			{
-				// In prod: the signer has to be enclave_signer_account, as this TrustedCall can only be constructed internally
-				ensure_enclave_signer_account(&signer)
-					.map_err(|_| StfError::LinkIdentityFailed(ErrorDetail::UnauthorizedSigner))?;
-			},
+		if_development_or!(
 			{
 				// In non-prod: we allow to use `Alice` as the dummy signer
 				ensure!(
 					ensure_enclave_signer_or_alice(&signer),
 					StfError::LinkIdentityFailed(ErrorDetail::UnauthorizedSigner)
 				);
+			},
+			{
+				// In prod: the signer has to be enclave_signer_account, as this TrustedCall can only be constructed internally
+				ensure_enclave_signer_account(&signer)
+					.map_err(|_| StfError::LinkIdentityFailed(ErrorDetail::UnauthorizedSigner))?;
 			}
 		);
 		IMTCall::link_identity { who, identity, web3networks }

--- a/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
@@ -51,7 +51,7 @@ use litentry_primitives::{
 use log::*;
 use std::{sync::Arc, vec::Vec};
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 use crate::helpers::{ensure_alice, ensure_enclave_signer_or_alice};
 
 impl TrustedCallSigned {

--- a/tee-worker/build.Dockerfile
+++ b/tee-worker/build.Dockerfile
@@ -67,7 +67,7 @@ RUN \
     make && sccache --show-stats; \
   fi
 
-RUN cargo test --release
+RUN cargo test --release --features development
 
 
 ### Base Runner Stage

--- a/tee-worker/cli/Cargo.toml
+++ b/tee-worker/cli/Cargo.toml
@@ -66,6 +66,6 @@ evm = ["ita-stf/evm", "pallet-evm"]
 teeracle = []
 sidechain = []
 offchain-worker = []
-production = []
+development = []
 # dcap feature flag is not used in this crate, but for easier build purposes only it present here as well
 dcap = []

--- a/tee-worker/cli/Cargo.toml
+++ b/tee-worker/cli/Cargo.toml
@@ -66,6 +66,9 @@ evm = ["ita-stf/evm", "pallet-evm"]
 teeracle = []
 sidechain = []
 offchain-worker = []
-development = []
+development = [
+    "ita-sgx-runtime/development",
+    "ita-stf/development",
+]
 # dcap feature flag is not used in this crate, but for easier build purposes only it present here as well
 dcap = []

--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/mod.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/mod.rs
@@ -17,6 +17,7 @@
 pub mod get_storage;
 pub mod id_graph;
 pub mod link_identity;
+#[cfg(feature = "development")]
 pub mod remove_identity;
 pub mod request_batch_vc;
 pub mod request_vc;

--- a/tee-worker/cli/src/trusted_base_cli/mod.rs
+++ b/tee-worker/cli/src/trusted_base_cli/mod.rs
@@ -94,6 +94,7 @@ pub enum TrustedBaseCommand {
 	RequestBatchVc(RequestBatchVcCommand),
 
 	/// Remove Identity from the prime identity
+	#[cfg(feature = "development")]
 	RemoveIdentity(RemoveIdentityCommand),
 }
 
@@ -116,6 +117,7 @@ impl TrustedBaseCommand {
 			TrustedBaseCommand::IDGraph(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::RequestVc(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::RequestBatchVc(cmd) => cmd.run(cli, trusted_cli),
+			#[cfg(feature = "development")]
 			TrustedBaseCommand::RemoveIdentity(cmd) => cmd.run(cli, trusted_cli),
 		}
 	}

--- a/tee-worker/core-primitives/attestation-handler/Cargo.toml
+++ b/tee-worker/core-primitives/attestation-handler/Cargo.toml
@@ -99,4 +99,4 @@ sgx = [
     "httparse/mesalock_sgx",
 ]
 test = []
-production = []
+development = []

--- a/tee-worker/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/tee-worker/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -71,9 +71,9 @@ pub const SIGRL_SUFFIX: &str = "/sgx/dev/attestation/v4/sigrl/";
 #[cfg(feature = "production")]
 pub const REPORT_SUFFIX: &str = "/sgx/dev/attestation/v4/report";
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 pub const SIGRL_SUFFIX: &str = "/sgx/dev/attestation/v4/sigrl/";
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 pub const REPORT_SUFFIX: &str = "/sgx/dev/attestation/v4/report";
 
 /// Trait to provide an abstraction to the attestation logic

--- a/tee-worker/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/tee-worker/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -66,9 +66,9 @@ use std::{
 pub const DEV_HOSTNAME: &str = "api.trustedservices.intel.com";
 
 // Litentry TODO: use `dev` for production temporary. Will switch to dcap later.
-#[cfg(feature = "production")]
+#[cfg(not(feature = "development"))]
 pub const SIGRL_SUFFIX: &str = "/sgx/dev/attestation/v4/sigrl/";
-#[cfg(feature = "production")]
+#[cfg(not(feature = "development"))]
 pub const REPORT_SUFFIX: &str = "/sgx/dev/attestation/v4/report";
 
 #[cfg(feature = "development")]

--- a/tee-worker/core-primitives/settings/Cargo.toml
+++ b/tee-worker/core-primitives/settings/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 litentry-primitives = { path = "../../litentry/primitives", default-features = false }
 
 [features]
-production = [
-    "litentry-primitives/production",
+development = [
+    "litentry-primitives/development",
 ]
 sidechain = []
 offchain-worker = []

--- a/tee-worker/core-primitives/settings/src/lib.rs
+++ b/tee-worker/core-primitives/settings/src/lib.rs
@@ -53,9 +53,9 @@ pub mod files {
 	// used by worker and enclave
 	pub const SHARDS_PATH: &str = "shards";
 
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	pub static RA_SPID_FILE: &str = "spid_production.txt";
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	pub static RA_API_KEY_FILE: &str = "key_production.txt";
 
 	#[cfg(feature = "development")]

--- a/tee-worker/core-primitives/settings/src/lib.rs
+++ b/tee-worker/core-primitives/settings/src/lib.rs
@@ -58,9 +58,9 @@ pub mod files {
 	#[cfg(feature = "production")]
 	pub static RA_API_KEY_FILE: &str = "key_production.txt";
 
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	pub static RA_SPID_FILE: &str = "spid.txt";
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	pub static RA_API_KEY_FILE: &str = "key.txt";
 
 	pub const SPID_MIN_LENGTH: usize = 32;

--- a/tee-worker/enclave-runtime/Cargo.toml
+++ b/tee-worker/enclave-runtime/Cargo.toml
@@ -27,6 +27,9 @@ production = [
     "litentry-primitives/production",
     "litentry-macros/production",
 ]
+development = [
+    "litentry-macros/development",
+]
 sidechain = ["itp-settings/sidechain", "itp-top-pool-author/sidechain"]
 offchain-worker = [
     "itp-settings/offchain-worker",

--- a/tee-worker/enclave-runtime/Cargo.toml
+++ b/tee-worker/enclave-runtime/Cargo.toml
@@ -18,16 +18,13 @@ evm = [
     "ita-sgx-runtime/evm",
     "ita-stf/evm",
 ]
-production = [
-    "ita-stf/production",
-    "itp-settings/production",
-    "itp-attestation-handler/production",
-    "lc-data-providers/production",
-    "lc-vc-task-receiver/production",
-    "litentry-primitives/production",
-    "litentry-macros/production",
-]
 development = [
+    "ita-stf/development",
+    "itp-settings/development",
+    "itp-attestation-handler/development",
+    "lc-data-providers/development",
+    "lc-vc-task-receiver/development",
+    "litentry-primitives/development",
     "litentry-macros/development",
 ]
 sidechain = ["itp-settings/sidechain", "itp-top-pool-author/sidechain"]

--- a/tee-worker/enclave-runtime/Makefile
+++ b/tee-worker/enclave-runtime/Makefile
@@ -43,7 +43,7 @@ else
 endif
 
 ifeq ($(SGX_PRODUCTION), 1)
-	ENCLAVE_FEATURES = --features=production,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+	ENCLAVE_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 else
 	ENCLAVE_FEATURES = --features=test,development,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 endif

--- a/tee-worker/enclave-runtime/Makefile
+++ b/tee-worker/enclave-runtime/Makefile
@@ -36,7 +36,7 @@ RUSTFLAGS :="-C target-feature=+avx2"
 
 ifeq ($(SGX_DEBUG), 1)
 	OUTPUT_PATH := debug
-	CARGO_TARGET := 
+	CARGO_TARGET :=
 else
 	OUTPUT_PATH := release
 	CARGO_TARGET := --release
@@ -45,7 +45,7 @@ endif
 ifeq ($(SGX_PRODUCTION), 1)
 	ENCLAVE_FEATURES = --features=production,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 else
-	ENCLAVE_FEATURES = --features=test,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+	ENCLAVE_FEATURES = --features=test,development,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 endif
 
 .PHONY: all

--- a/tee-worker/enclave-runtime/src/lib.rs
+++ b/tee-worker/enclave-runtime/src/lib.rs
@@ -151,7 +151,7 @@ pub unsafe extern "C" fn init(
 				builder.filter(Some(module), LevelFilter::Info);
 			});
 			builder.init();
-		},
+		}
 	);
 
 	let mu_ra_url =

--- a/tee-worker/enclave-runtime/src/lib.rs
+++ b/tee-worker/enclave-runtime/src/lib.rs
@@ -78,7 +78,7 @@ use itp_sgx_crypto::key_repository::AccessPubkey;
 use itp_storage::{StorageProof, StorageProofChecker};
 use itp_types::{ShardIdentifier, SignedBlock};
 use itp_utils::write_slice_and_whitespace_pad;
-use litentry_macros::if_production_or;
+use litentry_macros::if_development_or;
 use log::*;
 use once_cell::sync::OnceCell;
 use sgx_types::sgx_status_t;
@@ -134,7 +134,10 @@ pub unsafe extern "C" fn init(
 	encoded_base_dir_size: u32,
 ) -> sgx_status_t {
 	// Initialize the logging environment in the enclave.
-	if_production_or!(
+	if_development_or!(
+		env_logger::builder()
+			.format_timestamp(Some(env_logger::TimestampPrecision::Micros))
+			.init(),
 		{
 			let module_names = litentry_proc_macros::local_modules!();
 			println!(
@@ -149,9 +152,6 @@ pub unsafe extern "C" fn init(
 			});
 			builder.init();
 		},
-		env_logger::builder()
-			.format_timestamp(Some(env_logger::TimestampPrecision::Micros))
-			.init()
 	);
 
 	let mu_ra_url =

--- a/tee-worker/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/tee-worker/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -49,7 +49,7 @@ use its_sidechain::rpc_handler::{
 };
 use jsonrpc_core::{serde_json::json, IoHandler, Params, Value};
 use lc_scheduled_enclave::{ScheduledEnclaveUpdater, GLOBAL_SCHEDULED_ENCLAVE};
-use litentry_macros::if_not_production;
+use litentry_macros::if_development;
 use litentry_primitives::{DecryptableRequest, Identity};
 use log::debug;
 use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
@@ -345,7 +345,7 @@ where
 		Ok(json!(json_value))
 	});
 
-	if_not_production!({
+	if_development!({
 		use itp_types::{MrEnclave, SidechainBlockNumber};
 		// state_setScheduledEnclave, params: sidechainBlockNumber, hex encoded mrenclave
 		io.add_sync_method("state_setScheduledEnclave", move |params: Params| {

--- a/tee-worker/enclave-runtime/src/top_pool_execution.rs
+++ b/tee-worker/enclave-runtime/src/top_pool_execution.rs
@@ -75,7 +75,7 @@ use its_sidechain::{
 	validateer_fetch::ValidateerFetch,
 };
 use lc_scheduled_enclave::{ScheduledEnclaveUpdater, GLOBAL_SCHEDULED_ENCLAVE};
-use litentry_macros::if_not_production;
+use litentry_macros::if_development;
 use log::*;
 use sgx_types::sgx_status_t;
 use sp_core::{crypto::UncheckedFrom, Pair};
@@ -213,7 +213,7 @@ fn execute_top_pool_trusted_calls_internal() -> Result<()> {
 				ocall_api.clone(),
 			);
 
-			if_not_production!({
+			if_development!({
 				if let Some(ref fail_on_demand) = *fail_on_demand {
 					fail_on_demand.next_slot();
 					if fail_on_demand.check_before_on_slot() {
@@ -236,7 +236,7 @@ fn execute_top_pool_trusted_calls_internal() -> Result<()> {
 					state_handler,
 				)?;
 
-			if_not_production!({
+			if_development!({
 				if let Some(ref fail_on_demand) = *fail_on_demand {
 					if fail_on_demand.check_after_on_slot() {
 						Result::Err(crate::error::Error::Sgx(sgx_status_t::SGX_ERROR_UNEXPECTED))?;

--- a/tee-worker/enclave-runtime/src/top_pool_execution.rs
+++ b/tee-worker/enclave-runtime/src/top_pool_execution.rs
@@ -15,7 +15,7 @@
 
 */
 
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 use crate::initialization::global_components::GLOBAL_SIDECHAIN_FAIL_SLOT_ON_DEMAND_COMPONENT;
 use crate::{
 	error::{Error, Result},
@@ -188,7 +188,7 @@ fn execute_top_pool_trusted_calls_internal() -> Result<()> {
 
 	let authority = GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT.get()?.retrieve_key()?;
 
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	let fail_on_demand = GLOBAL_SIDECHAIN_FAIL_SLOT_ON_DEMAND_COMPONENT.get()?;
 
 	match yield_next_slot(

--- a/tee-worker/litentry/core/data-providers/Cargo.toml
+++ b/tee-worker/litentry/core/data-providers/Cargo.toml
@@ -72,3 +72,6 @@ std = [
 production = [
     "litentry-macros/production",
 ]
+development = [
+    "litentry-macros/development",
+]

--- a/tee-worker/litentry/core/data-providers/Cargo.toml
+++ b/tee-worker/litentry/core/data-providers/Cargo.toml
@@ -69,9 +69,6 @@ std = [
     "litentry-primitives/std",
     "chrono",
 ]
-production = [
-    "litentry-macros/production",
-]
 development = [
     "litentry-macros/development",
 ]

--- a/tee-worker/litentry/core/data-providers/src/lib.rs
+++ b/tee-worker/litentry/core/data-providers/src/lib.rs
@@ -45,7 +45,7 @@ use itc_rest_client::{
 	rest_client::RestClient,
 	Query, RestGet, RestPath, RestPost,
 };
-use litentry_macros::if_not_production;
+use litentry_macros::if_development;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::{thread, vec};
@@ -243,7 +243,7 @@ impl DataProviderConfig {
 		};
 
 		// we allow to override following config properties for non prod dev
-		if_not_production!({
+		if_development!({
 			if let Ok(v) = env::var("TWITTER_OFFICIAL_URL") {
 				config.set_twitter_official_url(v)?;
 			}

--- a/tee-worker/litentry/core/vc-task/receiver/Cargo.toml
+++ b/tee-worker/litentry/core/vc-task/receiver/Cargo.toml
@@ -100,4 +100,5 @@ development = [
     "ita-stf/development",
     "lc-data-providers/development",
     "litentry-macros/development",
+    "pallet-identity-management-tee/development",
 ]

--- a/tee-worker/litentry/core/vc-task/receiver/Cargo.toml
+++ b/tee-worker/litentry/core/vc-task/receiver/Cargo.toml
@@ -101,3 +101,6 @@ production = [
     "lc-data-providers/production",
     "litentry-macros/production",
 ]
+development = [
+    "litentry-macros/development",
+]

--- a/tee-worker/litentry/core/vc-task/receiver/Cargo.toml
+++ b/tee-worker/litentry/core/vc-task/receiver/Cargo.toml
@@ -96,11 +96,8 @@ std = [
     "itp-storage/std",
     "lc-vc-task-sender/std",
 ]
-production = [
-    "ita-stf/production",
-    "lc-data-providers/production",
-    "litentry-macros/production",
-]
 development = [
+    "ita-stf/development",
+    "lc-data-providers/development",
     "litentry-macros/development",
 ]

--- a/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
+++ b/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
@@ -53,7 +53,7 @@ use itp_types::{
 use lc_stf_task_receiver::{handler::assertion::create_credential_str, StfTaskContext};
 use lc_stf_task_sender::AssertionBuildRequest;
 use lc_vc_task_sender::init_vc_task_sender_storage;
-use litentry_macros::if_production_or;
+use litentry_macros::if_development_or;
 use litentry_primitives::{Assertion, DecryptableRequest, Identity, ParentchainBlockNumber};
 use log::*;
 use pallet_identity_management_tee::{identity_context::sort_id_graph, IdentityContext};
@@ -478,12 +478,12 @@ where
 		match assertion {
 			// the signer will be checked inside A13, as we don't seem to have access to ocall_api here
 			Assertion::A13(_) => (),
-			_ => if_production_or!(
-				ensure!(ensure_self(&signer, &who), "Unauthorized signer",),
+			_ => if_development_or!(
 				ensure!(
 					ensure_self(&signer, &who) || ensure_alice(&signer_account),
 					"Unauthorized signer",
-				)
+				),
+				ensure!(ensure_self(&signer, &who), "Unauthorized signer",)
 			),
 		}
 

--- a/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
+++ b/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
@@ -25,7 +25,7 @@ use codec::{Decode, Encode};
 use frame_support::{ensure, sp_runtime::traits::One};
 use futures::executor::ThreadPool;
 use ita_sgx_runtime::{pallet_imt::get_eligible_identities, BlockNumber, Hash, Runtime};
-#[cfg(not(feature = "production"))]
+#[cfg(feature = "development")]
 use ita_stf::helpers::ensure_alice;
 use ita_stf::{
 	aes_encrypt_default,

--- a/tee-worker/litentry/pallets/identity-management/Cargo.toml
+++ b/tee-worker/litentry/pallets/identity-management/Cargo.toml
@@ -38,3 +38,5 @@ std = [
     "pallet-balances/std",
     "litentry-primitives/std",
 ]
+
+development = []

--- a/tee-worker/litentry/pallets/identity-management/src/lib.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/lib.rs
@@ -221,7 +221,7 @@ pub mod pallet {
 			})
 		}
 
-		#[cfg(not(feature = "production"))]
+		#[cfg(feature = "development")]
 		#[pallet::call_index(5)]
 		#[pallet::weight({15_000_000})]
 		pub fn remove_identity(

--- a/tee-worker/litentry/primitives/Cargo.toml
+++ b/tee-worker/litentry/primitives/Cargo.toml
@@ -39,8 +39,8 @@ base64 = { version = "0.13", features = ["alloc"] }
 
 [features]
 default = ["std"]
-production = [
-    "parentchain-primitives/production",
+development = [
+    "parentchain-primitives/development",
 ]
 sgx = [
     "sgx_tstd",

--- a/tee-worker/service/Cargo.toml
+++ b/tee-worker/service/Cargo.toml
@@ -95,6 +95,9 @@ production = [
     "litentry-macros/production",
     "litentry-primitives/production",
 ]
+development = [
+    "litentry-macros/development",
+]
 dcap = []
 attesteer = ["dcap"]
 # Must be enabled to build a binary and link it with the enclave successfully.

--- a/tee-worker/service/Cargo.toml
+++ b/tee-worker/service/Cargo.toml
@@ -88,15 +88,12 @@ default = []
 evm = []
 sidechain = ["itp-settings/sidechain"]
 offchain-worker = ["itp-settings/offchain-worker"]
-production = [
-    "ita-stf/production",
-    "itp-settings/production",
-    "lc-data-providers/production",
-    "litentry-macros/production",
-    "litentry-primitives/production",
-]
 development = [
+    "ita-stf/development",
+    "itp-settings/development",
+    "lc-data-providers/development",
     "litentry-macros/development",
+    "litentry-primitives/development",
 ]
 dcap = []
 attesteer = ["dcap"]

--- a/tee-worker/service/src/enclave/api.rs
+++ b/tee-worker/service/src/enclave/api.rs
@@ -72,7 +72,7 @@ pub fn enclave_init(config: &Config) -> EnclaveResult<Enclave> {
 
 	// Step 2: call sgx_create_enclave to initialize an enclave instance
 	// Debug Support: 1 = debug mode, 0 = not debug mode
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	let debug = 1;
 	#[cfg(feature = "production")]
 	let debug = 0;

--- a/tee-worker/service/src/enclave/api.rs
+++ b/tee-worker/service/src/enclave/api.rs
@@ -74,7 +74,7 @@ pub fn enclave_init(config: &Config) -> EnclaveResult<Enclave> {
 	// Debug Support: 1 = debug mode, 0 = not debug mode
 	#[cfg(feature = "development")]
 	let debug = 1;
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	let debug = 0;
 
 	let mut misc_attr =

--- a/tee-worker/service/src/main_impl.rs
+++ b/tee-worker/service/src/main_impl.rs
@@ -96,7 +96,7 @@ pub(crate) fn main() {
 
 	// log this information, don't println because some python scripts for GA rely on the
 	// stdout from the service
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	info!("*** Starting service in SGX production mode");
 	#[cfg(feature = "development")]
 	info!("*** Starting service in SGX debug mode");
@@ -354,7 +354,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	println!("  DCAP is enabled");
 	#[cfg(not(feature = "dcap"))]
 	println!("  DCAP is disabled");
-	#[cfg(feature = "production")]
+	#[cfg(not(feature = "development"))]
 	println!("  Production Mode is enabled");
 	#[cfg(feature = "development")]
 	println!("  Production Mode is disabled");

--- a/tee-worker/service/src/main_impl.rs
+++ b/tee-worker/service/src/main_impl.rs
@@ -48,7 +48,7 @@ use its_peer_fetch::{
 use its_primitives::types::block::SignedBlock as SignedSidechainBlock;
 use its_storage::{interface::FetchBlocks, BlockPruner, SidechainStorageLock};
 use lc_data_providers::DataProviderConfig;
-use litentry_macros::if_production_or;
+use litentry_macros::if_development_or;
 use litentry_primitives::{Enclave as TeebagEnclave, ShardIdentifier, WorkerType};
 use log::*;
 use regex::Regex;
@@ -193,8 +193,7 @@ pub(crate) fn main() {
 
 		// litentry: start the mock-server if enabled
 		if config.enable_mock_server {
-			if_production_or!(
-				warn!("Mock server not started. Node is running in production mode."),
+			if_development_or!(
 				{
 					let mock_server_port = config
 						.try_parse_mock_server_port()
@@ -203,7 +202,8 @@ pub(crate) fn main() {
 						info!("*** Starting mock server");
 						let _ = lc_mock_server::run(mock_server_port);
 					});
-				}
+				},
+				warn!("Mock server not started. Node is running in production mode.")
 			)
 		}
 

--- a/tee-worker/service/src/main_impl.rs
+++ b/tee-worker/service/src/main_impl.rs
@@ -98,7 +98,7 @@ pub(crate) fn main() {
 	// stdout from the service
 	#[cfg(feature = "production")]
 	info!("*** Starting service in SGX production mode");
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	info!("*** Starting service in SGX debug mode");
 
 	info!("*** Running worker in mode: {:?} \n", WorkerModeProvider::worker_mode());
@@ -356,7 +356,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	println!("  DCAP is disabled");
 	#[cfg(feature = "production")]
 	println!("  Production Mode is enabled");
-	#[cfg(not(feature = "production"))]
+	#[cfg(feature = "development")]
 	println!("  Production Mode is disabled");
 	#[cfg(feature = "evm")]
 	println!("  EVM is enabled");


### PR DESCRIPTION
Including dev only code when the `production` feature is not enabled makes it posible to include unsafe code to the production build in the cases where the feature has not been properly propagated. These changes switch the logic to include prod code by default and only include dev code when explicitly specified.
