### PR TITLE
Bug fix: wrong call_index type and use recv_timeout

### DIFF
--- a/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
+++ b/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
@@ -565,7 +565,7 @@ where
 		let call_index = node_metadata_repo
 			.get_from_metadata(|m| m.vc_issued_call_indexes())
 			.map_err(|e| RequestVcErrorDetail::MetadataRetrievalFailed(e.to_string()))?
-			.map_err(|e| RequestVcErrorDetail::InvalidMetadata(format!("{:?}", e)));
+			.map_err(|e| RequestVcErrorDetail::InvalidMetadata(format!("{:?}", e)))?;
 
 		let key = maybe_key.ok_or(RequestVcErrorDetail::MissingAesKey)?;
 		let call = OpaqueCall::from_tuple(&(


### PR DESCRIPTION
### Context

The PR tries to fix two bugs:
- `call_index` should be `[u8; 2]`, not `Result`
- `recv()` has blocking behaviour, which causes the first `elapse()` to be evaluated too late as well as blocks the thread even after the last item is transferred

It serves as a hot fix - so if there's any better way of doing it we can have another PR