### PR TITLE
parachain-api: expose link_identity_callback

### DIFF
--- a/tee-worker/client-api/parachain-api/CHANGELOG.md
+++ b/tee-worker/client-api/parachain-api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.18-11.2] - 2024-07-26
+
+### Added
+
+-   `TrustedCall`: expose `link_identity_callback`.
+
 ## [0.9.18-11] - 2024-07-19
 
 ### Added

--- a/tee-worker/client-api/parachain-api/package.json
+++ b/tee-worker/client-api/parachain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.18-11",
+    "version": "0.9.18-11.2",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "curl -s -H \"Content-Type: application/json\" -d '{\"id\":\"1\", \"jsonrpc\":\"2.0\", \"method\": \"state_getMetadata\", \"params\":[]}' http://localhost:9944 > prepare-build/litentry-parachain-metadata.json",

--- a/tee-worker/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
+++ b/tee-worker/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
@@ -40,6 +40,24 @@ export default {
                     "(LitentryIdentity, LitentryIdentity, LitentryIdentity, Vec<Web3Network>, Option<RequestAesKey>, H256)",
                 __Unused_remove_identity: "Null",
                 request_batch_vc: "(LitentryIdentity, LitentryIdentity, BoundedVec<Assertion, ConstU32<32>>, Option<RequestAesKey>, H256)",
+
+                __Unused_7: "Null",
+                __Unused_8: "Null",
+                __Unused_9: "Null",
+                __Unused_10: "Null",
+                __Unused_11: "Null",
+                __Unused_12: "Null",
+                __Unused_13: "Null",
+                __Unused_14: "Null",
+                __Unused_15: "Null",
+                __Unused_16: "Null",
+                __Unused_17: "Null",
+                __Unused_18: "Null",
+                __Unused_19: "Null",
+
+                // this trusted call can only be requested directly by root or enclave_signer_account
+                link_identity_callback:
+                    "(LitentryIdentity, LitentryIdentity, LitentryIdentity, Vec<Web3Network>, Option<RequestAesKey>, H256)",
             },
         },
         TrustedOperationStatus: {


### PR DESCRIPTION
These changes make `TrustedCall::link_identity_callback` available for clients.

The `parachain-api` was built against `0.9.18-11` tag for publishing to not leak any other change from `dev` branch.

Published packages:
- parachain-api: https://www.npmjs.com/package/@litentry/parachain-api/v/0.9.18-11.2