### PR TITLE
Bump versions and use unified crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-primitives"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "base58",
  "frame-support",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "litentry-hex-utils"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -5557,11 +5557,11 @@ dependencies = [
 
 [[package]]
 name = "litentry-macros"
-version = "0.9.12"
+version = "0.1.0"
 
 [[package]]
 name = "litentry-parachain-runtime"
-version = "0.9.17"
+version = "0.1.0"
 dependencies = [
  "core-primitives",
  "cumulus-pallet-aura-ext",
@@ -5651,7 +5651,7 @@ dependencies = [
 
 [[package]]
 name = "litentry-proc-macros"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "litmus-parachain-runtime"
-version = "0.9.17"
+version = "0.1.0"
 dependencies = [
  "core-primitives",
  "cumulus-pallet-aura-ext",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "env_logger 0.9.3",
  "frame-support",
@@ -10684,7 +10684,7 @@ dependencies = [
 
 [[package]]
 name = "rococo-parachain-runtime"
-version = "0.9.17"
+version = "0.1.0"
 dependencies = [
  "core-primitives",
  "cumulus-pallet-aura-ext",
@@ -10956,7 +10956,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "0.9.17"
+version = "0.1.0"
 dependencies = [
  "core-primitives",
  "cumulus-pallet-parachain-system",

--- a/bitacross-worker/Cargo.lock
+++ b/bitacross-worker/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "bitacross-worker"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1030,7 +1030,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-primitives"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "base58",
  "frame-support",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "ita-parentchain-interface"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bc-enclave-registry",
  "bc-relayer-registry",
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "ita-sgx-runtime"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "ita-stf"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "itc-direct-rpc-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-tls-websocket-server",
  "itp-rpc",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "itc-offchain-worker-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-light-client",
  "itp-extrinsics-factory",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-block-import-dispatcher",
  "itc-parentchain-block-importer",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-block-import-dispatcher"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-block-importer",
  "itp-import-queue",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-block-importer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "ita-stf",
  "itc-parentchain-indirect-calls-executor",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-indirect-calls-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bc-enclave-registry",
  "bc-relayer-registry",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-light-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "finality-grandpa",
  "itc-parentchain-test",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "sp-runtime",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "itc-rest-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
  "http 0.2.1",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "itc-rpc-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "base58",
  "env_logger",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "itc-tls-websocket-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bit-vec",
  "chrono 0.4.26",
@@ -3250,7 +3250,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "itp-api-client-extensions"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "itp-api-client-types",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "itp-api-client-types"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "sp-runtime",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "itp-enclave-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "hex",
@@ -3345,14 +3345,14 @@ dependencies = [
 
 [[package]]
 name = "itp-enclave-api-ffi"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "sgx_types",
 ]
 
 [[package]]
 name = "itp-enclave-metrics"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "itp-extrinsics-factory"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "itp-hashing"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "sp-core",
 ]
@@ -3395,14 +3395,14 @@ dependencies = [
 
 [[package]]
 name = "itp-networking-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "sgx_tstd",
 ]
 
 [[package]]
 name = "itp-node-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-api-client-extensions",
  "itp-api-client-types",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-factory"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-api-client-types",
  "sp-core",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-metadata"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-api-client-types",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-metadata-provider"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api-metadata",
  "itp-stf-primitives",
@@ -3453,7 +3453,7 @@ dependencies = [
 
 [[package]]
 name = "itp-ocall-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-storage",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "itp-primitives-cache"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "lazy_static",
  "sgx_tstd",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "itp-rpc"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
@@ -3488,11 +3488,11 @@ dependencies = [
 
 [[package]]
 name = "itp-settings"
-version = "0.9.0"
+version = "0.1.0"
 
 [[package]]
 name = "itp-sgx-crypto"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "aes",
  "derive_more",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "itp-sgx-externalities"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "environmental 1.1.3",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "itp-sgx-runtime-primitives"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "pallet-balances",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "itc-parentchain-test",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-primitives"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-sgx-runtime-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-state-handler"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-hashing",
  "itp-settings",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-state-observer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "log 0.4.20",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "itp-storage"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "itp-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "itp-node-api",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "itp-time-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "chrono 0.4.11",
  "chrono 0.4.26",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "itp-top-pool"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "byteorder 1.4.3",
  "derive_more",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "itp-top-pool-author"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "futures 0.3.28",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "itp-types"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "itp-sgx-crypto",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "itp-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "litentry-hex-utils",
@@ -4137,14 +4137,14 @@ checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "litentry-hex-utils"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "litentry-macros"
-version = "0.9.12"
+version = "0.1.0"
 
 [[package]]
 name = "litentry-primitives"
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "litentry-proc-macros"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/bitacross-worker/app-libs/parentchain-interface/Cargo.toml
+++ b/bitacross-worker/app-libs/parentchain-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ita-parentchain-interface"
-version = "0.9.0"
+version = "0.1.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/bitacross-worker/app-libs/sgx-runtime/Cargo.toml
+++ b/bitacross-worker/app-libs/sgx-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ita-sgx-runtime"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/app-libs/stf/Cargo.toml
+++ b/bitacross-worker/app-libs/stf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ita-stf"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/enclave-api/Cargo.toml
+++ b/bitacross-worker/core-primitives/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-enclave-api"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/enclave-api/ffi/Cargo.toml
+++ b/bitacross-worker/core-primitives/enclave-api/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-enclave-api-ffi"
-version = "0.9.0"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bitacross-worker/core-primitives/enclave-metrics/Cargo.toml
+++ b/bitacross-worker/core-primitives/enclave-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-enclave-metrics"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/extrinsics-factory/Cargo.toml
+++ b/bitacross-worker/core-primitives/extrinsics-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-extrinsics-factory"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/hashing/Cargo.toml
+++ b/bitacross-worker/core-primitives/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-hashing"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/networking-utils/Cargo.toml
+++ b/bitacross-worker/core-primitives/networking-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-networking-utils"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/node-api/Cargo.toml
+++ b/bitacross-worker/core-primitives/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-node-api"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/node-api/api-client-extensions/Cargo.toml
+++ b/bitacross-worker/core-primitives/node-api/api-client-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-api-client-extensions"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/bitacross-worker/core-primitives/node-api/api-client-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-api-client-types"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/node-api/factory/Cargo.toml
+++ b/bitacross-worker/core-primitives/node-api/factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-node-api-factory"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/node-api/metadata-provider/Cargo.toml
+++ b/bitacross-worker/core-primitives/node-api/metadata-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-node-api-metadata-provider"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/node-api/metadata/Cargo.toml
+++ b/bitacross-worker/core-primitives/node-api/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-node-api-metadata"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/ocall-api/Cargo.toml
+++ b/bitacross-worker/core-primitives/ocall-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-ocall-api"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/primitives-cache/Cargo.toml
+++ b/bitacross-worker/core-primitives/primitives-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-primitives-cache"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/rpc/Cargo.toml
+++ b/bitacross-worker/core-primitives/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-rpc"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/settings/Cargo.toml
+++ b/bitacross-worker/core-primitives/settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-settings"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/sgx-runtime-primitives/Cargo.toml
+++ b/bitacross-worker/core-primitives/sgx-runtime-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-sgx-runtime-primitives"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/sgx/crypto/Cargo.toml
+++ b/bitacross-worker/core-primitives/sgx/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-sgx-crypto"
-version = "0.9.0"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bitacross-worker/core-primitives/stf-executor/Cargo.toml
+++ b/bitacross-worker/core-primitives/stf-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-stf-executor"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/stf-primitives/Cargo.toml
+++ b/bitacross-worker/core-primitives/stf-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-stf-primitives"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/stf-state-handler/Cargo.toml
+++ b/bitacross-worker/core-primitives/stf-state-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-stf-state-handler"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/stf-state-observer/Cargo.toml
+++ b/bitacross-worker/core-primitives/stf-state-observer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-stf-state-observer"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/storage/Cargo.toml
+++ b/bitacross-worker/core-primitives/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-storage"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/substrate-sgx/externalities/Cargo.toml
+++ b/bitacross-worker/core-primitives/substrate-sgx/externalities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-sgx-externalities"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network> and Parity Technologies <admin@parity.io>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/test/Cargo.toml
+++ b/bitacross-worker/core-primitives/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-test"
-version = "0.9.0"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/bitacross-worker/core-primitives/time-utils/Cargo.toml
+++ b/bitacross-worker/core-primitives/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-time-utils"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/top-pool-author/Cargo.toml
+++ b/bitacross-worker/core-primitives/top-pool-author/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-top-pool-author"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/top-pool/Cargo.toml
+++ b/bitacross-worker/core-primitives/top-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-top-pool"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core-primitives/types/Cargo.toml
+++ b/bitacross-worker/core-primitives/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-types"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = 'https://litentry.com/'
 repository = 'https://github.com/litentry/litentry-parachain'

--- a/bitacross-worker/core-primitives/utils/Cargo.toml
+++ b/bitacross-worker/core-primitives/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-utils"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = "https://litentry.com/"
 repository = "https://github.com/litentry/litentry-parachain"

--- a/bitacross-worker/core/direct-rpc-server/Cargo.toml
+++ b/bitacross-worker/core/direct-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-direct-rpc-server"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/offchain-worker-executor/Cargo.toml
+++ b/bitacross-worker/core/offchain-worker-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-offchain-worker-executor"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/parentchain/block-import-dispatcher/Cargo.toml
+++ b/bitacross-worker/core/parentchain/block-import-dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-block-import-dispatcher"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/parentchain/block-importer/Cargo.toml
+++ b/bitacross-worker/core/parentchain/block-importer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-block-importer"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/parentchain/indirect-calls-executor/Cargo.toml
+++ b/bitacross-worker/core/parentchain/indirect-calls-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-indirect-calls-executor"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/parentchain/light-client/Cargo.toml
+++ b/bitacross-worker/core/parentchain/light-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-light-client"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/parentchain/parentchain-crate/Cargo.toml
+++ b/bitacross-worker/core/parentchain/parentchain-crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/parentchain/test/Cargo.toml
+++ b/bitacross-worker/core/parentchain/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-test"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = 'https://litentry.com/'
 repository = 'https://github.com/litentry/litentry-parachain'

--- a/bitacross-worker/core/rest-client/Cargo.toml
+++ b/bitacross-worker/core/rest-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-rest-client"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/rpc-client/Cargo.toml
+++ b/bitacross-worker/core/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-rpc-client"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/core/tls-websocket-server/Cargo.toml
+++ b/bitacross-worker/core/tls-websocket-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-tls-websocket-server"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/bitacross-worker/enclave-runtime/Cargo.lock
+++ b/bitacross-worker/enclave-runtime/Cargo.lock
@@ -727,7 +727,7 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-primitives"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "base58",
  "frame-support",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "ita-parentchain-interface"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bc-enclave-registry",
  "bc-relayer-registry",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "ita-sgx-runtime"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "ita-stf"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "itc-direct-rpc-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-tls-websocket-server",
  "itp-rpc",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "itc-offchain-worker-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-light-client",
  "itp-extrinsics-factory",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-block-import-dispatcher",
  "itc-parentchain-block-importer",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-block-import-dispatcher"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-block-importer",
  "itp-import-queue",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-block-importer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "ita-stf",
  "itc-parentchain-indirect-calls-executor",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-indirect-calls-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bc-enclave-registry",
  "bc-relayer-registry",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-light-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "finality-grandpa",
  "itc-parentchain-test",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "sp-runtime",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "itc-tls-websocket-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bit-vec",
  "chrono 0.4.31",
@@ -2239,7 +2239,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "itp-api-client-types"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "sp-runtime",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "itp-enclave-metrics"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "itp-extrinsics-factory"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "itp-hashing"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "sp-core",
 ]
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-api-client-types",
  "itp-node-api-metadata",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-metadata"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-api-client-types",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-metadata-provider"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api-metadata",
  "itp-stf-primitives",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "itp-ocall-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-storage",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "itp-primitives-cache"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "lazy_static",
  "sgx_tstd",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "itp-rpc"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
@@ -2402,11 +2402,11 @@ dependencies = [
 
 [[package]]
 name = "itp-settings"
-version = "0.9.0"
+version = "0.1.0"
 
 [[package]]
 name = "itp-sgx-crypto"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "aes",
  "derive_more",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "itp-sgx-externalities"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "environmental 1.1.3",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "itp-sgx-runtime-primitives"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "pallet-balances",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "itc-parentchain-test",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-primitives"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-sgx-runtime-primitives",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-state-handler"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-hashing",
  "itp-settings",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-state-observer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "log",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "itp-storage"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "itp-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "itp-node-api",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "itp-time-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "chrono 0.4.11",
  "sgx_tstd",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "itp-top-pool"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "byteorder 1.4.3",
  "derive_more",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "itp-top-pool-author"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-ocall-api",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "itp-types"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "itp-sgx-crypto",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "itp-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "litentry-hex-utils",
@@ -2811,14 +2811,14 @@ dependencies = [
 
 [[package]]
 name = "litentry-hex-utils"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "litentry-macros"
-version = "0.9.12"
+version = "0.1.0"
 
 [[package]]
 name = "litentry-primitives"
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "litentry-proc-macros"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/bitacross-worker/service/Cargo.toml
+++ b/bitacross-worker/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'bitacross-worker'
-version = '0.0.1'
+version = '0.1.0'
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 build = 'build.rs'
 edition = '2021'

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Trust Computing GmbH <info@litentry.com>"]
 edition = '2021'
 name = 'core-primitives'
-version = '0.9.12'
+version = '0.1.0'
 
 [dependencies]
 base58 = { workspace = true }

--- a/primitives/core/macros/Cargo.toml
+++ b/primitives/core/macros/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['Trust Computing GmbH <info@litentry.com>']
 description = 'Proc-macros used by Litentry crates.'
 name = "litentry-macros"
-version = "0.9.12"
+version = "0.1.0"
 edition = "2021"
 
 [features]

--- a/primitives/core/proc-macros/Cargo.toml
+++ b/primitives/core/proc-macros/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['Trust Computing GmbH <info@litentry.com>']
 description = 'Proc-macros used by Litentry crates.'
 name = "litentry-proc-macros"
-version = "0.9.12"
+version = "0.1.0"
 edition = "2021"
 
 [lib]

--- a/primitives/hex/Cargo.toml
+++ b/primitives/hex/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['Trust Computing GmbH <info@litentry.com>']
 description = 'Litentry hex utils'
 name = "litentry-hex-utils"
-version = "0.9.12"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Trust Computing GmbH <info@litentry.com>"]
 edition = '2021'
 name = 'runtime-common'
-version = '0.9.17'
+version = '0.1.0'
 
 [dependencies]
 log = { workspace = true }

--- a/runtime/litentry/Cargo.toml
+++ b/runtime/litentry/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Trust Computing GmbH <info@litentry.com>"]
 edition = '2021'
 name = 'litentry-parachain-runtime'
-version = '0.9.17'
+version = '0.1.0'
 
 [dependencies]
 hex-literal = { workspace = true }

--- a/runtime/litentry/src/lib.rs
+++ b/runtime/litentry/src/lib.rs
@@ -163,7 +163,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litentry-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9191,
+	spec_version: 9192,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/litmus/Cargo.toml
+++ b/runtime/litmus/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Trust Computing GmbH <info@litentry.com>"]
 edition = '2021'
 name = 'litmus-parachain-runtime'
-version = '0.9.17'
+version = '0.1.0'
 
 [dependencies]
 hex-literal = { workspace = true }

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -165,7 +165,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litmus-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9191,
+	spec_version: 9192,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/rococo/Cargo.toml
+++ b/runtime/rococo/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Trust Computing GmbH <info@litentry.com>"]
 edition = '2021'
 name = 'rococo-parachain-runtime'
-version = '0.9.17'
+version = '0.1.0'
 
 [dependencies]
 hex-literal = { workspace = true }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -261,7 +261,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("rococo-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9191,
+	spec_version: 9192,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/tee-worker/Cargo.lock
+++ b/tee-worker/Cargo.lock
@@ -874,7 +874,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-primitives"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "base58",
  "frame-support",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "ita-parentchain-interface"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bs58",
  "env_logger 0.9.3",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "ita-sgx-runtime"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "ita-stf"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "itc-direct-rpc-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-tls-websocket-server",
  "itp-rpc",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "itc-offchain-worker-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-light-client",
  "itp-extrinsics-factory",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-block-import-dispatcher",
  "itc-parentchain-block-importer",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-block-import-dispatcher"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-block-importer",
  "itp-import-queue",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-block-importer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "ita-stf",
  "itc-parentchain-indirect-calls-executor",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-indirect-calls-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "binary-merkle-tree",
  "bs58",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-light-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "finality-grandpa",
  "itc-parentchain-test",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "sp-runtime",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "itc-rest-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
  "http 0.2.1",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "itc-rpc-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "base58",
  "env_logger 0.9.3",
@@ -3280,10 +3280,10 @@ dependencies = [
 
 [[package]]
 name = "itc-rpc-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.10.0",
+ "env_logger 0.9.3",
  "itp-enclave-api",
  "itp-rpc",
  "itp-utils",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "itc-tls-websocket-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bit-vec",
  "chrono 0.4.38",
@@ -3360,7 +3360,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "itp-api-client-extensions"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "itp-api-client-types",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "itp-api-client-types"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "sp-runtime",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "itp-enclave-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "hex",
@@ -3463,14 +3463,14 @@ dependencies = [
 
 [[package]]
 name = "itp-enclave-api-ffi"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "sgx_types",
 ]
 
 [[package]]
 name = "itp-enclave-metrics"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "lc-stf-task-sender",
  "litentry-primitives",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "itp-extrinsics-factory"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "itp-hashing"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "sp-core",
 ]
@@ -3516,14 +3516,14 @@ dependencies = [
 
 [[package]]
 name = "itp-networking-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "sgx_tstd",
 ]
 
 [[package]]
 name = "itp-node-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-api-client-extensions",
  "itp-api-client-types",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-factory"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-api-client-types",
  "sp-core",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-metadata"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-api-client-types",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-metadata-provider"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api-metadata",
  "itp-stf-primitives",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "itp-ocall-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-storage",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "itp-primitives-cache"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "lazy_static",
  "sgx_tstd",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "itp-rpc"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
@@ -3610,14 +3610,14 @@ dependencies = [
 
 [[package]]
 name = "itp-settings"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "litentry-primitives",
 ]
 
 [[package]]
 name = "itp-sgx-crypto"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "aes",
  "derive_more",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "itp-sgx-externalities"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "environmental 1.1.3",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "itp-sgx-runtime-primitives"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "pallet-balances",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "ita-sgx-runtime",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-primitives"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-sgx-runtime-primitives",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-state-handler"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-hashing",
  "itp-settings",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-state-observer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "log 0.4.20",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "itp-storage"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "itp-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "itp-node-api",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "itp-time-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "chrono 0.4.11",
  "chrono 0.4.38",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "itp-top-pool"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "byteorder 1.4.3",
  "derive_more",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "itp-top-pool-author"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "futures 0.3.28",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "itp-types"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "itp-sgx-crypto",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "itp-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "litentry-hex-utils",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "its-block-composer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api",
  "itp-settings",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "its-block-verification"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "itc-parentchain-test",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "its-consensus-aura"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "env_logger 0.9.3",
  "finality-grandpa",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "its-consensus-common"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "fork-tree",
  "itc-parentchain-light-client",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "its-consensus-slots"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "futures-timer",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "its-peer-fetch"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "its-rpc-handler"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "futures 0.3.28",
  "futures 0.3.8",
@@ -4123,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "its-sidechain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "its-block-composer",
  "its-consensus-aura",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "its-state"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "itp-sgx-externalities",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "its-storage"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-settings",
  "itp-time-utils",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "its-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "its-primitives",
@@ -4185,7 +4185,7 @@ dependencies = [
 
 [[package]]
 name = "its-validateer-fetch"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itc-parentchain-test",
@@ -5053,14 +5053,14 @@ dependencies = [
 
 [[package]]
 name = "litentry-hex-utils"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "litentry-macros"
-version = "0.9.12"
+version = "0.1.0"
 
 [[package]]
 name = "litentry-primitives"
@@ -5094,7 +5094,7 @@ dependencies = [
 
 [[package]]
 name = "litentry-proc-macros"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "litentry-worker"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6102,7 +6102,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/tee-worker/app-libs/parentchain-interface/Cargo.toml
+++ b/tee-worker/app-libs/parentchain-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ita-parentchain-interface"
-version = "0.9.0"
+version = "0.1.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/tee-worker/app-libs/sgx-runtime/Cargo.toml
+++ b/tee-worker/app-libs/sgx-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ita-sgx-runtime"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/app-libs/stf/Cargo.toml
+++ b/tee-worker/app-libs/stf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ita-stf"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/enclave-api/Cargo.toml
+++ b/tee-worker/core-primitives/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-enclave-api"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/enclave-api/ffi/Cargo.toml
+++ b/tee-worker/core-primitives/enclave-api/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-enclave-api-ffi"
-version = "0.9.0"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tee-worker/core-primitives/enclave-metrics/Cargo.toml
+++ b/tee-worker/core-primitives/enclave-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-enclave-metrics"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/extrinsics-factory/Cargo.toml
+++ b/tee-worker/core-primitives/extrinsics-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-extrinsics-factory"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/hashing/Cargo.toml
+++ b/tee-worker/core-primitives/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-hashing"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/networking-utils/Cargo.toml
+++ b/tee-worker/core-primitives/networking-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-networking-utils"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/node-api/Cargo.toml
+++ b/tee-worker/core-primitives/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-node-api"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/node-api/api-client-extensions/Cargo.toml
+++ b/tee-worker/core-primitives/node-api/api-client-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-api-client-extensions"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/tee-worker/core-primitives/node-api/api-client-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-api-client-types"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/node-api/factory/Cargo.toml
+++ b/tee-worker/core-primitives/node-api/factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-node-api-factory"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/node-api/metadata-provider/Cargo.toml
+++ b/tee-worker/core-primitives/node-api/metadata-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-node-api-metadata-provider"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/node-api/metadata/Cargo.toml
+++ b/tee-worker/core-primitives/node-api/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-node-api-metadata"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/ocall-api/Cargo.toml
+++ b/tee-worker/core-primitives/ocall-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-ocall-api"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/primitives-cache/Cargo.toml
+++ b/tee-worker/core-primitives/primitives-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-primitives-cache"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/rpc/Cargo.toml
+++ b/tee-worker/core-primitives/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-rpc"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/settings/Cargo.toml
+++ b/tee-worker/core-primitives/settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-settings"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/sgx-runtime-primitives/Cargo.toml
+++ b/tee-worker/core-primitives/sgx-runtime-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-sgx-runtime-primitives"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/sgx/crypto/Cargo.toml
+++ b/tee-worker/core-primitives/sgx/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-sgx-crypto"
-version = "0.9.0"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tee-worker/core-primitives/stf-executor/Cargo.toml
+++ b/tee-worker/core-primitives/stf-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-stf-executor"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/stf-primitives/Cargo.toml
+++ b/tee-worker/core-primitives/stf-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-stf-primitives"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/stf-state-handler/Cargo.toml
+++ b/tee-worker/core-primitives/stf-state-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-stf-state-handler"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/stf-state-observer/Cargo.toml
+++ b/tee-worker/core-primitives/stf-state-observer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-stf-state-observer"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/storage/Cargo.toml
+++ b/tee-worker/core-primitives/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-storage"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/substrate-sgx/externalities/Cargo.toml
+++ b/tee-worker/core-primitives/substrate-sgx/externalities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-sgx-externalities"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network> and Parity Technologies <admin@parity.io>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/test/Cargo.toml
+++ b/tee-worker/core-primitives/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-test"
-version = "0.9.0"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/tee-worker/core-primitives/time-utils/Cargo.toml
+++ b/tee-worker/core-primitives/time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-time-utils"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/top-pool-author/Cargo.toml
+++ b/tee-worker/core-primitives/top-pool-author/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-top-pool-author"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/top-pool/Cargo.toml
+++ b/tee-worker/core-primitives/top-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-top-pool"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core-primitives/types/Cargo.toml
+++ b/tee-worker/core-primitives/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-types"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = 'https://litentry.com/'
 repository = 'https://github.com/litentry/litentry-parachain'

--- a/tee-worker/core-primitives/utils/Cargo.toml
+++ b/tee-worker/core-primitives/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itp-utils"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = "https://litentry.com/"
 repository = "https://github.com/litentry/litentry-parachain"

--- a/tee-worker/core/direct-rpc-server/Cargo.toml
+++ b/tee-worker/core/direct-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-direct-rpc-server"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/offchain-worker-executor/Cargo.toml
+++ b/tee-worker/core/offchain-worker-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-offchain-worker-executor"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/parentchain/block-import-dispatcher/Cargo.toml
+++ b/tee-worker/core/parentchain/block-import-dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-block-import-dispatcher"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/parentchain/block-importer/Cargo.toml
+++ b/tee-worker/core/parentchain/block-importer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-block-importer"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/parentchain/indirect-calls-executor/Cargo.toml
+++ b/tee-worker/core/parentchain/indirect-calls-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-indirect-calls-executor"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/parentchain/light-client/Cargo.toml
+++ b/tee-worker/core/parentchain/light-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-light-client"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/parentchain/parentchain-crate/Cargo.toml
+++ b/tee-worker/core/parentchain/parentchain-crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/parentchain/test/Cargo.toml
+++ b/tee-worker/core/parentchain/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-parentchain-test"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = 'https://litentry.com/'
 repository = 'https://github.com/litentry/litentry-parachain'

--- a/tee-worker/core/rest-client/Cargo.toml
+++ b/tee-worker/core/rest-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-rest-client"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/rpc-client/Cargo.toml
+++ b/tee-worker/core/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-rpc-client"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/rpc-server/Cargo.toml
+++ b/tee-worker/core/rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-rpc-server"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/core/tls-websocket-server/Cargo.toml
+++ b/tee-worker/core/tls-websocket-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itc-tls-websocket-server"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/enclave-runtime/Cargo.lock
+++ b/tee-worker/enclave-runtime/Cargo.lock
@@ -605,7 +605,7 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-primitives"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "base58",
  "frame-support",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "ita-parentchain-interface"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bs58",
  "ita-sgx-runtime",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "ita-sgx-runtime"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "ita-stf"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "itc-direct-rpc-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-tls-websocket-server",
  "itp-rpc",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "itc-offchain-worker-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-light-client",
  "itp-extrinsics-factory",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-block-import-dispatcher",
  "itc-parentchain-block-importer",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-block-import-dispatcher"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-block-importer",
  "itp-import-queue",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-block-importer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "ita-stf",
  "itc-parentchain-indirect-calls-executor",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-indirect-calls-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "binary-merkle-tree",
  "bs58",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-light-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "finality-grandpa",
  "itc-parentchain-test",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "itc-parentchain-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "sp-runtime",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "itc-rest-client"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
  "http",
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "itc-tls-websocket-server"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "bit-vec",
  "chrono 0.4.31",
@@ -2302,7 +2302,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "itp-api-client-types"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "sp-runtime",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "itp-enclave-metrics"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "lc-stf-task-sender",
  "litentry-primitives",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "itp-extrinsics-factory"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "itp-hashing"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "sp-core",
 ]
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-api-client-types",
  "itp-node-api-metadata",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-metadata"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-api-client-types",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "itp-node-api-metadata-provider"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api-metadata",
  "itp-stf-primitives",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "itp-ocall-api"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-storage",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "itp-primitives-cache"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "lazy_static",
  "sgx_tstd",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "itp-rpc"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
@@ -2469,14 +2469,14 @@ dependencies = [
 
 [[package]]
 name = "itp-settings"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "litentry-primitives",
 ]
 
 [[package]]
 name = "itp-sgx-crypto"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "aes",
  "derive_more",
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "itp-sgx-externalities"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "environmental 1.1.3",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "itp-sgx-runtime-primitives"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "pallet-balances",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-executor"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "ita-sgx-runtime",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-primitives"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-sgx-runtime-primitives",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-state-handler"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-hashing",
  "itp-settings",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "itp-stf-state-observer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-types",
  "log",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "itp-storage"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "itp-test"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "itp-node-api",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "itp-time-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "chrono 0.4.11",
  "sgx_tstd",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "itp-top-pool"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "byteorder 1.4.3",
  "derive_more",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "itp-top-pool-author"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-enclave-metrics",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "itp-types"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "itp-sgx-crypto",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "itp-utils"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "hex",
  "litentry-hex-utils",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "its-block-composer"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itp-node-api",
  "itp-settings",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "its-block-verification"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "itp-types",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "its-consensus-aura"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "finality-grandpa",
  "ita-stf",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "its-consensus-common"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "itc-parentchain-light-client",
  "itertools 0.10.5",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "its-consensus-slots"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "hex",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "its-rpc-handler"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "futures 0.3.8",
  "itp-import-queue",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "its-sidechain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "its-block-composer",
  "its-consensus-aura",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "its-state"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "itp-sgx-externalities",
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "its-validateer-fetch"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "derive_more",
  "itp-ocall-api",
@@ -3415,14 +3415,14 @@ dependencies = [
 
 [[package]]
 name = "litentry-hex-utils"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "litentry-macros"
-version = "0.9.12"
+version = "0.1.0"
 
 [[package]]
 name = "litentry-primitives"
@@ -3453,7 +3453,7 @@ dependencies = [
 
 [[package]]
 name = "litentry-proc-macros"
-version = "0.9.12"
+version = "0.1.0"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parentchain"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/tee-worker/service/Cargo.toml
+++ b/tee-worker/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'litentry-worker'
-version = '0.0.2'
+version = '0.1.0'
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 build = 'build.rs'
 edition = '2021'

--- a/tee-worker/sidechain/block-composer/Cargo.toml
+++ b/tee-worker/sidechain/block-composer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-block-composer"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/block-verification/Cargo.toml
+++ b/tee-worker/sidechain/block-verification/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "its-block-verification"
 description = "Verification logic for sidechain blocks"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = "https://litentry.com/"
 repository = "https://github.com/litentry/litentry-parachain"

--- a/tee-worker/sidechain/consensus/aura/Cargo.toml
+++ b/tee-worker/sidechain/consensus/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-consensus-aura"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/consensus/common/Cargo.toml
+++ b/tee-worker/sidechain/consensus/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-consensus-common"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/consensus/slots/Cargo.toml
+++ b/tee-worker/sidechain/consensus/slots/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-consensus-slots"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/peer-fetch/Cargo.toml
+++ b/tee-worker/sidechain/peer-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-peer-fetch"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/rpc-handler/Cargo.toml
+++ b/tee-worker/sidechain/rpc-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-rpc-handler"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/sidechain-crate/Cargo.toml
+++ b/tee-worker/sidechain/sidechain-crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-sidechain"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/state/Cargo.toml
+++ b/tee-worker/sidechain/state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-state"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/storage/Cargo.toml
+++ b/tee-worker/sidechain/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-storage"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/sidechain/test/Cargo.toml
+++ b/tee-worker/sidechain/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-test"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = 'https://litentry.com/'
 repository = 'https://github.com/litentry/litentry-parachain'

--- a/tee-worker/sidechain/validateer-fetch/Cargo.toml
+++ b/tee-worker/sidechain/validateer-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "its-validateer-fetch"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 edition = "2021"
 

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -148,7 +148,7 @@ export async function assertVc(context: IntegrationTestContext, subject: CorePri
     // check runtime version is present
     assert.deepEqual(
         vcPayloadJson.issuer.runtimeVersion,
-        { parachain: 9191, sidechain: 109 },
+        { parachain: 9192, sidechain: 109 },
         'Check VC runtime version: it should equal the current defined versions'
     );
 

--- a/worker-pallets/parentchain/Cargo.toml
+++ b/worker-pallets/parentchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pallet-parentchain"
 description = "The remote attestation registry and verification pallet for litentry blockchains and parachains"
-version = "0.9.0"
+version = "0.1.0"
 authors = ['Trust Computing GmbH <info@litentry.com>', 'Integritee AG <hello@integritee.network>']
 homepage = 'https://litentry.com/'
 repository = 'https://github.com/litentry/litentry-parachain'


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

This PR:
- bumps runtime versions to 9192 for upcoming upgrades
- use `0.1.0` as version number for every crate, including worker binaries, as we are not ready to publish any of them. An exception is `litentry-collator` binary, which is already publicly used.