### PR TITLE
Fix evm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,9 @@ jobs:
           echo "::group::cargo clippy sidechain"
           cargo clippy --release --features sidechain,development -- -D warnings
           echo "::endgroup::"
+          echo "::group::cargo clippy evm"
+          cargo clippy --release --features evm,development -- -D warnings
+          echo "::endgroup::"          
           echo "::group::cargo clippy offchain-worker"
           cargo clean --profile release
           cargo clippy --release --features offchain-worker,development -- -D warnings

--- a/tee-worker/app-libs/sgx-runtime/src/lib.rs
+++ b/tee-worker/app-libs/sgx-runtime/src/lib.rs
@@ -326,6 +326,8 @@ construct_runtime!(
 		TransactionPayment: pallet_transaction_payment,
 		Sudo: pallet_sudo,
 		ParentchainLitentry: pallet_parentchain::<Instance1>,
+		ParentchainTargetA: pallet_parentchain::<Instance2>,
+		ParentchainTargetB: pallet_parentchain::<Instance3>,
 		IdentityManagement: pallet_imt,
 		Evm: pallet_evm,
 	}


### PR DESCRIPTION
The build for `evm` feature is broken again. There is a check for that in `scripts/pre-commit.sh` script but CI does not ensure code correctness.

This PR:
* fixes `evm` build
* adds `evm` feature check to CI