### PR TITLE
Use sha2-v0.8 for musig2-sgx crate

### DIFF
--- a/bitacross-worker/Cargo.lock
+++ b/bitacross-worker/Cargo.lock
@@ -374,8 +374,8 @@ dependencies = [
  "k256",
  "litentry-primitives",
  "log 0.4.20",
- "musig2 0.0.8 (git+https://github.com/kziemianek/musig2.git?tag=v0.0.8)",
  "musig2 0.0.8 (git+https://github.com/kziemianek/musig2.git?branch=master)",
+ "musig2 0.0.8 (git+https://github.com/kailai-wang/musig2.git?branch=use-sha2-0.8)",
  "parity-scale-codec",
  "rand 0.8.5",
  "sgx_rand",
@@ -400,8 +400,8 @@ dependencies = [
  "lc-direct-call",
  "litentry-primitives",
  "log 0.4.20",
- "musig2 0.0.8 (git+https://github.com/kziemianek/musig2.git?tag=v0.0.8)",
  "musig2 0.0.8 (git+https://github.com/kziemianek/musig2.git?branch=master)",
+ "musig2 0.0.8 (git+https://github.com/kailai-wang/musig2.git?branch=use-sha2-0.8)",
  "parity-scale-codec",
  "rand 0.8.5",
  "sgx_crypto_helper",
@@ -4523,22 +4523,6 @@ dependencies = [
 [[package]]
 name = "musig2"
 version = "0.0.8"
-source = "git+https://github.com/kziemianek/musig2.git?tag=v0.0.8#179f1eb5e7b9d7433bd1a5fd9af94477efb0fb38"
-dependencies = [
- "base16ct",
- "hmac 0.12.1",
- "k256",
- "once_cell 1.4.0 (git+https://github.com/mesalock-linux/once_cell-sgx?branch=master)",
- "secp 0.2.3 (git+https://github.com/kziemianek/secp.git?branch=sgx)",
- "secp256k1 0.28.0",
- "sgx_tstd",
- "sha2 0.10.8",
- "subtle 2.5.0 (git+https://github.com/kziemianek/subtle-sgx.git?branch=2.5.0-update)",
-]
-
-[[package]]
-name = "musig2"
-version = "0.0.8"
 source = "git+https://github.com/kziemianek/musig2.git?branch=master#cd5e61ac9ecdf842da58605ac7b07b6e359f08c5"
 dependencies = [
  "base16ct",
@@ -4549,6 +4533,23 @@ dependencies = [
  "secp256k1 0.28.0",
  "sha2 0.10.8",
  "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "musig2"
+version = "0.0.8"
+source = "git+https://github.com/kailai-wang/musig2.git?branch=use-sha2-0.8#93857e52abbe8f9898c9ec743eecb1380132abcb"
+dependencies = [
+ "base16ct",
+ "hmac 0.12.1",
+ "k256",
+ "once_cell 1.4.0 (git+https://github.com/mesalock-linux/once_cell-sgx?branch=master)",
+ "secp 0.2.3 (git+https://github.com/kziemianek/secp.git?branch=sgx)",
+ "secp256k1 0.28.0",
+ "sgx_tstd",
+ "sha2 0.10.8",
+ "sha2_v08_wrapper",
+ "subtle 2.5.0 (git+https://github.com/kziemianek/subtle-sgx.git?branch=2.5.0-update)",
 ]
 
 [[package]]
@@ -6902,6 +6903,14 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2_v08_wrapper"
+version = "0.1.0"
+source = "git+https://github.com/kailai-wang/sha2_v08#c41176becc675e84cd708e8b18ba2cd0c9cf8eb0"
+dependencies = [
+ "sha2 0.8.2",
 ]
 
 [[package]]

--- a/bitacross-worker/bitacross/core/bc-musig2-ceremony/Cargo.toml
+++ b/bitacross-worker/bitacross/core/bc-musig2-ceremony/Cargo.toml
@@ -12,7 +12,7 @@ musig2 = { package = "musig2", branch = "master", git = "https://github.com/kzie
 rand = { version = "0.8.5", optional = true }
 
 # sgx dependencies
-musig2_sgx = { package = "musig2", tag = "v0.0.8", git = "https://github.com/kziemianek/musig2.git", optional = true, features = ["k256"] }
+musig2_sgx = { package = "musig2", git = "https://github.com/kailai-wang/musig2.git", branch = "use-sha2-0.8", optional = true, features = ["k256"] }
 sgx_rand = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tstd = { git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "master", optional = true, features = ["net", "thread"] }
 

--- a/bitacross-worker/bitacross/core/bc-musig2-runner/Cargo.toml
+++ b/bitacross-worker/bitacross/core/bc-musig2-runner/Cargo.toml
@@ -26,7 +26,7 @@ k256 = { version = "0.13.3", default-features = false, features = ["ecdsa-core",
 lc-direct-call = { path = "../../../litentry/core/direct-call", default-features = false }
 litentry-primitives = { path = "../../../litentry/primitives", default-features = false }
 musig2 = { package = "musig2", branch = "master", git = "https://github.com/kziemianek/musig2.git", optional = true, features = ["k256"] }
-musig2_sgx = { package = "musig2", tag = "v0.0.8", git = "https://github.com/kziemianek/musig2.git", optional = true, features = ["k256"] }
+musig2_sgx = { package = "musig2", git = "https://github.com/kailai-wang/musig2.git", branch = "use-sha2-0.8", optional = true, features = ["k256"] }
 rand = { version = "0.8.5", optional = true }
 sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", default-features = false }
 sgx_rand = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/bitacross-worker/enclave-runtime/Cargo.lock
+++ b/bitacross-worker/enclave-runtime/Cargo.lock
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "musig2"
 version = "0.0.8"
-source = "git+https://github.com/kziemianek/musig2.git?tag=v0.0.8#179f1eb5e7b9d7433bd1a5fd9af94477efb0fb38"
+source = "git+https://github.com/kailai-wang/musig2.git?branch=use-sha2-0.8#93857e52abbe8f9898c9ec743eecb1380132abcb"
 dependencies = [
  "base16ct",
  "hmac",
@@ -2975,6 +2975,7 @@ dependencies = [
  "secp256k1 0.28.0",
  "sgx_tstd",
  "sha2 0.10.7",
+ "sha2_v08_wrapper",
  "subtle 2.5.0",
 ]
 
@@ -4307,6 +4308,14 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2_v08_wrapper"
+version = "0.1.0"
+source = "git+https://github.com/kailai-wang/sha2_v08#c41176becc675e84cd708e8b18ba2cd0c9cf8eb0"
+dependencies = [
+ "sha2 0.8.2",
 ]
 
 [[package]]

--- a/bitacross-worker/enclave-runtime/src/test/tests_main.rs
+++ b/bitacross-worker/enclave-runtime/src/test/tests_main.rs
@@ -154,7 +154,6 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		itc_parentchain::light_client::io::sgx_tests::sealing_creates_backup,
 
 		// test musig ceremony
-		// temporary commented out as it fails in HW Mode
 		bc_musig2_ceremony::sgx_tests::test_full_flow_with_3_ceremonies,
 
 		// these unit test (?) need an ipfs node running..

--- a/bitacross-worker/enclave-runtime/src/test/tests_main.rs
+++ b/bitacross-worker/enclave-runtime/src/test/tests_main.rs
@@ -155,7 +155,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 
 		// test musig ceremony
 		// temporary commented out as it fails in HW Mode
-		// bc_musig2_ceremony::sgx_tests::test_full_flow_with_3_ceremonies,
+		bc_musig2_ceremony::sgx_tests::test_full_flow_with_3_ceremonies,
 
 		// these unit test (?) need an ipfs node running..
 		// ipfs::test_creates_ipfs_content_struct_works,


### PR DESCRIPTION
### Context

As topic, the musig2-sgx crate with sha2-v0.8 wrapper could be found under: `https://github.com/kailai-wang/musig2` with branch = `use-sha2-0.8`

The background is during the smoke test of bitacross worker setup we found that the enclave crashed when initialising the musig2 ceremony - eventually we narrowed it down to panic within sha2 crate (only under HW mode):
```
    Sha256::new()
        .chain_update(&tag_hash)
        .chain_update(&tag_hash)
```
This consecutive update will simply crash the enclave.

After experiments downgrading the sha2 crate to v0.8 seems to work around this - at least the unit test will pass.

Please note the whole unit-test still won't pass for HW mode, but that's another problem, see P-811