### PR TITLE
Fix warnings and import installed openzeppelin

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/A1.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/A1.sol
@@ -18,10 +18,10 @@
 
 pragma solidity ^0.8.8;
 
-import {DynamicAssertion, Identity} from "DynamicAssertion.sol";
+import {DynamicAssertion, Identity} from "./DynamicAssertion.sol";
 
 contract A1 is DynamicAssertion {
-    function execute(Identity[] memory identities, string[] memory secrets)
+    function execute(Identity[] memory identities, string[] memory)
     public
     override
     returns (

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/A20.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/A20.sol
@@ -18,10 +18,10 @@
 
 pragma solidity ^0.8.8;
 
-import {DynamicAssertion, Identity, HttpHeader} from "DynamicAssertion.sol";
+import {DynamicAssertion, Identity, HttpHeader} from "./DynamicAssertion.sol";
 
 contract A20 is DynamicAssertion {
-    function execute(Identity[] memory identities, string[] memory secrets)
+    function execute(Identity[] memory identities, string[] memory)
     public
     override
     returns (

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/A6.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/A6.sol
@@ -19,7 +19,7 @@
 pragma solidity ^0.8.8;
 
 import {DynamicAssertion, Identity, HttpHeader} from "./DynamicAssertion.sol";
-import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.9.0/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 
 contract A6 is DynamicAssertion {
     function execute(Identity[] memory identities, string[] memory secrets)


### PR DESCRIPTION
I'm using https://remix.ethereum.org/ to test.

1. fix unused varibales warning
2. Error: not found DynamicAssertion.sol
3. Use the installed code as openzepplin suggested.


