### PR TITLE
Revert "build(deps): bump num_enum from 0.7.2 to 0.7.3"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6631,11 +6631,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
- "num_enum_derive 0.7.3",
+ "num_enum_derive 0.7.2",
 ]
 
 [[package]]
@@ -6652,9 +6652,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7380,7 +7380,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "num_enum 0.7.3",
+ "num_enum 0.7.2",
  "pallet-assets",
  "pallet-balances",
  "pallet-evm",
@@ -7425,7 +7425,7 @@ dependencies = [
  "frame-system",
  "hex-literal 0.4.1",
  "log",
- "num_enum 0.7.3",
+ "num_enum 0.7.2",
  "pallet-balances",
  "pallet-bridge",
  "pallet-bridge-transfer",
@@ -7480,7 +7480,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "num_enum 0.7.3",
+ "num_enum 0.7.2",
  "pallet-balances",
  "pallet-evm",
  "pallet-parachain-staking",
@@ -7507,7 +7507,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "num_enum 0.7.3",
+ "num_enum 0.7.2",
  "pallet-balances",
  "pallet-evm",
  "pallet-parachain-staking",
@@ -9932,7 +9932,7 @@ dependencies = [
  "hex-literal 0.4.1",
  "impl-trait-for-tuples",
  "log",
- "num_enum 0.7.3",
+ "num_enum 0.7.2",
  "pallet-evm",
  "parity-scale-codec",
  "precompile-utils-macro-v2",
@@ -9951,7 +9951,7 @@ version = "0.1.0"
 source = "git+https://github.com/litentry/precompile-utils?branch=main#261ec953f6614bf634e86d9e8967eae3f84486a1"
 dependencies = [
  "case",
- "num_enum 0.7.3",
+ "num_enum 0.7.2",
  "prettyplease 0.2.20",
  "proc-macro2",
  "quote",
@@ -10704,7 +10704,7 @@ dependencies = [
  "moonbeam-evm-tracer",
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
- "num_enum 0.7.3",
+ "num_enum 0.7.2",
  "orml-traits",
  "orml-xtokens",
  "pallet-account-fix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ jsonrpsee = { version = "0.16.3", features = ["server"] }
 tokio = { version = "1.39.2", features = ["macros", "sync"] }
 strum = { version = "0.26", default-features = false }
 strum_macros = { version = "0.26", default-features = false }
-num_enum = { version = "0.7.3", default-features = false }
+num_enum = { version = "0.7.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 rustc-hex = { version = "2.0.1", default-features = false }
 x509-cert = { version = "0.1.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Reverts litentry/litentry-parachain#2944

This update still cause trouble of 
```
error: package `num_enum v0.7.3` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.66.0
```