### PR TITLE
Adding register OIDC client call to identity management pallet

### DIFF
--- a/pallets/identity-management/src/lib.rs
+++ b/pallets/identity-management/src/lib.rs
@@ -43,11 +43,8 @@ pub mod weights;
 pub use crate::weights::WeightInfo;
 pub use pallet::*;
 
-use frame_support::traits::{ConstU32, Get};
 use pallet_teebag::ShardIdentifier;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use scale_info::TypeInfo;
-use sp_core::{RuntimeDebug, H256};
+use sp_core::H256;
 use sp_std::vec::Vec;
 
 const MAX_REDIRECT_URL_LEN: u32 = 256;
@@ -322,7 +319,7 @@ pub mod pallet {
 			redirect_uris: Vec<Vec<u8>>,
 		) -> DispatchResult {
 			let client_id = ensure_signed(origin)?;
-			ensure!(redirect_uris.len() > 0, Error::<T>::EmptyRedirectUris);
+			ensure!(!redirect_uris.is_empty(), Error::<T>::EmptyRedirectUris);
 			ensure!(
 				!OIDCClients::<T>::contains_key(&client_id),
 				Error::<T>::OIDCClientAlreadyRegistered

--- a/pallets/identity-management/src/lib.rs
+++ b/pallets/identity-management/src/lib.rs
@@ -314,6 +314,7 @@ pub mod pallet {
 		}
 
 		/// Register an OIDC client
+		// TODO: take a deposit to cover the storage cost and prevent spamming
 		#[pallet::call_index(6)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn register_oidc_client(

--- a/pallets/identity-management/src/lib.rs
+++ b/pallets/identity-management/src/lib.rs
@@ -184,6 +184,7 @@ pub mod pallet {
 
 	// OIDC clients who can use the OIDC flow
 	#[pallet::storage]
+	#[pallet::getter(fn oidc_client)]
 	pub type OIDCClients<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat,

--- a/pallets/identity-management/src/lib.rs
+++ b/pallets/identity-management/src/lib.rs
@@ -175,6 +175,9 @@ pub mod pallet {
 		OidcClientRegistered {
 			client_id: T::AccountId,
 		},
+		OidcClientUnregistered {
+			client_id: T::AccountId,
+		},
 	}
 
 	// delegatees who can send extrinsics(currently only `link_identity`) on users' behalf
@@ -206,6 +209,8 @@ pub mod pallet {
 		RedirectUriTooLong,
 		/// OIDC client already exists
 		OidcClientAlreadyRegistered,
+		/// OIDC client does not exists
+		OidcClientNotExist,
 	}
 
 	#[pallet::call]
@@ -338,6 +343,17 @@ pub mod pallet {
 			);
 
 			Self::deposit_event(Event::OidcClientRegistered { client_id });
+
+			Ok(())
+		}
+
+		#[pallet::call_index(7)]
+		#[pallet::weight({0})] // TODO: add weight
+		pub fn unregister_oidc_client(origin: OriginFor<T>) -> DispatchResult {
+			let client_id = ensure_signed(origin)?;
+			ensure!(OidcClients::<T>::contains_key(&client_id), Error::<T>::OidcClientNotExist);
+			OidcClients::<T>::remove(&client_id);
+			Self::deposit_event(Event::OidcClientUnregistered { client_id });
 
 			Ok(())
 		}

--- a/pallets/identity-management/src/lib.rs
+++ b/pallets/identity-management/src/lib.rs
@@ -347,6 +347,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Unregister an OIDC client
 		#[pallet::call_index(7)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn unregister_oidc_client(origin: OriginFor<T>) -> DispatchResult {

--- a/pallets/identity-management/src/lib.rs
+++ b/pallets/identity-management/src/lib.rs
@@ -315,7 +315,7 @@ pub mod pallet {
 
 		/// Register an OIDC client
 		#[pallet::call_index(6)]
-		#[pallet::weight({0})] // TODO: add weight
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn register_oidc_client(
 			origin: OriginFor<T>,
 			redirect_uris: Vec<Vec<u8>>,
@@ -348,7 +348,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(7)]
-		#[pallet::weight({0})] // TODO: add weight
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn unregister_oidc_client(origin: OriginFor<T>) -> DispatchResult {
 			let client_id = ensure_signed(origin)?;
 			ensure!(OidcClients::<T>::contains_key(&client_id), Error::<T>::OidcClientNotExist);

--- a/pallets/identity-management/src/mock.rs
+++ b/pallets/identity-management/src/mock.rs
@@ -161,6 +161,7 @@ impl pallet_identity_management::Config for Test {
 	type TEECallOrigin = EnsureEnclaveSigner<Self>;
 	type DelegateeAdminOrigin = EnsureRoot<Self::AccountId>;
 	type ExtrinsicWhitelistOrigin = IMPExtrinsicWhitelist;
+	type MaxOidcClientRedirectUris = ConstU32<3>;
 }
 
 impl pallet_group::Config for Test {

--- a/pallets/identity-management/src/mock.rs
+++ b/pallets/identity-management/src/mock.rs
@@ -161,7 +161,7 @@ impl pallet_identity_management::Config for Test {
 	type TEECallOrigin = EnsureEnclaveSigner<Self>;
 	type DelegateeAdminOrigin = EnsureRoot<Self::AccountId>;
 	type ExtrinsicWhitelistOrigin = IMPExtrinsicWhitelist;
-	type MaxOidcClientRedirectUris = ConstU32<3>;
+	type MaxOIDCClientRedirectUris = ConstU32<3>;
 }
 
 impl pallet_group::Config for Test {

--- a/pallets/identity-management/src/tests.rs
+++ b/pallets/identity-management/src/tests.rs
@@ -203,8 +203,9 @@ fn register_oidc_client_works() {
 			redirect_uris
 		));
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
-			crate::Event::OidcClientRegistered { client_id: alice },
+			crate::Event::OidcClientRegistered { client_id: alice.clone() },
 		));
+		assert!(OidcClients::<Test>::contains_key(&alice));
 	});
 }
 

--- a/pallets/identity-management/src/tests.rs
+++ b/pallets/identity-management/src/tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 #[allow(unused)]
-use crate::{mock::*, Error, OidcClients, ShardIdentifier};
+use crate::{mock::*, Error, OIDCClients, ShardIdentifier};
 use core_primitives::{ErrorDetail, IMPError};
 use frame_support::{assert_noop, assert_ok};
 use sp_core::H256;
@@ -203,9 +203,9 @@ fn register_oidc_client_works() {
 			redirect_uris
 		));
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
-			crate::Event::OidcClientRegistered { client_id: alice.clone() },
+			crate::Event::OIDCClientRegistered { client_id: alice.clone() },
 		));
-		assert!(OidcClients::<Test>::contains_key(&alice));
+		assert!(OIDCClients::<Test>::contains_key(&alice));
 	});
 }
 
@@ -234,7 +234,7 @@ fn register_oidc_client_already_registered_check_works() {
 				RuntimeOrigin::signed(alice.clone()),
 				redirect_uris
 			),
-			Error::<Test>::OidcClientAlreadyRegistered
+			Error::<Test>::OIDCClientAlreadyRegistered
 		);
 	});
 }
@@ -277,14 +277,14 @@ fn unregister_oidc_client_works() {
 			RuntimeOrigin::signed(alice.clone()),
 			redirect_uris
 		));
-		assert!(OidcClients::<Test>::contains_key(&alice));
+		assert!(OIDCClients::<Test>::contains_key(&alice));
 		assert_ok!(IdentityManagement::unregister_oidc_client(RuntimeOrigin::signed(
 			alice.clone()
 		)));
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
-			crate::Event::OidcClientUnregistered { client_id: alice.clone() },
+			crate::Event::OIDCClientUnregistered { client_id: alice.clone() },
 		));
-		assert_eq!(OidcClients::<Test>::contains_key(&alice), false);
+		assert_eq!(OIDCClients::<Test>::contains_key(&alice), false);
 	});
 }
 
@@ -294,7 +294,7 @@ fn unregister_oidc_client_does_not_exists_works() {
 		let bob: SystemAccountId = get_signer(BOB_PUBKEY);
 		assert_noop!(
 			IdentityManagement::unregister_oidc_client(RuntimeOrigin::signed(bob)),
-			Error::<Test>::OidcClientNotExist
+			Error::<Test>::OIDCClientDoesNotExist
 		);
 	});
 }
@@ -311,7 +311,7 @@ fn unregister_oidc_client_unauthorized_sender() {
 		let bob: SystemAccountId = get_signer(BOB_PUBKEY);
 		assert_noop!(
 			IdentityManagement::unregister_oidc_client(RuntimeOrigin::signed(bob)),
-			Error::<Test>::OidcClientNotExist
+			Error::<Test>::OIDCClientDoesNotExist
 		);
 	});
 }

--- a/pallets/identity-management/src/tests.rs
+++ b/pallets/identity-management/src/tests.rs
@@ -230,10 +230,7 @@ fn register_oidc_client_already_registered_check_works() {
 			redirect_uris.clone()
 		));
 		assert_noop!(
-			IdentityManagement::register_oidc_client(
-				RuntimeOrigin::signed(alice.clone()),
-				redirect_uris
-			),
+			IdentityManagement::register_oidc_client(RuntimeOrigin::signed(alice), redirect_uris),
 			Error::<Test>::OIDCClientAlreadyRegistered
 		);
 	});
@@ -284,7 +281,7 @@ fn unregister_oidc_client_works() {
 		System::assert_last_event(RuntimeEvent::IdentityManagement(
 			crate::Event::OIDCClientUnregistered { client_id: alice.clone() },
 		));
-		assert_eq!(OIDCClients::<Test>::contains_key(&alice), false);
+		assert!(!OIDCClients::<Test>::contains_key(&alice));
 	});
 }
 
@@ -305,7 +302,7 @@ fn unregister_oidc_client_unauthorized_sender() {
 		let alice: SystemAccountId = get_signer(ALICE_PUBKEY);
 		let redirect_uris = vec!["https://example.com".as_bytes().to_vec()];
 		assert_ok!(IdentityManagement::register_oidc_client(
-			RuntimeOrigin::signed(alice.clone()),
+			RuntimeOrigin::signed(alice),
 			redirect_uris
 		));
 		let bob: SystemAccountId = get_signer(BOB_PUBKEY);

--- a/runtime/litentry/src/lib.rs
+++ b/runtime/litentry/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litentry-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9185,
+	spec_version: 9186,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -152,7 +152,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litmus-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9185,
+	spec_version: 9186,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -246,7 +246,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("rococo-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9185,
+	spec_version: 9186,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -1023,6 +1023,7 @@ impl pallet_identity_management::Config for Runtime {
 	type TEECallOrigin = EnsureEnclaveSigner<Runtime>;
 	type DelegateeAdminOrigin = EnsureRootOrAllCouncil;
 	type ExtrinsicWhitelistOrigin = IMPExtrinsicWhitelist;
+	type MaxOIDCClientRedirectUris = ConstU32<10>;
 }
 
 impl pallet_bitacross::Config for Runtime {

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -148,7 +148,7 @@ export async function assertVc(context: IntegrationTestContext, subject: CorePri
     // check runtime version is present
     assert.deepEqual(
         vcPayloadJson.issuer.runtimeVersion,
-        { parachain: 9185, sidechain: 109 },
+        { parachain: 9186, sidechain: 109 },
         'Check VC runtime version: it should equal the current defined versions'
     );
 


### PR DESCRIPTION
This is part of the Litentry's OIDC POC. DApps that want to integrate litentry as OIDC provider need to register their redirect_uri's

There are a couple of TODO's for a later stage: 
- Add benchmarks for the new calls and use the calculated weights.
- Take a deposit when register oidc client.
