### PR TITLE
P-862 add chain-aio-image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .github/
 .githooks/
 **/target
-**/ts-tests
 **/local-setup
 
 # stuff under tee-worker/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,21 +426,13 @@ jobs:
 
       - name: Save docker image
         run: |
-          docker save litentry/litentry-parachain:latest | gzip > litentry-parachain-dev.tar.gz
-          docker save litentry/litentry-chain-aio:latest | gzip > litentry-chain-aio-dev.tar.gz
+          docker save litentry/litentry-parachain:latest litentry/litentry-chain-aio:latest | gzip > litentry-parachain-dev.tar.gz
 
       - name: Upload parachain docker image
         uses: actions/upload-artifact@v4
         with:
           name: litentry-parachain-dev
           path: litentry-parachain-dev.tar.gz
-          if-no-files-found: error
-
-      - name: Upload chain-aio docker image
-        uses: actions/upload-artifact@v4
-        with:
-          name: litentry-chain-aio-dev
-          path: litentry-chain-aio-dev.tar.gz
           if-no-files-found: error
 
       - name: Fail early
@@ -914,16 +906,11 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: litentry-chain-aio-dev
-
-      - uses: actions/download-artifact@v4
-        with:
           name: litentry-identity
 
       - name: Load docker image
         run: |
           docker load < litentry-parachain-dev.tar.gz
-          docker load < litentry-chain-aio-dev.tar.gz
           docker load < litentry-identity.tar.gz
           
       - name: Dockerhub login

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,14 +429,14 @@ jobs:
           docker save litentry/litentry-parachain:latest | gzip > litentry-parachain-dev.tar.gz
           docker save litentry/litentry-chain-aio:latest | gzip > litentry-chain-aio-dev.tar.gz
 
-      - name: Upload docker image
+      - name: Upload parachain docker image
         uses: actions/upload-artifact@v4
         with:
           name: litentry-parachain-dev
           path: litentry-parachain-dev.tar.gz
           if-no-files-found: error
 
-      - name: Upload docker image
+      - name: Upload chain-aio docker image
         uses: actions/upload-artifact@v4
         with:
           name: litentry-chain-aio-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,16 +422,25 @@ jobs:
         if: needs.set-condition.outputs.rebuild_parachain == 'false'
         run: |
           docker pull litentry/litentry-parachain:latest
+          docker pull litentry/litentry-chain-aio:latest
 
       - name: Save docker image
         run: |
           docker save litentry/litentry-parachain:latest | gzip > litentry-parachain-dev.tar.gz
+          docker save litentry/litentry-chain-aio:latest | gzip > litentry-chain-aio-dev.tar.gz
 
       - name: Upload docker image
         uses: actions/upload-artifact@v4
         with:
           name: litentry-parachain-dev
           path: litentry-parachain-dev.tar.gz
+          if-no-files-found: error
+
+      - name: Upload docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: litentry-chain-aio-dev
+          path: litentry-chain-aio-dev.tar.gz
           if-no-files-found: error
 
       - name: Fail early
@@ -905,13 +914,18 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
+          name: litentry-chain-aio-dev
+
+      - uses: actions/download-artifact@v4
+        with:
           name: litentry-identity
 
       - name: Load docker image
         run: |
           docker load < litentry-parachain-dev.tar.gz
+          docker load < litentry-chain-aio-dev.tar.gz
           docker load < litentry-identity.tar.gz
-
+          
       - name: Dockerhub login
         uses: docker/login-action@v3
         with:
@@ -923,6 +937,7 @@ jobs:
         if: needs.set-condition.outputs.rebuild_parachain == 'true'
         run: |
           docker push litentry/litentry-parachain
+          docker push litentry/litentry-chain-aio
 
       # only push TEE images if we rebuilt them
       - name: Push tee-worker image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN cargo build --locked --profile $PROFILE $BUILD_ARGS
 # ==========================
 # stage 2: packaging
 # ==========================
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS parachain
 LABEL maintainer="Trust Computing GmbH <info@litentry.com>"
 
 ARG PROFILE
@@ -49,3 +49,59 @@ VOLUME ["/data"]
 
 ENTRYPOINT ["/usr/local/bin/litentry-collator"]
 CMD ["--help"]
+
+FROM ubuntu:22.04 AS chain-aio
+LABEL maintainer="Trust Computing GmbH <info@litentry.com>"
+
+ARG PROFILE
+ENV NVM_DIR /opt/nvm
+
+# install netcat for healthcheck
+RUN apt-get update && \
+    apt install -yq build-essential ocaml ocamlbuild automake autoconf libtool wget \
+    python-is-python3 libssl-dev git cmake perl python3 dkms pip python3-click clang-13 \
+    lldb-13 lld-13 clangd net-tools libssl-dev libcurl4-openssl-dev protobuf-compiler \
+    libprotobuf-dev debhelper cmake reprepro unzip pkgconf libboost-dev libboost-system-dev \
+    libboost-thread-dev lsb-release libsystemd0 pkgconf jq python3-pip curl && \
+    apt-get install -yq ca-certificates && \
+    update-ca-certificates && \
+    wget -O /usr/local/bin/polkadot -q https://github.com/paritytech/polkadot/releases/download/v0.9.42/polkadot && \
+    chmod +x /usr/local/bin/polkadot && \
+    curl -fsSL https://deb.nodesource.com/setup_21.x | sudo -E bash - && \
+    apt-get update && apt-get install -y nodejs && \
+    npm install -g pnpm && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-key del 23E7166788B63E1E && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    apt update && apt install -y yarn  && \
+    mkdir -p $NVM_DIR && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && \
+    nvm install 18 && \
+    nvm use 18 && \
+    apt-get clean && \
+    rm -rf /var/cache/apt/lists 
+
+RUN useradd -m -u 1000 -U -s /bin/sh -d /litentry litentry && \
+	mkdir -p /opt/litentry/parachain /code/litentry-parachain && \
+	chown -R litentry:litentry /opt/litentry
+	
+COPY --from=builder /litentry/target/$PROFILE/litentry-collator /usr/local/bin
+RUN chmod +x /usr/local/bin/litentry-collator && \
+    # check if executable works in this container
+    /usr/local/bin/litentry-collator --version
+
+COPY ./node/src/chain_specs /code/litentry-parachain/node/src/chain_specs
+COPY ./ts-tests /code/litentry-parachain/ts-tests 
+RUN chown -R litentry:litentry /code
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER litentry
+
+EXPOSE 9615 9933 9936 9937 9944 9946 9947 30332 30333 30336 30337
+VOLUME ["/opt/litentry"]
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,7 +96,7 @@ COPY ./node/src/chain_specs /code/litentry-parachain/node/src/chain_specs
 COPY ./ts-tests /code/litentry-parachain/ts-tests 
 RUN chown -R litentry:litentry /code
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 USER litentry

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,6 +3,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 PARACHAIN_BASEDIR="/opt/litentry/parachain"
 REPO_DIR="/code/litentry-parachain"
+# Currently, only chain type rococo is supported.
+CHAIN='rococo'
 
 check(){
     if [ -z "$CHAIN" ]; then
@@ -119,7 +121,7 @@ watch_pid(){
 }
 
 main(){
-    check
+    # check
     init
     run_relay_alice
     sleep 5

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+PARACHAIN_BASEDIR="/opt/litentry/parachain"
+REPO_DIR="/code/litentry-parachain"
+
+check(){
+    if [ -z "$CHAIN" ]; then
+        export CHAIN="rococo"
+    fi
+
+    ALLOWED_VALUES=("rococo" "litmus" "litentry")
+
+    if [[ " ${ALLOWED_VALUES[@]} " =~ " ${CHAIN} " ]]; then
+        echo "CHAIN is set to a valid value: $CHAIN"
+    else
+        echo "Error: CHAIN environment variable must be one of: ${ALLOWED_VALUES[@]}"
+        exit 1
+    fi
+}
+
+init(){
+    cd "$PARACHAIN_BASEDIR" || exit
+    polkadot build-spec --chain rococo-local --disable-default-bootnode --raw > rococo-local-chain-spec.json
+    litentry-collator export-genesis-state --chain $CHAIN-dev > genesis-state
+    litentry-collator export-genesis-wasm --chain $CHAIN-dev > genesis-wasm
+}
+
+run_parachain_alice(){
+    echo "Starting parachain alice..."
+    local flags="--base-path ${PARACHAIN_BASEDIR}/para-alice \
+    --alice \
+    --collator \
+    --force-authoring \
+    --chain ${CHAIN}-dev \
+    --unsafe-ws-external \
+    --unsafe-rpc-external \
+    --rpc-cors=all \
+    --ws-max-connections 3000 \
+    --port 30333 \
+    --ws-port 9944 \
+    --rpc-port 9933 \
+    --execution wasm \
+    --state-pruning archive \
+    --blocks-pruning archive \
+    -- --execution wasm --chain ${PARACHAIN_BASEDIR}/rococo-local-chain-spec.json --port 30332 --ws-port 9943 --rpc-port 9932"
+    echo "Flags: ${flags}"
+
+    nohup litentry-collator ${flags} >> ${PARACHAIN_BASEDIR}/para-alice.log 2>&1 &
+    parachain_alice_pid=$!
+}
+
+run_relay_alice(){
+    echo "Starting relay alice..."
+    local flags="--base-path ${PARACHAIN_BASEDIR}/relay-alice \
+    --chain ${PARACHAIN_BASEDIR}/rococo-local-chain-spec.json \
+    --alice \
+    --port 30336 \
+    --ws-port 9946 \
+    --rpc-port 9936"
+    echo "Flags: ${flags}"
+
+    nohup polkadot ${flags} >> ${PARACHAIN_BASEDIR}/relay-alice.log 2>&1 &
+    relay_alice_pid=$!
+}
+
+run_relay_bob(){
+    echo "Starting relay bob..."
+    local flags="--base-path ${PARACHAIN_BASEDIR}/relay-bob \
+    --chain ${PARACHAIN_BASEDIR}/rococo-local-chain-spec.json \
+    --bob \
+    --port 30337 \
+    --ws-port 9947 \
+    --rpc-port 9937"
+    echo "Flags: ${flags}"
+
+    nohup polkadot ${flags} >> ${PARACHAIN_BASEDIR}/relay-bob.log 2>&1 &
+    relay_bob_pid=$!
+}
+
+register_parachain(){
+    echo "Register parathread now ..."
+    cd "$REPO_DIR" || exit
+    export PARACHAIN_ID=$(grep DEFAULT_PARA_ID node/src/chain_specs/$CHAIN.rs  | grep u32 | sed 's/.* = //;s/\;//')
+    cd "$REPO_DIR/ts-tests" || exit
+    if [[ -z "$NODE_ENV" ]]; then
+        echo "NODE_ENV=ci" > .env
+    else
+        echo "NODE_ENV=$NODE_ENV" > .env
+    fi
+    jq --arg genesis_state "$PARACHAIN_BASEDIR/genesis-state" --arg genesis_wasm "$PARACHAIN_BASEDIR/genesis-wasm" '.genesis_state_path = $genesis_state | .genesis_wasm_path = $genesis_wasm' config.ci.json > config.ci.json.1
+    mv config.ci.json.1 config.ci.json
+    pnpm install
+    pnpm run register-parathread 2>&1 | tee "$PARACHAIN_BASEDIR/register-parathread.log"
+
+    echo "Upgrade parathread to parachain in 90s ..."
+    # Wait for 90s to allow onboarding finish, after that we do the upgrade
+    sleep 90
+    pnpm run upgrade-parathread 2>&1 | tee "$PARACHAIN_BASEDIR/upgrade-parathread.log"
+
+    echo "wait for parachain to produce block #1..."
+    pnpm run wait-finalized-block 2>&1
+
+    echo
+    echo "done. please check $PARACHAIN_BASEDIR for generated files if need"
+}
+
+print_help(){
+    echo "Parachain ${CHAIN} initialized successfully!"
+    echo "If you need to monitor the logs, please try the command 'docker exec <containers name> tail -f /opt/litentry/parachain/para-alice.log'."
+    echo "Next, it will enter daemon mode."
+}
+
+watch_pid(){
+    wait -n ${relay_alice_pid} ${relay_bob_pid} ${parachain_alice_pid}
+    EXIT_STATUS=$?
+    kill ${relay_alice_pid} ${relay_bob_pid} ${parachain_alice_pid}
+    exit $EXIT_STATUS
+}
+
+main(){
+    check
+    init
+    run_relay_alice
+    sleep 5
+    run_relay_bob
+    sleep 5
+    run_parachain_alice
+    sleep 5
+    register_parachain
+    print_help
+    watch_pid
+}
+
+main 

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -58,6 +58,34 @@ docker build ${NOCACHE_FLAG} --pull -f ./docker/Dockerfile \
     --build-arg https_proxy="$PROXY" \
     --add-host=host.docker.internal:host-gateway \
     --network host \
+    --target parachain \
+    -t ${GITUSER}/${GITREPO}:${TAG} .
+
+# Tag it with latest if no tag parameter was provided
+[ -z "$2" ] && docker tag ${GITUSER}/${GITREPO}:${TAG} ${GITUSER}/${GITREPO}:latest
+
+# Show the list of available images for this repo
+echo "Image is ready"
+echo "------------------------------------------------------------"
+docker images | grep ${GITREPO}
+
+GITUSER=litentry
+GITREPO=litentry-chain-aio
+PROXY="${HTTP_PROXY//localhost/host.docker.internal}"
+
+# Build the image
+echo "------------------------------------------------------------"
+echo "Building ${GITUSER}/${GITREPO}:${TAG} docker image ..."
+docker build ${NOCACHE_FLAG} --pull -f ./docker/Dockerfile \
+    --build-arg PROFILE="$PROFILE" \
+    --build-arg BUILD_ARGS="$ARGS" \
+    --build-arg HTTP_PROXY="$PROXY" \
+    --build-arg HTTPS_PROXY="$PROXY" \
+    --build-arg http_proxy="$PROXY" \
+    --build-arg https_proxy="$PROXY" \
+    --add-host=host.docker.internal:host-gateway \
+    --network host \
+    --target chain-aio \
     -t ${GITUSER}/${GITREPO}:${TAG} .
 
 # Tag it with latest if no tag parameter was provided


### PR DESCRIPTION
### Context

To resolve this [task](https://linear.app/litentry/issue/P-862/prepare-a-new-docker-image-litentry-parachain-for-testing)

### Labels

- C1

### How (Optional)

I've added a new image litentry/litentry-chain-aio, based on the build logic of litentry-parachain. In the Dockerfile, I've added a new target to differentiate it from the regular litentry-parachain image.

The AIO (all-in-one) image integrates relay-chain and parachain, as well as automated registration features.

### Testing Evidences



