### PR TITLE
Use ubuntu22.04 base image for parachain build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN cargo build --locked --profile $PROFILE $BUILD_ARGS
 # ==========================
 # stage 2: packaging
 # ==========================
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="Trust Computing GmbH <info@litentry.com>"
 
 ARG PROFILE
@@ -29,14 +29,19 @@ ARG PROFILE
 COPY --from=builder /litentry/target/$PROFILE/litentry-collator /usr/local/bin
 
 # install netcat for healthcheck
-RUN apt-get update && apt-get install -yq netcat && cp /usr/bin/nc /usr/local/bin/
+RUN apt-get update && \
+    apt-get install -yq netcat ca-certificates && \
+    update-ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/cache/apt/lists && \
+    cp /usr/bin/nc /usr/local/bin/
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /litentry litentry && \
-	mkdir -p /data /litentry/.local/share && \
-	chown -R litentry:litentry /data && \
-	ln -s /data /litentry/.local/share/litentry-collator && \
-	# check if executable works in this container
-	/usr/local/bin/litentry-collator --version
+    mkdir -p /data /litentry/.local/share && \
+    chown -R litentry:litentry /data && \
+    ln -s /data /litentry/.local/share/litentry-collator && \
+    # check if executable works in this container
+    /usr/local/bin/litentry-collator --version
 
 USER litentry
 EXPOSE 30333 9933 9944 9615


### PR DESCRIPTION
### Context

We've found a problem that new docker image (0.9.18) with ubuntu 20.04 won't work with external relaychain rpc.

It _might_ be caused by the TLS cert verification problem as it tried to connect external rpc but failed.

![image](https://github.com/litentry/litentry-parachain/assets/7630809/cad15ce1-4d7b-4313-a0bd-b756f58d9b64)
