### PR TITLE
fix: P-861 return error in cli for Dynamic assertion

### DIFF
--- a/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
+++ b/tee-worker/cli/src/trusted_base_cli/commands/litentry/request_vc.rs
@@ -19,7 +19,7 @@ use crate::{
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
 	trusted_operation::{perform_trusted_operation, send_direct_vc_request},
-	Cli, CliResult, CliResultOk,
+	Cli, CliError, CliResult, CliResultOk,
 };
 use clap::Parser;
 use codec::Decode;
@@ -380,7 +380,7 @@ impl RequestVcCommand {
 				s.extend(a.as_str().split(' '));
 				AssertionCommand::parse_from(s).command.to_assertion()
 			})
-			.collect();
+			.collect::<Result<Vec<_>, _>>()?;
 
 		println!(">>> assertions: {:?}", assertions);
 
@@ -454,28 +454,28 @@ impl RequestVcCommand {
 
 impl Command {
 	// helper fn to convert a `Command` to `Assertion`
-	pub fn to_assertion(&self) -> Assertion {
+	pub fn to_assertion(&self) -> Result<Assertion, CliError> {
 		use Assertion::*;
 		match self {
-			Command::A1 => A1,
-			Command::A2(arg) => A2(to_para_str(&arg.guild_id)),
-			Command::A3(arg) => A3(
+			Command::A1 => Ok(A1),
+			Command::A2(arg) => Ok(A2(to_para_str(&arg.guild_id))),
+			Command::A3(arg) => Ok(A3(
 				to_para_str(&arg.guild_id),
 				to_para_str(&arg.channel_id),
 				to_para_str(&arg.role_id),
-			),
-			Command::A4(arg) => A4(to_para_str(&arg.minimum_amount)),
-			Command::A6 => A6,
-			Command::A7(arg) => A7(to_para_str(&arg.minimum_amount)),
-			Command::A8(arg) => A8(to_chains(&arg.networks)),
-			Command::A10(arg) => A10(to_para_str(&arg.minimum_amount)),
-			Command::A11(arg) => A11(to_para_str(&arg.minimum_amount)),
+			)),
+			Command::A4(arg) => Ok(A4(to_para_str(&arg.minimum_amount))),
+			Command::A6 => Ok(A6),
+			Command::A7(arg) => Ok(A7(to_para_str(&arg.minimum_amount))),
+			Command::A8(arg) => Ok(A8(to_chains(&arg.networks))),
+			Command::A10(arg) => Ok(A10(to_para_str(&arg.minimum_amount))),
+			Command::A11(arg) => Ok(A11(to_para_str(&arg.minimum_amount))),
 			Command::A13(arg) => {
 				let raw: [u8; 32] = decode_hex(&arg.account).unwrap().try_into().unwrap();
-				A13(raw.into())
+				Ok(A13(raw.into()))
 			},
-			Command::A14 => A14,
-			Command::Achainable(c) => match c {
+			Command::A14 => Ok(A14),
+			Command::Achainable(c) => Ok(match c {
 				AchainableCommand::AmountHolding(arg) =>
 					Achainable(AchainableParams::AmountHolding(AchainableAmountHolding {
 						name: to_para_str(&arg.name),
@@ -548,14 +548,14 @@ impl Command {
 						chain: to_chains(&arg.chain),
 						token: to_para_str(&arg.token),
 					})),
-			},
-			Command::A20 => A20,
-			Command::OneBlock(c) => match c {
+			}),
+			Command::A20 => Ok(A20),
+			Command::OneBlock(c) => Ok(match c {
 				OneblockCommand::Completion => OneBlock(OneBlockCourseType::CourseCompletion),
 				OneblockCommand::Outstanding => OneBlock(OneBlockCourseType::CourseOutstanding),
 				OneblockCommand::Participation => OneBlock(OneBlockCourseType::CourseParticipation),
-			},
-			Command::GenericDiscordRole(c) => match c {
+			}),
+			Command::GenericDiscordRole(c) => Ok(match c {
 				GenericDiscordRoleCommand::Contest(s) => match s {
 					ContestCommand::Legend =>
 						GenericDiscordRole(GenericDiscordRoleType::Contest(ContestType::Legend)),
@@ -571,29 +571,29 @@ impl Command {
 					SoraQuizCommand::Master =>
 						GenericDiscordRole(GenericDiscordRoleType::SoraQuiz(SoraQuizType::Master)),
 				},
-			},
-			Command::BnbDomainHolding => BnbDomainHolding,
-			Command::BnbDigitalDomainClub(c) => match c {
+			}),
+			Command::BnbDomainHolding => Ok(BnbDomainHolding),
+			Command::BnbDigitalDomainClub(c) => Ok(match c {
 				BnbDigitalDomainClubCommand::Bnb999ClubMember =>
 					BnbDigitDomainClub(BnbDigitDomainType::Bnb999ClubMember),
 				BnbDigitalDomainClubCommand::Bnb10kClubMember =>
 					BnbDigitDomainClub(BnbDigitDomainType::Bnb10kClubMember),
-			},
-			Command::VIP3MembershipCard(arg) => match arg {
+			}),
+			Command::VIP3MembershipCard(arg) => Ok(match arg {
 				VIP3MembershipCardLevelCommand::Gold =>
 					VIP3MembershipCard(VIP3MembershipCardLevel::Gold),
 				VIP3MembershipCardLevelCommand::Silver =>
 					VIP3MembershipCard(VIP3MembershipCardLevel::Silver),
-			},
-			Command::WeirdoGhostGangHolder => WeirdoGhostGangHolder,
-			Command::EVMAmountHolding(c) => match c {
+			}),
+			Command::WeirdoGhostGangHolder => Ok(WeirdoGhostGangHolder),
+			Command::EVMAmountHolding(c) => Ok(match c {
 				EVMAmountHoldingCommand::Ton => EVMAmountHolding(EVMTokenType::Ton),
 				EVMAmountHoldingCommand::Trx => EVMAmountHolding(EVMTokenType::Trx),
-			},
-			Command::CryptoSummary => CryptoSummary,
-			Command::LITStaking => LITStaking,
-			Command::BRC20AmountHolder => BRC20AmountHolder,
-			Command::TokenHoldingAmount(arg) => match arg {
+			}),
+			Command::CryptoSummary => Ok(CryptoSummary),
+			Command::LITStaking => Ok(LITStaking),
+			Command::BRC20AmountHolder => Ok(BRC20AmountHolder),
+			Command::TokenHoldingAmount(arg) => Ok(match arg {
 				TokenHoldingAmountCommand::Bnb => TokenHoldingAmount(Web3TokenType::Bnb),
 				TokenHoldingAmountCommand::Eth => TokenHoldingAmount(Web3TokenType::Eth),
 				TokenHoldingAmountCommand::SpaceId => TokenHoldingAmount(Web3TokenType::SpaceId),
@@ -621,16 +621,16 @@ impl Command {
 				TokenHoldingAmountCommand::Mcrt => TokenHoldingAmount(Web3TokenType::Mcrt),
 				TokenHoldingAmountCommand::Btc => TokenHoldingAmount(Web3TokenType::Btc),
 				TokenHoldingAmountCommand::Bean => TokenHoldingAmount(Web3TokenType::Bean),
-			},
-			Command::PlatformUser(arg) => match arg {
+			}),
+			Command::PlatformUser(arg) => Ok(match arg {
 				PlatformUserCommand::KaratDaoUser => PlatformUser(PlatformUserType::KaratDaoUser),
 				PlatformUserCommand::MagicCraftStakingUser =>
 					PlatformUser(PlatformUserType::MagicCraftStakingUser),
-			},
-			Command::NftHolder(arg) => match arg {
+			}),
+			Command::NftHolder(arg) => Ok(match arg {
 				NftHolderCommand::WeirdoGhostGang => NftHolder(Web3NftType::WeirdoGhostGang),
 				NftHolderCommand::Club3Sbt => NftHolder(Web3NftType::Club3Sbt),
-			},
+			}),
 			Command::Dynamic(arg) => {
 				let decoded_id = hex::decode(&arg.smart_contract_id.clone()).unwrap();
 				let id_bytes: [u8; 20] = decoded_id.try_into().unwrap();
@@ -643,8 +643,15 @@ impl Command {
 						"The dynamic params length {} is over the maximum value {}",
 						params_len, truncated_params_len
 					);
+					Err(CliError::Extrinsic {
+						msg: format!(
+							"The dynamic params length {} is over the maximum value {}",
+							params_len, truncated_params_len
+						),
+					})
+				} else {
+					Ok(Assertion::Dynamic(H160::from(id_bytes), truncated_params))
 				}
-				Assertion::Dynamic(H160::from(id_bytes), truncated_params)
 			},
 		}
 	}


### PR DESCRIPTION
 while params data size exceed the maximum params size


Follow up PR to address comment [here](https://github.com/litentry/litentry-parachain/pull/2812#discussion_r1642286228)

### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable

Happy pass:
```
~/repo/litentry-parachain/tee-worker$ ./bin/litentry-cli trusted -d link-identity did:litentry:substrate:0xd4e35b16ec6b417386b948e7eaf5cc642a243096cecf366e6313689b90969f42 did:litentry:evm:0x83067bAE0D4468455948B87DEe5B2585de331B7D bsc
will@ubuntu-16gb-CI:~/repo/litentry-parachain/tee-worker$ ./bin/litentry-cli trusted -d request-vc did:litentry:substrate:0xd4e35b16ec6b417386b948e7eaf5cc642a243096cecf366e6313689b90969f42 -a "dynamic 0000000000000000000000000000000000000001 000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046f72646900000000000000000000000000000000000000000000000000000000"
>>> identity: Substrate(Address32)
>>> nonce: 1
>>> assertions: [Dynamic(0x0000000000000000000000000000000000000001, BoundedVec([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 111, 114, 100, 105, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 1024))]
----Generated VC-----
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0x057a54bdeb21aa4ee08c01834fa4b08e347787b73d6b8a9cb591dd1aa02c9725","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:substrate:0xd4e35b16ec6b417386b948e7eaf5cc642a243096cecf366e6313689b90969f42","description":"The amount of a particular token you are holding","type":"Token Holding Amount","assertionText":"Dynamic(0x0000000000000000000000000000000000000001, BoundedVec([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 111, 114, 100, 105, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 1024))","assertions":[{"and":[{"src":"$token","op":"==","dst":"ordi"},{"src":"$holding_amount","op":">=","dst":"0"},{"src":"$holding_amount","op":"<","dst":"1"}]}],"values":[false],"endpoint":"wss://rpc.rococo-parachain.litentry.io/"},"issuer":{"id":"did:litentry:substrate:0x8b3f21f9c1d9fb2350920597e9f0f3e20aa415a2cfac589e2d9d3efc84f6fc3b","name":"Litentry TEE Worker","mrenclave":"588cUwmkxSQKTDq5xDbiUzgwZAsU35pNzLAy1sECwaLv","runtimeVersion":{"parachain":9181,"sidechain":107}},"issuanceDate":"2024-06-18T03:57:19.073331373+00:00","parachainBlockNumber":288,"sidechainBlockNumber":570,"proof":{"created":"2024-06-18T03:57:19.074189420+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"12417f4a720936945c72b83ec6da45f642bf77f8ef623052a186191194c5ea0bf3eef4c56b754f4d21abe87cff5048fa9fed8b90d695178e11cb2f16666e6a06","verificationMethod":"0x8b3f21f9c1d9fb2350920597e9f0f3e20aa415a2cfac589e2d9d3efc84f6fc3b"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/25-token-holding-amount/1-1-0.json","type":"JsonSchemaValidator2018"}}
```

Negative case:

```
~/repo/litentry-parachain/tee-worker$ ./bin/litentry-cli trusted -d request-vc did:litentry:substrate:0xd4e35b16ec6b417386b948e7eaf5cc642a243096cecf366e6313689b90969f42 -a "dynamic 0000000000000000000000000000000000000001 00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000480303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303032303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303133313030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303032303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303133313030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303032303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303133313030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303032303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303133313030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303032303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303133313030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303032303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303133313030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
>>> identity: Substrate(Address32)
>>> nonce: 1
The dynamic params length 1216 is over the maximum value 1024
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Extrinsic { msg: "The dynamic params length 1216 is over the maximum value 1024" }', cli/src/main.rs:28:35
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
