### PR TITLE
skip collator port check

### DIFF
--- a/local-setup/launch.py
+++ b/local-setup/launch.py
@@ -40,9 +40,6 @@ PORTS = [
     "BobWSPort",
     "BobRPCPort",
     "BobPort",
-    "CollatorWSPort",
-    "CollatorRPCPort",
-    "CollatorPort",
     "TrustedWorkerPort",
     "UntrustedWorkerPort",
     "MuRaPort",
@@ -216,6 +213,15 @@ def get_subcommand_flags(index):
         "--dev"
     ]))
 
+def add_collator_ports():
+    PORTS.extend(
+        [
+            "CollatorWSPort",
+            "CollatorRPCPort",
+            "CollatorPort",
+        ]
+    )    
+
 def main(processes, worker, workers_number, parachain_type, log_config_path, offset, parachain_dir):
     # Litentry
     if worker == "identity":
@@ -229,15 +235,18 @@ def main(processes, worker, workers_number, parachain_type, log_config_path, off
 
     print("Starting litentry parachain in background ...")
     if parachain_type == "local-docker":
+        add_collator_ports()
         os.environ['LITENTRY_PARACHAIN_DIR'] = parachain_dir
         setup_environment(offset, parachain_dir, worker_dir)
         # TODO: use Popen and copy the stdout also to node.log
         run(["./local-setup/start_parachain.sh"], check=True)
     elif parachain_type == "local-binary-standalone":
+        add_collator_ports()        
         os.environ['LITENTRY_PARACHAIN_DIR'] = parachain_dir
         setup_environment(offset, parachain_dir, worker_dir)
         run(["./scripts/launch-standalone.sh"], check=True)
     elif parachain_type == "local-binary":
+        add_collator_ports()        
         os.environ['LITENTRY_PARACHAIN_DIR'] = parachain_dir
         setup_environment(offset, parachain_dir, worker_dir)
         run(["./scripts/launch-local-binary.sh", "rococo"], check=True)


### PR DESCRIPTION
Changes `launch.py` to check collator ports only if collator is started. 
