### PR TITLE
fix mrenclave bitacross init

### DIFF
--- a/bitacross-worker/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/bitacross-worker/core-primitives/enclave-api/ffi/src/lib.rs
@@ -270,4 +270,6 @@ extern "C" {
 
 	pub fn publish_wallets(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
 
+	pub fn finish_enclave_init(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
+
 }

--- a/bitacross-worker/core-primitives/enclave-api/src/enclave_base.rs
+++ b/bitacross-worker/core-primitives/enclave-api/src/enclave_base.rs
@@ -94,6 +94,9 @@ pub trait EnclaveBase: Send + Sync + 'static {
 
 	/// Publish generated wallets on parachain
 	fn publish_wallets(&self) -> EnclaveResult<()>;
+
+	// finish enclave initialization
+	fn finish_enclave_init(&self) -> EnclaveResult<()>;
 }
 
 /// EnclaveApi implementation for Enclave struct
@@ -473,6 +476,17 @@ mod impl_ffi {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
 
 			let result = unsafe { ffi::publish_wallets(self.eid, &mut retval) };
+
+			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+			Ok(())
+		}
+
+		fn finish_enclave_init(&self) -> EnclaveResult<()> {
+			let mut retval = sgx_status_t::SGX_SUCCESS;
+
+			let result = unsafe { ffi::finish_enclave_init(self.eid, &mut retval) };
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));

--- a/bitacross-worker/enclave-runtime/Enclave.edl
+++ b/bitacross-worker/enclave-runtime/Enclave.edl
@@ -45,6 +45,8 @@ enclave {
 
 		public sgx_status_t publish_wallets();
 
+		public sgx_status_t finish_enclave_init();		
+
 		public sgx_status_t init_direct_invocation_server(
 			[in, size=server_addr_size] uint8_t* server_addr, uint32_t server_addr_size
 		);

--- a/bitacross-worker/enclave-runtime/src/initialization/mod.rs
+++ b/bitacross-worker/enclave-runtime/src/initialization/mod.rs
@@ -228,6 +228,14 @@ pub(crate) fn init_enclave(
 	Ok(())
 }
 
+pub(crate) fn finish_enclave_init() -> EnclaveResult<()> {
+	let attestation_handler = GLOBAL_ATTESTATION_HANDLER_COMPONENT.get()?;
+	let mrenclave = attestation_handler.get_mrenclave()?;
+	GLOBAL_SCHEDULED_ENCLAVE.init(mrenclave).map_err(|e| Error::Other(e.into()))?;
+
+	Ok(())
+}
+
 pub(crate) fn publish_wallets() -> EnclaveResult<()> {
 	let metadata_repository = get_node_metadata_repository_from_integritee_solo_or_parachain()?;
 	let extrinsics_factory = get_extrinsic_factory_from_integritee_solo_or_parachain()?;
@@ -288,10 +296,6 @@ fn run_bit_across_handler() -> Result<(), Error> {
 	let shielding_key_repository = GLOBAL_SHIELDING_KEY_REPOSITORY_COMPONENT.get()?;
 	let ethereum_key_repository = GLOBAL_ETHEREUM_KEY_REPOSITORY_COMPONENT.get()?;
 	let bitcoin_key_repository = GLOBAL_BITCOIN_KEY_REPOSITORY_COMPONENT.get()?;
-
-	let attestation_handler = GLOBAL_ATTESTATION_HANDLER_COMPONENT.get()?;
-	let mrenclave = attestation_handler.get_mrenclave()?;
-	GLOBAL_SCHEDULED_ENCLAVE.init(mrenclave).map_err(|e| Error::Other(e.into()))?;
 
 	#[allow(clippy::unwrap_used)]
 	let ocall_api = GLOBAL_OCALL_API_COMPONENT.get()?;

--- a/bitacross-worker/enclave-runtime/src/lib.rs
+++ b/bitacross-worker/enclave-runtime/src/lib.rs
@@ -398,6 +398,16 @@ pub unsafe extern "C" fn publish_wallets() -> sgx_status_t {
 	sgx_status_t::SGX_SUCCESS
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn finish_enclave_init() -> sgx_status_t {
+	if let Err(e) = initialization::finish_enclave_init() {
+		error!("Failed to finish enclave init: {:?}", e);
+		return sgx_status_t::SGX_ERROR_UNEXPECTED
+	}
+
+	sgx_status_t::SGX_SUCCESS
+}
+
 /// Call this once at worker startup to initialize the TOP pool and direct invocation RPC server.
 ///
 /// This function will run the RPC server on the same thread as it is called and will loop there.

--- a/bitacross-worker/service/src/main_impl.rs
+++ b/bitacross-worker/service/src/main_impl.rs
@@ -616,6 +616,7 @@ fn start_worker<E, T, InitializationHandler>(
 
 	// Publish generated custiodian wallets
 	enclave.publish_wallets();
+	enclave.finish_enclave_init();
 
 	ita_parentchain_interface::event_subscriber::subscribe_to_parentchain_events(
 		&litentry_rpc_api,

--- a/bitacross-worker/service/src/tests/mocks/enclave_api_mock.rs
+++ b/bitacross-worker/service/src/tests/mocks/enclave_api_mock.rs
@@ -122,6 +122,10 @@ impl EnclaveBase for EnclaveMock {
 	fn publish_wallets(&self) -> EnclaveResult<()> {
 		unimplemented!()
 	}
+
+	fn finish_enclave_init(&self) -> EnclaveResult<()> {
+		unimplemented!()
+	}
 }
 
 impl Sidechain for EnclaveMock {


### PR DESCRIPTION
`GLOBAL_SCHEDULED_ENCLAVE.init` must happen after `OCallBridge::initialize`. `run_bit_across_handler` is run in separate thread so we got race condition and worker sometimes panics during the startup with following message:

```
^[[0m^[[38;5;8m[^[[0m2024-05-08T13:03:18.935997Z ^[[0m^[[32mINFO ^[[0m bc_relayer_registry::sgx^[[0m^[[38;5;8m]^[[0m Seal relayer registry to file: {}
^[[0m^[[38;5;8m[^[[0m2024-05-08T13:03:18.936132Z ^[[0m^[[34mDEBUG^[[0m enclave_runtime::ocall::attestation_ocall^[[0m^[[38;5;8m]^[[0m initializing MY_MRENCLAVE cache
thread '<unnamed>' panicked at 'Component factory has not been set. Use `initialize()`', service/src/ocall_bridge/bridge_api.rs:48:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
```

