### PR TITLE
feat: support bean token holding on combo mainnet

### DIFF
--- a/primitives/core/src/assertion/network.rs
+++ b/primitives/core/src/assertion/network.rs
@@ -99,6 +99,9 @@ pub enum Web3Network {
 	// solana
 	#[codec(index = 16)]
 	Solana,
+	// combo L2 of BSC
+	#[codec(index = 17)]
+	Combo,
 }
 
 // mainly used in CLI
@@ -123,7 +126,7 @@ impl Web3Network {
 	}
 
 	pub fn is_evm(&self) -> bool {
-		matches!(self, Self::Ethereum | Self::Bsc | Self::Polygon | Self::Arbitrum)
+		matches!(self, Self::Ethereum | Self::Bsc | Self::Polygon | Self::Arbitrum | Self::Combo)
 	}
 
 	pub fn is_bitcoin(&self) -> bool {
@@ -195,6 +198,7 @@ mod tests {
 					Web3Network::Polygon => true,
 					Web3Network::Arbitrum => true,
 					Web3Network::Solana => false,
+					Web3Network::Combo => true,
 				}
 			)
 		})
@@ -223,6 +227,7 @@ mod tests {
 					Web3Network::Polygon => false,
 					Web3Network::Arbitrum => false,
 					Web3Network::Solana => false,
+					Web3Network::Combo => false,
 				}
 			)
 		})
@@ -251,6 +256,7 @@ mod tests {
 					Web3Network::Polygon => false,
 					Web3Network::Arbitrum => false,
 					Web3Network::Solana => false,
+					Web3Network::Combo => false,
 				}
 			)
 		})
@@ -279,6 +285,7 @@ mod tests {
 					Web3Network::Polygon => false,
 					Web3Network::Arbitrum => false,
 					Web3Network::Solana => true,
+					Web3Network::Combo => false,
 				}
 			)
 		})

--- a/primitives/core/src/assertion/web3_token.rs
+++ b/primitives/core/src/assertion/web3_token.rs
@@ -136,7 +136,7 @@ impl Web3TokenType {
 			Self::Shib | Self::Leo | Self::Imx => vec![Web3Network::Ethereum],
 			Self::Atom => vec![Web3Network::Ethereum, Web3Network::Bsc, Web3Network::Polygon],
 			Self::Cro => vec![Web3Network::Ethereum, Web3Network::Solana],
-			Self::Bean => vec![Web3Network::Bsc],
+			Self::Bean => vec![Web3Network::Bsc, Web3Network::Combo],
 			_ => vec![Web3Network::Ethereum],
 		}
 	}

--- a/tee-worker/litentry/core/assertion-build/src/lib.rs
+++ b/tee-worker/litentry/core/assertion-build/src/lib.rs
@@ -186,6 +186,7 @@ fn pubkey_to_address(network: &Web3Network, pubkey: &str) -> String {
 		| Web3Network::Bsc
 		| Web3Network::Polygon
 		| Web3Network::Arbitrum
+		| Web3Network::Combo
 		| Web3Network::Solana => "".to_string(),
 	}
 }

--- a/tee-worker/litentry/core/common/src/lib.rs
+++ b/tee-worker/litentry/core/common/src/lib.rs
@@ -49,5 +49,6 @@ pub fn web3_network_to_chain(network: &Web3Network) -> &'static str {
 		Web3Network::Polygon => "polygon",
 		Web3Network::Arbitrum => "arbitrum",
 		Web3Network::Solana => "solana",
+		Web3Network::Combo => "combo-mainnet",
 	}
 }

--- a/tee-worker/litentry/core/common/src/lib.rs
+++ b/tee-worker/litentry/core/common/src/lib.rs
@@ -49,6 +49,6 @@ pub fn web3_network_to_chain(network: &Web3Network) -> &'static str {
 		Web3Network::Polygon => "polygon",
 		Web3Network::Arbitrum => "arbitrum",
 		Web3Network::Solana => "solana",
-		Web3Network::Combo => "combo-mainnet",
+		Web3Network::Combo => "combo",
 	}
 }

--- a/tee-worker/litentry/core/common/src/web3_token/mod.rs
+++ b/tee-worker/litentry/core/common/src/web3_token/mod.rs
@@ -249,6 +249,7 @@ impl TokenAddress for Web3TokenType {
 
 			// Bean
 			(Self::Bean, Web3Network::Bsc) => Some("0x07da81e9a684ab87fad7206b3bc8d0866f48cc7c"),
+			(Self::Bean, Web3Network::Combo) => Some("0xba7b9936a965fac23bb7a8190364fa60622b3cff"),
 
 			_ => None,
 		}

--- a/tee-worker/litentry/core/common/src/web3_token/token_decimals_filter.rs
+++ b/tee-worker/litentry/core/common/src/web3_token/token_decimals_filter.rs
@@ -83,7 +83,7 @@ pub const TOKEN_DECIMALS_9: (u32, [(Web3TokenType, Web3Network); 4]) = (
 	],
 );
 
-pub const TOKEN_DECIMALS_18: (u32, [(Web3TokenType, Web3Network); 49]) = (
+pub const TOKEN_DECIMALS_18: (u32, [(Web3TokenType, Web3Network); 50]) = (
 	18,
 	[
 		// Bnb
@@ -167,6 +167,7 @@ pub const TOKEN_DECIMALS_18: (u32, [(Web3TokenType, Web3Network); 49]) = (
 		(Web3TokenType::Inj, Web3Network::Bsc),
 		// Bean
 		(Web3TokenType::Bean, Web3Network::Bsc),
+		(Web3TokenType::Bean, Web3Network::Combo),
 	],
 );
 

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -188,6 +188,7 @@ pub fn web3_network_to_chain(network: &Web3Network) -> String {
 		Web3Network::Polygon => "polygon".into(),
 		Web3Network::Arbitrum => "arbitrum".into(),
 		Web3Network::Solana => "solana".into(),
+		Web3Network::Combo => "combo-mainnet".into(),
 	}
 }
 

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -188,7 +188,7 @@ pub fn web3_network_to_chain(network: &Web3Network) -> String {
 		Web3Network::Polygon => "polygon".into(),
 		Web3Network::Arbitrum => "arbitrum".into(),
 		Web3Network::Solana => "solana".into(),
-		Web3Network::Combo => "combo-mainnet".into(),
+		Web3Network::Combo => "combo".into(),
 	}
 }
 

--- a/tee-worker/litentry/core/data-providers/src/nodereal_jsonrpc.rs
+++ b/tee-worker/litentry/core/data-providers/src/nodereal_jsonrpc.rs
@@ -95,7 +95,7 @@ impl NoderealChain {
 			NoderealChain::Aptos => "aptos",
 			NoderealChain::Opt => "opt",
 			NoderealChain::Polygon => "polygon",
-			NoderealChain::Combo => "combo-mainnet",
+			NoderealChain::Combo => "combo",
 		}
 	}
 }

--- a/tee-worker/litentry/core/data-providers/src/nodereal_jsonrpc.rs
+++ b/tee-worker/litentry/core/data-providers/src/nodereal_jsonrpc.rs
@@ -79,6 +79,8 @@ pub enum NoderealChain {
 	Opt,
 	// Polygon
 	Polygon,
+	// Combo
+	Combo,
 }
 
 impl NoderealChain {
@@ -91,6 +93,7 @@ impl NoderealChain {
 			NoderealChain::Aptos => "aptos",
 			NoderealChain::Opt => "opt",
 			NoderealChain::Polygon => "polygon",
+			NoderealChain::Combo => "combo-mainnet",
 		}
 	}
 }

--- a/tee-worker/litentry/core/data-providers/src/nodereal_jsonrpc.rs
+++ b/tee-worker/litentry/core/data-providers/src/nodereal_jsonrpc.rs
@@ -58,6 +58,8 @@ impl Web3NetworkNoderealJsonrpcClient for Web3Network {
 				Some(NoderealJsonrpcClient::new(NoderealChain::Eth, data_provider_config)),
 			Web3Network::Polygon =>
 				Some(NoderealJsonrpcClient::new(NoderealChain::Polygon, data_provider_config)),
+			Web3Network::Combo =>
+				Some(NoderealJsonrpcClient::new(NoderealChain::Combo, data_provider_config)),
 			_ => None,
 		}
 	}

--- a/tee-worker/litentry/core/evm-dynamic-assertions/src/lib.rs
+++ b/tee-worker/litentry/core/evm-dynamic-assertions/src/lib.rs
@@ -197,6 +197,7 @@ pub fn network_to_token(network: &Web3Network) -> Token {
 			Web3Network::Polygon => 14,
 			Web3Network::Arbitrum => 15,
 			Web3Network::Solana => 16,
+			Web3Network::Combo => 17,
 		}
 		.into(),
 	)

--- a/tee-worker/litentry/core/service/src/web3_token/token_balance/common.rs
+++ b/tee-worker/litentry/core/service/src/web3_token/token_balance/common.rs
@@ -49,7 +49,7 @@ pub fn get_balance(
 			let token_address = token_type.get_token_address(network).unwrap_or_default();
 
 			match network {
-				Web3Network::Bsc | Web3Network::Ethereum => {
+				Web3Network::Bsc | Web3Network::Ethereum | Web3Network::Combo => {
 					let decimals = token_type.get_decimals(network);
 					match network.create_nodereal_jsonrpc_client(data_provider_config) {
 						Some(mut client) => {


### PR DESCRIPTION
This adds new web3network `combo` and supports `holding amount` calculation for bean. 
I couldn't perform e2e test. 


