### PR TITLE
Fix crate unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,8 @@ jobs:
         working-directory: ./tee-worker
         run: |
           cargo test --release -p pallet-* --lib
+          cargo test --release -p lc-* --lib
+          cargo test --release -p litentry-primitives --lib
 
       - name: Tee-worker clippy
         working-directory: ./tee-worker

--- a/tee-worker/app-libs/stf/src/getter.rs
+++ b/tee-worker/app-libs/stf/src/getter.rs
@@ -15,6 +15,7 @@
 
 */
 
+use crate::{println, vec, String, ToString, Vec};
 use codec::{Decode, Encode};
 use ita_sgx_runtime::{IdentityManagement, System};
 use itp_stf_interface::ExecuteGetter;
@@ -25,8 +26,6 @@ use litentry_macros::if_development_or;
 use litentry_primitives::{Identity, LitentryMultiSignature};
 use log::*;
 use sp_core::blake2_256;
-use sp_std::vec;
-use std::prelude::v1::*;
 
 #[cfg(feature = "evm")]
 use ita_sgx_runtime::{AddressMapping, HashedAddressMapping};
@@ -218,7 +217,7 @@ impl ExecuteGetter for TrustedGetterSigned {
 					let info = System::account(&account_id);
 					debug!("TrustedGetter free_balance");
 					debug!("AccountInfo for {} is {:?}", account_id_to_string(&who), info);
-					std::println!("⣿STF⣿ 🔍 TrustedGetter query: free balance for ⣿⣿⣿ is ⣿⣿⣿",);
+					println!("⣿STF⣿ 🔍 TrustedGetter query: free balance for ⣿⣿⣿ is ⣿⣿⣿",);
 					Some(info.data.free.encode())
 				} else {
 					None

--- a/tee-worker/app-libs/stf/src/helpers.rs
+++ b/tee-worker/app-libs/stf/src/helpers.rs
@@ -14,7 +14,7 @@
 	limitations under the License.
 
 */
-use crate::ENCLAVE_ACCOUNT_KEY;
+use crate::{Vec, ENCLAVE_ACCOUNT_KEY};
 use codec::{Decode, Encode};
 use frame_support::ensure;
 use ita_sgx_runtime::{ParentchainLitentry, ParentchainTargetA, ParentchainTargetB};
@@ -29,7 +29,6 @@ use itp_utils::stringify::account_id_to_string;
 use litentry_primitives::{ErrorDetail, Identity, Web3ValidationData};
 use log::*;
 use sp_core::blake2_256;
-use std::prelude::v1::*;
 
 #[cfg(feature = "development")]
 pub use non_prod::*;

--- a/tee-worker/app-libs/stf/src/lib.rs
+++ b/tee-worker/app-libs/stf/src/lib.rs
@@ -29,6 +29,12 @@ extern crate core;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
+use sp_std::{boxed::Box, vec, vec::Vec};
+use std::{
+	convert::From, fmt::Debug, format, marker::PhantomData, prelude::v1::*, println,
+	string::ToString, sync::Arc,
+};
+
 pub use getter::*;
 pub use stf_sgx_primitives::{types::*, Stf};
 pub use trusted_call::*;

--- a/tee-worker/app-libs/stf/src/stf_sgx.rs
+++ b/tee-worker/app-libs/stf/src/stf_sgx.rs
@@ -18,8 +18,9 @@
 #[cfg(feature = "test")]
 use crate::test_genesis::test_genesis_setup;
 use crate::{
+	format,
 	helpers::{enclave_signer_account, get_shard_vaults, shard_creation_info, shard_vault},
-	Stf, ENCLAVE_ACCOUNT_KEY,
+	vec, Arc, Box, Debug, From, Stf, Vec, ENCLAVE_ACCOUNT_KEY,
 };
 use codec::{Decode, Encode};
 use frame_support::traits::{OriginTrait, UnfilteredDispatchable};
@@ -47,15 +48,13 @@ use itp_types::{
 use itp_utils::stringify::account_id_to_string;
 use log::*;
 use sp_runtime::traits::StaticLookup;
-use std::{fmt::Debug, format, prelude::v1::*, sync::Arc, vec};
 
 impl<TCS, G, State, Runtime, AccountId> InitState<State, AccountId> for Stf<TCS, G, State, Runtime>
 where
 	State: SgxExternalitiesTrait + Debug,
 	<State as SgxExternalitiesTrait>::SgxExternalitiesType: core::default::Default,
 	Runtime: frame_system::Config<AccountId = AccountId> + pallet_balances::Config,
-	<<Runtime as frame_system::Config>::Lookup as StaticLookup>::Source:
-		std::convert::From<AccountId>,
+	<<Runtime as frame_system::Config>::Lookup as StaticLookup>::Source: From<AccountId>,
 	AccountId: Encode,
 {
 	fn init_state(enclave_account: AccountId) -> State {

--- a/tee-worker/app-libs/stf/src/stf_sgx_primitives.rs
+++ b/tee-worker/app-libs/stf/src/stf_sgx_primitives.rs
@@ -15,7 +15,7 @@
 
 */
 
-use std::marker::PhantomData;
+use crate::PhantomData;
 
 pub mod types {
 	pub use itp_types::{AccountData, AccountInfo, BlockNumber, Header as ParentchainHeader};

--- a/tee-worker/app-libs/stf/src/trusted_call.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call.rs
@@ -19,19 +19,17 @@
 use sp_core::{H160, U256};
 
 #[cfg(feature = "evm")]
-use std::vec::Vec;
-
-#[cfg(feature = "evm")]
 use crate::evm_helpers::{create_code_hash, evm_create2_address, evm_create_address};
 #[cfg(feature = "development")]
 use crate::helpers::ensure_enclave_signer_or_alice;
 use crate::{
+	format,
 	helpers::{enclave_signer_account, ensure_enclave_signer_account, ensure_self},
 	trusted_call_result::{
 		ActivateIdentityResult, DeactivateIdentityResult, RequestVCResult,
 		SetIdentityNetworksResult, TrustedCallResult,
 	},
-	Getter,
+	Arc, Getter, String, ToString, Vec,
 };
 use codec::{Decode, Encode};
 use frame_support::{ensure, traits::UnfilteredDispatchable};
@@ -67,7 +65,6 @@ use sp_core::{
 };
 use sp_io::hashing::blake2_256;
 use sp_runtime::{traits::ConstU32, BoundedVec, MultiAddress};
-use std::{format, prelude::v1::*, sync::Arc};
 
 pub type IMTCall = ita_sgx_runtime::IdentityManagementCall<Runtime>;
 pub type IMT = ita_sgx_runtime::pallet_imt::Pallet<Runtime>;

--- a/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
+++ b/tee-worker/app-libs/stf/src/trusted_call_litentry.rs
@@ -24,6 +24,7 @@ use crate::{
 		verify_web3_identity,
 	},
 	trusted_call_result::{LinkIdentityResult, TrustedCallResult},
+	Arc, Vec,
 };
 use codec::Encode;
 use frame_support::{dispatch::UnfilteredDispatchable, ensure, sp_runtime::traits::One};
@@ -49,7 +50,6 @@ use litentry_primitives::{
 	Assertion, ErrorDetail, Identity, RequestAesKey, ValidationData, Web3Network,
 };
 use log::*;
-use std::{sync::Arc, vec::Vec};
 
 #[cfg(feature = "development")]
 use crate::helpers::{ensure_alice, ensure_enclave_signer_or_alice};

--- a/tee-worker/core-primitives/enclave-metrics/Cargo.toml
+++ b/tee-worker/core-primitives/enclave-metrics/Cargo.toml
@@ -18,9 +18,11 @@ substrate-fixed = { default-features = false, git = "https://github.com/encointe
 [features]
 default = ["std"]
 std = [
-    "substrate-fixed/std",
     "codec/std",
+    "lc-stf-task-sender/std",
+    "substrate-fixed/std",
 ]
 sgx = [
     "sgx_tstd",
+    "lc-stf-task-sender/sgx",
 ]

--- a/tee-worker/core/parentchain/indirect-calls-executor/Cargo.toml
+++ b/tee-worker/core/parentchain/indirect-calls-executor/Cargo.toml
@@ -77,6 +77,8 @@ std = [
     # litentry
     "litentry-primitives/std",
     "itp-utils/std",
+    "parachain-core-primitives/std",
+    "sp-std/std",
     "lc-scheduled-enclave/std",
 ]
 sgx = [

--- a/tee-worker/litentry/core/identity-verification/src/web2/mod.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web2/mod.rs
@@ -17,9 +17,6 @@
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-#[cfg(all(not(feature = "std"), feature = "sgx"))]
-use crate::sgx_reexport_prelude::*;
-
 #[cfg(all(feature = "std", feature = "sgx"))]
 compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
 

--- a/tee-worker/litentry/core/identity-verification/src/web2/twitter/helpers.rs
+++ b/tee-worker/litentry/core/identity-verification/src/web2/twitter/helpers.rs
@@ -2,8 +2,6 @@
 extern crate sgx_rand as rand;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
-#[cfg(all(not(feature = "std"), feature = "sgx"))]
-use crate::sgx_reexport_prelude::*;
 
 use rand::{thread_rng, Rng};
 use std::{string::String, vec::Vec};

--- a/tee-worker/litentry/core/stf-task/receiver/Cargo.toml
+++ b/tee-worker/litentry/core/stf-task/receiver/Cargo.toml
@@ -51,6 +51,7 @@ itp-test = { path = "../../../../core-primitives/test" }
 itp-top-pool-author = { path = "../../../../core-primitives/top-pool-author", features = ["mocks"] }
 itp-top-pool = { path = "../../../../core-primitives/top-pool", features = ["mocks"] }
 itp-stf-executor = { path = "../../../../core-primitives/stf-executor", features = ["mocks"] }
+itp-sgx-crypto = { path = "../../../../core-primitives/sgx/crypto", features = ["mocks"] }
 base58 = "0.2"
 jsonrpc-core = { version = "18" }
 lazy_static = { version = "1.1.0" }
@@ -82,6 +83,7 @@ std = [
     "futures",
     "log/std",
     "thiserror",
+    "ita-stf/std",
     "itc-peer-top-broadcaster/std",
     "itp-types/std",
     "itp-top-pool-author/std",

--- a/tee-worker/litentry/core/stf-task/sender/src/error.rs
+++ b/tee-worker/litentry/core/stf-task/sender/src/error.rs
@@ -17,7 +17,7 @@
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 use crate::sgx_reexport_prelude::*;
 
-use std::boxed::Box;
+use crate::{Box, StdError};
 
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -29,5 +29,5 @@ pub enum Error {
 	#[error("Could not access Mutex")]
 	MutexAccess,
 	#[error(transparent)]
-	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
+	Other(#[from] Box<dyn StdError + Sync + Send + 'static>),
 }

--- a/tee-worker/litentry/core/stf-task/sender/src/lib.rs
+++ b/tee-worker/litentry/core/stf-task/sender/src/lib.rs
@@ -42,9 +42,13 @@ pub use request::*;
 use std::sync::Mutex;
 #[cfg(feature = "sgx")]
 use std::sync::SgxMutex as Mutex;
-use std::sync::{
-	mpsc::{channel, Receiver, Sender},
-	Arc,
+use std::{
+	boxed::Box,
+	error::Error as StdError,
+	sync::{
+		mpsc::{channel, Receiver, Sender},
+		Arc,
+	},
 };
 
 pub type StfSender = Sender<RequestType>;

--- a/tee-worker/litentry/core/vc-task/receiver/Cargo.toml
+++ b/tee-worker/litentry/core/vc-task/receiver/Cargo.toml
@@ -76,6 +76,7 @@ sgx = [
 std = [
     "futures",
     "log/std",
+    "ita-stf/std",
     "itp-types/std",
     "itp-top-pool-author/std",
     "itp-stf-executor/std",


### PR DESCRIPTION
### Context

This PR adds the crate unit tests under `tee-worker/litentry/` into CI and fixes them:

```
        working-directory: ./tee-worker
        run: |
          cargo test --release -p pallet-* --lib
          cargo test --release -p lc-* --lib
          cargo test --release -p litentry-primitives --lib
```