### PR TITLE
Disable docker build record upload

### DIFF
--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -191,6 +191,8 @@ jobs:
 
       - name: Build local builder
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: tee-worker/build.Dockerfile
@@ -206,6 +208,8 @@ jobs:
 
       - name: Build worker
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: tee-worker/build.Dockerfile
@@ -259,6 +263,8 @@ jobs:
 
       - name: Build local builder
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: bitacross-worker/build.Dockerfile
@@ -274,6 +280,8 @@ jobs:
 
       - name: Build worker
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: bitacross-worker/build.Dockerfile


### PR DESCRIPTION
### Context

As topic, based on https://docs.docker.com/build/ci/github-actions/build-summary/

It seems our releasing process somehow has prolems with it:
https://github.com/litentry/litentry-parachain/actions/runs/9826021732