### PR TITLE
feat: P-675 VC generation will use all identity-dependent web3 networks

### DIFF
--- a/tee-worker/litentry/pallets/identity-management/src/identity_context.rs
+++ b/tee-worker/litentry/pallets/identity-management/src/identity_context.rs
@@ -94,7 +94,7 @@ pub fn get_eligible_identities<T: Config>(
 		.iter()
 		.filter_map(|item| {
 			if item.1.is_active() {
-				let mut networks = item.1.web3networks.to_vec();
+				let mut networks = item.0.default_web3networks();
 				// filter out identities whose web3networks are not supported by this specific `assertion`.
 				// We do it here before every request sending because:
 				// - it's a common step for all assertion buildings, for those assertions which only


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

We used to check if user has enabled some networks before VC generation can use it, now we will ignore that setting and simply us all of user's relevant identity for  all networks that we supported for the VC to be generated. 

This change doesn't modify the api interface so it's a non breaking changes to client.

This is a only phase 1 of the change, where phase 2 we may still add support for disable some of the networks for  an  identity so user has  option to use all of them. although for now the only client, IDH, prefers to use all networks for all users. In phase 2 there might be bigger breaking changes so we will do it separately.

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


link-identity: only link evm identity with polygon
```
cargo run --bin litentry-cli  --features development -- trusted -d link-identity did:litentry:substrate:0xd4e35b16ec6b417386b948e7eaf5cc642a243096cecf366e6313689b90969f42 did:litentry:evm:0x9F8cCdaFCc39F3c7D6EBf637c9151673CBc36b88
polygon
```

request-vc: bnb support bsc and ethereum, so call eth-mainnet and bsc-mainnet to get balance
```
cargo run --bin litentry-cli  --features development -- trusted -d request-vc did:litentry:substrate:0xd4e35b16ec6b417386b948e7eaf5cc642a243096cecf366e6313689b90969f42 -a "token-holding-amount bnb"
```
logs:
<img width="572" alt="Screenshot 2024-04-10 at 11 30 42 am" src="https://github.com/litentry/litentry-parachain/assets/120463031/8f1db4ea-b0fe-4561-ae24-2b11a3ea3294">


the resulting vc json:
```
{
   "@context":[
      "https://www.w3.org/2018/credentials/v1",
      "https://w3id.org/security/suites/ed25519-2020/v1"
   ],
   "id":"0xfcf45d96994e2a7ad908452bce0c2c2e9380e150d82fa24067de390766d32566",
   "type":[
      "VerifiableCredential"
   ],
   "credentialSubject":{
      "id":"did:litentry:substrate:0xd4e35b16ec6b417386b948e7eaf5cc642a243096cecf366e6313689b90969f42",
      "description":"The amount of a particular token you are holding",
      "type":"Token Holding Amount",
      "assertionText":"TokenHoldingAmount(Bnb)",
      "assertions":[
         {
            "and":[
               {
                  "src":"$token",
                  "op":"==",
                  "dst":"BNB"
               },
               {
                  "or":[
                     {
                        "and":[
                           {
                              "src":"$network",
                              "op":"==",
                              "dst":"bsc"
                           }
                        ]
                     },
                     {
                        "and":[
                           {
                              "src":"$network",
                              "op":"==",
                              "dst":"ethereum"
                           },
                           {
                              "src":"$address",
                              "op":"==",
                              "dst":"0xb8c77482e45f1f44de1745f52c74426c631bdd52"
                           }
                        ]
                     }
                  ]
               },
               {
                  "src":"$holding_amount",
                  "op":">=",
                  "dst":"0"
               },
               {
                  "src":"$holding_amount",
                  "op":"<",
                  "dst":"1"
               }
            ]
         }
      ],
      "values":[
         false
      ],
      "endpoint":"http://localhost:9933/"
   },
   "issuer":{
      "id":"did:litentry:substrate:0xbcbc6dc9fc214b1d9bca7fa35b86a009c9ffb8c1520c479750884a72a7d71e96",
      "name":"Litentry TEE Worker",
      "mrenclave":"5kb5EwbfLk7T32fuZgosxmUEjJ2Ewd633q4CW9QmGEV4"
   },
   "issuanceDate":"2024-10-05T09:30:29.855597607+00:00",
   "parachainBlockNumber":1342,
   "sidechainBlockNumber":2698,
   "proof":{
      "created":"2024-04-10T09:30:29.857622014+00:00",
      "type":"Ed25519Signature2020",
      "proofPurpose":"assertionMethod",
      "proofValue":"d9176e9b0c34a27a52d456b25153d5d768f8cc3a81c2ad43f6fea5322c2600e56be3f11f9ec1eb78d5bcccfde7e955abba44facb3eaf281a4d42a08469f0a602",
      "verificationMethod":"0xbcbc6dc9fc214b1d9bca7fa35b86a009c9ffb8c1520c479750884a72a7d71e96"
   },
   "credentialSchema":{
      "id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/21-evm-holding-amount/1-0-0.json",
      "type":"JsonSchemaValidator2018"
   }
}
```