### PR TITLE
Hotfix LIT/DOT Holder VC

### DIFF
--- a/runtime/litentry/src/lib.rs
+++ b/runtime/litentry/src/lib.rs
@@ -143,7 +143,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litentry-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9180,
+	spec_version: 9181,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -151,7 +151,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litmus-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9180,
+	spec_version: 9181,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -243,7 +243,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("rococo-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9180,
+	spec_version: 9181,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/tee-worker/app-libs/sgx-runtime/src/lib.rs
+++ b/tee-worker/app-libs/sgx-runtime/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node-template"),
 	impl_name: create_runtime_str!("node-template"),
 	authoring_version: 1,
-	spec_version: 106,
+	spec_version: 107,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/tee-worker/litentry/core/assertion-build/src/achainable/mod.rs
+++ b/tee-worker/litentry/core/assertion-build/src/achainable/mod.rs
@@ -111,7 +111,7 @@ pub fn request_achainable(
 		)
 	})?;
 
-	Ok(false)
+	Ok(result)
 }
 
 pub fn request_uniswap_v2_or_v3_user(

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -59,8 +59,11 @@ impl AchainableClient {
 	pub fn query_system_label(&mut self, address: &str, params: Params) -> Result<bool, Error> {
 		// TODO: double-check it with Zhouhui if we don't ever need metadata here
 		let body = ReqBody::new_with_false_metadata(address.into(), params);
-		self.post(SystemLabelReqPath::default(), &body)
-			.and_then(AchainableClient::parse)
+		let r = self
+			.post(SystemLabelReqPath::default(), &body)
+			.and_then(AchainableClient::parse);
+		debug!("r is {:?}", r);
+		r
 	}
 
 	fn parse_class_of_year(value: serde_json::Value) -> Result<String, Error> {
@@ -117,7 +120,10 @@ impl AchainableResultParser for AchainableClient {
 	fn parse(value: serde_json::Value) -> Result<Self::Item, Error> {
 		value
 			.get("result")
-			.and_then(|res| res.as_bool())
+			.and_then(|res| {
+				debug!("parse result: {}", res);
+				res.as_bool()
+			})
 			.ok_or_else(|| Error::AchainableError("Achainable Parse result error".to_string()))
 	}
 }
@@ -696,7 +702,8 @@ fn check_achainable_label(
 	address: &str,
 	params: Params,
 ) -> Result<bool, Error> {
-	let body = ReqBody::new(address.into(), params);
+	// TODO: double-check it with Zhouhui if we don't ever need metadata here
+	let body = ReqBody::new_with_false_metadata(address.into(), params);
 	client
 		.post(SystemLabelReqPath::default(), &body)
 		.and_then(AchainableClient::parse)

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -57,7 +57,8 @@ impl AchainableClient {
 	}
 
 	pub fn query_system_label(&mut self, address: &str, params: Params) -> Result<bool, Error> {
-		let body = ReqBody::new(address.into(), params);
+		// TODO: double-check it with Zhouhui if we don't ever need metadata here
+		let body = ReqBody::new_with_false_metadata(address.into(), params);
 		self.post(SystemLabelReqPath::default(), &body)
 			.and_then(AchainableClient::parse)
 	}
@@ -96,8 +97,13 @@ impl AchainablePost for AchainableClient {
 		let response = self
 			.client
 			.post_capture::<SystemLabelReqPath, ReqBody, serde_json::Value>(params, body);
-		debug!("ReqBody response: {:?}", response);
-		response.map_err(|e| Error::AchainableError(format!("Achainable response error: {}", e)))
+		match response {
+			Ok(r) => {
+				debug!("ReqBody response: {}", r);
+				Ok(r)
+			},
+			Err(e) => Err(Error::AchainableError(format!("Achainable response error: {}", e))),
+		}
 	}
 }
 

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -803,7 +803,10 @@ impl AchainableAccountTotalTransactions for AchainableClient {
 				let amount = "1".to_string();
 
 				let param = ParamsBasicTypeWithAmount::new(name, network, amount);
-				let body = ReqBody::new(address.into(), Params::ParamsBasicTypeWithAmount(param));
+				let body = ReqBody::new_with_false_metadata(
+					address.into(),
+					Params::ParamsBasicTypeWithAmount(param),
+				);
 				let tx =
 					self.post(SystemLabelReqPath::default(), &body).and_then(Self::parse_txs)?;
 				txs += tx;

--- a/tee-worker/litentry/core/data-providers/src/achainable.rs
+++ b/tee-worker/litentry/core/data-providers/src/achainable.rs
@@ -59,11 +59,8 @@ impl AchainableClient {
 	pub fn query_system_label(&mut self, address: &str, params: Params) -> Result<bool, Error> {
 		// TODO: double-check it with Zhouhui if we don't ever need metadata here
 		let body = ReqBody::new_with_false_metadata(address.into(), params);
-		let r = self
-			.post(SystemLabelReqPath::default(), &body)
-			.and_then(AchainableClient::parse);
-		debug!("r is {:?}", r);
-		r
+		self.post(SystemLabelReqPath::default(), &body)
+			.and_then(AchainableClient::parse)
 	}
 
 	fn parse_class_of_year(value: serde_json::Value) -> Result<String, Error> {
@@ -120,10 +117,7 @@ impl AchainableResultParser for AchainableClient {
 	fn parse(value: serde_json::Value) -> Result<Self::Item, Error> {
 		value
 			.get("result")
-			.and_then(|res| {
-				debug!("parse result: {}", res);
-				res.as_bool()
-			})
+			.and_then(|res| res.as_bool())
 			.ok_or_else(|| Error::AchainableError("Achainable Parse result error".to_string()))
 	}
 }

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -156,7 +156,7 @@ export async function assertVc(context: IntegrationTestContext, subject: CorePri
     // check runtime version is present
     assert.deepEqual(
         vcPayloadJson.issuer.runtimeVersion,
-        { parachain: 9180, sidechain: 106 },
+        { parachain: 9181, sidechain: 107 },
         'Check VC runtime version: it should equal the current defined versions'
     );
 


### PR DESCRIPTION
### Context

It may fix other VCs incidentally too.

The root cause is we missed one place during the AbortStrategy refactoring, so it always returns `false`.

I also don't think we need metadata for `query_system_label` or `check_achainable_label` (btw what are the differences between these?), with metadata I could get response that consists of 10000 lines of JSON...

Additionally, I think `total_transactions` doesn't need metadata either

But please double-check it @higherordertech @zhouhuitian 