### PR TITLE
Keep assertionText field as default empty

### DIFF
--- a/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/handler/assertion.rs
@@ -300,8 +300,6 @@ where
 	credential.credential_subject.endpoint =
 		context.data_provider_config.credential_endpoint.to_string();
 
-	credential.credential_subject.assertion_text = format!("{:?}", req.assertion);
-
 	if let Some(schema) = credential_schema::get_schema_url(&req.assertion) {
 		credential.credential_schema.id = schema;
 	}


### PR DESCRIPTION
### Context

As topic - a minor PR to remove the current assertionText assignment, which is basically the debug formatter of assertion type.

@jonalvarezz - or do you want me to remove this field completely? If yes we (you) have to change the schema.

If the only purpose of this field is to "identify" the assertion, I'd like to remove it completely. As the client should conduct their own ways of identifying the credential if they have such needs (e.g. by adding extra fields).