### PR TITLE
revert info! back to println!

### DIFF
--- a/tee-worker/service/src/main_impl.rs
+++ b/tee-worker/service/src/main_impl.rs
@@ -240,7 +240,7 @@ pub(crate) fn main() {
 	} else if matches.is_present("signing-key") {
 		setup::generate_signing_key_file(enclave.as_ref());
 		let tee_accountid = enclave_account(enclave.as_ref());
-		info!("Enclave signing account: {:}", &tee_accountid.to_ss58check());
+		println!("Enclave signing account: {:}", &tee_accountid.to_ss58check());
 	} else if matches.is_present("dump-ra") {
 		info!("*** Perform RA and dump cert to disk");
 		#[cfg(not(feature = "dcap"))]


### PR DESCRIPTION
very minor change, but `info!` can't be catched within shell script.