### PR TITLE
Do not monitor writable events for ws server

### DIFF
--- a/tee-worker/core/tls-websocket-server/src/connection.rs
+++ b/tee-worker/core/tls-websocket-server/src/connection.rs
@@ -94,6 +94,7 @@ where
 				match tls_session.process_new_packets() {
 					Ok(_) => {
 						if tls_session.is_handshaking() {
+							trace!("TLS session is in handshake");
 							return ConnectionState::TlsHandshake
 						}
 						ConnectionState::Alive

--- a/tee-worker/core/tls-websocket-server/src/lib.rs
+++ b/tee-worker/core/tls-websocket-server/src/lib.rs
@@ -158,7 +158,6 @@ pub(crate) trait WebSocketConnection: Send + Sync {
 		match self.socket() {
 			Some(s) => {
 				poll.deregister(s)?;
-
 				Ok(())
 			},
 			None => Err(WebSocketError::ConnectionClosed),

--- a/tee-worker/core/tls-websocket-server/src/lib.rs
+++ b/tee-worker/core/tls-websocket-server/src/lib.rs
@@ -153,4 +153,15 @@ pub(crate) trait WebSocketConnection: Send + Sync {
 			None => Err(WebSocketError::ConnectionClosed),
 		}
 	}
+
+	fn deregister(&mut self, poll: &mio::Poll) -> WebSocketResult<()> {
+		match self.socket() {
+			Some(s) => {
+				poll.deregister(s)?;
+
+				Ok(())
+			},
+			None => Err(WebSocketError::ConnectionClosed),
+		}
+	}
 }

--- a/tee-worker/core/tls-websocket-server/src/stream_state.rs
+++ b/tee-worker/core/tls-websocket-server/src/stream_state.rs
@@ -54,7 +54,7 @@ impl<S: Read + Write> MaybeServerTlsStream<S> {
 
 	pub fn wants_write(&self) -> bool {
 		match self {
-			MaybeServerTlsStream::Plain(_) => true,
+			MaybeServerTlsStream::Plain(_) => false, // do not monitor writable events for non-tls server
 			MaybeServerTlsStream::Rustls(s) => s.sess.wants_write(),
 		}
 	}

--- a/tee-worker/core/tls-websocket-server/src/ws_server.rs
+++ b/tee-worker/core/tls-websocket-server/src/ws_server.rs
@@ -122,6 +122,7 @@ where
 
 			if connection.is_closed() {
 				trace!("Connection {:?} is closed, removing", token);
+				connection.deregister(poll)?;
 				connections_lock.remove(&token);
 				trace!(
 					"Closed {:?}, {} active connections remaining",

--- a/ts-tests/integration-tests/evm-contract.test.ts
+++ b/ts-tests/integration-tests/evm-contract.test.ts
@@ -178,7 +178,7 @@ describeLitentry('Test EVM Module Contract', ``, (context) => {
             console.log(`Tx successful with hash: ${createReceipt.transactionHash}`);
         };
         const setMsg = await setMessage(deployed.contractAddress!, evmAccountRaw, 'Goodbye World');
-        const sayMsg = await sayMessage(deployed.contractAddress!)
+        const sayMsg = await sayMessage(deployed.contractAddress!);
         const setResult = sayMsg === 'Goodbye World' ? 1 : 0;
         assert.equal(1, setResult, 'Contract modified storage query mismatch');
 


### PR DESCRIPTION
### Context

As topic, otherwise we are trapped in an endless loop of writable readiness, which causes 100% cpu.

So IMO we shouldn't monitor the writable event as there's no case that server proactively writes something after the handshake (and even if there is we don't want to handle it)

This PR adds the `deregister` call too.

This PR **might** fix the multi-worker CI failure - or at least a remedy for it.


