### PR TITLE
chore(client-api): update parachain-api package to include DarenMarket

### DIFF
--- a/tee-worker/client-api/parachain-api/CHANGELOG.md
+++ b/tee-worker/client-api/parachain-api/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   (#2930) `PlatformUserType`: Add `DarenMarket`
+
+### Changed
+
+-   (#2930) `PlatformUserType`: rename `MagicCraftStakingUser` to `MagicCraftStaking`
+-   (#2930) `PlatformUserType`: rename `KaratDaoUser` to `KaratDao`
+
 ## [0.9.18-10] - 2024-07-15
 
 Matching version for [parachain-release v0.9.18-10](https://github.com/litentry/litentry-parachain/releases/tag/v0.9.18-10)

--- a/tee-worker/client-api/parachain-api/package.json
+++ b/tee-worker/client-api/parachain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.18-10",
+    "version": "0.9.18-10-next.0",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "curl -s -H \"Content-Type: application/json\" -d '{\"id\":\"1\", \"jsonrpc\":\"2.0\", \"method\": \"state_getMetadata\", \"params\":[]}' http://localhost:9944 > prepare-build/litentry-parachain-metadata.json",


### PR DESCRIPTION
This is a follow up update for `parachain-api` amid #2903 

It publishes a preview _next_ version containing the `DarenMarket` support.

Published packages:
- parachain-api: https://www.npmjs.com/package/@litentry/parachain-api/v/0.9.18-10-next.0
- sidechain-api: (no update needed; can't wait until next release)