### PR TITLE
fix: potential state mismatch caused by failed indirect trusted_call

### DIFF
--- a/tee-worker/core-primitives/stf-executor/src/error.rs
+++ b/tee-worker/core-primitives/stf-executor/src/error.rs
@@ -17,13 +17,17 @@
 
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 use crate::sgx_reexport_prelude::*;
+use crate::RpcResponseValue;
 
 use itp_stf_primitives::error::StfError;
+use itp_types::parentchain::ParentchainCall;
 use sgx_types::sgx_status_t;
-use std::{boxed::Box, format};
+use sp_core::H256;
+use std::{boxed::Box, format, vec::Vec};
 
 pub type Result<T> = core::result::Result<T, Error>;
 
+/// TODO: Add new error type with extrinsic callbacks
 /// STF-Executor error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -49,6 +53,8 @@ pub enum Error {
 	Crypto(itp_sgx_crypto::error::Error),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
+	#[error("Stf Execution Error: {0}")]
+	StfExecutionError(H256, Vec<ParentchainCall>, RpcResponseValue),
 }
 
 impl From<sgx_status_t> for Error {

--- a/tee-worker/core-primitives/stf-executor/src/lib.rs
+++ b/tee-worker/core-primitives/stf-executor/src/lib.rs
@@ -180,6 +180,7 @@ where
 	pub state_hash_before_execution: H256,
 	pub executed_operations: Vec<ExecutedOperation<TCS, G>>,
 	pub state_after_execution: Externalities,
+	pub failed_operations: Vec<(H256, Vec<ParentchainCall>, RpcResponseValue)>,
 }
 
 impl<Externalities, TCS, G> BatchExecutionResult<Externalities, TCS, G>
@@ -195,6 +196,10 @@ where
 			.collect()
 	}
 
+	pub fn get_failed_operations_extrinsic_callbacks(&self) -> Vec<ParentchainCall> {
+		self.failed_operations.clone().into_iter().flat_map(|f| f.1).collect()
+	}
+
 	/// Returns all successfully exectued operation hashes.
 	pub fn get_executed_operation_hashes(&self) -> Vec<H256> {
 		self.executed_operations
@@ -203,9 +208,18 @@ where
 			.collect()
 	}
 
+	// Returns all failed operation hashes
+	pub fn get_failed_operation_hashes(&self) -> Vec<H256> {
+		self.failed_operations.clone().into_iter().map(|e| e.0).collect()
+	}
+
 	/// Returns all operations that were not executed.
 	pub fn get_failed_operations(&self) -> Vec<ExecutedOperation<TCS, G>> {
-		self.executed_operations.iter().filter(|ec| !ec.is_success()).cloned().collect()
+		self.executed_operations
+			.iter()
+			.filter(|ec: &&ExecutedOperation<TCS, G>| !ec.is_success())
+			.cloned()
+			.collect()
 	}
 
 	// Litentry: returns all (top_hash, (rpc_response_value, force_wait) tuples

--- a/tee-worker/core-primitives/stf-executor/src/lib.rs
+++ b/tee-worker/core-primitives/stf-executor/src/lib.rs
@@ -285,6 +285,7 @@ mod tests {
 	) -> BatchExecutionResult<SgxExternalities, TrustedCallSignedMock, GetterMock> {
 		BatchExecutionResult {
 			executed_operations: executed_calls,
+			failed_operations: Default::default(),
 			state_hash_before_execution: H256::default(),
 			state_after_execution: SgxExternalities::default(),
 		}

--- a/tee-worker/core-primitives/stf-executor/src/mocks.rs
+++ b/tee-worker/core-primitives/stf-executor/src/mocks.rs
@@ -104,6 +104,7 @@ where
 			executed_operations,
 			state_hash_before_execution: H256::default(),
 			state_after_execution: updated_state,
+			failed_operations: std::vec![],
 		})
 	}
 }

--- a/tee-worker/enclave-runtime/src/test/tests_main.rs
+++ b/tee-worker/enclave-runtime/src/test/tests_main.rs
@@ -204,6 +204,7 @@ fn test_compose_block() {
 		.compose_block(
 			&latest_parentchain_header(),
 			signed_top_hashes,
+			Default::default(),
 			shard,
 			state_hash_before_execution,
 			&state,
@@ -365,6 +366,7 @@ fn test_create_block_and_confirmation_works() {
 		.compose_block(
 			&latest_parentchain_header(),
 			executed_operation_hashes,
+			Default::default(),
 			shard,
 			execution_result.state_hash_before_execution,
 			&execution_result.state_after_execution,
@@ -415,6 +417,7 @@ fn test_create_state_diff() {
 		.compose_block(
 			&latest_parentchain_header(),
 			executed_operation_hashes,
+			Default::default(),
 			shard,
 			execution_result.state_hash_before_execution,
 			&execution_result.state_after_execution,

--- a/tee-worker/sidechain/block-composer/src/block_composer.rs
+++ b/tee-worker/sidechain/block-composer/src/block_composer.rs
@@ -45,6 +45,7 @@ pub trait ComposeBlock<Externalities, ParentchainBlock: ParentchainBlockTrait> {
 		&self,
 		latest_parentchain_header: &<ParentchainBlock as ParentchainBlockTrait>::Header,
 		top_call_hashes: Vec<H256>,
+		failed_top_call_hashes: Vec<H256>,
 		shard: ShardIdentifier,
 		state_hash_apriori: H256,
 		aposteriori_state: &Externalities,
@@ -112,6 +113,7 @@ where
 		&self,
 		latest_parentchain_header: &ParentchainBlock::Header,
 		top_call_hashes: Vec<H256>,
+		failed_top_call_hashes: Vec<H256>,
 		shard: ShardIdentifier,
 		state_hash_apriori: H256,
 		aposteriori_state: &Externalities,
@@ -155,6 +157,7 @@ where
 			author_public,
 			latest_parentchain_header.hash(),
 			top_call_hashes,
+			failed_top_call_hashes,
 			payload,
 			now_as_millis(),
 		);

--- a/tee-worker/sidechain/consensus/aura/src/block_importer.rs
+++ b/tee-worker/sidechain/consensus/aura/src/block_importer.rs
@@ -150,12 +150,24 @@ impl<
 			.block_data()
 			.signed_top_hashes()
 			.iter()
+			.map(|hash: &H256| (TrustedOperationOrHash::Hash(*hash), true))
+			.collect();
+
+		let failed_operations = sidechain_block
+			.block_data()
+			.failed_top_hashes()
+			.iter()
 			.map(|hash| (TrustedOperationOrHash::Hash(*hash), true))
 			.collect();
 
 		let _calls_failed_to_remove = self
 			.top_pool_author
 			.remove_calls_from_pool(sidechain_block.header().shard_id(), executed_operations);
+
+		// TODO: Refactor this later
+		let _calls_failed_to_remove = self
+			.top_pool_author
+			.remove_calls_from_pool(sidechain_block.header().shard_id(), failed_operations);
 
 		// In case the executed call did not originate in our own TOP pool, we will not be able to remove it from our TOP pool.
 		// So this error will occur frequently, without it meaning that something really went wrong.

--- a/tee-worker/sidechain/primitives/src/traits/mod.rs
+++ b/tee-worker/sidechain/primitives/src/traits/mod.rs
@@ -66,6 +66,8 @@ pub trait BlockData: Encode + Decode + Send + Sync + Debug + Clone {
 	fn block_author(&self) -> &Self::Public;
 	/// get reference of extrinsics of block
 	fn signed_top_hashes(&self) -> &[H256];
+	/// get reference of failed extrinsics of block
+	fn failed_top_hashes(&self) -> &[H256];
 	/// get encrypted payload
 	fn encrypted_state_diff(&self) -> &Vec<u8>;
 	/// get the `blake2_256` hash of the block
@@ -77,6 +79,7 @@ pub trait BlockData: Encode + Decode + Send + Sync + Debug + Clone {
 		author: Self::Public,
 		layer_one_head: H256,
 		signed_top_hashes: Vec<H256>,
+		failed_top_hashes: Vec<H256>,
 		encrypted_payload: Vec<u8>,
 		timestamp: u64,
 	) -> Self;

--- a/tee-worker/sidechain/primitives/src/types/block.rs
+++ b/tee-worker/sidechain/primitives/src/types/block.rs
@@ -127,6 +127,7 @@ mod tests {
 			H256::random(),
 			Default::default(),
 			Default::default(),
+			Default::default(),
 			timestamp_now(),
 		);
 

--- a/tee-worker/sidechain/primitives/src/types/block_data.rs
+++ b/tee-worker/sidechain/primitives/src/types/block_data.rs
@@ -35,6 +35,8 @@ pub struct BlockData {
 	pub block_author: ed25519::Public,
 	/// Hashes of signed trusted operations.
 	pub signed_top_hashes: Vec<H256>,
+	/// Hashes of failed trusted operations
+	pub failed_top_hashes: Vec<H256>,
 	/// Encrypted state payload.
 	pub encrypted_state_diff: Vec<u8>,
 }
@@ -58,6 +60,12 @@ impl BlockDataTrait for BlockData {
 	fn signed_top_hashes(&self) -> &[H256] {
 		&self.signed_top_hashes
 	}
+
+	/// Get reference of failed extrinsics of block
+	fn failed_top_hashes(&self) -> &[H256] {
+		&self.failed_top_hashes
+	}
+
 	/// Get encrypted payload.
 	fn encrypted_state_diff(&self) -> &Vec<u8> {
 		&self.encrypted_state_diff
@@ -67,6 +75,7 @@ impl BlockDataTrait for BlockData {
 		block_author: Self::Public,
 		layer_one_head: H256,
 		signed_top_hashes: Vec<H256>,
+		failed_top_hashes: Vec<H256>,
 		encrypted_state_diff: Vec<u8>,
 		timestamp: Timestamp,
 	) -> BlockData {
@@ -75,6 +84,7 @@ impl BlockDataTrait for BlockData {
 			timestamp,
 			layer_one_head,
 			signed_top_hashes,
+			failed_top_hashes,
 			block_author,
 			encrypted_state_diff,
 		}

--- a/tee-worker/sidechain/test/src/sidechain_block_data_builder.rs
+++ b/tee-worker/sidechain/test/src/sidechain_block_data_builder.rs
@@ -34,6 +34,7 @@ pub struct SidechainBlockDataBuilder {
 	layer_one_head: H256,
 	signer: ed25519::Pair,
 	signed_top_hashes: Vec<H256>,
+	failed_top_hashes: Vec<H256>,
 	encrypted_state_diff: Vec<u8>,
 }
 
@@ -44,6 +45,7 @@ impl Default for SidechainBlockDataBuilder {
 			layer_one_head: Default::default(),
 			signer: Pair::from_seed(&ENCLAVE_SEED),
 			signed_top_hashes: Default::default(),
+			failed_top_hashes: Default::default(),
 			encrypted_state_diff: Default::default(),
 		}
 	}
@@ -56,6 +58,7 @@ impl SidechainBlockDataBuilder {
 			layer_one_head: BlockHash::random(),
 			signer: Pair::from_seed(&ENCLAVE_SEED),
 			signed_top_hashes: vec![H256::random(), H256::random()],
+			failed_top_hashes: vec![H256::random(), H256::random()],
 			encrypted_state_diff: vec![1, 3, 42, 8, 11, 33],
 		}
 	}
@@ -91,6 +94,7 @@ impl SidechainBlockDataBuilder {
 			block_author: self.signer.public(),
 			layer_one_head: self.layer_one_head,
 			signed_top_hashes: self.signed_top_hashes,
+			failed_top_hashes: self.failed_top_hashes,
 			encrypted_state_diff: self.encrypted_state_diff,
 		}
 	}


### PR DESCRIPTION
TODO: 
- Need to update unit tests or add 
- Need to refactor some parts of the code 
- Should check no problems in CI especially multi-worker
- Should update RPC values for error variants 


So there are two types of failures in STF Execution 
### 1. Invalid Trusted Call 
- Does not read the sidechain state 
- Cannot mutate the sidechain state 
https://github.com/litentry/litentry-parachain/blob/9a188ee6b4a88c0d9ea345e9fdfa238040321bd5/tee-worker/core-primitives/stf-executor/src/executor.rs#L112
https://github.com/litentry/litentry-parachain/blob/9a188ee6b4a88c0d9ea345e9fdfa238040321bd5/tee-worker/core-primitives/stf-executor/src/executor.rs#L120
### 2. Stf Execution Failure 
- These read state of the sidechain state 
- Can potentially increment account nonce even in failure, which is a mutation to the sidechain state 
https://github.com/litentry/litentry-parachain/blob/9a188ee6b4a88c0d9ea345e9fdfa238040321bd5/tee-worker/core-primitives/stf-executor/src/executor.rs#L136

However both are treated the same as ` Ok(ExecutedOperation::failed(..))` and thereby not included in the block, 
Only successfully executed trusted operations are included in the block. 

### State Transition Problem 
<img width="837" alt="Screenshot 2024-07-16 at 6 54 49 PM" src="https://github.com/user-attachments/assets/74bb2367-d8e2-4446-bd5e-0a49f62e870e">

A blockchain operates as a state transition function, Each transaction mutates the state creating a new state and this transaction is included in the block. However here we are mutating the state but we have no transaction to show for which is fundamentally against the concept of being a state transition function. 