### PR TITLE
Mention all processable TrustedCalls

### DIFF
--- a/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
+++ b/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
@@ -318,7 +318,7 @@ pub fn run_vc_handler_runner<ShieldingKeyRepository, A, S, H, O, N, AR>(
 			send_vc_response(
 				connection_hash,
 				context.clone(),
-				Err(RequestVcErrorDetail::UnexpectedCall("Expected request_batch_vc ".to_string())),
+				Err(RequestVcErrorDetail::UnexpectedCall("Expected request_vc or request_batch_vc ".to_string())),
 				0u8,
 				0u8,
 				false,

--- a/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
+++ b/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
@@ -318,7 +318,9 @@ pub fn run_vc_handler_runner<ShieldingKeyRepository, A, S, H, O, N, AR>(
 			send_vc_response(
 				connection_hash,
 				context.clone(),
-				Err(RequestVcErrorDetail::UnexpectedCall("Expected request_vc or request_batch_vc ".to_string())),
+				Err(RequestVcErrorDetail::UnexpectedCall(
+					"Expected request_vc or request_batch_vc ".to_string(),
+				)),
 				0u8,
 				0u8,
 				false,


### PR DESCRIPTION
Adjust error message so it informs about all `TrustedCall` types allowed.