### PR TITLE
`Vc.issuer.id` should be the enclave account

### DIFF
--- a/tee-worker/app-libs/sgx-runtime/src/lib.rs
+++ b/tee-worker/app-libs/sgx-runtime/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node-template"),
 	impl_name: create_runtime_str!("node-template"),
 	authoring_version: 1,
-	spec_version: 107,
+	spec_version: 108,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/tee-worker/core-primitives/stf-executor/src/enclave_signer.rs
+++ b/tee-worker/core-primitives/stf-executor/src/enclave_signer.rs
@@ -33,7 +33,6 @@ use itp_stf_primitives::{
 use itp_stf_state_observer::traits::ObserveState;
 use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{Index, ShardIdentifier};
-use log::*;
 use sp_core::{ed25519::Pair as Ed25519Pair, Pair};
 use std::{boxed::Box, sync::Arc, vec::Vec};
 
@@ -113,8 +112,7 @@ where
 	G: PartialEq + Encode + Decode + Debug + Send + Sync,
 {
 	fn get_enclave_account(&self) -> Result<AccountId> {
-		let enclave_call_signing_key = self.get_enclave_call_signing_key()?;
-		Ok(enclave_call_signing_key.public().into())
+		self.get_enclave_call_signing_key().map(|key| key.public().into())
 	}
 
 	fn sign_call_with_self<TC: Encode + Debug + TrustedCallSigning<TCS>>(
@@ -143,11 +141,7 @@ where
 		))
 	}
 
-	fn sign(&self, payload: &[u8]) -> Result<(AccountId, Vec<u8>)> {
-		let enclave_account = self.get_enclave_account()?;
-		let enclave_call_signing_key = self.get_enclave_call_signing_key()?;
-
-		debug!("	[EnclaveSigner] VC pubkey: {:?}", enclave_call_signing_key.public().to_vec());
-		Ok((enclave_account, enclave_call_signing_key.sign(payload).0.to_vec()))
+	fn sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
+		self.get_enclave_call_signing_key().map(|key| key.sign(payload).0.to_vec())
 	}
 }

--- a/tee-worker/core-primitives/stf-executor/src/mocks.rs
+++ b/tee-worker/core-primitives/stf-executor/src/mocks.rs
@@ -142,8 +142,8 @@ impl<TCS: PartialEq + Encode + Debug> StfEnclaveSigning<TCS> for StfEnclaveSigne
 		Ok(trusted_call.sign(&KeyPair::Ed25519(Box::new(self.signer)), 1, &self.mr_enclave, shard))
 	}
 
-	fn sign(&self, _payload: &[u8]) -> Result<(AccountId, Vec<u8>)> {
-		Ok((self.signer.public().into(), [0u8; 32].to_vec()))
+	fn sign(&self, _payload: &[u8]) -> Result<Vec<u8>> {
+		Ok([0u8; 32].to_vec())
 	}
 }
 

--- a/tee-worker/core-primitives/stf-executor/src/traits.rs
+++ b/tee-worker/core-primitives/stf-executor/src/traits.rs
@@ -48,8 +48,8 @@ where
 		shard: &ShardIdentifier,
 	) -> Result<TCS>;
 
-	// litentry
-	fn sign(&self, payload: &[u8]) -> Result<(AccountId, Vec<u8>)>;
+	// litentry: sign an opaque payload
+	fn sign(&self, payload: &[u8]) -> Result<Vec<u8>>;
 }
 
 /// Proposes a state update to `Externalities`.

--- a/tee-worker/enclave-runtime/src/initialization/mod.rs
+++ b/tee-worker/enclave-runtime/src/initialization/mod.rs
@@ -265,10 +265,13 @@ fn run_stf_task_handler() -> Result<(), Error> {
 		author_api.clone(),
 	));
 
+	let enclave_account = Arc::new(GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT.get()?.retrieve_key()?);
+
 	let stf_task_context = StfTaskContext::new(
 		shielding_key_repository,
 		author_api,
 		stf_enclave_signer,
+		enclave_account,
 		state_handler,
 		ocall_api,
 		data_provider_config,
@@ -295,10 +298,13 @@ fn run_vc_issuance() -> Result<(), Error> {
 		author_api.clone(),
 	));
 
+	let enclave_account = Arc::new(GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT.get()?.retrieve_key()?);
+
 	let stf_task_context = StfTaskContext::new(
 		shielding_key_repository,
 		author_api,
 		stf_enclave_signer,
+		enclave_account,
 		state_handler,
 		ocall_api,
 		data_provider_config,

--- a/tee-worker/enclave-runtime/src/test/enclave_signer_tests.rs
+++ b/tee-worker/enclave-runtime/src/test/enclave_signer_tests.rs
@@ -35,7 +35,7 @@ use itp_stf_primitives::{
 use itp_stf_state_observer::mock::ObserveStateMock;
 use itp_test::mock::onchain_mock::OnchainMock;
 use itp_top_pool_author::{mocks::AuthorApiMock, traits::AuthorApi};
-use itp_types::{parentchain::ParentchainId, RsaRequest};
+use itp_types::RsaRequest;
 use litentry_primitives::Identity;
 use sgx_crypto_helper::{rsa3072::Rsa3072KeyPair, RsaKeyPair};
 use sp_core::Pair;

--- a/tee-worker/enclave-runtime/src/test/tests_main.rs
+++ b/tee-worker/enclave-runtime/src/test/tests_main.rs
@@ -57,7 +57,7 @@ use itp_stf_primitives::{
 use itp_stf_state_handler::handle_state::HandleState;
 use itp_test::mock::handle_state_mock;
 use itp_top_pool_author::{test_utils::submit_operation_to_top_pool, traits::AuthorApi};
-use itp_types::{parentchain::ParentchainId, AccountId, Balance, Block, Header};
+use itp_types::{AccountId, Balance, Block, Header};
 use its_primitives::{
 	traits::{
 		Block as BlockTrait, BlockData, Header as SidechainHeaderTrait,

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -38,8 +38,7 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 use codec::{Decode, Encode};
 use itp_stf_primitives::types::ShardIdentifier;
 use itp_time_utils::{from_iso8601, now_as_iso8601};
-use itp_types::{AccountId, BlockNumber as SidechainBlockNumber};
-use itp_utils::stringify::account_id_to_string;
+use itp_types::BlockNumber as SidechainBlockNumber;
 use litentry_primitives::{Identity, ParentchainBlockNumber, Web3Network};
 use log::*;
 use scale_info::TypeInfo;
@@ -123,7 +122,6 @@ pub struct IssuerRuntimeVersion {
 #[derive(Serialize, Deserialize, Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo)]
 #[serde(rename_all = "camelCase")]
 pub struct Issuer {
-	/// ID of the TEE Worker
 	pub id: String,
 	pub name: String,
 	pub mrenclave: String,
@@ -133,10 +131,6 @@ pub struct Issuer {
 impl Issuer {
 	pub fn is_empty(&self) -> bool {
 		self.mrenclave.is_empty() || self.mrenclave.is_empty()
-	}
-
-	pub fn set_id(&mut self, id: &AccountId) {
-		self.id = account_id_to_string(id);
 	}
 }
 
@@ -191,19 +185,20 @@ pub struct Proof {
 	/// Purpose of this proof, generally it is expected as a fixed value, such as 'assertionMethod'
 	pub proof_purpose: String,
 	/// The digital signature value(signature of hash)
+	/// TODO: it should be base-encoded value according to https://www.w3.org/TR/vc-data-integrity/#proofs
 	pub proof_value: String,
-	/// The public key from Issuer
+	/// Verification method, here it's the public key of the VC signer
 	pub verification_method: String,
 }
 
 impl Proof {
-	pub fn new(sig: &Vec<u8>, issuer: &AccountId) -> Self {
+	pub fn new(sig: &Vec<u8>, verification_method: String) -> Self {
 		Proof {
 			created: now_as_iso8601(),
 			proof_type: ProofType::Ed25519Signature2020,
 			proof_purpose: PROOF_PURPOSE.to_string(),
 			proof_value: format!("{}", HexDisplay::from(sig)),
-			verification_method: account_id_to_string(issuer),
+			verification_method,
 		}
 	}
 
@@ -274,8 +269,8 @@ impl Credential {
 		Ok(vc)
 	}
 
-	pub fn add_proof(&mut self, sig: &Vec<u8>, issuer: &AccountId) {
-		self.proof = Some(Proof::new(sig, issuer));
+	pub fn add_proof(&mut self, sig: &Vec<u8>, verification_method: String) {
+		self.proof = Some(Proof::new(sig, verification_method));
 	}
 
 	fn generate_id(&mut self) {

--- a/tee-worker/litentry/core/credentials/src/lib.rs
+++ b/tee-worker/litentry/core/credentials/src/lib.rs
@@ -566,6 +566,7 @@ pub fn format_assertion_to_date() -> String {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use itp_types::AccountId;
 
 	#[test]
 	fn eval_simple_success() {

--- a/tee-worker/litentry/core/stf-task/receiver/src/lib.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/lib.rs
@@ -56,7 +56,7 @@ use lc_dynamic_assertion::AssertionLogicRepository;
 use lc_evm_dynamic_assertions::AssertionRepositoryItem;
 use lc_stf_task_sender::{init_stf_task_sender_storage, RequestType};
 use log::*;
-use sp_core::H160;
+use sp_core::{ed25519::Pair as Ed25519Pair, H160};
 use std::{
 	boxed::Box,
 	format,
@@ -99,6 +99,7 @@ pub struct StfTaskContext<
 	pub shielding_key: Arc<ShieldingKeyRepository>,
 	pub author_api: Arc<A>,
 	pub enclave_signer: Arc<S>,
+	pub enclave_account: Arc<Ed25519Pair>,
 	pub state_handler: Arc<H>,
 	pub ocall_api: Arc<O>,
 	pub data_provider_config: Arc<DataProviderConfig>,
@@ -118,10 +119,12 @@ where
 	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoEncrypt + 'static,
 	H::StateT: SgxExternalitiesTrait,
 {
+	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		shielding_key: Arc<ShieldingKeyRepository>,
 		author_api: Arc<A>,
 		enclave_signer: Arc<S>,
+		enclave_account: Arc<Ed25519Pair>,
 		state_handler: Arc<H>,
 		ocall_api: Arc<O>,
 		data_provider_config: Arc<DataProviderConfig>,
@@ -131,6 +134,7 @@ where
 			shielding_key,
 			author_api,
 			enclave_signer,
+			enclave_account,
 			state_handler,
 			ocall_api,
 			data_provider_config,

--- a/tee-worker/litentry/core/stf-task/receiver/src/test.rs
+++ b/tee-worker/litentry/core/stf-task/receiver/src/test.rs
@@ -13,6 +13,7 @@ use itp_top_pool_author::mocks::AuthorApiMock;
 use lc_evm_dynamic_assertions::repository::EvmAssertionRepository;
 use lc_stf_task_sender::{SendStfRequest, StfRequestSender};
 use litentry_primitives::Assertion;
+use sp_core::{ed25519::Pair as Ed25519Pair, Pair};
 
 #[test]
 fn test_threadpool_behaviour() {
@@ -20,6 +21,7 @@ fn test_threadpool_behaviour() {
 	let shielding_key_repository_mock = KeyRepositoryMock::new(shielding_key.clone());
 	let author_mock = AuthorApiMock::default();
 	let stf_enclave_signer_mock = StfEnclaveSignerMock::default();
+	let enclave_account = Ed25519Pair::from_string("//Alice", None).unwrap();
 	let handle_state_mock = HandleStateMock::default();
 	let onchain_mock = OnchainMock::default();
 	let data_provider_conifg = DataProviderConfig::new().unwrap();
@@ -28,6 +30,7 @@ fn test_threadpool_behaviour() {
 		Arc::new(shielding_key_repository_mock),
 		author_mock.into(),
 		stf_enclave_signer_mock.into(),
+		enclave_account.into(),
 		handle_state_mock.into(),
 		onchain_mock.into(),
 		data_provider_conifg.into(),

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -118,41 +118,33 @@ export async function assertVc(context: IntegrationTestContext, subject: CorePri
     const { proof, ...vcWithoutProof } = vcPayloadJson;
 
     // step 5
-    // prepare teebag enclave registry data for further checks
-    const parachainBlockHash = await context.api.query.system.blockHash(vcPayloadJson.parachainBlockNumber);
-    const apiAtVcIssuedBlock = await context.api.at(parachainBlockHash);
-    const enclaveIdentifier = await apiAtVcIssuedBlock.query.teebag.enclaveIdentifier('Identity');
-    const lastRegisteredEnclave = (
-        await apiAtVcIssuedBlock.query.teebag.enclaveRegistry(enclaveIdentifier[enclaveIdentifier.length - 1])
-    ).unwrap();
-
-    // step 6
     // check vc signature
     const signature = Buffer.from(hexToU8a(`0x${proof.proofValue}`));
     const message = Buffer.from(JSON.stringify(vcWithoutProof));
-    const vcPubkeyBytes = context.api.createType('Option<Bytes>', lastRegisteredEnclave.vcPubkey).unwrap();
-    const vcPubkey = Buffer.from(hexToU8a(vcPubkeyBytes.toHex()));
+    const vcPubkey = Buffer.from(hexToU8a(proof.verificationMethod));
     const signatureStatus = await ed.verify(signature, message, vcPubkey);
-
     assert.isTrue(signatureStatus, 'Check Vc signature error: signature should be valid');
 
-    // step 7
-    // check VC mrenclave with enclave's mrenclave from registry
+    // step 6
+    // lookup the teebag enclave regsitry to check mrenclave and vcPubkey
+    const parachainBlockHash = await context.api.query.system.blockHash(vcPayloadJson.parachainBlockNumber);
+    const apiAtVcIssuedBlock = await context.api.at(parachainBlockHash);
+    const enclaveAccount = trimPrefix(vcPayloadJson.issuer.id, 'did:litentry:substrate:');
+    const registeredEnclave = (await apiAtVcIssuedBlock.query.teebag.enclaveRegistry(enclaveAccount)).unwrap();
+
     assert.equal(
         vcPayloadJson.issuer.mrenclave,
-        base58.encode(lastRegisteredEnclave.mrenclave),
+        base58.encode(registeredEnclave.mrenclave),
         "Check VC mrenclave: it should equal enclave's mrenclave from parachains enclave registry"
     );
 
-    // step 8
-    // check vc issuer id
     assert.equal(
-        vcPayloadJson.issuer.id,
-        `did:litentry:substrate:${vcPubkeyBytes.toHex()}`,
-        "Check VC id: it should equal enclave's pubkey from parachains enclave registry"
+        proof.verificationMethod,
+        registeredEnclave.vcPubkey,
+        "Check VC pubkey: it should equal enclave's vcPubkey from parachains enclave registry"
     );
 
-    // step 9
+    // step 7
     // check runtime version is present
     assert.deepEqual(
         vcPayloadJson.issuer.runtimeVersion,
@@ -160,9 +152,8 @@ export async function assertVc(context: IntegrationTestContext, subject: CorePri
         'Check VC runtime version: it should equal the current defined versions'
     );
 
-    // step 10
+    // step 8
     // validate VC against schema
-
     const schemaResult = await validateVcSchema(vcPayloadJson);
 
     if (schemaResult.errors) console.log('Schema Validation errors: ', schemaResult.errors);
@@ -197,4 +188,11 @@ export async function assertIdGraphHash(
     const queriedIdGraphHash = (await getIdGraphHash(context, teeShieldingKey, identity)).toHex();
     console.log('queried id graph hash: ', queriedIdGraphHash);
     assert.equal(computedIdGraphHash, queriedIdGraphHash);
+}
+
+function trimPrefix(str: string, prefix: string): string {
+    if (str.startsWith(prefix)) {
+        return str.substring(prefix.length);
+    }
+    return str;
 }

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -148,7 +148,7 @@ export async function assertVc(context: IntegrationTestContext, subject: CorePri
     // check runtime version is present
     assert.deepEqual(
         vcPayloadJson.issuer.runtimeVersion,
-        { parachain: 9181, sidechain: 107 },
+        { parachain: 9181, sidechain: 108 },
         'Check VC runtime version: it should equal the current defined versions'
     );
 


### PR DESCRIPTION
### Context

As topic ... instead of vc_pubkey.

We need this value to find the mapped enclave in `teebag.enclaveRegistry`, see the linked issue.

@jonalvarezz - please check how can the new-sdk verify old vc, maybe by checking timestamp/block-number? Actually, this can be a more general question when there's breaking change, and we might need a more elegant solution 
