### PR TITLE
Refactoring force-migrate-shard

### DIFF
--- a/tee-worker/service/src/cli.yml
+++ b/tee-worker/service/src/cli.yml
@@ -161,6 +161,7 @@ subcommands:
                     long: force-migrate-shard
                     help: Force migrate the shard before starting the worker
                     required: false
+                    takes_value: true
     - request-state:
           about: (DEPRECATED) join a shard by requesting key provisioning from another worker
           args:

--- a/tee-worker/service/src/config.rs
+++ b/tee-worker/service/src/config.rs
@@ -319,7 +319,7 @@ pub struct RunConfig {
 	/// parentchain which should be used for shielding/unshielding the stf's native token
 	pub shielding_target: Option<ParentchainId>,
 	/// Whether to migrate the shard before initializing the enclave
-	pub force_migrate_shard: bool,
+	pub force_migrate_shard: Option<String>,
 }
 
 impl RunConfig {
@@ -365,7 +365,7 @@ impl From<&ArgMatches<'_>> for RunConfig {
 			),
 		});
 
-		let force_migrate_shard = m.is_present("force-migrate-shard");
+		let force_migrate_shard = m.value_of("force-migrate-shard").map(|s| s.to_string());
 
 		Self { skip_ra, dev, shard, marblerun_base_url, shielding_target, force_migrate_shard }
 	}


### PR DESCRIPTION
This PR introduces the following changes:

- Now the new shard hex value needs to be pass along the `force-migrate-shard` flag.
- `mrenclave` command also prints the hex value.
- The enclave is re-initialized after force-migrate-shard.
