### PR TITLE
Litentry parachain launch fix

### DIFF
--- a/docker/package.json
+++ b/docker/package.json
@@ -9,5 +9,6 @@
   },
   "dependencies": {
     "@open-web3/parachain-launch": "github:Kailai-Wang/parachain-launch#87874c95b1738cb3f2a9fa1beef599a3b7dbfaf0"
-  }
+  },
+  "packageManager": "pnpm@8.7.6"
 }

--- a/docker/package.json
+++ b/docker/package.json
@@ -4,7 +4,7 @@
   "main": "",
   "license": "GPL-3.0",
   "scripts": {
-    "build": "cd node_modules/@open-web3/parachain-launch && corepack yarn install && corepack yarn run build",
+    "build": "cd node_modules/@open-web3/parachain-launch && corepack pnpm install && corepack pnpm run build",
     "start": "node_modules/.bin/parachain-launch"
   },
   "dependencies": {


### PR DESCRIPTION
Recently we encoutered few CI failures:

https://github.com/litentry/litentry-parachain/actions/runs/8714290367/job/23904372197


This PR attempts to fix this by:

* changing `yarn` to `pnpm` in `litentry-parachain-launch`
* specifying `packageManager` for `litentry-parachain-launch`
