### PR TITLE
refactor: use println! instead of info!

### DIFF
--- a/tee-worker/service/src/main_impl.rs
+++ b/tee-worker/service/src/main_impl.rs
@@ -238,7 +238,7 @@ pub(crate) fn main() {
 	} else if matches.is_present("signing-key") {
 		setup::generate_signing_key_file(enclave.as_ref());
 		let tee_accountid = enclave_account(enclave.as_ref());
-		info!("Enclave signing account: {:}", &tee_accountid.to_ss58check());
+		println!("Enclave signing account: {:}", &tee_accountid.to_ss58check());
 	} else if matches.is_present("dump-ra") {
 		info!("*** Perform RA and dump cert to disk");
 		#[cfg(not(feature = "dcap"))]
@@ -252,7 +252,7 @@ pub(crate) fn main() {
 			enclave.dump_dcap_ra_cert_to_disk().unwrap();
 		}
 	} else if matches.is_present("mrenclave") {
-		info!("{}", enclave.get_fingerprint().unwrap().encode().to_base58());
+		println!("{}", enclave.get_fingerprint().unwrap().encode().to_base58());
 	} else if let Some(sub_matches) = matches.subcommand_matches("init-shard") {
 		setup::init_shard(
 			enclave.as_ref(),


### PR DESCRIPTION
This is a simple PR to use `println!` instead of `info!`, I've looked all the CLI commands, And only at two places I felt like we should be using `println!` instead of `info!`. 


