### PR TITLE
Fix multi worker scheduled enclave test 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,37 +800,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - test_name: lit-di-bitcoin-identity-multiworker-test
-          # - test_name: lit-di-evm-identity-multiworker-test
-          # - test_name: lit-di-solana-identity-multiworker-test
-          # - test_name: lit-di-substrate-identity-multiworker-test
-          # - test_name: lit-di-vc-multiworker-test
-          # - test_name: lit-dr-vc-multiworker-test
-          # - test_name: lit-resume-worker
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
-          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-di-bitcoin-identity-multiworker-test
+          - test_name: lit-di-evm-identity-multiworker-test
+          - test_name: lit-di-solana-identity-multiworker-test
+          - test_name: lit-di-substrate-identity-multiworker-test
+          - test_name: lit-di-vc-multiworker-test
+          - test_name: lit-dr-vc-multiworker-test
+          - test_name: lit-resume-worker
           - test_name: lit-scheduled-enclave-multiworker-test
     steps:
       - uses: actions/checkout@v4
@@ -868,7 +844,7 @@ jobs:
           docker compose -f litentry-parachain.build.yml build
 
       - name: Integration multi worker test ${{ matrix.test_name }}
-        # if: needs.set-condition.outputs.run_tee_test == 'true'
+        if: needs.set-condition.outputs.run_tee_test == 'true'
         timeout-minutes: 40
         run: |
           cd tee-worker/docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::cargo clippy offchain-worker develpment"
           cargo clippy --release --features offchain-worker,development -- -D warnings
-          echo "::endgroup::"                                        
+          echo "::endgroup::"
 
       - name: Clean up disk
         working-directory: ./tee-worker
@@ -323,7 +323,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::cargo clippy offchain-worker develpment"
           cargo clippy --release --features offchain-worker,development -- -D warnings
-          echo "::endgroup::"                                        
+          echo "::endgroup::"
 
       - name: Fail early
         if: failure()
@@ -800,13 +800,37 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_name: lit-di-bitcoin-identity-multiworker-test
-          - test_name: lit-di-evm-identity-multiworker-test
-          - test_name: lit-di-solana-identity-multiworker-test
-          - test_name: lit-di-substrate-identity-multiworker-test
-          - test_name: lit-di-vc-multiworker-test
-          - test_name: lit-dr-vc-multiworker-test
-          - test_name: lit-resume-worker
+          # - test_name: lit-di-bitcoin-identity-multiworker-test
+          # - test_name: lit-di-evm-identity-multiworker-test
+          # - test_name: lit-di-solana-identity-multiworker-test
+          # - test_name: lit-di-substrate-identity-multiworker-test
+          # - test_name: lit-di-vc-multiworker-test
+          # - test_name: lit-dr-vc-multiworker-test
+          # - test_name: lit-resume-worker
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
+          - test_name: lit-scheduled-enclave-multiworker-test
           - test_name: lit-scheduled-enclave-multiworker-test
     steps:
       - uses: actions/checkout@v4
@@ -844,7 +868,7 @@ jobs:
           docker compose -f litentry-parachain.build.yml build
 
       - name: Integration multi worker test ${{ matrix.test_name }}
-        if: needs.set-condition.outputs.run_tee_test == 'true'
+        # if: needs.set-condition.outputs.run_tee_test == 'true'
         timeout-minutes: 40
         run: |
           cd tee-worker/docker

--- a/tee-worker/ts-tests/integration-tests/scheduled_enclave.test.ts
+++ b/tee-worker/ts-tests/integration-tests/scheduled_enclave.test.ts
@@ -62,7 +62,7 @@ describe('Scheduled Enclave', function () {
         const validMrEnclave = '97f516a61ff59c5eab74b8a9b1b7273d6986b9c0e6c479a4010e22402ca7cee6';
 
         await setScheduledEnclave(context.api, expectedBlockNumber, validMrEnclave);
-        const timeSpanForWorkersSync = 0;
+        const timeSpanForWorkersSync = 2;
         await waitForBlock(context.api, expectedBlockNumber + timeSpanForWorkersSync);
 
         response = await callRPC(buildRequest('state_getScheduledEnclave'));

--- a/tee-worker/ts-tests/integration-tests/scheduled_enclave.test.ts
+++ b/tee-worker/ts-tests/integration-tests/scheduled_enclave.test.ts
@@ -52,7 +52,7 @@ describe('Scheduled Enclave', function () {
             string
         ][];
 
-        assert.equal(scheduledEnclaveList.length, 1);
+        assert.equal(scheduledEnclaveList.length, 1, 'Initial number of enclave should be 1');
 
         // set new mrenclave
         const lastBlock = await context.api.rpc.chain.getBlock();
@@ -62,7 +62,8 @@ describe('Scheduled Enclave', function () {
         const validMrEnclave = '97f516a61ff59c5eab74b8a9b1b7273d6986b9c0e6c479a4010e22402ca7cee6';
 
         await setScheduledEnclave(context.api, expectedBlockNumber, validMrEnclave);
-        await waitForBlock(context.api, expectedBlockNumber);
+        const timeSpanForWorkersSync = 0;
+        await waitForBlock(context.api, expectedBlockNumber + timeSpanForWorkersSync);
 
         response = await callRPC(buildRequest('state_getScheduledEnclave'));
         scheduledEnclaveList = context.api.createType('Vec<(u64, [u8; 32])>', response.value).toJSON() as [


### PR DESCRIPTION
### Context

test failed because workers have to sync state and it might take a bit of time, where test was designed to check immediately a the block for scheduled enclave. This PR fixes the the test by increasing awaiting time

### Testing Evidences

Before https://github.com/litentry/litentry-parachain/actions/runs/8936500614
After https://github.com/litentry/litentry-parachain/actions/runs/8936891499


