### PR TITLE
p-799 Update client-api api docs

### DIFF
--- a/tee-worker/client-api/parachain-api/README.md
+++ b/tee-worker/client-api/parachain-api/README.md
@@ -8,13 +8,26 @@ These types were auto generated using [Polkadot.js Type Generation](https://polk
 
 1. Install the package from NPM
 
-   ```
+   ```typescript
    npm install @litentry/parachain-api
    ```
 
-2. Import type definitions as needed:
+2. Extend and decorate the API's types with:
 
+   ```typescript
+   import { identity, vc, trusted_operations, sidechain } from 'parachain-api';
+     
+   const types = { ...identity.types, ...vc.types, ...trusted_operations.types, ...sidechain.types };
+   
+   const api = await ApiPromise.create({
+           provider,
+           types,
+       });
    ```
+
+3. Import type definitions as needed:
+
+   ```typescript
    import type { LitentryIdentity } from '@litentry/parachain-api';
    
    function myFunction(identity: LitentryIdentity) {
@@ -32,7 +45,7 @@ Versions in the pattern of `x.x.x-next.x` feature the most recent code version t
 
 1. Build the package
 
-   ```
+   ```typescript
    pnpm run build
    ```
 
@@ -40,11 +53,10 @@ Versions in the pattern of `x.x.x-next.x` feature the most recent code version t
 
 3. Publish the distribution files
 
-   ```
+   ```typescript
    npm publish --access=public
    ```
 
 ## How to regenerate types
 
 Please read the commands of [client-api](https://github.com/litentry/litentry-parachain/blob/dev/tee-worker/client-api/README.md).
-

--- a/tee-worker/client-api/parachain-api/README.md
+++ b/tee-worker/client-api/parachain-api/README.md
@@ -1,0 +1,50 @@
+# Parachain-api
+
+This library contains the Litentry Network API types and types definitions.
+
+These types were auto generated using [Polkadot.js Type Generation](https://polkadot.js.org/docs/api/examples/promise/typegen/)
+
+## How to use it
+
+1. Install the package from NPM
+
+   ```
+   npm install @litentry/parachain-api
+   ```
+
+2. Import type definitions as needed:
+
+   ```
+   import type { LitentryIdentity } from '@litentry/parachain-api';
+   
+   function myFunction(identity: LitentryIdentity) {
+     // ...
+   }
+   ```
+
+## Versions
+
+This package is distributed under two main tags: `next` and `latest`.
+
+Versions in the pattern of `x.x.x-next.x` feature the most recent code version to work with `tee-dev`. E.g., `1.0.0-next.0`. Once stable and once the Litentry Protocol is upgraded, the version will be tagged as `latest` and should be used against `tee-prod`. E.g.`1.0.0`. 
+
+## Publish new versions
+
+1. Build the package
+
+   ```
+   pnpm run build
+   ```
+
+2. [Update your published package version number](https://docs.npmjs.com/updating-your-published-package-version-number)
+
+3. Publish the distribution files
+
+   ```
+   npm publish --access=public
+   ```
+
+## How to regenerate types
+
+Please read the commands of [client-api](https://github.com/litentry/litentry-parachain/blob/dev/tee-worker/client-api/README.md).
+

--- a/tee-worker/client-api/sidechain-api/README.md
+++ b/tee-worker/client-api/sidechain-api/README.md
@@ -8,16 +8,16 @@ These types were auto generated using [Polkadot.js Type Generation](https://polk
 
 1. Install the package from NPM
 
-   ```
+   ```typescript
    npm install @litentry/sidechain-api
    ```
 
 2. Import type definitions as needed:
 
-   ```
-   import type { PalletIdentityManagementTeeIdentityContext } from '@litentry/sidechain-api';
+   ```typescript
+   import type { LitentryIdentity } from '@litentry/sidechain-api';
    
-   function myFunction(identity: PalletIdentityManagementTeeIdentityContext) {
+   function myFunction(identity: LitentryIdentity) {
      // ...
    }
    ```
@@ -32,7 +32,7 @@ Versions in the pattern of `x.x.x-next.x` feature the most recent code version t
 
 1. Build the package
 
-   ```
+   ```typescript
    pnpm run build
    ```
 
@@ -40,11 +40,10 @@ Versions in the pattern of `x.x.x-next.x` feature the most recent code version t
 
 3. Publish the distribution files
 
-   ```
+   ```typescript
    npm publish --access=public
    ```
 
 ## How to regenerate types
 
-Please read the commands of [client-api](https://github.com/litentry/litentry-parachain/blob/dev/tee-worker/client-api/README.md).
-
+Please read the commands of [client-api](https://github.com/litentry/litentry-sidechain/blob/dev/tee-worker/client-api/README.md).

--- a/tee-worker/client-api/sidechain-api/README.md
+++ b/tee-worker/client-api/sidechain-api/README.md
@@ -1,0 +1,50 @@
+# Sidechain-api
+
+This library contains the Litentry Network API types and types definitions.
+
+These types were auto generated using [Polkadot.js Type Generation](https://polkadot.js.org/docs/api/examples/promise/typegen/)
+
+## How to use it
+
+1. Install the package from NPM
+
+   ```
+   npm install @litentry/sidechain-api
+   ```
+
+2. Import type definitions as needed:
+
+   ```
+   import type { PalletIdentityManagementTeeIdentityContext } from '@litentry/sidechain-api';
+   
+   function myFunction(identity: PalletIdentityManagementTeeIdentityContext) {
+     // ...
+   }
+   ```
+
+## Versions
+
+This package is distributed under two main tags: `next` and `latest`.
+
+Versions in the pattern of `x.x.x-next.x` feature the most recent code version to work with `tee-dev`. E.g., `1.0.0-next.0`. Once stable and once the Litentry Protocol is upgraded, the version will be tagged as `latest` and should be used against `tee-prod`. E.g.`1.0.0`. 
+
+## Publish new versions
+
+1. Build the package
+
+   ```
+   pnpm run build
+   ```
+
+2. [Update your published package version number](https://docs.npmjs.com/updating-your-published-package-version-number)
+
+3. Publish the distribution files
+
+   ```
+   npm publish --access=public
+   ```
+
+## How to regenerate types
+
+Please read the commands of [client-api](https://github.com/litentry/litentry-parachain/blob/dev/tee-worker/client-api/README.md).
+


### PR DESCRIPTION
### Context
After migrating client-api to npm registry, adding a readme will make the package homepage of npm registry look better instead of a blank page.
https://www.npmjs.com/package/@litentry/parachain-api?activeTab=readme


