### PR TITLE
Use LinkIdentityRequested event instead of link_identity extrinsic

### DIFF
--- a/pallets/identity-management/src/benchmarking.rs
+++ b/pallets/identity-management/src/benchmarking.rs
@@ -62,7 +62,13 @@ benchmarks! {
 		let encrypted_web3networks = vec![1u8; 2048];
 	}: _(RawOrigin::Signed(caller.clone()), shard, caller.clone(), encrypted_did, encrypted_validation_data, encrypted_web3networks)
 	verify {
-		assert_last_event::<T>(Event::LinkIdentityRequested{ shard }.into());
+		assert_last_event::<T>(Event::LinkIdentityRequested{
+			shard,
+			account: caller.clone(),
+			encrypted_identity: vec![1u8; 2048],
+			encrypted_validation_data: vec![1u8; 2048],
+			encrypted_web3networks: vec![1u8; 2048],
+		}.into());
 	}
 
 	// Benchmark `deactivate_identity`. There are no worst conditions. The benchmark showed that

--- a/pallets/identity-management/src/benchmarking.rs
+++ b/pallets/identity-management/src/benchmarking.rs
@@ -64,7 +64,7 @@ benchmarks! {
 	verify {
 		assert_last_event::<T>(Event::LinkIdentityRequested{
 			shard,
-			account: caller.clone(),
+			account: caller,
 			encrypted_identity: vec![1u8; 2048],
 			encrypted_validation_data: vec![1u8; 2048],
 			encrypted_web3networks: vec![1u8; 2048],

--- a/pallets/identity-management/src/lib.rs
+++ b/pallets/identity-management/src/lib.rs
@@ -81,6 +81,10 @@ pub mod pallet {
 		// TODO: do we need account as event parameter? This needs to be decided by F/E
 		LinkIdentityRequested {
 			shard: ShardIdentifier,
+			account: T::AccountId,
+			encrypted_identity: Vec<u8>, // TODO: check if this is the correct type
+			encrypted_validation_data: Vec<u8>,
+			encrypted_web3networks: Vec<u8>,
 		},
 		DeactivateIdentityRequested {
 			shard: ShardIdentifier,
@@ -210,7 +214,13 @@ pub mod pallet {
 				who == user || Delegatee::<T>::contains_key(&who),
 				Error::<T>::UnauthorizedUser
 			);
-			Self::deposit_event(Event::LinkIdentityRequested { shard });
+			Self::deposit_event(Event::LinkIdentityRequested {
+				shard,
+				account: user,
+				encrypted_identity,
+				encrypted_validation_data,
+				encrypted_web3networks,
+			});
 			Ok(().into())
 		}
 

--- a/pallets/identity-management/src/lib.rs
+++ b/pallets/identity-management/src/lib.rs
@@ -82,7 +82,7 @@ pub mod pallet {
 		LinkIdentityRequested {
 			shard: ShardIdentifier,
 			account: T::AccountId,
-			encrypted_identity: Vec<u8>, // TODO: check if this is the correct type
+			encrypted_identity: Vec<u8>,
 			encrypted_validation_data: Vec<u8>,
 			encrypted_web3networks: Vec<u8>,
 		},

--- a/pallets/identity-management/src/tests.rs
+++ b/pallets/identity-management/src/tests.rs
@@ -33,13 +33,19 @@ fn link_identity_without_delegatee_works() {
 		assert_ok!(IdentityManagement::link_identity(
 			RuntimeOrigin::signed(alice.clone()),
 			shard,
-			alice,
+			alice.clone(),
 			vec![1u8; 2048],
 			vec![1u8; 2048],
 			vec![1u8; 2048],
 		));
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
-			crate::Event::LinkIdentityRequested { shard },
+			crate::Event::LinkIdentityRequested {
+				shard,
+				account: alice,
+				encrypted_identity: vec![1u8; 2048],
+				encrypted_validation_data: vec![1u8; 2048],
+				encrypted_web3networks: vec![1u8; 2048],
+			},
 		));
 	});
 }
@@ -53,13 +59,19 @@ fn link_identity_with_authorized_delegatee_works() {
 		assert_ok!(IdentityManagement::link_identity(
 			RuntimeOrigin::signed(eddie), // authorized delegatee set in initialisation
 			shard,
-			alice,
+			alice.clone(),
 			vec![1u8; 2048],
 			vec![1u8; 2048],
 			vec![1u8; 2048],
 		));
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
-			crate::Event::LinkIdentityRequested { shard },
+			crate::Event::LinkIdentityRequested {
+				shard,
+				account: alice,
+				encrypted_identity: vec![1u8; 2048],
+				encrypted_validation_data: vec![1u8; 2048],
+				encrypted_web3networks: vec![1u8; 2048],
+			},
 		));
 	});
 }
@@ -156,13 +168,19 @@ fn extrinsic_whitelist_origin_works() {
 		assert_ok!(IdentityManagement::link_identity(
 			RuntimeOrigin::signed(alice.clone()),
 			shard,
-			alice,
+			alice.clone(),
 			vec![1u8; 2048],
 			vec![1u8; 2048],
 			vec![1u8; 2048],
 		));
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
-			crate::Event::LinkIdentityRequested { shard },
+			crate::Event::LinkIdentityRequested {
+				shard,
+				account: alice,
+				encrypted_identity: vec![1u8; 2048],
+				encrypted_validation_data: vec![1u8; 2048],
+				encrypted_web3networks: vec![1u8; 2048],
+			},
 		));
 	});
 }

--- a/tee-worker/app-libs/parentchain-interface/src/integritee/event_filter.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/integritee/event_filter.rs
@@ -22,6 +22,7 @@ use itp_api_client_types::Events;
 use itp_types::{
 	parentchain::{
 		BalanceTransfer, ExtrinsicFailed, ExtrinsicStatus, ExtrinsicSuccess, FilterEvents,
+		LinkIdentityRequested,
 	},
 	H256,
 };
@@ -74,6 +75,23 @@ impl FilterEvents for FilterableEvents {
 			.iter()
 			.flatten() // flatten filters out the nones
 			.filter_map(|ev| match ev.as_event::<BalanceTransfer>() {
+				Ok(maybe_event) => maybe_event,
+				Err(e) => {
+					log::error!("Could not decode event: {:?}", e);
+					None
+				},
+			})
+			.collect())
+	}
+
+	fn get_link_identity_events(
+		&self,
+	) -> core::result::Result<Vec<LinkIdentityRequested>, Self::Error> {
+		Ok(self
+			.to_events()
+			.iter()
+			.flatten()
+			.filter_map(|ev| match ev.as_event::<LinkIdentityRequested>() {
 				Ok(maybe_event) => maybe_event,
 				Err(e) => {
 					log::error!("Could not decode event: {:?}", e);

--- a/tee-worker/app-libs/parentchain-interface/src/integritee/event_handler.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/integritee/event_handler.rs
@@ -15,7 +15,9 @@
 
 */
 
-use codec::Encode;
+use codec::{Decode, Encode};
+
+use sp_std::vec::Vec;
 
 pub use ita_sgx_runtime::{Balance, Index};
 use ita_stf::{Getter, TrustedCall, TrustedCallSigned};
@@ -25,6 +27,7 @@ use itp_types::parentchain::{
 	AccountId, FilterEvents, HandleParentchainEvents, ParentchainError, ParentchainId,
 };
 use litentry_hex_utils::hex_encode;
+use litentry_primitives::{Identity, ValidationData, Web3Network};
 use log::*;
 
 pub struct ParentchainEventHandler {}
@@ -53,6 +56,42 @@ impl ParentchainEventHandler {
 
 		Ok(())
 	}
+
+	fn link_identity<Executor: IndirectExecutor<TrustedCallSigned, Error>>(
+		executor: &Executor,
+		account: &AccountId,
+		encrypted_identity: Vec<u8>,
+		encrypted_validation_data: Vec<u8>,
+		encrypted_web3networks: Vec<u8>,
+	) -> Result<(), Error> {
+		let shard = executor.get_default_shard();
+		let enclave_account_id = executor.get_enclave_account().expect("no enclave account");
+
+		let identity: Identity =
+			Identity::decode(&mut executor.decrypt(&encrypted_identity)?.as_slice())?;
+		let validation_data =
+			ValidationData::decode(&mut executor.decrypt(&encrypted_validation_data)?.as_slice())?;
+		let web3networks: Vec<Web3Network> =
+			Decode::decode(&mut executor.decrypt(&encrypted_web3networks)?.as_slice())?;
+
+		let trusted_call = TrustedCall::link_identity(
+			enclave_account_id.into(),
+			account.clone().into(),
+			identity,
+			validation_data,
+			web3networks,
+			None,
+			Default::default(),
+		);
+		let signed_trusted_call = executor.sign_call_with_self(&trusted_call, &shard)?;
+		let trusted_operation =
+			TrustedOperation::<TrustedCallSigned, Getter>::indirect_call(signed_trusted_call);
+
+		let encrypted_trusted_call = executor.encrypt(&trusted_operation.encode())?;
+		executor.submit_trusted_call(shard, encrypted_trusted_call);
+
+		Ok(())
+	}
 }
 
 impl<Executor> HandleParentchainEvents<Executor, TrustedCallSigned, Error>
@@ -65,12 +104,11 @@ where
 		events: impl FilterEvents,
 		vault_account: &AccountId,
 	) -> Result<(), Error> {
-		let filter_events = events.get_transfer_events();
-		trace!(
-			"filtering transfer events to shard vault account: {}",
-			hex_encode(vault_account.encode().as_slice())
-		);
-		if let Ok(events) = filter_events {
+		if let Ok(events) = events.get_transfer_events() {
+			trace!(
+				"filtering transfer events to shard vault account: {}",
+				hex_encode(vault_account.encode().as_slice())
+			);
 			events
 				.iter()
 				.filter(|&event| event.to == *vault_account)
@@ -82,6 +120,25 @@ where
 				})
 				.map_err(|_| ParentchainError::ShieldFundsFailure)?;
 		}
+
+		debug!("Handling link_identity events");
+
+		if let Ok(events) = events.get_link_identity_events() {
+			events
+				.iter()
+				.try_for_each(|event| {
+					info!("found link_identity_event: {}", event);
+					Self::link_identity(
+						executor,
+						&event.account,
+						event.encrypted_identity.clone(),
+						event.encrypted_validation_data.clone(),
+						event.encrypted_web3networks.clone(),
+					)
+				})
+				.map_err(|_| ParentchainError::LinkIdentityFailure)?;
+		}
+
 		Ok(())
 	}
 }

--- a/tee-worker/app-libs/parentchain-interface/src/integritee/mod.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/integritee/mod.rs
@@ -144,10 +144,6 @@ impl<NodeMetadata: NodeMetadataTrait> FilterIntoDataFrom<NodeMetadata> for Extri
 			let args = decode_and_log_error::<InvokeArgs>(call_args)?;
 			Some(IndirectCall::Invoke(args))
 		// Litentry
-		} else if index == metadata.link_identity_call_indexes().ok()? {
-			let args = decode_and_log_error::<LinkIdentityArgs>(call_args)?;
-			let hashed_extrinsic = xt.hashed_extrinsic;
-			Some(IndirectCall::LinkIdentity(args, address, hashed_extrinsic))
 		} else if index == metadata.deactivate_identity_call_indexes().ok()? {
 			let args = decode_and_log_error::<DeactivateIdentityArgs>(call_args)?;
 			let hashed_extrinsic = xt.hashed_extrinsic;

--- a/tee-worker/app-libs/parentchain-interface/src/target_a/event_filter.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/target_a/event_filter.rs
@@ -22,6 +22,7 @@ use itp_api_client_types::Events;
 use itp_types::{
 	parentchain::{
 		BalanceTransfer, ExtrinsicFailed, ExtrinsicStatus, ExtrinsicSuccess, FilterEvents,
+		LinkIdentityRequested,
 	},
 	H256,
 };
@@ -73,6 +74,23 @@ impl FilterEvents for FilterableEvents {
 			.iter()
 			.flatten() // flatten filters out the nones
 			.filter_map(|ev| match ev.as_event::<BalanceTransfer>() {
+				Ok(maybe_event) => maybe_event,
+				Err(e) => {
+					log::error!("Could not decode event: {:?}", e);
+					None
+				},
+			})
+			.collect())
+	}
+
+	fn get_link_identity_events(
+		&self,
+	) -> core::result::Result<Vec<LinkIdentityRequested>, Self::Error> {
+		Ok(self
+			.to_events()
+			.iter()
+			.flatten()
+			.filter_map(|ev| match ev.as_event::<LinkIdentityRequested>() {
 				Ok(maybe_event) => maybe_event,
 				Err(e) => {
 					log::error!("Could not decode event: {:?}", e);

--- a/tee-worker/app-libs/parentchain-interface/src/target_b/event_filter.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/target_b/event_filter.rs
@@ -22,6 +22,7 @@ use itp_api_client_types::Events;
 use itp_types::{
 	parentchain::{
 		BalanceTransfer, ExtrinsicFailed, ExtrinsicStatus, ExtrinsicSuccess, FilterEvents,
+		LinkIdentityRequested,
 	},
 	H256,
 };
@@ -73,6 +74,23 @@ impl FilterEvents for FilterableEvents {
 			.iter()
 			.flatten() // flatten filters out the nones
 			.filter_map(|ev| match ev.as_event::<BalanceTransfer>() {
+				Ok(maybe_event) => maybe_event,
+				Err(e) => {
+					log::error!("Could not decode event: {:?}", e);
+					None
+				},
+			})
+			.collect())
+	}
+
+	fn get_link_identity_events(
+		&self,
+	) -> core::result::Result<Vec<LinkIdentityRequested>, Self::Error> {
+		Ok(self
+			.to_events()
+			.iter()
+			.flatten()
+			.filter_map(|ev| match ev.as_event::<LinkIdentityRequested>() {
 				Ok(maybe_event) => maybe_event,
 				Err(e) => {
 					log::error!("Could not decode event: {:?}", e);

--- a/tee-worker/cli/src/base_cli/commands/litentry/link_identity.rs
+++ b/tee-worker/cli/src/base_cli/commands/litentry/link_identity.rs
@@ -76,7 +76,7 @@ impl LinkIdentityCommand {
 		);
 
 		let tx_hash = chain_api.submit_and_watch_extrinsic_until(xt, XtStatus::Broadcast).unwrap();
-		info!("[+] LinkIdentityCommand TrustedOperation got finalized. Hash: {:?}", tx_hash);
+		println!("[+] LinkIdentityCommand got finalized. Hash: {:?}", tx_hash);
 
 		Ok(CliResultOk::None)
 	}

--- a/tee-worker/core-primitives/types/src/parentchain.rs
+++ b/tee-worker/core-primitives/types/src/parentchain.rs
@@ -142,6 +142,34 @@ impl StaticEvent for BalanceTransfer {
 }
 
 #[derive(Encode, Decode, Debug)]
+pub struct LinkIdentityRequested {
+	pub shard: ShardIdentifier,
+	pub account: AccountId,
+	pub encrypted_identity: Vec<u8>,
+	pub encrypted_validation_data: Vec<u8>,
+	pub encrypted_web3networks: Vec<u8>,
+}
+
+impl core::fmt::Display for LinkIdentityRequested {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		let message = format!(
+			"LinkIdentityRequested :: shard: {}, account: {}, identity: {:?}, validation_data: {:?}, web3networks: {:?}",
+			self.shard,
+			account_id_to_string::<AccountId>(&self.account),
+			self.encrypted_identity,
+			self.encrypted_validation_data,
+			self.encrypted_web3networks
+		);
+		write!(f, "{}", message)
+	}
+}
+
+impl StaticEvent for LinkIdentityRequested {
+	const PALLET: &'static str = "IdentityManagement";
+	const EVENT: &'static str = "LinkIdentityRequested";
+}
+
+#[derive(Encode, Decode, Debug)]
 pub struct ParentchainBlockProcessed {
 	pub shard: ShardIdentifier,
 	pub block_number: BlockNumber,

--- a/tee-worker/core-primitives/types/src/parentchain.rs
+++ b/tee-worker/core-primitives/types/src/parentchain.rs
@@ -212,6 +212,7 @@ where
 pub enum ParentchainError {
 	ShieldFundsFailure,
 	FunctionalityDisabled,
+	LinkIdentityFailure,
 }
 
 impl core::fmt::Display for ParentchainError {
@@ -219,6 +220,7 @@ impl core::fmt::Display for ParentchainError {
 		let message = match &self {
 			ParentchainError::ShieldFundsFailure => "Parentchain Error: ShieldFundsFailure",
 			ParentchainError::FunctionalityDisabled => "Parentchain Error: FunctionalityDisabled",
+			ParentchainError::LinkIdentityFailure => "Parentchain Error: LinkIdentityFailure",
 		};
 		write!(f, "{}", message)
 	}

--- a/tee-worker/core-primitives/types/src/parentchain.rs
+++ b/tee-worker/core-primitives/types/src/parentchain.rs
@@ -93,6 +93,10 @@ pub trait FilterEvents {
 	fn get_extrinsic_statuses(&self) -> core::result::Result<Vec<ExtrinsicStatus>, Self::Error>;
 
 	fn get_transfer_events(&self) -> core::result::Result<Vec<BalanceTransfer>, Self::Error>;
+
+	fn get_link_identity_events(
+		&self,
+	) -> core::result::Result<Vec<LinkIdentityRequested>, Self::Error>;
 }
 
 #[derive(Encode, Decode, Debug)]

--- a/tee-worker/core/parentchain/block-importer/src/block_importer.rs
+++ b/tee-worker/core/parentchain/block-importer/src/block_importer.rs
@@ -181,7 +181,7 @@ impl<
 			// incl. shielding and unshielding.
 			match self
 				.indirect_calls_executor
-				.execute_indirect_calls_in_extrinsics(&block, &raw_events)
+				.execute_indirect_calls_in_block(&block, &raw_events)
 			{
 				Ok(Some(confirm_processed_parentchain_block_call)) => {
 					calls.push(confirm_processed_parentchain_block_call);

--- a/tee-worker/core/parentchain/indirect-calls-executor/src/executor.rs
+++ b/tee-worker/core/parentchain/indirect-calls-executor/src/executor.rs
@@ -142,7 +142,7 @@ impl<
 	TCS: PartialEq + Encode + Decode + Debug + Clone + Send + Sync + TrustedCallVerification,
 	G: PartialEq + Encode + Decode + Debug + Clone + Send + Sync,
 {
-	fn execute_indirect_calls_in_extrinsics<ParentchainBlock>(
+	fn execute_indirect_calls_in_block<ParentchainBlock>(
 		&self,
 		block: &ParentchainBlock,
 		events: &[u8],
@@ -368,7 +368,7 @@ mod test {
 			.build();
 
 		indirect_calls_executor
-			.execute_indirect_calls_in_extrinsics(&parentchain_block, &Vec::new())
+			.execute_indirect_calls_in_block(&parentchain_block, &Vec::new())
 			.unwrap();
 
 		assert_eq!(1, top_pool_author.pending_tops(shard_id()).unwrap().len());

--- a/tee-worker/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/tee-worker/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -15,7 +15,10 @@ use itp_sgx_runtime_primitives::types::{AccountId, Balance};
 use itp_stf_primitives::{traits::IndirectExecutor, types::Signature};
 use itp_test::mock::stf_mock::{GetterMock, TrustedCallMock, TrustedCallSignedMock};
 use itp_types::{
-	parentchain::{BalanceTransfer, ExtrinsicStatus, FilterEvents, HandleParentchainEvents},
+	parentchain::{
+		BalanceTransfer, ExtrinsicStatus, FilterEvents, HandleParentchainEvents,
+		LinkIdentityRequested,
+	},
 	Address, RsaRequest, ShardIdentifier, H256,
 };
 use log::*;
@@ -173,6 +176,12 @@ impl FilterEvents for MockEvents {
 			amount: Balance::default(),
 		};
 		Ok(Vec::from([transfer]))
+	}
+
+	fn get_link_identity_events(
+		&self,
+	) -> core::result::Result<Vec<LinkIdentityRequested>, Self::Error> {
+		Ok(Vec::new())
 	}
 }
 

--- a/tee-worker/core/parentchain/indirect-calls-executor/src/traits.rs
+++ b/tee-worker/core/parentchain/indirect-calls-executor/src/traits.rs
@@ -28,7 +28,7 @@ pub trait ExecuteIndirectCalls {
 	/// Scans blocks for extrinsics that ask the enclave to execute some actions.
 	/// Executes indirect invocation calls, including shielding and unshielding calls.
 	/// Returns all unshielding call confirmations as opaque calls and the hashes of executed shielding calls.
-	fn execute_indirect_calls_in_extrinsics<ParentchainBlock>(
+	fn execute_indirect_calls_in_block<ParentchainBlock>(
 		&self,
 		block: &ParentchainBlock,
 		events: &[u8],


### PR DESCRIPTION
This is the step to migrating to using events instead of extrinsics as indirect call triggers. I'll be adding one by one in separate PR's to make it easier to review


