### PR TITLE
Avoid nested ErrorDetail in assertion building

### DIFF
--- a/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs
+++ b/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs
@@ -45,15 +45,8 @@ pub fn build(
 		})
 		.collect::<Vec<(Web3Network, String)>>();
 
-	let result =
-		get_token_balance(token_type.clone(), addresses, data_provider_config).map_err(|e| {
-			Error::RequestVCFailed(
-				Assertion::TokenHoldingAmount(token_type.clone()),
-				ErrorDetail::DataProviderError(ErrorString::truncate_from(
-					format!("{e:?}").as_bytes().to_vec(),
-				)),
-			)
-		});
+	let result = get_token_balance(token_type.clone(), addresses, data_provider_config)
+		.map_err(|e| Error::RequestVCFailed(Assertion::TokenHoldingAmount(token_type.clone()), e));
 
 	match result {
 		Ok(value) => {


### PR DESCRIPTION
### Context

A small PR as topic

The initial code wraps an extra layer of error even if `e` is already `ErrorDetail`

https://github.com/litentry/litentry-parachain/blob/62f5b3ad964f2783b368f149194466121ab38f13/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs#L49-L56