### PR TITLE
feat: add a parachain event for completion of contract sync

### DIFF
--- a/pallets/evm-assertions/src/mock.rs
+++ b/pallets/evm-assertions/src/mock.rs
@@ -104,6 +104,7 @@ impl pallet_evm_assertions::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type AssertionId = H160;
 	type ContractDevOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type TEECallOrigin = frame_system::EnsureRoot<Self::AccountId>;
 }
 
 parameter_types! {

--- a/pallets/evm-assertions/src/tests.rs
+++ b/pallets/evm-assertions/src/tests.rs
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
-use crate::{mock::*, Error};
+use crate::{mock::*, Assertion, Error};
 use frame_support::{assert_noop, assert_ok};
 use sp_core::H160;
 
@@ -61,5 +61,35 @@ fn should_not_create_new_assertion_if_exists() {
 			),
 			Error::<Test>::AssertionExists
 		);
+	});
+}
+
+#[test]
+fn should_remove_assertion_if_failed_to_store() {
+	new_test_ext().execute_with(|| {
+		let assertion_id: H160 = H160::from_slice(&[1u8; 20]);
+		let byte_code = [0u8; 256].to_vec();
+		let secrets = vec![[2u8; 13].to_vec(), [3u8; 32].to_vec()];
+
+		assert_ok!(EvmAssertions::create_assertion(
+			RuntimeOrigin::root(),
+			assertion_id,
+			byte_code.clone(),
+			secrets.clone()
+		));
+
+		assert_eq!(
+			EvmAssertions::assertions(assertion_id),
+			Some(Assertion { byte_code: byte_code.clone(), secrets: secrets.clone() })
+		);
+
+		assert_ok!(EvmAssertions::void_assertion(
+			RuntimeOrigin::root(),
+			assertion_id,
+			byte_code.clone(),
+			secrets.clone()
+		));
+
+		assert_eq!(EvmAssertions::assertions(assertion_id), None);
 	});
 }

--- a/pallets/evm-assertions/src/tests.rs
+++ b/pallets/evm-assertions/src/tests.rs
@@ -78,17 +78,9 @@ fn should_remove_assertion_if_failed_to_store() {
 			secrets.clone()
 		));
 
-		assert_eq!(
-			EvmAssertions::assertions(assertion_id),
-			Some(Assertion { byte_code: byte_code.clone(), secrets: secrets.clone() })
-		);
+		assert_eq!(EvmAssertions::assertions(assertion_id), Some(Assertion { byte_code, secrets }));
 
-		assert_ok!(EvmAssertions::void_assertion(
-			RuntimeOrigin::root(),
-			assertion_id,
-			byte_code.clone(),
-			secrets.clone()
-		));
+		assert_ok!(EvmAssertions::void_assertion(RuntimeOrigin::root(), assertion_id,));
 
 		assert_eq!(EvmAssertions::assertions(assertion_id), None);
 	});

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1034,6 +1034,7 @@ impl pallet_evm_assertions::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type AssertionId = H160;
 	type ContractDevOrigin = pallet_collective::EnsureMember<AccountId, DeveloperCommitteeInstance>;
+	type TEECallOrigin = EnsureEnclaveSigner<Runtime>;
 }
 
 // Temporary for bitacross team to test

--- a/tee-worker/app-libs/parentchain-interface/src/integritee/event_handler.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/integritee/event_handler.rs
@@ -212,8 +212,10 @@ where
 		&self,
 		executor: &Executor,
 		events: impl FilterEvents,
-	) -> Result<Vec<H256>, Error> {
+	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error> {
 		let mut handled_events: Vec<H256> = Vec::new();
+		let mut successful_assertion_ids: Vec<H160> = Vec::new();
+		let mut failed_assertion_ids: Vec<H160> = Vec::new();
 		if let Ok(events) = events.get_link_identity_events() {
 			debug!("Handling link_identity events");
 			events
@@ -309,6 +311,11 @@ where
 					let result =
 						self.store_assertion(executor, event.id, event.byte_code, event.secrets);
 					handled_events.push(event_hash);
+					if result.is_ok() {
+						successful_assertion_ids.push(event.id);
+					} else {
+						failed_assertion_ids.push(event.id)
+					}
 					result
 				})
 				.map_err(|_| ParentchainEventProcessingError::AssertionCreatedFailure)?;
@@ -323,7 +330,7 @@ where
 			});
 		}
 
-		Ok(handled_events)
+		Ok((handled_events, successful_assertion_ids, failed_assertion_ids))
 	}
 }
 

--- a/tee-worker/app-libs/parentchain-interface/src/integritee/event_handler.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/integritee/event_handler.rs
@@ -24,7 +24,7 @@ use itp_stf_primitives::{traits::IndirectExecutor, types::TrustedOperation};
 use itp_types::{
 	parentchain::{
 		events::ParentchainBlockProcessed, AccountId, FilterEvents, HandleParentchainEvents,
-		ParentchainEventProcessingError,
+		ParentchainEventProcessingError, ProcessedEventsArtifacts,
 	},
 	RsaRequest, H256,
 };
@@ -212,7 +212,7 @@ where
 		&self,
 		executor: &Executor,
 		events: impl FilterEvents,
-	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error> {
+	) -> Result<ProcessedEventsArtifacts, Error> {
 		let mut handled_events: Vec<H256> = Vec::new();
 		let mut successful_assertion_ids: Vec<H160> = Vec::new();
 		let mut failed_assertion_ids: Vec<H160> = Vec::new();

--- a/tee-worker/app-libs/parentchain-interface/src/target_a/event_handler.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/target_a/event_handler.rs
@@ -20,9 +20,8 @@ pub use ita_sgx_runtime::{Balance, Index};
 use ita_stf::TrustedCallSigned;
 use itc_parentchain_indirect_calls_executor::error::Error;
 use itp_stf_primitives::traits::IndirectExecutor;
-use itp_types::parentchain::{FilterEvents, HandleParentchainEvents};
+use itp_types::parentchain::{FilterEvents, HandleParentchainEvents, ProcessedEventsArtifacts};
 use log::*;
-use sp_core::{H160, H256};
 use sp_std::vec::Vec;
 
 pub struct ParentchainEventHandler {}
@@ -36,7 +35,7 @@ where
 		&self,
 		_executor: &Executor,
 		_events: impl FilterEvents,
-	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error> {
+	) -> Result<ProcessedEventsArtifacts, Error> {
 		debug!("not handling any events for target a");
 		Ok((Vec::new(), Vec::new(), Vec::new()))
 	}

--- a/tee-worker/app-libs/parentchain-interface/src/target_a/event_handler.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/target_a/event_handler.rs
@@ -22,7 +22,7 @@ use itc_parentchain_indirect_calls_executor::error::Error;
 use itp_stf_primitives::traits::IndirectExecutor;
 use itp_types::parentchain::{FilterEvents, HandleParentchainEvents};
 use log::*;
-use sp_core::H256;
+use sp_core::{H160, H256};
 use sp_std::vec::Vec;
 
 pub struct ParentchainEventHandler {}
@@ -36,8 +36,8 @@ where
 		&self,
 		_executor: &Executor,
 		_events: impl FilterEvents,
-	) -> Result<Vec<H256>, Error> {
+	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error> {
 		debug!("not handling any events for target a");
-		Ok(Vec::new())
+		Ok((Vec::new(), Vec::new(), Vec::new()))
 	}
 }

--- a/tee-worker/app-libs/parentchain-interface/src/target_b/event_handler.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/target_b/event_handler.rs
@@ -20,9 +20,8 @@ pub use ita_sgx_runtime::{Balance, Index};
 use ita_stf::TrustedCallSigned;
 use itc_parentchain_indirect_calls_executor::error::Error;
 use itp_stf_primitives::traits::IndirectExecutor;
-use itp_types::parentchain::{FilterEvents, HandleParentchainEvents};
+use itp_types::parentchain::{FilterEvents, HandleParentchainEvents, ProcessedEventsArtifacts};
 use log::*;
-use sp_core::{H160, H256};
 use sp_std::vec::Vec;
 
 pub struct ParentchainEventHandler {}
@@ -36,7 +35,7 @@ where
 		&self,
 		_executor: &Executor,
 		_events: impl FilterEvents,
-	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error> {
+	) -> Result<ProcessedEventsArtifacts, Error> {
 		debug!("not handling any events for target B");
 		Ok((Vec::new(), Vec::new(), Vec::new()))
 	}

--- a/tee-worker/app-libs/parentchain-interface/src/target_b/event_handler.rs
+++ b/tee-worker/app-libs/parentchain-interface/src/target_b/event_handler.rs
@@ -22,7 +22,7 @@ use itc_parentchain_indirect_calls_executor::error::Error;
 use itp_stf_primitives::traits::IndirectExecutor;
 use itp_types::parentchain::{FilterEvents, HandleParentchainEvents};
 use log::*;
-use sp_core::H256;
+use sp_core::{H160, H256};
 use sp_std::vec::Vec;
 
 pub struct ParentchainEventHandler {}
@@ -36,8 +36,8 @@ where
 		&self,
 		_executor: &Executor,
 		_events: impl FilterEvents,
-	) -> Result<Vec<H256>, Error> {
+	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error> {
 		debug!("not handling any events for target B");
-		Ok(Vec::new())
+		Ok((Vec::new(), Vec::new(), Vec::new()))
 	}
 }

--- a/tee-worker/core-primitives/node-api/metadata/src/lib.rs
+++ b/tee-worker/core-primitives/node-api/metadata/src/lib.rs
@@ -20,7 +20,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use crate::{
-	error::Result, pallet_balances::BalancesCallIndexes, pallet_imp::IMPCallIndexes,
+	error::Result, pallet_balances::BalancesCallIndexes,
+	pallet_evm_assertion::EvmAssertionsCallIndexes, pallet_imp::IMPCallIndexes,
 	pallet_proxy::ProxyCallIndexes, pallet_system::SystemConstants,
 	pallet_teebag::TeebagCallIndexes, pallet_timestamp::TimestampCallIndexes,
 	pallet_utility::UtilityCallIndexes, pallet_vcmp::VCMPCallIndexes,
@@ -33,6 +34,7 @@ pub use itp_api_client_types::{Metadata, MetadataError};
 
 pub mod error;
 pub mod pallet_balances;
+pub mod pallet_evm_assertion;
 pub mod pallet_imp;
 pub mod pallet_proxy;
 pub mod pallet_system;
@@ -55,6 +57,7 @@ pub trait NodeMetadataTrait:
 	+ ProxyCallIndexes
 	+ BalancesCallIndexes
 	+ TimestampCallIndexes
+	+ EvmAssertionsCallIndexes
 {
 }
 
@@ -66,7 +69,8 @@ impl<
 			+ UtilityCallIndexes
 			+ ProxyCallIndexes
 			+ BalancesCallIndexes
-			+ TimestampCallIndexes,
+			+ TimestampCallIndexes
+			+ EvmAssertionsCallIndexes,
 	> NodeMetadataTrait for T
 {
 }

--- a/tee-worker/core-primitives/node-api/metadata/src/metadata_mocks.rs
+++ b/tee-worker/core-primitives/node-api/metadata/src/metadata_mocks.rs
@@ -16,7 +16,8 @@
 */
 
 use crate::{
-	error::Result, pallet_balances::BalancesCallIndexes, pallet_imp::IMPCallIndexes,
+	error::Result, pallet_balances::BalancesCallIndexes,
+	pallet_evm_assertion::EvmAssertionsCallIndexes, pallet_imp::IMPCallIndexes,
 	pallet_proxy::ProxyCallIndexes, pallet_system::SystemConstants,
 	pallet_teebag::TeebagCallIndexes, pallet_timestamp::TimestampCallIndexes,
 	pallet_utility::UtilityCallIndexes, pallet_vcmp::VCMPCallIndexes, runtime_call::RuntimeCall,
@@ -64,6 +65,10 @@ pub struct NodeMetadataMock {
 	vcmp_request_vc: u8,
 	vcmp_vc_issued: u8,
 	vcmp_some_error: u8,
+	// EVM Assertion
+	evm_assertions_module: u8,
+	evm_assertions_store_assertion: u8,
+	evm_assertions_void_assertion: u8,
 
 	utility_module: u8,
 	utility_batch: u8,
@@ -115,6 +120,10 @@ impl NodeMetadataMock {
 			vcmp_request_vc: 0u8,
 			vcmp_vc_issued: 3u8,
 			vcmp_some_error: 9u8,
+
+			evm_assertions_module: 76u8,
+			evm_assertions_store_assertion: 77u8,
+			evm_assertions_void_assertion: 78u8,
 
 			utility_module: 80u8,
 			utility_batch: 0u8,
@@ -289,5 +298,15 @@ impl BalancesCallIndexes for NodeMetadataMock {
 impl TimestampCallIndexes for NodeMetadataMock {
 	fn timestamp_set_call_indexes(&self) -> Result<[u8; 2]> {
 		Ok([self.timestamp_module, self.timestamp_set])
+	}
+}
+
+impl EvmAssertionsCallIndexes for NodeMetadataMock {
+	fn store_assertion_call_indexes(&self) -> Result<[u8; 2]> {
+		Ok([self.evm_assertions_module, self.evm_assertions_store_assertion])
+	}
+
+	fn void_assertion_call_indexes(&self) -> Result<[u8; 2]> {
+		Ok([self.evm_assertions_module, self.evm_assertions_void_assertion])
 	}
 }

--- a/tee-worker/core-primitives/node-api/metadata/src/pallet_evm_assertion.rs
+++ b/tee-worker/core-primitives/node-api/metadata/src/pallet_evm_assertion.rs
@@ -1,0 +1,36 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{error::Result, NodeMetadata};
+
+/// Pallet name:
+const EVM_ASSERTION: &str = "EvmAssertions";
+
+pub trait EvmAssertionsCallIndexes {
+	fn store_assertion_call_indexes(&self) -> Result<[u8; 2]>;
+	fn void_assertion_call_indexes(&self) -> Result<[u8; 2]>;
+}
+
+impl EvmAssertionsCallIndexes for NodeMetadata {
+	fn store_assertion_call_indexes(&self) -> Result<[u8; 2]> {
+		self.call_indexes(EVM_ASSERTION, "store_assertion")
+	}
+
+	fn void_assertion_call_indexes(&self) -> Result<[u8; 2]> {
+		self.call_indexes(EVM_ASSERTION, "void_assertion")
+	}
+}

--- a/tee-worker/core-primitives/types/src/parentchain/mod.rs
+++ b/tee-worker/core-primitives/types/src/parentchain/mod.rs
@@ -124,6 +124,8 @@ pub enum ExtrinsicStatus {
 	Failed,
 }
 
+pub type ProcessedEventsArtifacts = (Vec<H256>, Vec<H160>, Vec<H160>);
+
 pub trait HandleParentchainEvents<Executor, TCS, Error>
 where
 	Executor: IndirectExecutor<TCS, Error>,
@@ -133,7 +135,7 @@ where
 		&self,
 		executor: &Executor,
 		events: impl FilterEvents,
-	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error>;
+	) -> Result<ProcessedEventsArtifacts, Error>;
 }
 
 #[derive(Debug)]

--- a/tee-worker/core-primitives/types/src/parentchain/mod.rs
+++ b/tee-worker/core-primitives/types/src/parentchain/mod.rs
@@ -28,7 +28,7 @@ use events::{
 use itp_stf_primitives::traits::{IndirectExecutor, TrustedCallVerification};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use sp_core::{bounded::alloc, H256};
+use sp_core::{bounded::alloc, H160, H256};
 use sp_runtime::{generic::Header as HeaderG, traits::BlakeTwo256, MultiAddress, MultiSignature};
 
 use self::events::ParentchainBlockProcessed;
@@ -133,7 +133,7 @@ where
 		&self,
 		executor: &Executor,
 		events: impl FilterEvents,
-	) -> Result<Vec<H256>, Error>;
+	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error>;
 }
 
 #[derive(Debug)]

--- a/tee-worker/core/parentchain/block-importer/src/block_importer.rs
+++ b/tee-worker/core/parentchain/block-importer/src/block_importer.rs
@@ -184,8 +184,8 @@ impl<
 				&raw_events,
 				self.ocall_api.clone(),
 			) {
-				Ok(Some(confirm_processed_parentchain_block_call)) => {
-					calls.push(confirm_processed_parentchain_block_call);
+				Ok(Some(opaque_calls)) => {
+					calls.extend(opaque_calls);
 				},
 				Ok(None) => trace!("omitting confirmation call to non-integritee parentchain"),
 				Err(e) => error!("[{:?}] Error executing relevant events: {:?}", id, e),

--- a/tee-worker/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/tee-worker/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -7,7 +7,7 @@ use itp_types::{
 			ActivateIdentityRequested, AssertionCreated, DeactivateIdentityRequested,
 			EnclaveUnauthorized, LinkIdentityRequested, OpaqueTaskPosted, VCRequested,
 		},
-		FilterEvents, HandleParentchainEvents,
+		FilterEvents, HandleParentchainEvents, ProcessedEventsArtifacts,
 	},
 	RsaRequest, H256,
 };
@@ -83,7 +83,7 @@ where
 		&self,
 		_: &Executor,
 		_: impl FilterEvents,
-	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error> {
+	) -> Result<ProcessedEventsArtifacts, Error> {
 		Ok((
 			Vec::from([H256::default()]),
 			Vec::from([H160::default()]),

--- a/tee-worker/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/tee-worker/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -11,6 +11,7 @@ use itp_types::{
 	},
 	RsaRequest, H256,
 };
+use sp_core::H160;
 use std::vec::Vec;
 
 pub struct TestEventCreator;
@@ -78,7 +79,15 @@ impl<Executor> HandleParentchainEvents<Executor, TrustedCallSignedMock, Error>
 where
 	Executor: IndirectExecutor<TrustedCallSignedMock, Error>,
 {
-	fn handle_events(&self, _: &Executor, _: impl FilterEvents) -> Result<Vec<H256>, Error> {
-		Ok(Vec::from([H256::default()]))
+	fn handle_events(
+		&self,
+		_: &Executor,
+		_: impl FilterEvents,
+	) -> Result<(Vec<H256>, Vec<H160>, Vec<H160>), Error> {
+		Ok((
+			Vec::from([H256::default()]),
+			Vec::from([H160::default()]),
+			Vec::from([H160::default()]),
+		))
 	}
 }

--- a/tee-worker/core/parentchain/indirect-calls-executor/src/traits.rs
+++ b/tee-worker/core/parentchain/indirect-calls-executor/src/traits.rs
@@ -21,6 +21,7 @@ use core::fmt::Debug;
 use itp_ocall_api::EnclaveMetricsOCallApi;
 use itp_stf_primitives::traits::{IndirectExecutor, TrustedCallVerification};
 use itp_types::{OpaqueCall, H256};
+use sp_core::H160;
 use sp_runtime::traits::{Block as ParentchainBlockTrait, Header};
 use std::{sync::Arc, vec::Vec};
 
@@ -34,7 +35,7 @@ pub trait ExecuteIndirectCalls {
 		block: &ParentchainBlock,
 		events: &[u8],
 		metrics_api: Arc<OCallApi>,
-	) -> Result<Option<OpaqueCall>>
+	) -> Result<Option<Vec<OpaqueCall>>>
 	where
 		ParentchainBlock: ParentchainBlockTrait<Hash = H256>,
 		OCallApi: EnclaveMetricsOCallApi;
@@ -50,6 +51,10 @@ pub trait ExecuteIndirectCalls {
 	) -> Result<OpaqueCall>
 	where
 		ParentchainBlock: ParentchainBlockTrait<Hash = H256>;
+
+	fn create_assertion_stored_call(&self, assertion_ids: Vec<H160>) -> Result<Vec<OpaqueCall>>;
+
+	fn create_assertion_voided_call(&self, assertion_ids: Vec<H160>) -> Result<Vec<OpaqueCall>>;
 }
 
 /// Trait that should be implemented on indirect calls to be executed.


### PR DESCRIPTION
This adds a callback extrinsic to signal the parachain that the assertion has been succesfully stored and if failure then it removes the assertion from the parachain storage so that it can be retried. 


