### PR TITLE
Add worker `cargo test` to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ name: General CI
 # - fmt
 # - set-condition
 # - parachain-build-dev
-# - tee-build
+# - identity-build
 #
 # [4] please note that job-level if `env` is not supported:
 # https://github.com/actions/runner/issues/1189
@@ -240,7 +240,7 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.5
 
-  tee-clippy:
+  identity-clippy:
     runs-on: ubuntu-latest
     needs:
       - fmt
@@ -348,6 +348,12 @@ jobs:
           sudo apt-get update && \
           sudo apt-get install -yq openssl clang libclang-dev cmake protobuf-compiler
 
+      - name: Pallet unittests
+        working-directory: ./bitacross-worker
+        run: |
+          cargo test --release -p lc-* --lib
+          cargo test --release -p litentry-primitives --lib
+
       - name: bitacross-worker clippy
         working-directory: ./bitacross-worker
         run: |
@@ -438,7 +444,7 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.5
 
-  tee-build:
+  identity-build:
     runs-on: ubuntu-latest
     needs:
       - fmt
@@ -711,7 +717,7 @@ jobs:
     needs:
       - set-condition
       - parachain-build-dev
-      - tee-build
+      - identity-build
     strategy:
       fail-fast: false
       matrix:
@@ -799,7 +805,7 @@ jobs:
     needs:
       - set-condition
       - parachain-build-dev
-      - tee-build
+      - identity-build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,14 +240,18 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.5
 
-  identity-clippy:
+  tee-check:
     runs-on: ubuntu-latest
     needs:
       - fmt
       - set-condition
       - sequentialise
-    if: needs.set-condition.outputs.rebuild_tee == 'true'
     container: "litentry/litentry-tee-dev:latest"
+    strategy:
+      matrix:
+        type:
+          - tee # TODO: switch to identity
+          - bitacross
     steps:
       - uses: actions/checkout@v4
 
@@ -256,142 +260,50 @@ jobs:
           sudo apt-get update && \
           sudo apt-get install -yq openssl clang libclang-dev cmake protobuf-compiler
 
-      - name: Pallet unittests
+      - name: Cargo test
+        working-directory: ./${{ matrix.type }}-worker
+        run: |
+          cargo test --release
+
+      - name: Worker common clippy
+        working-directory: ./${{ matrix.type }}-worker
+        run: |
+          for d in . enclave-runtime; do
+            pushd "$d"
+            echo "::group::cargo clippy all"
+            cargo clippy --release -- -D warnings
+            echo "::endgroup::"
+            echo "::group::cargo clippy development"
+            cargo clippy --release --features development -- -D warnings
+            echo "::endgroup::"
+            echo "::group::cargo clippy offchain-worker"
+            cargo clippy --release --features offchain-worker -- -D warnings
+            echo "::group::cargo clippy offchain-worker,development"
+            cargo clippy --release --features offchain-worker,development -- -D warnings
+            echo "::endgroup::"
+            popd
+          done
+
+      - name: Identity-worker specific clippy
+        if: matrix.type == 'tee'
         working-directory: ./tee-worker
         run: |
-          cargo test --release -p pallet-* --lib
-          cargo test --release -p lc-* --lib
-          cargo test --release -p litentry-primitives --lib
-
-      - name: Tee-worker clippy
-        working-directory: ./tee-worker
-        run: |
-          echo "::group::cargo clippy no features"
-          cargo clippy --release -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy sidechain"
-          cargo clippy --release --features sidechain -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy evm"
-          cargo clippy --release --features evm -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy offchain-worker"
-          cargo clippy --release --features offchain-worker -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy development"
-          cargo clippy --release --features development -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy sidechain development"
-          cargo clippy --release --features sidechain,development -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy evm development"
-          cargo clippy --release --features evm,development -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy offchain-worker develpment"
-          cargo clippy --release --features offchain-worker,development -- -D warnings
-          echo "::endgroup::"
-
-      - name: Clean up disk
-        working-directory: ./tee-worker
-        run: |
-          echo "::group::Show disk usage"
-          df -h .
-          echo "::endgroup::"
-          cargo clean --profile release
-          echo "::group::Show disk usage"
-          df -h .
-          echo "::endgroup::"
-
-      - name: Tee-enclave clippy
-        working-directory: ./tee-worker/enclave-runtime
-        run: |
-          echo "::group::cargo clippy no features"
-          cargo clippy --release -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy sidechain"
-          cargo clippy --release --features sidechain -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy offchain-worker"
-          cargo clippy --release --features offchain-worker -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy development"
-          cargo clippy --release --features development -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy sidechain development"
-          cargo clippy --release --features sidechain,development -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy evm development"
-          cargo clippy --release --features evm,development -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy offchain-worker develpment"
-          cargo clippy --release --features offchain-worker,development -- -D warnings
-          echo "::endgroup::"
-
-      - name: Fail early
-        if: failure()
-        uses: andymckay/cancel-action@0.5
-
-  bitacross-clippy:
-    runs-on: ubuntu-latest
-    needs:
-      - fmt
-      - set-condition
-      - sequentialise
-    if: needs.set-condition.outputs.rebuild_bitacross == 'true'
-    #    todo: we might want to change this image in the future
-    container: "litentry/litentry-tee-dev:latest"
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update && \
-          sudo apt-get install -yq openssl clang libclang-dev cmake protobuf-compiler
-
-      - name: Pallet unittests
-        working-directory: ./bitacross-worker
-        run: |
-          cargo test --release -p lc-* --lib
-          cargo test --release -p litentry-primitives --lib
-
-      - name: bitacross-worker clippy
-        working-directory: ./bitacross-worker
-        run: |
-          echo "::group::cargo clippy all"
-          cargo clippy --release -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy offchain-worker"
-          cargo clean --profile release
-          cargo clippy --release --features offchain-worker -- -D warnings
-          echo "::group::cargo clippy offchain-worker,development"
-          cargo clean --profile release
-          cargo clippy --release --features offchain-worker,development -- -D warnings
-          echo "::endgroup::"
-
-      - name: Clean up disk
-        working-directory: ./bitacross-worker
-        run: |
-          echo "::group::Show disk usage"
-          df -h .
-          echo "::endgroup::"
-          cargo clean --profile release
-          echo "::group::Show disk usage"
-          df -h .
-          echo "::endgroup::"
-
-      - name: bitacross-enclave clippy
-        working-directory: ./bitacross-worker/enclave-runtime
-        run: |
-          echo "::group::cargo clippy all"
-          cargo clippy --release -- -D warnings
-          echo "::endgroup::"
-          echo "::group::cargo clippy offchain-worker"
-          cargo clean --profile release
-          cargo clippy --release --features offchain-worker -- -D warnings
-          echo "::group::cargo clippy offchain-worker,development"
-          cargo clean --profile release
-          cargo clippy --release --features offchain-worker,development -- -D warnings
-          echo "::endgroup::"
+          for d in . enclave-runtime; do
+            pushd "$d"
+            echo "::group::cargo clippy sidechain"
+            cargo clippy --release --features sidechain -- -D warnings
+            echo "::endgroup::"
+            echo "::group::cargo clippy evm"
+            cargo clippy --release --features evm -- -D warnings
+            echo "::endgroup::"
+            echo "::group::cargo clippy sidechain development"
+            cargo clippy --release --features sidechain,development -- -D warnings
+            echo "::endgroup::"
+            echo "::group::cargo clippy evm development"
+            cargo clippy --release --features evm,development -- -D warnings
+            echo "::endgroup::"
+            popd
+          done
 
       - name: Fail early
         if: failure()
@@ -712,7 +624,7 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.5
 
-  tee-single-worker-test:
+  identity-single-worker-test:
     runs-on: ubuntu-latest
     needs:
       - set-condition
@@ -799,7 +711,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 3
 
-  tee-multi-worker-test:
+  identity-multi-worker-test:
     runs-on: ubuntu-latest
     continue-on-error: true
     needs:
@@ -888,7 +800,7 @@ jobs:
   #
   # Only try to push docker image when
   #   - parachain-ts-test passes
-  #   - tee-single-worker-test passes
+  #   - identity-single-worker-test passes
   #   - set-condition.outputs.push_docker is `true`
   # Whether the parachain or tee-worker image will actually be pushed still depends on if a new image was built/rebuilt.
   # This is important not to overwrite any other jobs where a rebuild **was** triggered.
@@ -902,7 +814,7 @@ jobs:
     needs:
       - set-condition
       - parachain-ts-test
-      - tee-single-worker-test
+      - identity-single-worker-test
     if: ${{ !failure() && needs.set-condition.outputs.push_docker == 'true' }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
 
       - name: Worker common clippy
         working-directory: ./${{ matrix.type }}-worker
+        shell: bash
         run: |
           for d in . enclave-runtime; do
             pushd "$d"
@@ -287,6 +288,7 @@ jobs:
       - name: Identity-worker specific clippy
         if: matrix.type == 'tee'
         working-directory: ./tee-worker
+        shell: bash
         run: |
           for d in . enclave-runtime; do
             pushd "$d"

--- a/bitacross-worker/litentry/core/direct-call/Cargo.toml
+++ b/bitacross-worker/litentry/core/direct-call/Cargo.toml
@@ -28,6 +28,7 @@ sgx_tstd = { git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "m
 k256 = { version = "0.13.3", features = ["ecdsa-core", "schnorr"] }
 rand = { version = "0.7" }
 hex = { version = "0.4" }
+itp-sgx-crypto = { path = "../../../core-primitives/sgx/crypto", features = ["mocks"] }
 
 [features]
 default = ["std"]

--- a/bitacross-worker/litentry/core/direct-call/src/handler/nonce_share.rs
+++ b/bitacross-worker/litentry/core/direct-call/src/handler/nonce_share.rs
@@ -90,11 +90,11 @@ pub fn handle<ER: EnclaveRegistryLookup, AK: AccessKey<KeyType = SchnorrPair>>(
 pub mod test {
 	use crate::handler::nonce_share::{handle, NonceShareError, SchnorrPair};
 	use alloc::sync::Arc;
-	use bc_enclave_registry::{EnclaveRegistry, EnclaveRegistryLookup, EnclaveRegistryUpdater};
+	use bc_enclave_registry::{EnclaveRegistry, EnclaveRegistryUpdater};
 	use bc_musig2_ceremony::{CeremonyCommandsRegistry, CeremonyRegistry, SignBitcoinPayload};
 	use codec::alloc::sync::Mutex;
 	use itp_sgx_crypto::{key_repository::AccessKey, Error};
-	use parentchain_primitives::{Address32, Identity};
+	use parentchain_primitives::Identity;
 	use sp_core::{sr25519, Pair};
 
 	struct SignerAccess {}
@@ -116,7 +116,8 @@ pub mod test {
 		let ceremony_registry = Arc::new(Mutex::new(CeremonyRegistry::<SignerAccess>::new()));
 		let ceremony_commands_registry = Arc::new(Mutex::new(CeremonyCommandsRegistry::new()));
 		let enclave_registry = Arc::new(EnclaveRegistry::default());
-		enclave_registry.update(alice_key_pair.public().into(), "localhost:2000".to_string());
+		let _ =
+			enclave_registry.update(alice_key_pair.public().into(), "localhost:2000".to_string());
 
 		// when
 		let result = handle(

--- a/bitacross-worker/litentry/core/direct-call/src/handler/partial_signature_share.rs
+++ b/bitacross-worker/litentry/core/direct-call/src/handler/partial_signature_share.rs
@@ -76,7 +76,7 @@ pub mod test {
 	};
 	use alloc::sync::Arc;
 	use bc_enclave_registry::{EnclaveRegistry, EnclaveRegistryUpdater};
-	use bc_musig2_ceremony::{CeremonyCommandsRegistry, CeremonyRegistry, SignBitcoinPayload};
+	use bc_musig2_ceremony::{CeremonyRegistry, SignBitcoinPayload};
 	use codec::alloc::sync::Mutex;
 	use itp_sgx_crypto::{key_repository::AccessKey, Error};
 	use parentchain_primitives::Identity;
@@ -100,7 +100,8 @@ pub mod test {
 		let ceremony_id = SignBitcoinPayload::Derived(vec![]);
 		let ceremony_registry = Arc::new(Mutex::new(CeremonyRegistry::<SignerAccess>::new()));
 		let enclave_registry = Arc::new(EnclaveRegistry::default());
-		enclave_registry.update(alice_key_pair.public().into(), "localhost:2000".to_string());
+		let _ =
+			enclave_registry.update(alice_key_pair.public().into(), "localhost:2000".to_string());
 
 		// when
 		let result = handle(

--- a/bitacross-worker/litentry/core/direct-call/src/handler/sign_bitcoin.rs
+++ b/bitacross-worker/litentry/core/direct-call/src/handler/sign_bitcoin.rs
@@ -99,17 +99,14 @@ pub mod test {
 	use bc_relayer_registry::{RelayerRegistry, RelayerRegistryUpdater};
 	use bc_signer_registry::{PubKey, SignerRegistryLookup};
 	use codec::alloc::sync::Mutex;
-	use itp_sgx_crypto::{
-		key_repository::AccessKey, mocks::KeyRepositoryMock, schnorr::Pair as SchnorrPair, Error,
-	};
-	use k256::elliptic_curve::{rand_core, PublicKey};
+	use itp_sgx_crypto::{key_repository::AccessKey, schnorr::Pair as SchnorrPair, Error};
 	use parentchain_primitives::{Address32, Identity};
 	use sp_core::{sr25519, Pair};
 
 	struct SignersRegistryMock {}
 
 	impl SignerRegistryLookup for SignersRegistryMock {
-		fn contains_key(&self, account: &Address32) -> bool {
+		fn contains_key(&self, _account: &Address32) -> bool {
 			true
 		}
 


### PR DESCRIPTION
### Context

For both identity-worker and bc-worker.

CI yml code is simplified a bit using matrix.

The `cargo test` in Dockefile is retained as we might build image with customised flags.