### PR TITLE
Fix bc-worker build

### DIFF
--- a/bitacross-worker/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/bitacross-worker/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -49,7 +49,9 @@ use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{DirectRequestStatus, RsaRequest, ShardIdentifier, H256};
 use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use jsonrpc_core::{serde_json::json, IoHandler, Params, Value};
-use lc_scheduled_enclave::{ScheduledEnclaveUpdater, GLOBAL_SCHEDULED_ENCLAVE};
+#[cfg(feature = "development")]
+use lc_scheduled_enclave::ScheduledEnclaveUpdater;
+use lc_scheduled_enclave::GLOBAL_SCHEDULED_ENCLAVE;
 use litentry_macros::if_development;
 use litentry_primitives::{AesRequest, DecryptableRequest};
 use log::debug;

--- a/bitacross-worker/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/bitacross-worker/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -49,7 +49,7 @@ use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{DirectRequestStatus, RsaRequest, ShardIdentifier, H256};
 use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use jsonrpc_core::{serde_json::json, IoHandler, Params, Value};
-use lc_scheduled_enclave::GLOBAL_SCHEDULED_ENCLAVE;
+use lc_scheduled_enclave::{ScheduledEnclaveUpdater, GLOBAL_SCHEDULED_ENCLAVE};
 use litentry_macros::if_development;
 use litentry_primitives::{AesRequest, DecryptableRequest};
 use log::debug;


### PR DESCRIPTION
### Context
this PR fixes missing usage of type

```rs
   --> src/rpc/worker_api_direct.rs:346:46
    |
346 | ...                   return match GLOBAL_SCHEDULED_ENCLAVE.update(bn, enclave_to_set) {
    |                                                             ^^^^^^ method not found in `GLOBAL_SCHEDULED_ENCLAVE`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
18  | use lc_scheduled_enclave::ScheduledEnclaveUpdater;
 ```

was broken by [this PR](https://github.com/litentry/litentry-parachain/pull/2620/files#diff-be10719c49f6f4fc36bc4b54ffda6f5a023254abf927033cd2b93396b8a027dcR52)
