### PR TITLE
P-858 add aesmd server in docker

### DIFF
--- a/tee-worker/entrypoint.sh
+++ b/tee-worker/entrypoint.sh
@@ -11,6 +11,11 @@ check_env(){
     fi
 }
 
+# run as root
+start_aesm(){
+    sudo bash -c "source /etc/environment && /opt/intel/sgx-aesm-service/aesm/aesm_service" 2>&1 &
+}
+
 copy_files(){
     for file in key.txt key_production.txt mrenclave.txt spid.txt spid_production.txt; do
         wkdir_file="${DATA_DIR}/${file}"
@@ -34,4 +39,5 @@ runtime(){
 
 check_env
 copy_files
+start_aesm
 runtime $@ >> ${log_file} 2>&1


### PR DESCRIPTION
### Context


### Labels
- C1

### How (Optional)

### Testing Evidences
```bash
ubuntu@tee-staging:~$ docker run -it --rm     --device=/dev/sgx_enclave     --device=/dev/sgx_provision     --device=/dev/sgx_vepc     --entrypoint bash   xkl:test
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

litentry@e53adb63070e:/data$ sudo bash -c "source /etc/environment && /opt/intel/sgx-aesm-service/aesm/aesm_service"
aesm_service: warning: Turn to daemon. Use "--no-daemon" option to execute in foreground.
litentry@e53adb63070e:/data$ aesm_service[13]: The server sock is 0x55e355ff5fe0

litentry@e53adb63070e:/data$ ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
litentry       1       0  0 07:44 pts/0    00:00:00 bash
root          13       1  0 07:44 ?        00:00:00 /opt/intel/sgx-aesm-service/aesm/aesm_service
litentry      20       1  0 07:44 pts/0    00:00:00 ps -ef
```


