### PR TITLE
P-910 dockerfile fix

### DIFF
--- a/bitacross-worker/build.Dockerfile
+++ b/bitacross-worker/build.Dockerfile
@@ -147,6 +147,11 @@ ARG UID=1000
 RUN adduser -u ${UID} --disabled-password --gecos '' litentry
 RUN adduser -u ${UID} litentry sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+# to fix Multi-node distributed worker encounters SGX permission errors.
+RUN groupadd -g 121 sgx_prv && \
+    groupadd -g 108 sgx && \
+    usermod -aG sgx litentry && \
+    usermod -aG sgx_prv litentry
 
 COPY --from=local-builder:latest /opt/sgxsdk /opt/sgxsdk
 COPY --from=local-builder:latest /lib/x86_64-linux-gnu/libsgx* /lib/x86_64-linux-gnu/

--- a/tee-worker/build.Dockerfile
+++ b/tee-worker/build.Dockerfile
@@ -152,6 +152,11 @@ ARG UID=1000
 RUN adduser -u ${UID} --disabled-password --gecos '' litentry
 RUN adduser -u ${UID} litentry sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+# to fix Multi-node distributed worker encounters SGX permission errors.
+RUN groupadd -g 121 sgx_prv && \
+    groupadd -g 108 sgx && \
+    usermod -aG sgx litentry && \
+    usermod -aG sgx_prv litentry
 
 COPY --from=local-builder:latest /opt/sgxsdk /opt/sgxsdk
 COPY --from=local-builder:latest /lib/x86_64-linux-gnu/libsgx* /lib/x86_64-linux-gnu/


### PR DESCRIPTION
### Context

### Labels

Please apply following PR-related labels when appropriate:
- `C1`

### How (Optional)

### Testing Evidences
In the Bitacross staging environment, we employ this method for hotfixes, building local images to run the instances.
```bash
devops@bit-across-staging-2:~$ cat Dockerfile
FROM litentry/bitacross-worker:v0.9.18-06 AS origin


FROM litentry/bitacross-worker:v0.9.18-02 AS runner

USER root

RUN groupadd -g 121 sgx_prv && \
    groupadd -g 108 sgx && \
    usermod -aG sgx litentry && \
    usermod -aG sgx_prv litentry

USER litentry

COPY --from=origin /usr/local/bin/bitacross-worker /usr/local/bin/bitacross-worker
COPY --from=origin /origin/bitacross-worker /origin/bitacross-worker
COPY --from=origin /origin/enclave.signed.so /origin/enclave.signed.so
```