### PR TITLE
quick-fix: assertion contracts tests

### DIFF
--- a/.github/file-filter.yml
+++ b/.github/file-filter.yml
@@ -37,6 +37,7 @@ tee_test: &tee_test
   - 'tee-worker/cli/*.sh'
   - 'docker/**'
   - 'tee-worker/docker/*.yml'
+  - 'tee-worker/litentry/core/assertion-build/src/dynamic/contracts/**'
 
 bitacross_src: &bitacross_src
   - 'bitacross-worker/**/*.rs'

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/vc/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/vc/definitions.ts
@@ -38,7 +38,16 @@ export default {
             },
         },
         AssertionSupportedNetwork: {
-            _enum: ["Polkadot", "Kusama", "Litentry", "Litmus", "__UnsupportedLitentryRococo", "Khala", "__UnsupportedSubstrateTestnet", "Ethereum"],
+            _enum: [
+                "Polkadot",
+                "Kusama",
+                "Litentry",
+                "Litmus",
+                "__UnsupportedLitentryRococo",
+                "Khala",
+                "__UnsupportedSubstrateTestnet",
+                "Ethereum",
+            ],
         },
         DynamicParams: {
             smart_contract_id: "[u8;20]",

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/vc/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/vc/definitions.ts
@@ -38,16 +38,7 @@ export default {
             },
         },
         AssertionSupportedNetwork: {
-            _enum: [
-                "Polkadot",
-                "Kusama",
-                "Litentry",
-                "Litmus",
-                "__UnsupportedLitentryRococo",
-                "Khala",
-                "__UnsupportedSubstrateTestnet",
-                "Ethereum",
-            ],
+            _enum: ["Polkadot", "Kusama", "Litentry", "Litmus", "__UnsupportedLitentryRococo", "Khala", "__UnsupportedSubstrateTestnet", "Ethereum"],
         },
         DynamicParams: {
             smart_contract_id: "[u8;20]",

--- a/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
+++ b/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
@@ -132,7 +132,6 @@ describe('Test Vc (direct request)', function () {
 
         const abiCoder = new ethers.utils.AbiCoder();
         const encodedData = abiCoder.encode(['string'], ['bnb']);
-        console.log(encodedData);
 
         const assertion = {
             dynamic: context.api.createType('DynamicParams', [

--- a/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
+++ b/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
@@ -66,6 +66,7 @@ describe('Test Vc (direct request)', function () {
         const createAssertionEventsPromise = subscribeToEvents('evmAssertions', 'AssertionCreated', context.api);
 
         const proposal = context.api.tx.evmAssertions.createAssertion(assertionId, contractBytecode, [
+            // At least three secrets are required here.
             secret,
             secret,
             secret,

--- a/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
+++ b/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
@@ -65,7 +65,11 @@ describe('Test Vc (direct request)', function () {
         const assertionId = '0x0000000000000000000000000000000000000003';
         const createAssertionEventsPromise = subscribeToEvents('evmAssertions', 'AssertionCreated', context.api);
 
-        const proposal = context.api.tx.evmAssertions.createAssertion(assertionId, contractBytecode, [secret]);
+        const proposal = context.api.tx.evmAssertions.createAssertion(assertionId, contractBytecode, [
+            secret,
+            secret,
+            secret,
+        ]);
         await context.api.tx.developerCommittee.execute(proposal, proposal.encodedLength).signAndSend(alice);
 
         const event = (await createAssertionEventsPromise).map((e) => e);
@@ -121,17 +125,19 @@ describe('Test Vc (direct request)', function () {
     });
 
     step('requesting VC for deployed contract', async function () {
-        await sleep(30);
+        // await sleep(30);
         const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
         const nonce = (await getSidechainNonce(context, aliceSubstrateIdentity)).toNumber();
 
         const abiCoder = new ethers.utils.AbiCoder();
         const encodedData = abiCoder.encode(['string'], ['bnb']);
+        console.log(encodedData);
+
         const assertion = {
             dynamic: context.api.createType('DynamicParams', [
                 Uint8Array.from(Buffer.from('0000000000000000000000000000000000000003', 'hex')),
                 encodedData,
-                false,
+                true,
             ]),
         };
 

--- a/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
+++ b/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
@@ -125,7 +125,7 @@ describe('Test Vc (direct request)', function () {
     });
 
     step('requesting VC for deployed contract', async function () {
-        // await sleep(30);
+        await sleep(30);
         const requestIdentifier = `0x${randomBytes(32).toString('hex')}`;
         const nonce = (await getSidechainNonce(context, aliceSubstrateIdentity)).toNumber();
 


### PR DESCRIPTION
### Context

fix https://github.com/litentry/litentry-parachain/actions/runs/10047804865/job/27782346298

Reason: ts-tests only set [one secret](https://github.com/litentry/litentry-parachain/blob/dev/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts#L68) when deploying contracts, that when requesting `bnb`, noderealclient needs to be used,it needs [secrets[1]](https://github.com/litentry/litentry-parachain/blob/dev/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/TokenQueryLogic.sol#L67), which is out of index of array,that causes the secret to be unable to be decoded when requesting dynamic contracts.

Solution: Adding at least 3 secrets.


