### PR TITLE
Close connection in case of error other than `WouldBlock`

### DIFF
--- a/bitacross-worker/core/tls-websocket-server/src/connection.rs
+++ b/bitacross-worker/core/tls-websocket-server/src/connection.rs
@@ -27,7 +27,7 @@ use log::*;
 use mio::{event::Event, net::TcpStream, Poll, Ready, Token};
 use rustls::{ServerSession, Session};
 use std::{
-	format, io,
+	format,
 	string::{String, ToString},
 	sync::Arc,
 	time::Instant,
@@ -149,13 +149,6 @@ where
 				Err(e) => match e {
 					tungstenite::Error::ConnectionClosed => return Ok(true),
 					tungstenite::Error::AlreadyClosed => return Ok(true),
-					tungstenite::Error::Io(e) => match e.kind() {
-						io::ErrorKind::BrokenPipe => return Ok(true),
-						_ => error!(
-							"Failed to read message from web-socket (connection {}): {:?}",
-							self.connection_token.0, e
-						),
-					},
 					_ => error!(
 						"Failed to read message from web-socket (connection {}): {:?}",
 						self.connection_token.0, e

--- a/bitacross-worker/core/tls-websocket-server/src/connection.rs
+++ b/bitacross-worker/core/tls-websocket-server/src/connection.rs
@@ -27,7 +27,7 @@ use log::*;
 use mio::{event::Event, net::TcpStream, Poll, Ready, Token};
 use rustls::{ServerSession, Session};
 use std::{
-	format,
+	format, io,
 	string::{String, ToString},
 	sync::Arc,
 	time::Instant,
@@ -149,6 +149,13 @@ where
 				Err(e) => match e {
 					tungstenite::Error::ConnectionClosed => return Ok(true),
 					tungstenite::Error::AlreadyClosed => return Ok(true),
+					tungstenite::Error::Io(e) => match e.kind() {
+						io::ErrorKind::BrokenPipe => return Ok(true),
+						_ => error!(
+							"Failed to read message from web-socket (connection {}): {:?}",
+							self.connection_token.0, e
+						),
+					},
 					_ => error!(
 						"Failed to read message from web-socket (connection {}): {:?}",
 						self.connection_token.0, e

--- a/tee-worker/core/tls-websocket-server/src/connection.rs
+++ b/tee-worker/core/tls-websocket-server/src/connection.rs
@@ -27,7 +27,7 @@ use log::*;
 use mio::{event::Event, net::TcpStream, Poll, Ready, Token};
 use rustls::{ServerSession, Session};
 use std::{
-	format,
+	format, io,
 	string::{String, ToString},
 	sync::Arc,
 	time::Instant,
@@ -149,6 +149,13 @@ where
 				Err(e) => match e {
 					tungstenite::Error::ConnectionClosed => return Ok(true),
 					tungstenite::Error::AlreadyClosed => return Ok(true),
+					tungstenite::Error::Io(e) => match e.kind() {
+						io::ErrorKind::BrokenPipe => return Ok(true),
+						_ => error!(
+							"Failed to read message from web-socket (connection {}): {:?}",
+							self.connection_token.0, e
+						),
+					},
 					_ => error!(
 						"Failed to read message from web-socket (connection {}): {:?}",
 						self.connection_token.0, e


### PR DESCRIPTION
For example close connection if pipe was closed, otherwise it will try to constantly read data from connection.

```
[2024-07-02T11:13:31.748010Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:31.749369Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:31.749412Z DEBUG enclave_runtime::rpc::worker_api_direct] worker_api_direct rpc was called: bitacross_getSealedSigners
[2024-07-02T11:13:31.749422Z DEBUG itc_direct_rpc_server::rpc_ws_handler] RPC response string: Some("{\"jsonrpc\":\"2.0\",\"result\":[],\"id\":1}")
[2024-07-02T11:13:32.908192Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.908367Z DEBUG enclave_runtime::rpc::worker_api_direct] worker_api_direct rpc was called: bitacross_getSealedSigners
[2024-07-02T11:13:32.908413Z DEBUG itc_direct_rpc_server::rpc_ws_handler] RPC response string: Some("{\"jsonrpc\":\"2.0\",\"result\":[],\"id\":2}")
[2024-07-02T11:13:32.908667Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.908712Z DEBUG enclave_runtime::rpc::worker_api_direct] worker_api_direct rpc was called: bitacross_getSealedSigners
[2024-07-02T11:13:32.908738Z DEBUG itc_direct_rpc_server::rpc_ws_handler] RPC response string: Some("{\"jsonrpc\":\"2.0\",\"result\":[],\"id\":3}")
[2024-07-02T11:13:32.908791Z ERROR itc_tls_websocket_server::connection] Failed to handle web-socket message (connection 13): SocketWriteError("Io(Os { code: 32, kind: BrokenPipe, message: \"Broken pipe\" })")
[2024-07-02T11:13:32.908914Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.908948Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.909115Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.909146Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.909262Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.909293Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.909410Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.909440Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.909556Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.909586Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.909752Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.909783Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.909914Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.909946Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.910062Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.910093Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.910209Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.910239Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
[2024-07-02T11:13:32.910390Z INFO  itc_tls_websocket_server::ws_server] KZ: Connection (token Token(13)) activity event
[2024-07-02T11:13:32.910421Z ERROR itc_tls_websocket_server::connection] Failed to read message from web-socket (connection 13): Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })

```