### PR TITLE
chore: add missing tests in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,6 +776,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - test_name: lit-di-bitcoin-identity-multiworker-test
           - test_name: lit-di-evm-identity-multiworker-test
           - test_name: lit-di-solana-identity-multiworker-test
           - test_name: lit-di-substrate-identity-multiworker-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -777,6 +777,7 @@ jobs:
       matrix:
         include:
           - test_name: lit-di-evm-identity-multiworker-test
+          - test_name: lit-di-solana-identity-multiworker-test
           - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-di-vc-multiworker-test
           - test_name: lit-dr-vc-multiworker-test

--- a/tee-worker/docker/lit-di-bitcoin-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-bitcoin-identity-multiworker-test.yml
@@ -1,0 +1,28 @@
+services:
+    lit-di-bitcoin-identity-multiworker-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-di-bitcoin-identity-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_bitcoin_identity.test.ts 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge

--- a/tee-worker/docker/lit-di-solana-identity-multiworker-test.yml
+++ b/tee-worker/docker/lit-di-solana-identity-multiworker-test.yml
@@ -1,0 +1,28 @@
+services:
+    lit-di-solana-identity-multiworker-test:
+        image: litentry/litentry-cli:latest
+        container_name: litentry-di-solana-identity-test
+        volumes:
+            - ../ts-tests:/ts-tests
+            - ../client-api:/client-api
+            - ../cli:/usr/local/worker-cli
+        build:
+            context: ..
+            dockerfile: build.Dockerfile
+            target: deployed-client
+        depends_on:
+            litentry-node:
+                condition: service_healthy
+            litentry-worker-1:
+                condition: service_healthy
+            litentry-worker-2:
+                condition: service_healthy
+            litentry-worker-3:
+                condition: service_healthy
+        networks:
+            - litentry-test-network
+        entrypoint: "bash -c '/usr/local/worker-cli/lit_ts_integration_test.sh di_solana_identity.test.ts 2>&1' "
+        restart: "no"
+networks:
+    litentry-test-network:
+        driver: bridge


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

as titles

added all ts tests for multi-worker tests too
also renamed bit to make the unique test name to show in ci:

<img width="1077" alt="Screenshot 2024-04-12 at 12 14 36 pm" src="https://github.com/litentry/litentry-parachain/assets/120463031/762d0fca-259a-4a24-8269-4f2453c4538b">

<img width="1040" alt="Screenshot 2024-04-12 at 1 36 10 pm" src="https://github.com/litentry/litentry-parachain/assets/120463031/1b5eb3d7-d001-4321-80d6-91dc80a548a5">


### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement



### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


