### PR TITLE
Do not pass this PR

### DIFF
--- a/ts-tests/common/setup/setup-bridge.ts
+++ b/ts-tests/common/setup/setup-bridge.ts
@@ -150,14 +150,15 @@ async function setupCrossChainTransfer(
     }
 
     const resource = await pConfig.api.query.chainBridge.resources(destResourceId);
-    if (resource.toHuman() !== 'BridgeTransfer.transfer') {
-        extrinsic.push(
-            await sudoWrapperGC(
-                pConfig.api,
-                pConfig.api.tx.chainBridge.setResource(destResourceId, 'BridgeTransfer.transfer')
-            )
-        );
-    }
+
+    // Force token bridge resource to be some wrong input method
+    extrinsic.push(
+        await sudoWrapperGC(
+            pConfig.api,
+            pConfig.api.tx.chainBridge.setResource(destResourceId, 'AAAAAAAAAA')
+        )
+    );
+    console.log('Oh yes! Resource is worng! But still works?');
 
     const fee = await pConfig.api.query.chainBridge.bridgeFee(sourceChainID);
     if (!fee || fee.toString() !== parachainFee.toString()) {


### PR DESCRIPTION
chore: add wrong script on purpose
To make sure that token bridge **Resource** storage is not used.