### PR TITLE
quick-fix: add developer committee to basefilter

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -399,7 +399,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				RuntimeCall::Democracy(..) |
 					RuntimeCall::Council(..) |
 					RuntimeCall::TechnicalCommittee(..) |
-					RuntimeCall::Treasury(..)
+					RuntimeCall::Treasury(..) |
+					RuntimeCall::DeveloperCommittee(..)
 			),
 		}
 	}
@@ -1290,7 +1291,8 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 				RuntimeCall::ExtrinsicFilter(_) |
 				RuntimeCall::Multisig(_) |
 				RuntimeCall::Council(_) |
-				RuntimeCall::TechnicalCommittee(_)
+				RuntimeCall::TechnicalCommittee(_) |
+				RuntimeCall::DeveloperCommittee(_)
 		) {
 			// always allow core calls
 			return true
@@ -1325,6 +1327,7 @@ impl Contains<RuntimeCall> for NormalModeFilter {
 			// memberships
 			RuntimeCall::CouncilMembership(_) |
 			RuntimeCall::TechnicalCommitteeMembership(_) |
+			RuntimeCall::DeveloperCommitteeMembership(_) |
 			// democracy, we don't subdivide the calls, so we allow public proposals
 			RuntimeCall::Democracy(_) |
 			// Preimage


### PR DESCRIPTION
I missed this step in the previous PR, this should solve call filtered errors. 



Also attaching a screenshot of how you can call the evm assertions moving forward. 
<img width="1257" alt="Screenshot 2024-07-03 at 3 53 04 PM" src="https://github.com/litentry/litentry-parachain/assets/42486737/37856ed1-53ca-4a82-97d1-7f0ae93cc497">
