### PR TITLE
client-api: release latest versions

### DIFF
--- a/tee-worker/client-api/parachain-api/CHANGELOG.md
+++ b/tee-worker/client-api/parachain-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.18-10] - 2024-07-15
+
+Matching version for [parachain-release v0.9.18-10](https://github.com/litentry/litentry-parachain/releases/tag/v0.9.18-10)
+
 ## [0.9.18-next.8] - 2024-07-02
 
 Routinely update

--- a/tee-worker/client-api/parachain-api/package.json
+++ b/tee-worker/client-api/parachain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.18-next.8",
+    "version": "0.9.18-10",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "curl -s -H \"Content-Type: application/json\" -d '{\"id\":\"1\", \"jsonrpc\":\"2.0\", \"method\": \"state_getMetadata\", \"params\":[]}' http://localhost:9944 > prepare-build/litentry-parachain-metadata.json",

--- a/tee-worker/client-api/sidechain-api/CHANGELOG.md
+++ b/tee-worker/client-api/sidechain-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.18-10] - 2024-07-16
+
+Align version with [parachain-release v0.9.18-10](https://github.com/litentry/litentry-parachain/releases/tag/v0.9.18-10)
+
 ## [0.0.2-10] - 2024-07-15
 
 Matching version for [parachain-release v0.9.18-10](https://github.com/litentry/litentry-parachain/releases/tag/v0.9.18-10)

--- a/tee-worker/client-api/sidechain-api/CHANGELOG.md
+++ b/tee-worker/client-api/sidechain-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2-10] - 2024-07-15
+
+Matching version for [parachain-release v0.9.18-10](https://github.com/litentry/litentry-parachain/releases/tag/v0.9.18-10)
+
 ## [0.0.2-next.5] - 2024-07-02
 
 Routinely update

--- a/tee-worker/client-api/sidechain-api/package.json
+++ b/tee-worker/client-api/sidechain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.0.2-next.5",
+    "version": "0.0.2-10",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "../../bin/litentry-cli print-sgx-metadata-raw > prepare-build/litentry-sidechain-metadata.json",

--- a/tee-worker/client-api/sidechain-api/package.json
+++ b/tee-worker/client-api/sidechain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.0.2-10",
+    "version": "0.9.18-10",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "../../bin/litentry-cli print-sgx-metadata-raw > prepare-build/litentry-sidechain-metadata.json",


### PR DESCRIPTION
Release "stable" version amid the [parachain-release v0.9.18-10](https://github.com/litentry/litentry-parachain/releases/tag/v0.9.18-10)

Published versions in NPM:
- parachain-api: https://www.npmjs.com/package/@litentry/parachain-api/v/0.9.18-10
- sidechain-api: https://www.npmjs.com/package/@litentry/sidechain-api/v/0.9.18-10
