### PR TITLE
fix bitacross indirect-calls-executor tests

### DIFF
--- a/bitacross-worker/core/parentchain/indirect-calls-executor/src/executor.rs
+++ b/bitacross-worker/core/parentchain/indirect-calls-executor/src/executor.rs
@@ -353,7 +353,6 @@ mod test {
 		TestStfEnclaveSigner,
 		TestTopPoolAuthor,
 		TestNodeMetadataRepository,
-		MockExtrinsicFilter<MockParentchainExtrinsicParser>,
 		TestEventCreator,
 		MockParentchainEventHandler,
 		TrustedCallSignedMock,

--- a/bitacross-worker/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/bitacross-worker/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -1,6 +1,6 @@
 use crate::{
 	error::{Error, Result as ICResult},
-	filter_metadata::{EventsFromMetadata, FilterIntoDataFrom},
+	filter_metadata::EventsFromMetadata,
 	IndirectDispatch,
 };
 use bc_relayer_registry::RelayerRegistry;
@@ -10,10 +10,7 @@ use core::marker::PhantomData;
 use litentry_primitives::DecryptableRequest;
 
 use bc_enclave_registry::EnclaveRegistry;
-use itp_node_api::{
-	api_client::{CallIndex, PairSignature, UncheckedExtrinsicV4},
-	metadata::NodeMetadataTrait,
-};
+use itp_node_api::api_client::{CallIndex, PairSignature, UncheckedExtrinsicV4};
 use itp_sgx_runtime_primitives::types::{AccountId, Balance};
 use itp_stf_primitives::{traits::IndirectExecutor, types::Signature};
 use itp_test::mock::stf_mock::{GetterMock, TrustedCallMock, TrustedCallSignedMock};
@@ -27,52 +24,6 @@ use itp_types::{
 use log::*;
 use std::vec::Vec;
 
-/// Default filter we use for the Integritee-Parachain.
-pub struct MockExtrinsicFilter<ExtrinsicParser> {
-	_phantom: PhantomData<ExtrinsicParser>,
-}
-
-impl<ExtrinsicParser, NodeMetadata: NodeMetadataTrait> FilterIntoDataFrom<NodeMetadata>
-	for MockExtrinsicFilter<ExtrinsicParser>
-where
-	ExtrinsicParser: ParseExtrinsic,
-{
-	type Output = IndirectCall;
-	type ParseParentchainMetadata = ExtrinsicParser;
-
-	fn filter_into_from_metadata(
-		encoded_data: &[u8],
-		metadata: &NodeMetadata,
-	) -> Option<Self::Output> {
-		let call_mut = &mut &encoded_data[..];
-
-		// Todo: the filter should not need to parse, only filter. This should directly be configured
-		// in the indirect executor.
-		let xt = match Self::ParseParentchainMetadata::parse(call_mut) {
-			Ok(xt) => xt,
-			Err(e) => {
-				log::error!(
-					"[ShieldFundsAndInvokeFilter] Could not parse parentchain extrinsic: {:?}",
-					e
-				);
-				return None
-			},
-		};
-		let index = xt.call_index;
-		let call_args = &mut &xt.call_args[..];
-		log::trace!(
-			"[ShieldFundsAndInvokeFilter] attempting to execute indirect call with index {:?}",
-			index
-		);
-		if index == metadata.post_opaque_task_call_indexes().ok()? {
-			log::debug!("executing invoke call");
-			let args = InvokeArgs::decode(call_args).unwrap();
-			Some(IndirectCall::Invoke(args))
-		} else {
-			None
-		}
-	}
-}
 pub struct ExtrinsicParser<SignedExtra> {
 	_phantom: PhantomData<SignedExtra>,
 }


### PR DESCRIPTION
* Fixes `itc-parentchain-indirect-calls-executor` package tests

`IndirectCallsFilter` was removed from `IndirectCallsExecutor` generics recently but mocks used in tests were not adjusted.
