### PR TITLE
fix: VC range clause fix

### DIFF
--- a/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs
+++ b/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs
@@ -449,11 +449,6 @@ mod tests {
 								src: "$holding_amount".into(),
 								op: Op::GreaterThan,
 								dst: "0".into()
-							}),
-							Box::new(AssertionLogic::Item {
-								src: "$holding_amount".into(),
-								op: Op::LessThan,
-								dst: "1".into()
 							})
 						]
 					}

--- a/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs
+++ b/tee-worker/litentry/core/assertion-build-v2/src/token_holding_amount/mod.rs
@@ -447,7 +447,7 @@ mod tests {
 							create_network_address_assertion_logics(Web3TokenType::Nfp),
 							Box::new(AssertionLogic::Item {
 								src: "$holding_amount".into(),
-								op: Op::GreaterEq,
+								op: Op::GreaterThan,
 								dst: "0".into()
 							}),
 							Box::new(AssertionLogic::Item {
@@ -483,7 +483,7 @@ mod tests {
 							create_network_address_assertion_logics(Web3TokenType::Nfp),
 							Box::new(AssertionLogic::Item {
 								src: "$holding_amount".into(),
-								op: Op::GreaterEq,
+								op: Op::GreaterThan,
 								dst: "0".into()
 							}),
 							Box::new(AssertionLogic::Item {

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/TokenHoldingAmount.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/TokenHoldingAmount.sol
@@ -68,6 +68,7 @@ abstract contract TokenHoldingAmount is DynamicAssertion {
         string[] memory assertions = assembleAssertions(
             min,
             max,
+            balance,
             tokenLowercaseName
         );
 
@@ -134,12 +135,13 @@ abstract contract TokenHoldingAmount is DynamicAssertion {
     function assembleAssertions(
         uint256 min,
         int256 max,
+        uint256 balance,
         string memory tokenName
     ) private pure returns (string[] memory) {
         string memory variable = "$holding_amount";
         AssertionLogic.CompositeCondition memory cc = AssertionLogic
             .CompositeCondition(
-                new AssertionLogic.Condition[](max > 0 ? 3 : 2),
+                new AssertionLogic.Condition[](max > 0 && balance > 0 ? 3 : 2),
                 true
             );
         AssertionLogic.andOp(
@@ -153,10 +155,12 @@ abstract contract TokenHoldingAmount is DynamicAssertion {
             cc,
             1,
             variable,
-            AssertionLogic.Op.GreaterEq,
+            min == 0
+                ? AssertionLogic.Op.GreaterThan
+                : AssertionLogic.Op.GreaterEq,
             StringShift.toShiftedString(min, Constants.decimals_factor)
         );
-        if (max > 0) {
+        if (max > 0 && balance > 0) {
             AssertionLogic.andOp(
                 cc,
                 2,

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/TokenHoldingAmount.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/TokenHoldingAmount.sol
@@ -45,7 +45,7 @@ abstract contract TokenHoldingAmount is DynamicAssertion {
         string
             memory description = "The amount of a particular token you are holding";
         string memory assertion_type = "Token Holding Amount";
-        schema_url = "https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/25-token-holding-amount/1-1-3.json";
+        schema_url = "https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/25-token-holding-amount/1-1-4.json";
 
         string memory tokenLowercaseName = abi.decode(params, (string));
 

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/tests/token-holding-amount.ts
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/tests/token-holding-amount.ts
@@ -54,13 +54,8 @@ describe('TokenHoldingAmount', () => {
                         },
                         {
                             src: '$holding_amount',
-                            op: Op.GTE,
+                            op: Op.GT,
                             dst: '0',
-                        },
-                        {
-                            src: '$holding_amount',
-                            op: Op.LT,
-                            dst: '1',
                         },
                     ],
                 },
@@ -118,7 +113,7 @@ describe('TokenHoldingAmount', () => {
                         },
                         {
                             src: '$holding_amount',
-                            op: Op.GTE,
+                            op: Op.GT,
                             dst: '0',
                         },
                         {

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/tests/token-holding-amount.ts
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/tests/token-holding-amount.ts
@@ -29,7 +29,7 @@ describe('TokenHoldingAmount', () => {
         await expectAssertionResult(contract, val, {
             tokenType: 'Token Holding Amount',
             tokenDesc: 'The amount of a particular token you are holding',
-            schemaUrl: assembleSchemaUrl('25-token-holding-amount/1-1-3.json'),
+            schemaUrl: assembleSchemaUrl('25-token-holding-amount/1-1-4.json'),
             assertions: [assertion],
             result,
         })

--- a/tee-worker/litentry/core/assertion-build/src/nodereal/amount_holding/evm_amount_holding.rs
+++ b/tee-worker/litentry/core/assertion-build/src/nodereal/amount_holding/evm_amount_holding.rs
@@ -226,7 +226,7 @@ mod tests {
 							create_ton_network_assertion_logic(),
 							Box::new(AssertionLogic::Item {
 								src: "$holding_amount".into(),
-								op: Op::GreaterEq,
+								op: Op::GreaterThan,
 								dst: "0".into()
 							}),
 							Box::new(AssertionLogic::Item {

--- a/tee-worker/litentry/core/credentials-v2/src/token_holding_amount/mod.rs
+++ b/tee-worker/litentry/core/credentials-v2/src/token_holding_amount/mod.rs
@@ -91,11 +91,13 @@ fn update_assertion(token_type: Web3TokenType, balance: f64, credential: &mut Cr
 				if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
 				&min,
 			);
-			let max_item =
-				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
 
 			assertion = assertion.add_item(min_item);
-			assertion = assertion.add_item(max_item);
+			if balance > 0_f64 {
+				let max_item =
+					AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
+				assertion = assertion.add_item(max_item);
+			}
 
 			credential.credential_subject.values.push(index != 0 || balance > 0_f64);
 		},

--- a/tee-worker/litentry/core/credentials-v2/src/token_holding_amount/mod.rs
+++ b/tee-worker/litentry/core/credentials-v2/src/token_holding_amount/mod.rs
@@ -86,8 +86,11 @@ fn update_assertion(token_type: Web3TokenType, balance: f64, credential: &mut Cr
 		Some(index) => {
 			let min = format!("{}", token_holding_amount_range[index]);
 			let max = format!("{}", token_holding_amount_range[index + 1]);
-			let min_item =
-				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::GreaterEq, &min);
+			let min_item = AssertionLogic::new_item(
+				ASSERTION_KEYS.holding_amount,
+				if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
+				&min,
+			);
 			let max_item =
 				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
 

--- a/tee-worker/litentry/core/credentials/src/brc20/amount_holder.rs
+++ b/tee-worker/litentry/core/credentials/src/brc20/amount_holder.rs
@@ -155,11 +155,13 @@ fn update_assertion(token: &BRC20Token, balance: f64, credential: &mut Credentia
 				if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
 				&min,
 			);
-			let max_item =
-				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
 
 			assertion = assertion.add_item(min_item);
-			assertion = assertion.add_item(max_item);
+			if balance > 0_f64 {
+				let max_item =
+					AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
+				assertion = assertion.add_item(max_item);
+			}
 
 			credential.credential_subject.values.push(index != 0 || balance > 0_f64);
 		},

--- a/tee-worker/litentry/core/credentials/src/brc20/amount_holder.rs
+++ b/tee-worker/litentry/core/credentials/src/brc20/amount_holder.rs
@@ -150,8 +150,11 @@ fn update_assertion(token: &BRC20Token, balance: f64, credential: &mut Credentia
 		Some(index) => {
 			let min = format!("{}", range[index]);
 			let max = format!("{}", range[index + 1]);
-			let min_item =
-				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::GreaterEq, &min);
+			let min_item = AssertionLogic::new_item(
+				ASSERTION_KEYS.holding_amount,
+				if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
+				&min,
+			);
 			let max_item =
 				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
 

--- a/tee-worker/litentry/core/credentials/src/credential_schema.rs
+++ b/tee-worker/litentry/core/credentials/src/credential_schema.rs
@@ -52,10 +52,10 @@ pub fn get_schema_url(assertion: &Assertion) -> Option<String> {
 
 		Assertion::Achainable(params) => match params {
 			AchainableParams::AmountHolding(_) =>
-				Some(format!("{BASE_URL}/17-token-holding-amount/1-1-0.json")),
+				Some(format!("{BASE_URL}/17-token-holding-amount/1-1-2.json")),
 
 			AchainableParams::AmountToken(_) =>
-				Some(format!("{BASE_URL}/17-token-holding-amount/1-1-0.json")),
+				Some(format!("{BASE_URL}/17-token-holding-amount/1-1-2.json")),
 
 			AchainableParams::Amount(_) => Some(format!("{BASE_URL}/11-token-holder/1-1-0.json")),
 
@@ -86,10 +86,10 @@ pub fn get_schema_url(assertion: &Assertion) -> Option<String> {
 			Some(format!("{BASE_URL}/14-generic-discord-role/1-1-0.json")),
 
 		Assertion::BnbDomainHolding =>
-			Some(format!("{BASE_URL}/15-bnb-domain-holding-amount/1-1-0.json")),
+			Some(format!("{BASE_URL}/15-bnb-domain-holding-amount/1-1-1.json")),
 
 		Assertion::BnbDigitDomainClub(_) =>
-			Some(format!("{BASE_URL}/16-bnb-3d-4d-club-domain-holding-amount/1-1-0.json")),
+			Some(format!("{BASE_URL}/16-bnb-3d-4d-club-domain-holding-amount/1-1-1.json")),
 
 		Assertion::VIP3MembershipCard(_) =>
 			Some(format!("{BASE_URL}/19-vip3-card-holder/1-1-0.json")),
@@ -97,13 +97,13 @@ pub fn get_schema_url(assertion: &Assertion) -> Option<String> {
 		Assertion::WeirdoGhostGangHolder =>
 			Some(format!("{BASE_URL}/18-weirdoghostgang-holder/1-1-0.json")),
 
-		Assertion::LITStaking => Some(format!("{BASE_URL}/17-token-holding-amount/1-1-0.json")),
+		Assertion::LITStaking => Some(format!("{BASE_URL}/17-token-holding-amount/1-1-2.json")),
 
 		Assertion::EVMAmountHolding(_) =>
-			Some(format!("{BASE_URL}/21-evm-holding-amount/1-1-0.json")),
+			Some(format!("{BASE_URL}/21-evm-holding-amount/1-1-2.json")),
 
 		Assertion::BRC20AmountHolder =>
-			Some(format!("{BASE_URL}/20-token-holding-amount-list/1-1-0.json")),
+			Some(format!("{BASE_URL}/20-token-holding-amount-list/1-1-1.json")),
 
 		Assertion::CryptoSummary => Some(format!("{BASE_URL}/23-crypto-summary/1-1-0.json")),
 
@@ -112,7 +112,7 @@ pub fn get_schema_url(assertion: &Assertion) -> Option<String> {
 		Assertion::NftHolder(_) => Some(format!("{BASE_URL}/26-nft-holder/1-1-2.json")),
 
 		Assertion::TokenHoldingAmount(_) =>
-			Some(format!("{BASE_URL}/25-token-holding-amount/1-1-3.json")),
+			Some(format!("{BASE_URL}/25-token-holding-amount/1-1-4.json")),
 
 		Assertion::Dynamic(..) => None,
 	}

--- a/tee-worker/litentry/core/credentials/src/litentry_profile/token_balance.rs
+++ b/tee-worker/litentry/core/credentials/src/litentry_profile/token_balance.rs
@@ -81,7 +81,11 @@ fn update_assertion(token: ETokenAddress, balance: f64, credential: &mut Credent
 		Some(index) => {
 			let min = format!("{}", range[index]);
 			let max = format!("{}", range[index + 1]);
-			let min_item = AssertionLogic::new_item(content, Op::GreaterEq, &min);
+			let min_item = AssertionLogic::new_item(
+				content,
+				if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
+				&min,
+			);
 			let max_item = AssertionLogic::new_item(content, Op::LessThan, &max);
 
 			assertion = assertion.add_item(min_item);

--- a/tee-worker/litentry/core/credentials/src/litentry_profile/token_balance.rs
+++ b/tee-worker/litentry/core/credentials/src/litentry_profile/token_balance.rs
@@ -86,10 +86,12 @@ fn update_assertion(token: ETokenAddress, balance: f64, credential: &mut Credent
 				if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
 				&min,
 			);
-			let max_item = AssertionLogic::new_item(content, Op::LessThan, &max);
 
 			assertion = assertion.add_item(min_item);
-			assertion = assertion.add_item(max_item);
+			if balance > 0_f64 {
+				let max_item = AssertionLogic::new_item(content, Op::LessThan, &max);
+				assertion = assertion.add_item(max_item);
+			}
 
 			credential.credential_subject.values.push(index != 0 || balance > 0_f64);
 		},

--- a/tee-worker/litentry/core/credentials/src/nodereal/amount_holding/evm_amount_holding.rs
+++ b/tee-worker/litentry/core/credentials/src/nodereal/amount_holding/evm_amount_holding.rs
@@ -118,11 +118,13 @@ fn update_assertion(token_type: EVMTokenType, balance: f64, credential: &mut Cre
 				if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
 				&min,
 			);
-			let max_item =
-				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
 
 			assertion = assertion.add_item(min_item);
-			assertion = assertion.add_item(max_item);
+			if balance > 0_f64 {
+				let max_item =
+					AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
+				assertion = assertion.add_item(max_item);
+			}
 
 			credential.credential_subject.values.push(index != 0 || balance > 0_f64);
 		},

--- a/tee-worker/litentry/core/credentials/src/nodereal/amount_holding/evm_amount_holding.rs
+++ b/tee-worker/litentry/core/credentials/src/nodereal/amount_holding/evm_amount_holding.rs
@@ -113,8 +113,11 @@ fn update_assertion(token_type: EVMTokenType, balance: f64, credential: &mut Cre
 		Some(index) => {
 			let min = format!("{}", &EVM_HOLDING_AMOUNT_RANGE[index]);
 			let max = format!("{}", &EVM_HOLDING_AMOUNT_RANGE[index + 1]);
-			let min_item =
-				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::GreaterEq, &min);
+			let min_item = AssertionLogic::new_item(
+				ASSERTION_KEYS.holding_amount,
+				if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
+				&min,
+			);
 			let max_item =
 				AssertionLogic::new_item(ASSERTION_KEYS.holding_amount, Op::LessThan, &max);
 

--- a/tee-worker/litentry/core/credentials/src/nodereal/bnb_domain/mod.rs
+++ b/tee-worker/litentry/core/credentials/src/nodereal/bnb_domain/mod.rs
@@ -43,7 +43,7 @@ pub trait RangeCredentialDetail {
 				let max = range[index];
 				let min_item = AssertionLogic::new_item(
 					breakdown,
-					if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
+					if index == 1 { Op::GreaterThan } else { Op::GreaterEq },
 					&format!("{}", min),
 				);
 

--- a/tee-worker/litentry/core/credentials/src/nodereal/bnb_domain/mod.rs
+++ b/tee-worker/litentry/core/credentials/src/nodereal/bnb_domain/mod.rs
@@ -46,10 +46,14 @@ pub trait RangeCredentialDetail {
 					if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
 					&format!("{}", min),
 				);
-				let max_item =
-					AssertionLogic::new_item(breakdown, Op::LessThan, &format!("{}", max));
 
-				vec![min_item, max_item]
+				if amount > 0 {
+					let max_item =
+						AssertionLogic::new_item(breakdown, Op::LessThan, &format!("{}", max));
+					vec![min_item, max_item]
+				} else {
+					vec![min_item]
+				}
 			},
 			None => {
 				// >= last value

--- a/tee-worker/litentry/core/credentials/src/nodereal/bnb_domain/mod.rs
+++ b/tee-worker/litentry/core/credentials/src/nodereal/bnb_domain/mod.rs
@@ -41,8 +41,11 @@ pub trait RangeCredentialDetail {
 			Some(index) => {
 				let min = range[index - 1];
 				let max = range[index];
-				let min_item =
-					AssertionLogic::new_item(breakdown, Op::GreaterEq, &format!("{}", min));
+				let min_item = AssertionLogic::new_item(
+					breakdown,
+					if index == 0 { Op::GreaterThan } else { Op::GreaterEq },
+					&format!("{}", min),
+				);
 				let max_item =
 					AssertionLogic::new_item(breakdown, Op::LessThan, &format!("{}", max));
 


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

solved P-717, it changed multiple rust VC and solidity VC that output range clause.
needs schema change PR: https://github.com/litentry/vc-jsonschema/pull/43

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable

token-holding-amount: true
./bin/litentry-cli trusted -d request-vc did:litentry:evm:0x0000000000D9455CC7EB92D06E00582A982f68fe -a "token-holding-amount mcrt"
>>> identity: Evm(Address20)
>>> nonce: 0
>>> assertions: [TokenHoldingAmount(Mcrt)]
----Generated VC-----
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0x2fe1fcae0cd34f82b943a43569c8e6b48c438a60e710c4252ae1bf18ca526b66","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:evm:0x0000000000d9455cc7eb92d06e00582a982f68fe","description":"The amount of a particular token you are holding","type":"Token Holding Amount","assertionText":"","assertions":[{"and":[{"src":"$token","op":"==","dst":"MCRT"},{"or":[{"and":[{"src":"$network","op":"==","dst":"bsc"},{"src":"$address","op":"==","dst":"0x4b8285aB433D8f69CB48d5Ad62b415ed1a221e4f"}]},{"and":[{"src":"$network","op":"==","dst":"ethereum"},{"src":"$address","op":"==","dst":"0xde16ce60804a881e9f8c4ebb3824646edecd478d"}]},{"and":[{"src":"$network","op":"==","dst":"solana"},{"src":"$address","op":"==","dst":"FADm4QuSUF1K526LvTjvbJjKzeeipP6bj5bSzp3r6ipq"}]}]},{"src":"$holding_amount","op":">","dst":"0"},{"src":"$holding_amount","op":"<","dst":"2000"}]}],"values":[true],"endpoint":"wss://rpc.rococo-parachain.litentry.io"},"issuer":{"id":"did:litentry:substrate:0x0b9df679f406a51a2e53b87d8e3fc86e792e277fe932d9535b40692bec9e3789","name":"Litentry TEE Worker","mrenclave":"fVfWLhckhXPcawmc7SJs1JCzB6dGQ3EiA9YZEQfT47X","runtimeVersion":{"parachain":9186,"sidechain":109}},"issuanceDate":"2024-08-05T08:01:14.956558519+00:00","parachainBlockNumber":86,"sidechainBlockNumber":164,"proof":{"created":"2024-08-05T08:01:14.956791182+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"412642b4e5423ca048374bb3bc465582467016e59e98ccfc24f04129ef202b291cb64c853688c13648998a9083d2f1e1bbe532131797354f910c29bf32d8f000","verificationMethod":"0x44da3459814cb003846aece78984e0d064f6b7c1b4c3e4c7bf03b598ea550ba4"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/25-token-holding-amount/1-1-3.json","type":"JsonSchemaValidator2018"}}


token-holding-amount: false
./bin/litentry-cli trusted -d request-vc did:litentry:evm:0xf7a80341b681fc007d7b2d7a37671e04dfb3d5de -a "token-holding-amount comp"
>>> identity: Evm(Address20)
>>> nonce: 0
>>> assertions: [TokenHoldingAmount(Comp)]
----Generated VC-----
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0x601fbddb24b98da7508b373dd7bbd41ee1a41f179810c901424abf7488aab4da","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:evm:0xf7a80341b681fc007d7b2d7a37671e04dfb3d5de","description":"The amount of a particular token you are holding","type":"Token Holding Amount","assertionText":"","assertions":[{"and":[{"src":"$token","op":"==","dst":"COMP"},{"or":[{"and":[{"src":"$network","op":"==","dst":"ethereum"},{"src":"$address","op":"==","dst":"0xc00e94cb662c3520282e6f5717214004a7f26888"}]}]},{"src":"$holding_amount","op":">","dst":"0"}]}],"values":[false],"endpoint":"wss://rpc.rococo-parachain.litentry.io"},"issuer":{"id":"did:litentry:substrate:0x0b9df679f406a51a2e53b87d8e3fc86e792e277fe932d9535b40692bec9e3789","name":"Litentry TEE Worker","mrenclave":"fVfWLhckhXPcawmc7SJs1JCzB6dGQ3EiA9YZEQfT47X","runtimeVersion":{"parachain":9186,"sidechain":109}},"issuanceDate":"2024-08-05T08:02:05.912054901+00:00","parachainBlockNumber":90,"sidechainBlockNumber":172,"proof":{"created":"2024-08-05T08:02:05.912285022+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"4da925ea90ec481f55e538091d241a3f46cd7729afe4068f70b8264d0ecdef4cf03808c04a20a434a6aa5785f7ca548bb4ff70fddbec62d1d125a65e3bb7d707","verificationMethod":"0x44da3459814cb003846aece78984e0d064f6b7c1b4c3e4c7bf03b598ea550ba4"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/25-token-holding-amount/1-1-3.json","type":"JsonSchemaValidator2018"}}


evm-amount-holding: false
./bin/litentry-cli trusted -d request-vc did:litentry:evm:0xf7a80341b681fc007d7b2d7a37671e04dfb3d5de -a "evm-amount-holding ton"
>>> identity: Evm(Address20)
>>> nonce: 0
>>> assertions: [EVMAmountHolding(Ton)]
----Generated VC-----
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0x231d044d445789c8394d8556ce24a5e701b1581b1ed9ad3f960f6cd13a366d1d","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:evm:0xf7a80341b681fc007d7b2d7a37671e04dfb3d5de","description":"The amount of a particular token you are holding","type":"Token Holding Amount","assertionText":"","assertions":[{"and":[{"src":"$token","op":"==","dst":"TON"},{"or":[{"and":[{"src":"$network","op":"==","dst":"ethereum"},{"src":"$address","op":"==","dst":"0x582d872a1b094fc48f5de31d3b73f2d9be47def1"}]},{"and":[{"src":"$network","op":"==","dst":"bsc"},{"src":"$address","op":"==","dst":"0x76a797a59ba2c17726896976b7b3747bfd1d220f"}]}]},{"src":"$holding_amount","op":">","dst":"0"}]}],"values":[false],"endpoint":"wss://rpc.rococo-parachain.litentry.io"},"issuer":{"id":"did:litentry:substrate:0x0b9df679f406a51a2e53b87d8e3fc86e792e277fe932d9535b40692bec9e3789","name":"Litentry TEE Worker","mrenclave":"fVfWLhckhXPcawmc7SJs1JCzB6dGQ3EiA9YZEQfT47X","runtimeVersion":{"parachain":9186,"sidechain":109}},"issuanceDate":"2024-08-05T08:03:10.140037886+00:00","parachainBlockNumber":96,"sidechainBlockNumber":183,"proof":{"created":"2024-08-05T08:03:10.140254508+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"8549b27449594549a1c0285227aae39ef62ef81151f24d8cca11d3ba12b793638270e8bff14c97cda8efda07688e774538e739f645c12444f788215baa05090b","verificationMethod":"0x44da3459814cb003846aece78984e0d064f6b7c1b4c3e4c7bf03b598ea550ba4"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/21-evm-holding-amount/1-1-0.json","type":"JsonSchemaValidator2018"}}


brc20-amount-holder: false
./bin/litentry-cli trusted -d request-vc did:litentry:bitcoin:0x027325c885ecad783cf4f0dd7fb6ea937c19e113c3c8eb4cfd0c732aacb71ce9a4 -a "brc20-amount-holder"
>>> identity: Bitcoin(Address33)
>>> nonce: 0
>>> assertions: [BRC20AmountHolder]
----Generated VC-----
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0xd1d9ee169c55c53095a05b382a7d71661127188ac1a46abc3a97f74c8bed9460","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:bitcoin:0x027325c885ecad783cf4f0dd7fb6ea937c19e113c3c8eb4cfd0c732aacb71ce9a4","description":"The amount of a particular token you are holding","type":"Token holding amount list","assertionText":"","assertions":[{"and":[{"src":"$token","op":"==","dst":"$ordi"},{"src":"$holding_amount","op":">","dst":"0"}]},{"and":[{"src":"$token","op":"==","dst":"$sats"},{"src":"$holding_amount","op":">","dst":"0"}]},{"and":[{"src":"$token","op":"==","dst":"$rats"},{"src":"$holding_amount","op":">","dst":"0"}]},{"and":[{"src":"$token","op":"==","dst":"$MMSS"},{"src":"$holding_amount","op":">","dst":"0"}]},{"and":[{"src":"$token","op":"==","dst":"$long"},{"src":"$holding_amount","op":">","dst":"0"}]},{"and":[{"src":"$token","op":"==","dst":"$cats"},{"src":"$holding_amount","op":">","dst":"0"}]},{"and":[{"src":"$token","op":"==","dst":"$BTCs"},{"src":"$holding_amount","op":">","dst":"0"}]}],"values":[false,false,false,false,false,false,false],"endpoint":"wss://rpc.rococo-parachain.litentry.io"},"issuer":{"id":"did:litentry:substrate:0x0b9df679f406a51a2e53b87d8e3fc86e792e277fe932d9535b40692bec9e3789","name":"Litentry TEE Worker","mrenclave":"8AxocYzEKmPF1JTAP3mFDnf1EPqaH76JRF7QSC8Mph85","runtimeVersion":{"parachain":9186,"sidechain":109}},"issuanceDate":"2024-08-05T08:37:34.612238127+00:00","parachainBlockNumber":6,"sidechainBlockNumber":2,"proof":{"created":"2024-08-05T08:37:34.612466121+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"73828b11b4c7925056f94971ae58e28193dd337fa1ac64bbb05cc1b96b2cc538e0b32f59bc2b30a9dd7181c31df6d10cc987d1ffb7981c696409d45bb8083002","verificationMethod":"0x44da3459814cb003846aece78984e0d064f6b7c1b4c3e4c7bf03b598ea550ba4"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/20-token-holding-amount-list/1-1-0.json","type":"JsonSchemaValidator2018"}}


achainable: false
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0xefe96beff5fd30db2d85e9416e5f872f64c70b624f8139cfd680f4265378493a","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:evm:0xf7a80341b681fc007d7b2d7a37671e04dfb3d5de","description":"The amount of a particular token you are holding","type":"Token holding amount","assertionText":"","assertions":[{"and":[{"src":"$comp_holding_amount","op":">","dst":"0"}]}],"values":[false],"endpoint":"wss://rpc.rococo-parachain.litentry.io"},"issuer":{"id":"did:litentry:substrate:0x0b9df679f406a51a2e53b87d8e3fc86e792e277fe932d9535b40692bec9e3789","name":"Litentry TEE Worker","mrenclave":"GTytHjS9rwX2gSVaAmwvxXmEeBSEGPxbtPaPsigUPcA4","runtimeVersion":{"parachain":9186,"sidechain":109}},"issuanceDate":"2024-08-05T09:27:13.383946847+00:00","parachainBlockNumber":44,"sidechainBlockNumber":80,"proof":{"created":"2024-08-05T09:27:13.470678320+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"3f5c51529ae9d7d98f60ad5728bd67343b59d0d8149ced65e55e1a6ffce02bebc91fe2294c8211f7a7e777033384e0074bc408a8fd4e32ab04d196d2258db10c","verificationMethod":"0x44da3459814cb003846aece78984e0d064f6b7c1b4c3e4c7bf03b598ea550ba4"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/17-token-holding-amount/1-1-0.json","type":"JsonSchemaValidator2018"}}
