### PR TITLE
fix: A8 wrong network in VC

### DIFF
--- a/primitives/core/src/assertion/mod.rs
+++ b/primitives/core/src/assertion/mod.rs
@@ -143,7 +143,7 @@ pub enum Assertion {
 	Dynamic(DynamicParams)
 }
 
-pub const A8_SUPPORTED_NETWORKS: [Web3Network; 6] = [
+const A8_SUPPORTED_NETWORKS: [Web3Network; 6] = [
 	Web3Network::Polkadot,
 	Web3Network::Kusama,
 	Web3Network::Litentry,

--- a/primitives/core/src/assertion/mod.rs
+++ b/primitives/core/src/assertion/mod.rs
@@ -143,6 +143,15 @@ pub enum Assertion {
 	Dynamic(DynamicParams)
 }
 
+pub const A8_SUPPORTED_NETWORKS: [Web3Network; 6] = [
+	Web3Network::Polkadot,
+	Web3Network::Kusama,
+	Web3Network::Litentry,
+	Web3Network::Litmus,
+	Web3Network::Khala,
+	Web3Network::Ethereum,
+];
+
 impl Assertion {
 	// Given an assertion enum type, retrieve the supported web3 networks.
 	// So we limit the network types on the assertion definition level.
@@ -164,7 +173,11 @@ impl Assertion {
 			Self::VIP3MembershipCard(..) |
 			Self::WeirdoGhostGangHolder => vec![Web3Network::Ethereum],
 			// total tx over `networks`
-			Self::A8(network) => network.to_vec(),
+			Self::A8(networks) => networks
+				.into_iter()
+				.filter(|network| A8_SUPPORTED_NETWORKS.contains(*network))
+				.cloned()
+				.collect::<Vec<_>>(),
 			// Achainable Assertions
 			Self::Achainable(arg) => arg.chains(),
 			// OneBlock Assertion

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/vc/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/vc/definitions.ts
@@ -38,7 +38,7 @@ export default {
             },
         },
         AssertionSupportedNetwork: {
-            _enum: ["Litentry", "Litmus", "LitentryRococo", "Polkadot", "Kusama", "Khala", "Ethereum", "TestNet"],
+            _enum: ["Polkadot", "Kusama", "Litentry", "Litmus", "__UnsupportedLitentryRococo", "Khala", "__UnsupportedSubstrateTestnet", "Ethereum"],
         },
         DynamicParams: {
             smart_contract_id: "[u8;20]",


### PR DESCRIPTION
P-926 added enum A8SupportedNetwork to matching ts types, removed unsupported network by dataprovider for A8

!!!! This is a breaking change !!!

### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

1 This VC used achainable, and it only supported a subset of networks as below, instead all the network that we defined:
ethereum, polkadot, kusama, litmus, litentry, khala
![image](https://github.com/user-attachments/assets/a34f577d-52c4-414d-a671-3af34483fc9a)



### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable
Before the fix:
<img width="748" alt="Screenshot 2024-07-17 at 5 18 48 pm" src="https://github.com/user-attachments/assets/06a34ac7-0aa2-406a-a7eb-5d04996a6904">

<img width="743" alt="Screenshot 2024-07-17 at 5 19 11 pm" src="https://github.com/user-attachments/assets/76ff20c2-dbe2-4d63-8e70-f49418afeaec">

After the fix:
<img width="745" alt="Screenshot 2024-07-17 at 5 19 37 pm" src="https://github.com/user-attachments/assets/61c0b7a9-da5b-4a9b-9519-185956f9b98e">

<img width="769" alt="Screenshot 2024-07-17 at 5 20 00 pm" src="https://github.com/user-attachments/assets/dbcaf882-525c-4c4a-950d-2aa24052a300">


