### PR TITLE
P 948 added more networks dataprovider for erc20 amount VC

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/libraries/AssertionLogic.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/libraries/AssertionLogic.sol
@@ -18,6 +18,8 @@
 
 pragma solidity ^0.8.8;
 
+import "./StringCleaner.sol";
+
 library AssertionLogic {
     enum Op {
         GreaterThan,
@@ -95,24 +97,27 @@ library AssertionLogic {
 
         result = string(abi.encodePacked(result, "}"));
 
-        return result;
+        // the assembled result may contain some invisible characters that cause the unit test failure, so we need to clear it here.
+        return StringCleaner.cleanString(result);
     }
 
     function toString(
         Condition memory condition
     ) internal pure returns (string memory) {
-        return
-            string(
-                abi.encodePacked(
-                    '{"src":"',
-                    condition.src,
-                    '","op":"',
-                    operatorToString(condition.op),
-                    '","dst":"',
-                    condition.dst,
-                    '"}'
-                )
-            );
+        string memory result = string(
+            abi.encodePacked(
+                '{"src":"',
+                condition.src,
+                '","op":"',
+                operatorToString(condition.op),
+                '","dst":"',
+                condition.dst,
+                '"}'
+            )
+        );
+
+        // the assembled result may contain some invisible characters that cause the unit test failure, so we need to clear it here.
+        return StringCleaner.cleanString(result);
     }
 
     function operatorToString(Op op) internal pure returns (string memory) {

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/libraries/Identities.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/libraries/Identities.sol
@@ -248,4 +248,32 @@ library Identities {
         }
         return (false);
     }
+
+    function web3_network_to_chain(
+        uint32 network
+    ) internal pure returns (string memory chain) {
+        if (network == Web3Networks.Polkadot) {
+            chain = "polkadot";
+        } else if (network == Web3Networks.Kusama) {
+            chain = "kusama";
+        } else if (network == Web3Networks.Litentry) {
+            chain = "litentry";
+        } else if (network == Web3Networks.Litmus) {
+            chain = "litmus";
+        } else if (network == Web3Networks.Khala) {
+            chain = "khala";
+        } else if (network == Web3Networks.Ethereum) {
+            chain = "ethereum";
+        } else if (network == Web3Networks.Bsc) {
+            chain = "bsc";
+        } else if (network == Web3Networks.Polygon) {
+            chain = "polygon";
+        } else if (network == Web3Networks.Arbitrum) {
+            chain = "arbitrum";
+        } else if (network == Web3Networks.Solana) {
+            chain = "solana";
+        } else if (network == Web3Networks.Combo) {
+            chain = "combo";
+        }
+    }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/libraries/StringCleaner.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/libraries/StringCleaner.sol
@@ -1,0 +1,66 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title StringCleaner
+ * @dev A library for cleaning strings by removing non-visible ASCII characters.
+ */
+library StringCleaner {
+    /**
+     * @dev Cleans the input string by removing non-visible ASCII characters.
+     * It iterates through each character in the string and retains only visible characters
+     * (ASCII range 0x20 to 0x7E).
+     * @param str The input string to be cleaned.
+     * @return The cleaned string with only visible characters.
+     */
+    function cleanString(
+        string memory str
+    ) internal pure returns (string memory) {
+        bytes memory b = bytes(str);
+        bytes memory cleaned = new bytes(b.length);
+        uint256 cleanedIndex = 0;
+
+        for (uint256 i = 0; i < b.length; i++) {
+            bytes1 char = b[i];
+            if (isVisibleChar(char)) {
+                cleaned[cleanedIndex] = char;
+                cleanedIndex++;
+            }
+        }
+
+        // Create a new bytes array of the correct length and copy cleaned characters into it
+        bytes memory trimmedCleaned = new bytes(cleanedIndex);
+        for (uint256 j = 0; j < cleanedIndex; j++) {
+            trimmedCleaned[j] = cleaned[j];
+        }
+
+        return string(trimmedCleaned);
+    }
+
+    /**
+     * @dev Checks if a given character is a visible ASCII character.
+     * This includes characters in the ASCII range from 0x20 (space) to 0x7E (~).
+     * @param char The character to be checked.
+     * @return True if the character is visible, false otherwise.
+     */
+    function isVisibleChar(bytes1 char) internal pure returns (bool) {
+        return (char >= 0x20 && char <= 0x7E);
+    }
+}

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/libraries/StringComparison.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/libraries/StringComparison.sol
@@ -1,0 +1,64 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+library StringComparison {
+    /**
+     * @notice Converts a given string to lowercase.
+     * @dev This function iterates through each character of the input string,
+     *      checks if it is an uppercase letter (A-Z), and converts it to the
+     *      corresponding lowercase letter (a-z). Characters outside the range
+     *      of uppercase letters remain unchanged.
+     * @param str The input string to be converted to lowercase.
+     * @return A new string with all uppercase letters converted to lowercase.
+     */
+    function toLower(string memory str) internal pure returns (string memory) {
+        bytes memory bStr = bytes(str);
+        bytes memory bLower = new bytes(bStr.length);
+
+        for (uint i = 0; i < bStr.length; i++) {
+            // Uppercase character range in ASCII: A-Z (65-90)
+            if (bStr[i] >= 0x41 && bStr[i] <= 0x5A) {
+                // Convert to lowercase by adding 32 (A -> a, B -> b, ..., Z -> z)
+                bLower[i] = bytes1(uint8(bStr[i]) + 32);
+            } else {
+                bLower[i] = bStr[i];
+            }
+        }
+
+        return string(bLower);
+    }
+
+    /**
+     * @notice Compares two strings for equality, ignoring case.
+     * @dev Converts both input strings to lowercase using the `toLower` function
+     *      and then compares their keccak256 hashes to determine if they are equal.
+     * @param str1 The first string to compare.
+     * @param str2 The second string to compare.
+     * @return A boolean value indicating whether the two strings are equal, ignoring case.
+     */
+    function compareStringsIgnoreCase(
+        string memory str1,
+        string memory str2
+    ) internal pure returns (bool) {
+        return
+            keccak256(abi.encodePacked(toLower(str1))) ==
+            keccak256(abi.encodePacked(toLower(str2)));
+    }
+}

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockHexToNumber.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockHexToNumber.sol
@@ -19,37 +19,34 @@
 pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
+import { HttpHeader } from "../libraries/Http.sol";
+
 import "hardhat/console.sol";
 
-contract MockParseDecimal {
+contract MockHexToNumber {
     receive() external payable {}
 
     fallback() external payable {
-        (string memory stringValue, uint8 decimals) = abi.decode(
-            msg.data,
-            (string, uint8)
-        );
+        string memory hexString = abi.decode(msg.data, (string));
 
         bool success = true;
         uint256 value = 0;
 
-        if (Strings.equal(stringValue, "0.1") && decimals == 18) {
-            value = 1 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "1") && decimals == 18) {
-            value = 1 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "1.1") && decimals == 18) {
-            value = 11 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "5") && decimals == 18) {
-            value = 5 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "30") && decimals == 18) {
-            value = 30 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "600.1") && decimals == 18) {
-            value = 6001 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "parse_decimal_fail")) {
-            success = false;
+        if (Strings.equal(hexString, "0x1")) {
+            value = 1;
+        } else if (Strings.equal(hexString, "0x2FAF080")) {
+            value = 50 * 10 ** 6;
+        } else if (Strings.equal(hexString, "0x5AF3107A4000")) {
+            value = 1 * 10 ** 14;
+        } else if (Strings.equal(hexString, "0x1BC16D674EC80000")) {
+            value = 2 * 10 ** 18;
+        } else if (Strings.equal(hexString, "0x5150AE84A8CDF00000")) {
+            value = 1500 * 10 ** 18;
+        } else if (Strings.equal(hexString, "0xCB49B44BA602D800000")) {
+            value = 60000 * 10 ** 18;
         }
 
-        console.log("parse_decimal>>", stringValue, decimals, value);
+        console.log("hex_to_number>", hexString, value);
 
         bytes memory encodedResult = abi.encode(success, value);
 

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockHttpGet.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockHttpGet.sol
@@ -19,37 +19,37 @@
 pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
+import { HttpHeader } from "../libraries/Http.sol";
+
 import "hardhat/console.sol";
 
-contract MockParseDecimal {
+contract MockHttpGet {
     receive() external payable {}
 
     fallback() external payable {
-        (string memory stringValue, uint8 decimals) = abi.decode(
-            msg.data,
-            (string, uint8)
-        );
+        (string memory url, ) = abi.decode(msg.data, (string, HttpHeader[]));
 
         bool success = true;
-        uint256 value = 0;
+        string memory value = "";
 
-        if (Strings.equal(stringValue, "0.1") && decimals == 18) {
-            value = 1 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "1") && decimals == 18) {
-            value = 1 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "1.1") && decimals == 18) {
-            value = 11 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "5") && decimals == 18) {
-            value = 5 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "30") && decimals == 18) {
-            value = 30 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "600.1") && decimals == 18) {
-            value = 6001 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "parse_decimal_fail")) {
-            success = false;
+        // moralis
+        if (
+            Strings.equal(
+                url,
+                "https://deep-index.moralis.io/api/v2.2/0x50BcC2FEA4A95283b196bdEF4DEa5B27AFD6323c/erc20?chain=polygon&token_addresses[0]=0xac51C4c48Dc3116487eD4BC16542e27B5694Da1b"
+            )
+        ) {
+            value = '[{"token_address":"0xac51C4c48Dc3116487eD4BC16542e27B5694Da1b","balance":"30"}]';
+        } else if (
+            Strings.equal(
+                url,
+                "https://deep-index.moralis.io/api/v2.2/0xbF98D4df371c2dE965a36E02b4c2E0DA89090818/erc20?chain=arbitrum&token_addresses[0]=0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+            )
+        ) {
+            value = '[{"token_address":"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1","balance":"5"}]';
         }
 
-        console.log("parse_decimal>>", stringValue, decimals, value);
+        console.log("http_get>>", url, value);
 
         bytes memory encodedResult = abi.encode(success, value);
 

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockHttpPostString.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockHttpPostString.sol
@@ -1,0 +1,108 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.8;
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import { HttpHeader } from "../libraries/Http.sol";
+
+import "hardhat/console.sol";
+
+contract MockHttpPostString {
+    receive() external payable {}
+
+    fallback() external payable {
+        (
+            string memory url,
+            string memory jsonPointer,
+            string memory payload,
+
+        ) = abi.decode(msg.data, (string, string, string, HttpHeader[]));
+
+        bool success = true;
+        string memory value = "0";
+
+        // nodereal eth
+        if (Strings.equal(url, "https://eth-mainnet.nodereal.io/v1/0x12345")) {
+            if (
+                Strings.equal(
+                    payload,
+                    '{"jsonrpc": "2.0", "method": "nr_getTokenBalance20", "id": 1, "params": ["0x8D983cb9388EaC77af0474fA441C4815500Cb7BB","0xA7Ee59E733E613CC957FE203A2935E85cE39D08A", "latest"]}'
+                )
+            ) {
+                value = "0x1";
+            } else if (
+                Strings.equal(
+                    payload,
+                    '{"jsonrpc": "2.0", "method": "nr_getTokenBalance20", "id": 1, "params": ["0x2260fac5e5542a773aa44fbcfedf7c193bc2c599","0x1C89Edd4FC080D71F92701C0794a16DbE573d4B8", "latest"]}'
+                )
+            ) {
+                // 0.0001 * 10^18
+                value = "0x5AF3107A4000";
+            } else if (
+                Strings.equal(
+                    payload,
+                    '{"jsonrpc": "2.0", "method": "nr_getTokenBalance20", "id": 1, "params": ["0x8D983cb9388EaC77af0474fA441C4815500Cb7BB","0x50BcC2FEA4A95283b196bdEF4DEa5B27AFD6323c", "latest"]}'
+                )
+            ) {
+                // 50 * 10^6
+                value = "0x2FAF080";
+            }
+        } else if (
+            Strings.equal(url, "https://bsc-mainnet.nodereal.io/v1/0x12345")
+        ) {
+            if (
+                Strings.equal(
+                    payload,
+                    '{"jsonrpc": "2.0", "method": "nr_getTokenBalance20", "id": 1, "params": ["0x0eb3a705fc54725037cc9e008bdede697f62f335","0xA7Ee59E733E613CC957FE203A2935E85cE39D08A", "latest"]}'
+                )
+            ) {
+                // 2 * 10^18
+                value = "0x1BC16D674EC80000";
+            }
+        } else if (
+            Strings.equal(url, "https://combo-mainnet.nodereal.io/v1/0x12345")
+        ) {
+            if (
+                Strings.equal(
+                    payload,
+                    '{"jsonrpc": "2.0", "method": "nr_getTokenBalance20", "id": 1, "params": ["0xba7b9936a965fac23bb7a8190364fa60622b3cff","0xa298cA90a4aa6029e26Dacc33b85c3847875615e", "latest"]}'
+                )
+            ) {
+                // 1500 * 10^18
+                value = "0x5150AE84A8CDF00000";
+            } else if (
+                Strings.equal(
+                    payload,
+                    '{"jsonrpc": "2.0", "method": "nr_getTokenBalance20", "id": 1, "params": ["0xba7b9936a965fac23bb7a8190364fa60622b3cff","0x0d4E9A8E1c26747c3d62a883b0Af5a916D6985c5", "latest"]}'
+                )
+            ) {
+                // 60000 * 10^18
+                value = "0xCB49B44BA602D800000";
+            }
+        }
+
+        console.log("http_post_string>>", url, jsonPointer, value);
+
+        bytes memory encodedResult = abi.encode(success, value);
+
+        assembly {
+            return(add(encodedResult, 0x20), mload(encodedResult))
+        }
+    }
+}

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockJsonGetArrayLen.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockJsonGetArrayLen.sol
@@ -19,37 +19,39 @@
 pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
+import { HttpHeader } from "../libraries/Http.sol";
+
 import "hardhat/console.sol";
 
-contract MockParseDecimal {
+contract MockJsonGetArrayLen {
     receive() external payable {}
 
     fallback() external payable {
-        (string memory stringValue, uint8 decimals) = abi.decode(
+        (string memory json, string memory pointer) = abi.decode(
             msg.data,
-            (string, uint8)
+            (string, string)
         );
 
         bool success = true;
-        uint256 value = 0;
+        int64 value = 0;
 
-        if (Strings.equal(stringValue, "0.1") && decimals == 18) {
-            value = 1 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "1") && decimals == 18) {
-            value = 1 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "1.1") && decimals == 18) {
-            value = 11 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "5") && decimals == 18) {
-            value = 5 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "30") && decimals == 18) {
-            value = 30 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "600.1") && decimals == 18) {
-            value = 6001 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "parse_decimal_fail")) {
-            success = false;
+        if (
+            Strings.equal(
+                json,
+                '[{"token_address":"0xac51C4c48Dc3116487eD4BC16542e27B5694Da1b","balance":"30"}]'
+            ) && Strings.equal(pointer, "")
+        ) {
+            value = 1;
+        } else if (
+            Strings.equal(
+                json,
+                '[{"token_address":"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1","balance":"5"}]'
+            ) && Strings.equal(pointer, "")
+        ) {
+            value = 1;
         }
 
-        console.log("parse_decimal>>", stringValue, decimals, value);
+        console.log("json_get_array_len>>", json, pointer);
 
         bytes memory encodedResult = abi.encode(success, value);
 

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockJsonGetString.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/mocks/MockJsonGetString.sol
@@ -19,37 +19,47 @@
 pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
+import { HttpHeader } from "../libraries/Http.sol";
+
 import "hardhat/console.sol";
 
-contract MockParseDecimal {
+contract MockJsonGetString {
     receive() external payable {}
 
     fallback() external payable {
-        (string memory stringValue, uint8 decimals) = abi.decode(
+        (string memory json, string memory pointer) = abi.decode(
             msg.data,
-            (string, uint8)
+            (string, string)
         );
 
         bool success = true;
-        uint256 value = 0;
+        string memory value = "";
 
-        if (Strings.equal(stringValue, "0.1") && decimals == 18) {
-            value = 1 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "1") && decimals == 18) {
-            value = 1 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "1.1") && decimals == 18) {
-            value = 11 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "5") && decimals == 18) {
-            value = 5 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "30") && decimals == 18) {
-            value = 30 * 10 ** 18;
-        } else if (Strings.equal(stringValue, "600.1") && decimals == 18) {
-            value = 6001 * 10 ** 17;
-        } else if (Strings.equal(stringValue, "parse_decimal_fail")) {
-            success = false;
+        if (
+            Strings.equal(
+                json,
+                '[{"token_address":"0xac51C4c48Dc3116487eD4BC16542e27B5694Da1b","balance":"30"}]'
+            )
+        ) {
+            if (Strings.equal(pointer, "/0/token_address")) {
+                value = "0xac51C4c48Dc3116487eD4BC16542e27B5694Da1b";
+            } else if (Strings.equal(pointer, "/0/balance")) {
+                value = "30";
+            }
+        } else if (
+            Strings.equal(
+                json,
+                '[{"token_address":"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1","balance":"5"}]'
+            )
+        ) {
+            if (Strings.equal(pointer, "/0/token_address")) {
+                value = "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1";
+            } else if (Strings.equal(pointer, "/0/balance")) {
+                value = "5";
+            }
         }
 
-        console.log("parse_decimal>>", stringValue, decimals, value);
+        console.log("json_get_string>>", json, pointer, value);
 
         bytes memory encodedResult = abi.encode(success, value);
 

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/tests/StringCleanerTest.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/tests/StringCleanerTest.sol
@@ -1,0 +1,29 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.8;
+
+import "../libraries/StringCleaner.sol";
+
+contract StringCleanerTest {
+    function cleanString(
+        string memory text
+    ) public pure returns (string memory) {
+        return StringCleaner.cleanString(text);
+    }
+}

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/tests/StringComparisonTest.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/tests/StringComparisonTest.sol
@@ -1,0 +1,30 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.8;
+
+import "../libraries/StringComparison.sol";
+
+contract StringComparisonTest {
+    function compareStringsIgnoreCase(
+        string memory str1,
+        string memory str2
+    ) public pure returns (bool) {
+        return StringComparison.compareStringsIgnoreCase(str1, str2);
+    }
+}

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/Btc.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/Btc.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.8;
 import "./Constants.sol";
 import { BRC20 } from "./brc20/BRC20.sol";
 library Btc {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         // [0.0, 0.001, 0.1, 0.3, 0.6, 1.0, 2.0, 5.0, 10.0, 15.0, 25.0, 30.0, 40.0, 50.0];
         // all ranges multiplied by decimals_factor(1000).
         uint256[] memory ranges = new uint256[](14);
@@ -38,21 +38,27 @@ library Btc {
         ranges[11] = 30000;
         ranges[12] = 40000;
         ranges[13] = 50000;
-        return ranges;
+        return TokenInfoRanges(ranges, 3);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        uint32[] memory networks = BRC20.getDefaultTokenNetworks();
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](networks.length);
-        for (uint i = 0; i < networks.length; i++) {
-            tokenInfoList[i] = TokenInfo(
-                networks[i],
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        uint32[] memory defaultNetworks = BRC20.getDefaultTokenNetworks();
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](
+            defaultNetworks.length
+        );
+        for (uint i = 0; i < defaultNetworks.length; i++) {
+            networks[i] = TokenInfoNetwork(
+                defaultNetworks[i],
                 "",
                 DataProviderTypes.BlockchainInfoClient,
                 8
             );
         }
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/Constants.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/Constants.sol
@@ -19,14 +19,25 @@
 pragma solidity ^0.8.8;
 
 struct TokenInfo {
+    uint256[] ranges;
+    // Some ranges are decimals, need convert them to int with multiply by rangeDecimals.
+    uint256 rangeDecimals;
+    // Different networks for same token may have different decimals, need use maxDecimals as multiplier factor.
+    uint8 maxDecimals;
+    TokenInfoNetwork[] networks;
+}
+
+struct TokenInfoNetwork {
     uint32 network;
     string tokenAddress;
-    uint8 dataprovierType;
+    uint8 dataProvierType;
     uint8 decimals;
 }
 
-library Constants {
-    uint256 constant decimals_factor = 1000;
+struct TokenInfoRanges {
+    uint256[] ranges;
+    // Some ranges are decimals, need convert them to int with multiply by rangeDecimals.
+    uint256 rangeDecimals;
 }
 
 library DataProviderTypes {

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/NoderealClient.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/NoderealClient.sol
@@ -73,7 +73,10 @@ library NoderealClient {
     }
 
     function isSupportedNetwork(uint32 network) internal pure returns (bool) {
-        return network == Web3Networks.Bsc || network == Web3Networks.Ethereum;
+        return
+            network == Web3Networks.Bsc ||
+            network == Web3Networks.Ethereum ||
+            network == Web3Networks.Combo;
     }
 
     function getNetworkUrl(
@@ -83,6 +86,8 @@ library NoderealClient {
             url = "https://bsc-mainnet.nodereal.io/v1/";
         } else if (network == Web3Networks.Ethereum) {
             url = "https://eth-mainnet.nodereal.io/v1/";
+        } else if (network == Web3Networks.Combo) {
+            url = "https://combo-mainnet.nodereal.io/v1/";
         }
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/TokenMapping.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/TokenMapping.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.8.8;
 
 import { TokenQueryLogic } from "./TokenQueryLogic.sol";
 import "../libraries/Identities.sol";
+import "./Constants.sol";
 
 // brc20
 import { Btcs } from "./brc20/Btcs.sol";
@@ -77,279 +78,173 @@ import { Btc } from "./Btc.sol";
 contract TokenMapping is TokenQueryLogic {
     constructor() {
         // btcs
-        tokenRanges["btcs"] = Btcs.getTokenRanges();
-        for (uint8 i = 0; i < BRC20.getBrc20TokenInfo().length; i++) {
-            tokenInfo["btcs"].push(BRC20.getBrc20TokenInfo()[i]);
-        }
+        setTokenInfo("btcs", Btcs.getTokenRanges(), BRC20.getTokenNetworks());
 
         // cats
-        tokenRanges["cats"] = Cats.getTokenRanges();
-        for (uint8 i = 0; i < BRC20.getBrc20TokenInfo().length; i++) {
-            tokenInfo["cats"].push(BRC20.getBrc20TokenInfo()[i]);
-        }
+        setTokenInfo("cats", Cats.getTokenRanges(), BRC20.getTokenNetworks());
 
         // long
-        tokenRanges["long"] = Long.getTokenRanges();
-        for (uint8 i = 0; i < BRC20.getBrc20TokenInfo().length; i++) {
-            tokenInfo["long"].push(BRC20.getBrc20TokenInfo()[i]);
-        }
+        setTokenInfo("long", Long.getTokenRanges(), BRC20.getTokenNetworks());
 
         // mmss
-        tokenRanges["mmss"] = Mmss.getTokenRanges();
-        for (uint8 i = 0; i < BRC20.getBrc20TokenInfo().length; i++) {
-            tokenInfo["mmss"].push(BRC20.getBrc20TokenInfo()[i]);
-        }
+        setTokenInfo("mmss", Mmss.getTokenRanges(), BRC20.getTokenNetworks());
 
         // ordi
-        tokenRanges["ordi"] = Ordi.getTokenRanges();
-        for (uint8 i = 0; i < BRC20.getBrc20TokenInfo().length; i++) {
-            tokenInfo["ordi"].push(BRC20.getBrc20TokenInfo()[i]);
-        }
+        setTokenInfo("ordi", Ordi.getTokenRanges(), BRC20.getTokenNetworks());
 
         // rats
-        tokenRanges["rats"] = Rats.getTokenRanges();
-        for (uint8 i = 0; i < BRC20.getBrc20TokenInfo().length; i++) {
-            tokenInfo["rats"].push(BRC20.getBrc20TokenInfo()[i]);
-        }
+        setTokenInfo("rats", Rats.getTokenRanges(), BRC20.getTokenNetworks());
 
         // sats
-        tokenRanges["sats"] = Sats.getTokenRanges();
-        for (uint8 i = 0; i < BRC20.getBrc20TokenInfo().length; i++) {
-            tokenInfo["sats"].push(BRC20.getBrc20TokenInfo()[i]);
-        }
+        setTokenInfo("sats", Sats.getTokenRanges(), BRC20.getTokenNetworks());
 
         // Btc
-        tokenRanges["btc"] = Btc.getTokenRanges();
-        for (uint8 i = 0; i < Btc.getTokenInfo().length; i++) {
-            tokenInfo["btc"].push(Btc.getTokenInfo()[i]);
-        }
+        setTokenInfo("btc", Btc.getTokenRanges(), Btc.getTokenNetworks());
 
         // ada
-        tokenRanges["ada"] = Ada.getTokenRanges();
-        for (uint8 i = 0; i < Ada.getTokenInfo().length; i++) {
-            tokenInfo["ada"].push(Ada.getTokenInfo()[i]);
-        }
+        setTokenInfo("ada", Ada.getTokenRanges(), Ada.getTokenNetworks());
 
         // amp
-        tokenRanges["amp"] = Amp.getTokenRanges();
-        for (uint8 i = 0; i < Amp.getTokenInfo().length; i++) {
-            tokenInfo["amp"].push(Amp.getTokenInfo()[i]);
-        }
+        setTokenInfo("amp", Amp.getTokenRanges(), Amp.getTokenNetworks());
 
         // atom
-        tokenRanges["atom"] = Atom.getTokenRanges();
-        for (uint8 i = 0; i < Atom.getTokenInfo().length; i++) {
-            tokenInfo["atom"].push(Atom.getTokenInfo()[i]);
-        }
+        setTokenInfo("atom", Atom.getTokenRanges(), Atom.getTokenNetworks());
 
         // bch
-        tokenRanges["bch"] = Bch.getTokenRanges();
-        for (uint8 i = 0; i < Bch.getTokenInfo().length; i++) {
-            tokenInfo["bch"].push(Bch.getTokenInfo()[i]);
-        }
+        setTokenInfo("bch", Bch.getTokenRanges(), Bch.getTokenNetworks());
 
         // bean
-        tokenRanges["bean"] = Bean.getTokenRanges();
-        for (uint8 i = 0; i < Bean.getTokenInfo().length; i++) {
-            tokenInfo["bean"].push(Bean.getTokenInfo()[i]);
-        }
+        setTokenInfo("bean", Bean.getTokenRanges(), Bean.getTokenNetworks());
 
         // bnb
-        tokenRanges["bnb"] = Bnb.getTokenRanges();
-        for (uint8 i = 0; i < Bnb.getTokenInfo().length; i++) {
-            tokenInfo["bnb"].push(Bnb.getTokenInfo()[i]);
-        }
+        setTokenInfo("bnb", Bnb.getTokenRanges(), Bnb.getTokenNetworks());
 
         // comp
-        tokenRanges["comp"] = Comp.getTokenRanges();
-        for (uint8 i = 0; i < Comp.getTokenInfo().length; i++) {
-            tokenInfo["comp"].push(Comp.getTokenInfo()[i]);
-        }
+        setTokenInfo("comp", Comp.getTokenRanges(), Comp.getTokenNetworks());
 
         // cro
-        tokenRanges["cro"] = Cro.getTokenRanges();
-        for (uint8 i = 0; i < Cro.getTokenInfo().length; i++) {
-            tokenInfo["cro"].push(Cro.getTokenInfo()[i]);
-        }
+        setTokenInfo("cro", Cro.getTokenRanges(), Cro.getTokenNetworks());
 
         // crv
-        tokenRanges["crv"] = Crv.getTokenRanges();
-        for (uint8 i = 0; i < Crv.getTokenInfo().length; i++) {
-            tokenInfo["crv"].push(Crv.getTokenInfo()[i]);
-        }
+        setTokenInfo("crv", Crv.getTokenRanges(), Crv.getTokenNetworks());
 
         // dai
-        tokenRanges["dai"] = Dai.getTokenRanges();
-        for (uint8 i = 0; i < Dai.getTokenInfo().length; i++) {
-            tokenInfo["dai"].push(Dai.getTokenInfo()[i]);
-        }
+        setTokenInfo("dai", Dai.getTokenRanges(), Dai.getTokenNetworks());
 
         // doge
-        tokenRanges["doge"] = Doge.getTokenRanges();
-        for (uint8 i = 0; i < Doge.getTokenInfo().length; i++) {
-            tokenInfo["doge"].push(Doge.getTokenInfo()[i]);
-        }
+        setTokenInfo("doge", Doge.getTokenRanges(), Doge.getTokenNetworks());
 
         // dydx
-        tokenRanges["dydx"] = Dydx.getTokenRanges();
-        for (uint8 i = 0; i < Dydx.getTokenInfo().length; i++) {
-            tokenInfo["dydx"].push(Dydx.getTokenInfo()[i]);
-        }
+        setTokenInfo("dydx", Dydx.getTokenRanges(), Dydx.getTokenNetworks());
 
         // etc
-        tokenRanges["etc"] = Etc.getTokenRanges();
-        for (uint8 i = 0; i < Etc.getTokenInfo().length; i++) {
-            tokenInfo["etc"].push(Etc.getTokenInfo()[i]);
-        }
+        setTokenInfo("etc", Etc.getTokenRanges(), Etc.getTokenNetworks());
 
         // eth
-        tokenRanges["eth"] = Eth.getTokenRanges();
-        for (uint8 i = 0; i < Eth.getTokenInfo().length; i++) {
-            tokenInfo["eth"].push(Eth.getTokenInfo()[i]);
-        }
+        setTokenInfo("eth", Eth.getTokenRanges(), Eth.getTokenNetworks());
 
         // fil
-        tokenRanges["fil"] = Fil.getTokenRanges();
-        for (uint8 i = 0; i < Fil.getTokenInfo().length; i++) {
-            tokenInfo["fil"].push(Fil.getTokenInfo()[i]);
-        }
+        setTokenInfo("fil", Fil.getTokenRanges(), Fil.getTokenNetworks());
 
         // grt
-        tokenRanges["grt"] = Grt.getTokenRanges();
-        for (uint8 i = 0; i < Grt.getTokenInfo().length; i++) {
-            tokenInfo["grt"].push(Grt.getTokenInfo()[i]);
-        }
+        setTokenInfo("grt", Grt.getTokenRanges(), Grt.getTokenNetworks());
 
         // gtc
-        tokenRanges["gtc"] = Gtc.getTokenRanges();
-        for (uint8 i = 0; i < Gtc.getTokenInfo().length; i++) {
-            tokenInfo["gtc"].push(Gtc.getTokenInfo()[i]);
-        }
+        setTokenInfo("gtc", Gtc.getTokenRanges(), Gtc.getTokenNetworks());
 
         // gusd
-        tokenRanges["gusd"] = Gusd.getTokenRanges();
-        for (uint8 i = 0; i < Gusd.getTokenInfo().length; i++) {
-            tokenInfo["gusd"].push(Gusd.getTokenInfo()[i]);
-        }
+        setTokenInfo("gusd", Gusd.getTokenRanges(), Gusd.getTokenNetworks());
 
         // imx
-        tokenRanges["imx"] = Imx.getTokenRanges();
-        for (uint8 i = 0; i < Imx.getTokenInfo().length; i++) {
-            tokenInfo["imx"].push(Imx.getTokenInfo()[i]);
-        }
+        setTokenInfo("imx", Imx.getTokenRanges(), Imx.getTokenNetworks());
 
         // inj
-        tokenRanges["inj"] = Inj.getTokenRanges();
-        for (uint8 i = 0; i < Inj.getTokenInfo().length; i++) {
-            tokenInfo["inj"].push(Inj.getTokenInfo()[i]);
-        }
+        setTokenInfo("inj", Inj.getTokenRanges(), Inj.getTokenNetworks());
 
         // leo
-        tokenRanges["leo"] = Leo.getTokenRanges();
-        for (uint8 i = 0; i < Leo.getTokenInfo().length; i++) {
-            tokenInfo["leo"].push(Leo.getTokenInfo()[i]);
-        }
+        setTokenInfo("leo", Leo.getTokenRanges(), Leo.getTokenNetworks());
 
         // link
-        tokenRanges["link"] = Link.getTokenRanges();
-        for (uint8 i = 0; i < Link.getTokenInfo().length; i++) {
-            tokenInfo["link"].push(Link.getTokenInfo()[i]);
-        }
+        setTokenInfo("link", Link.getTokenRanges(), Link.getTokenNetworks());
 
         // lit
-        tokenRanges["lit"] = Lit.getTokenRanges();
-        for (uint8 i = 0; i < Lit.getTokenInfo().length; i++) {
-            tokenInfo["lit"].push(Lit.getTokenInfo()[i]);
-        }
+        setTokenInfo("lit", Lit.getTokenRanges(), Lit.getTokenNetworks());
 
         // matic
-        tokenRanges["matic"] = Matic.getTokenRanges();
-        for (uint8 i = 0; i < Matic.getTokenInfo().length; i++) {
-            tokenInfo["matic"].push(Matic.getTokenInfo()[i]);
-        }
+        setTokenInfo("matic", Matic.getTokenRanges(), Matic.getTokenNetworks());
 
         // mcrt
-        tokenRanges["mcrt"] = Mcrt.getTokenRanges();
-        for (uint8 i = 0; i < Mcrt.getTokenInfo().length; i++) {
-            tokenInfo["mcrt"].push(Mcrt.getTokenInfo()[i]);
-        }
+        setTokenInfo("mcrt", Mcrt.getTokenRanges(), Mcrt.getTokenNetworks());
 
         // nfp
-        tokenRanges["nfp"] = Nfp.getTokenRanges();
-        for (uint8 i = 0; i < Nfp.getTokenInfo().length; i++) {
-            tokenInfo["nfp"].push(Nfp.getTokenInfo()[i]);
-        }
+        setTokenInfo("nfp", Nfp.getTokenRanges(), Nfp.getTokenNetworks());
 
         // people
-        tokenRanges["people"] = People.getTokenRanges();
-        for (uint8 i = 0; i < People.getTokenInfo().length; i++) {
-            tokenInfo["people"].push(People.getTokenInfo()[i]);
-        }
+        setTokenInfo(
+            "people",
+            People.getTokenRanges(),
+            People.getTokenNetworks()
+        );
 
         // shib
-        tokenRanges["shib"] = Shib.getTokenRanges();
-        for (uint8 i = 0; i < Shib.getTokenInfo().length; i++) {
-            tokenInfo["shib"].push(Shib.getTokenInfo()[i]);
-        }
+        setTokenInfo("shib", Shib.getTokenRanges(), Shib.getTokenNetworks());
 
         // sol
-        tokenRanges["sol"] = Sol.getTokenRanges();
-        for (uint8 i = 0; i < Sol.getTokenInfo().length; i++) {
-            tokenInfo["sol"].push(Sol.getTokenInfo()[i]);
-        }
+        setTokenInfo("sol", Sol.getTokenRanges(), Sol.getTokenNetworks());
 
         // spaceid
-        tokenRanges["spaceid"] = SpaceId.getTokenRanges();
-        for (uint8 i = 0; i < SpaceId.getTokenInfo().length; i++) {
-            tokenInfo["spaceid"].push(SpaceId.getTokenInfo()[i]);
-        }
+        setTokenInfo(
+            "spaceid",
+            SpaceId.getTokenRanges(),
+            SpaceId.getTokenNetworks()
+        );
 
         // ton
-        tokenRanges["ton"] = Ton.getTokenRanges();
-        for (uint8 i = 0; i < Ton.getTokenInfo().length; i++) {
-            tokenInfo["ton"].push(Ton.getTokenInfo()[i]);
-        }
+        setTokenInfo("ton", Ton.getTokenRanges(), Ton.getTokenNetworks());
 
         // trx
-        tokenRanges["trx"] = Trx.getTokenRanges();
-        for (uint8 i = 0; i < Trx.getTokenInfo().length; i++) {
-            tokenInfo["trx"].push(Trx.getTokenInfo()[i]);
-        }
+        setTokenInfo("trx", Trx.getTokenRanges(), Trx.getTokenNetworks());
 
         // tusd
-        tokenRanges["tusd"] = Tusd.getTokenRanges();
-        for (uint8 i = 0; i < Tusd.getTokenInfo().length; i++) {
-            tokenInfo["tusd"].push(Tusd.getTokenInfo()[i]);
-        }
+        setTokenInfo("tusd", Tusd.getTokenRanges(), Tusd.getTokenNetworks());
 
         // uni
-        tokenRanges["uni"] = Uni.getTokenRanges();
-        for (uint8 i = 0; i < Uni.getTokenInfo().length; i++) {
-            tokenInfo["uni"].push(Uni.getTokenInfo()[i]);
-        }
+        setTokenInfo("uni", Uni.getTokenRanges(), Uni.getTokenNetworks());
 
         // usdc
-        tokenRanges["usdc"] = Usdc.getTokenRanges();
-        for (uint8 i = 0; i < Usdc.getTokenInfo().length; i++) {
-            tokenInfo["usdc"].push(Usdc.getTokenInfo()[i]);
-        }
+        setTokenInfo("usdc", Usdc.getTokenRanges(), Usdc.getTokenNetworks());
 
         // usdd
-        tokenRanges["usdd"] = Usdd.getTokenRanges();
-        for (uint8 i = 0; i < Usdd.getTokenInfo().length; i++) {
-            tokenInfo["usdd"].push(Usdd.getTokenInfo()[i]);
-        }
+        setTokenInfo("usdd", Usdd.getTokenRanges(), Usdd.getTokenNetworks());
 
         // usdt
-        tokenRanges["usdt"] = Usdt.getTokenRanges();
-        for (uint8 i = 0; i < Usdt.getTokenInfo().length; i++) {
-            tokenInfo["usdt"].push(Usdt.getTokenInfo()[i]);
-        }
+        setTokenInfo("usdt", Usdt.getTokenRanges(), Usdt.getTokenNetworks());
 
         // wbtc
-        tokenRanges["wbtc"] = Wbtc.getTokenRanges();
-        for (uint8 i = 0; i < Wbtc.getTokenInfo().length; i++) {
-            tokenInfo["wbtc"].push(Wbtc.getTokenInfo()[i]);
+        setTokenInfo("wbtc", Wbtc.getTokenRanges(), Wbtc.getTokenNetworks());
+    }
+
+    function setTokenInfo(
+        string memory tokenName,
+        TokenInfoRanges memory ranges,
+        TokenInfoNetwork[] memory networks
+    ) private {
+        TokenInfo storage tokenInfo = tokens[tokenName];
+
+        delete tokenInfo.ranges;
+        for (uint i = 0; i < ranges.ranges.length; i++) {
+            tokenInfo.ranges.push(ranges.ranges[i]);
         }
+        tokenInfo.rangeDecimals = ranges.rangeDecimals;
+
+        delete tokenInfo.networks;
+        uint8 maxDecimals = 0;
+        for (uint i = 0; i < networks.length; i++) {
+            if (maxDecimals < networks[i].decimals) {
+                maxDecimals = networks[i].decimals;
+            }
+            tokenInfo.networks.push(networks[i]);
+        }
+        tokenInfo.maxDecimals = maxDecimals;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/BRC20.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/BRC20.sol
@@ -31,18 +31,25 @@ library BRC20 {
         networks[4] = Web3Networks.BitcoinP2wsh;
         return networks;
     }
-    function getBrc20TokenInfo() internal pure returns (TokenInfo[] memory) {
-        uint32[] memory networks = BRC20.getDefaultTokenNetworks();
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](networks.length);
-        for (uint i = 0; i < networks.length; i++) {
-            tokenInfoList[i] = TokenInfo(
-                networks[i],
+
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        uint32[] memory defaultNetworks = BRC20.getDefaultTokenNetworks();
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](
+            defaultNetworks.length
+        );
+        for (uint i = 0; i < defaultNetworks.length; i++) {
+            networks[i] = TokenInfoNetwork(
+                defaultNetworks[i],
                 "",
                 DataProviderTypes.GeniidataClient,
                 18
             );
         }
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Btcs.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Btcs.sol
@@ -23,17 +23,17 @@ import "../Constants.sol";
 import "./BRC20.sol";
 
 library Btcs {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](9);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 5 * Constants.decimals_factor;
-        ranges[3] = 20 * Constants.decimals_factor;
-        ranges[4] = 50 * Constants.decimals_factor;
-        ranges[5] = 100 * Constants.decimals_factor;
-        ranges[6] = 200 * Constants.decimals_factor;
-        ranges[7] = 500 * Constants.decimals_factor;
-        ranges[8] = 800 * Constants.decimals_factor;
-        return ranges;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 5;
+        ranges[3] = 20;
+        ranges[4] = 50;
+        ranges[5] = 100;
+        ranges[6] = 200;
+        ranges[7] = 500;
+        ranges[8] = 800;
+        return TokenInfoRanges(ranges, 0);
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Cats.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Cats.sol
@@ -23,16 +23,16 @@ import "../Constants.sol";
 import "./BRC20.sol";
 
 library Cats {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](8);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 10000 * Constants.decimals_factor;
-        ranges[3] = 50000 * Constants.decimals_factor;
-        ranges[4] = 100000 * Constants.decimals_factor;
-        ranges[5] = 200000 * Constants.decimals_factor;
-        ranges[6] = 500000 * Constants.decimals_factor;
-        ranges[7] = 800000 * Constants.decimals_factor;
-        return ranges;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 10000;
+        ranges[3] = 50000;
+        ranges[4] = 100000;
+        ranges[5] = 200000;
+        ranges[6] = 500000;
+        ranges[7] = 800000;
+        return TokenInfoRanges(ranges, 0);
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Long.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Long.sol
@@ -23,17 +23,17 @@ import "../Constants.sol";
 import "./BRC20.sol";
 
 library Long {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](9);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 20 * Constants.decimals_factor;
-        ranges[3] = 50 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 1000 * Constants.decimals_factor;
-        ranges[7] = 2000 * Constants.decimals_factor;
-        ranges[8] = 3000 * Constants.decimals_factor;
-        return ranges;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 20;
+        ranges[3] = 50;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 1000;
+        ranges[7] = 2000;
+        ranges[8] = 3000;
+        return TokenInfoRanges(ranges, 0);
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Mmss.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Mmss.sol
@@ -23,17 +23,17 @@ import "../Constants.sol";
 import "./BRC20.sol";
 
 library Mmss {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](9);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 20 * Constants.decimals_factor;
-        ranges[3] = 50 * Constants.decimals_factor;
-        ranges[4] = 100 * Constants.decimals_factor;
-        ranges[5] = 200 * Constants.decimals_factor;
-        ranges[6] = 500 * Constants.decimals_factor;
-        ranges[7] = 1000 * Constants.decimals_factor;
-        ranges[8] = 2000 * Constants.decimals_factor;
-        return ranges;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 20;
+        ranges[3] = 50;
+        ranges[4] = 100;
+        ranges[5] = 200;
+        ranges[6] = 500;
+        ranges[7] = 1000;
+        ranges[8] = 2000;
+        return TokenInfoRanges(ranges, 0);
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Ordi.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Ordi.sol
@@ -23,16 +23,16 @@ import "../Constants.sol";
 import "./BRC20.sol";
 
 library Ordi {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](8);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 5 * Constants.decimals_factor;
-        ranges[3] = 20 * Constants.decimals_factor;
-        ranges[4] = 50 * Constants.decimals_factor;
-        ranges[5] = 100 * Constants.decimals_factor;
-        ranges[6] = 200 * Constants.decimals_factor;
-        ranges[7] = 500 * Constants.decimals_factor;
-        return ranges;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 5;
+        ranges[3] = 20;
+        ranges[4] = 50;
+        ranges[5] = 100;
+        ranges[6] = 200;
+        ranges[7] = 500;
+        return TokenInfoRanges(ranges, 0);
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Rats.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Rats.sol
@@ -23,17 +23,17 @@ import "../Constants.sol";
 import "./BRC20.sol";
 
 library Rats {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](9);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 40000 * Constants.decimals_factor;
-        ranges[3] = 200000 * Constants.decimals_factor;
-        ranges[4] = 1000000 * Constants.decimals_factor;
-        ranges[5] = 2000000 * Constants.decimals_factor;
-        ranges[6] = 4000000 * Constants.decimals_factor;
-        ranges[7] = 10000000 * Constants.decimals_factor;
-        ranges[8] = 2000000 * Constants.decimals_factor;
-        return ranges;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 40000;
+        ranges[3] = 200000;
+        ranges[4] = 1000000;
+        ranges[5] = 2000000;
+        ranges[6] = 4000000;
+        ranges[7] = 10000000;
+        ranges[8] = 2000000;
+        return TokenInfoRanges(ranges, 0);
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Sats.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/brc20/Sats.sol
@@ -23,17 +23,17 @@ import "../Constants.sol";
 import "./BRC20.sol";
 
 library Sats {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](9);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 40000000 * Constants.decimals_factor;
-        ranges[3] = 200000000 * Constants.decimals_factor;
-        ranges[4] = 500000000 * Constants.decimals_factor;
-        ranges[5] = 1000000000 * Constants.decimals_factor;
-        ranges[6] = 2000000000 * Constants.decimals_factor;
-        ranges[7] = 4000000000 * Constants.decimals_factor;
-        ranges[8] = 6000000000 * Constants.decimals_factor;
-        return ranges;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 40000000;
+        ranges[3] = 200000000;
+        ranges[4] = 500000000;
+        ranges[5] = 1000000000;
+        ranges[6] = 2000000000;
+        ranges[7] = 4000000000;
+        ranges[8] = 6000000000;
+        return TokenInfoRanges(ranges, 0);
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Ada.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Ada.sol
@@ -21,26 +21,31 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Ada {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](7);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1000 * Constants.decimals_factor;
-        ranges[2] = 5000 * Constants.decimals_factor;
-        ranges[3] = 20000 * Constants.decimals_factor;
-        ranges[4] = 50000 * Constants.decimals_factor;
-        ranges[5] = 100000 * Constants.decimals_factor;
-        ranges[6] = 300000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1000;
+        ranges[2] = 5000;
+        ranges[3] = 20000;
+        ranges[4] = 50000;
+        ranges[5] = 100000;
+        ranges[6] = 300000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x3EE2200Efb3400fAbB9AacF31297cBdD1d435D47",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Amp.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Amp.sol
@@ -21,30 +21,34 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Amp {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Atom.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Atom.sol
@@ -22,32 +22,42 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Atom {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](6);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 5 * Constants.decimals_factor;
-        ranges[3] = 20 * Constants.decimals_factor;
-        ranges[4] = 50 * Constants.decimals_factor;
-        ranges[5] = 80 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 5;
+        ranges[3] = 20;
+        ranges[4] = 50;
+        ranges[5] = 80;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](3);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x8D983cb9388EaC77af0474fA441C4815500Cb7BB",
             DataProviderTypes.NoderealClient,
-            18
+            6
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x0eb3a705fc54725037cc9e008bdede697f62f335",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        networks[2] = TokenInfoNetwork(
+            Web3Networks.Polygon,
+            "0xac51C4c48Dc3116487eD4BC16542e27B5694Da1b",
+            DataProviderTypes.MoralisClient,
+            6
+        );
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Bch.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Bch.sol
@@ -22,30 +22,34 @@ import "../Constants.sol";
 import "../../libraries/Identities.sol";
 
 library Bch {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](6);
 
-        // all ranges multiplied by decimals_factor(1000).
+        // all ranges multiplied by decimals_factor(10).
         // pub const BCH_AMOUNT_RANGE: [f64; 6] = [0.0, 0.1, 0.5, 2.0, 6.0, 12.0];
 
         ranges[0] = 0;
-        ranges[1] = 100;
-        ranges[2] = 500;
-        ranges[3] = 2000;
-        ranges[4] = 6000;
-        ranges[5] = 12000;
+        ranges[1] = 1;
+        ranges[2] = 5;
+        ranges[3] = 20;
+        ranges[4] = 60;
+        ranges[5] = 120;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 1);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x8fF795a6F4D97E7887C79beA79aba5cc76444aDf",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Bean.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Bean.sol
@@ -25,31 +25,35 @@ struct TokenNetwork {
     string tokenAddress;
 }
 library Bean {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](5);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1500 * Constants.decimals_factor;
-        ranges[2] = 5000 * Constants.decimals_factor;
-        ranges[3] = 10000 * Constants.decimals_factor;
-        ranges[4] = 50000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1500;
+        ranges[2] = 5000;
+        ranges[3] = 10000;
+        ranges[4] = 50000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x07da81e9a684ab87fad7206b3bc8d0866f48cc7c",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
-            Web3Networks.Ethereum,
+        networks[1] = TokenInfoNetwork(
+            Web3Networks.Combo,
             "0xba7b9936a965fac23bb7a8190364fa60622b3cff",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Bnb.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Bnb.sol
@@ -22,36 +22,40 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Bnb {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "Native Token",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xb8c77482e45f1f44de1745f52c74426c631bdd52",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Comp.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Comp.sol
@@ -22,31 +22,35 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Comp {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xc00e94cb662c3520282e6f5717214004a7f26888",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Cro.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Cro.sol
@@ -22,33 +22,37 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Cro {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](7);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1000 * Constants.decimals_factor;
-        ranges[2] = 5000 * Constants.decimals_factor;
-        ranges[3] = 20000 * Constants.decimals_factor;
-        ranges[4] = 50000 * Constants.decimals_factor;
-        ranges[5] = 100000 * Constants.decimals_factor;
-        ranges[6] = 300000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1000;
+        ranges[2] = 5000;
+        ranges[3] = 20000;
+        ranges[4] = 50000;
+        ranges[5] = 100000;
+        ranges[6] = 300000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Solana,
             "DvjMYMVeXgKxaixGKpzQThLoG98nc7HSU7eanzsdCboA",
             DataProviderTypes.MoralisClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Crv.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Crv.sol
@@ -22,31 +22,35 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Crv {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xdac17f958d2ee523a2206206994597c13d831ec7",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Cvx.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Cvx.sol
@@ -22,31 +22,35 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Cvx {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Dai.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Dai.sol
@@ -22,42 +22,58 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Dai {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](9);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 10 * Constants.decimals_factor;
-        ranges[2] = 30 * Constants.decimals_factor;
-        ranges[3] = 80 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 1000 * Constants.decimals_factor;
-        ranges[7] = 2000 * Constants.decimals_factor;
-        ranges[8] = 5000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 10;
+        ranges[2] = 30;
+        ranges[3] = 80;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 1000;
+        ranges[7] = 2000;
+        ranges[8] = 5000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](3);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](5);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x6b175474e89094c44da98b954eedeac495271d0f",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[2] = TokenInfo(
+        networks[2] = TokenInfoNetwork(
             Web3Networks.Solana,
             "EjmyN6qEC1Tf1JxiG1ae7UTJhUxSwk1TCWNWqxWV4J6o",
+            DataProviderTypes.MoralisClient,
+            8
+        );
+        networks[3] = TokenInfoNetwork(
+            Web3Networks.Arbitrum,
+            "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+            DataProviderTypes.MoralisClient,
+            18
+        );
+        networks[4] = TokenInfoNetwork(
+            Web3Networks.Polygon,
+            "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
             DataProviderTypes.MoralisClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Doge.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Doge.sol
@@ -21,27 +21,31 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Doge {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](7);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1000 * Constants.decimals_factor;
-        ranges[2] = 5000 * Constants.decimals_factor;
-        ranges[3] = 20000 * Constants.decimals_factor;
-        ranges[4] = 50000 * Constants.decimals_factor;
-        ranges[5] = 100000 * Constants.decimals_factor;
-        ranges[6] = 300000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1000;
+        ranges[2] = 5000;
+        ranges[3] = 20000;
+        ranges[4] = 50000;
+        ranges[5] = 100000;
+        ranges[6] = 300000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0xba2ae424d960c26247dd6c32edc70b295c744c43",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Dydx.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Dydx.sol
@@ -22,31 +22,35 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Dydx {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x92d6c1e31e14520e676a687f0a93788b716beff5",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Etc.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Etc.sol
@@ -22,26 +22,30 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Etc {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](6);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 5 * Constants.decimals_factor;
-        ranges[3] = 20 * Constants.decimals_factor;
-        ranges[4] = 50 * Constants.decimals_factor;
-        ranges[5] = 80 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 5;
+        ranges[3] = 20;
+        ranges[4] = 50;
+        ranges[5] = 80;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x3d6545b08693dae087e957cb1180ee38b9e3c25e",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Eth.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Eth.sol
@@ -21,40 +21,44 @@ pragma solidity ^0.8.8;
 import "../../libraries/Identities.sol";
 import "../Constants.sol";
 library Eth {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
 
-        // all ranges multiplied by decimals_factor(1000).
+        // all ranges multiplied by decimals_factor(100).
         // pub const ETH_AMOUNT_RANGE: [f64; 10] = [0.0, 0.01, 0.05, 0.2, 0.6, 1.2, 3.0, 8.0, 20.0, 50.0];
         ranges[0] = 0;
-        ranges[1] = 10;
-        ranges[2] = 50;
-        ranges[3] = 200;
-        ranges[4] = 600;
-        ranges[5] = 1200;
-        ranges[6] = 3000;
-        ranges[7] = 8000;
-        ranges[8] = 20000;
-        ranges[9] = 50000;
+        ranges[1] = 1;
+        ranges[2] = 5;
+        ranges[3] = 20;
+        ranges[4] = 60;
+        ranges[5] = 120;
+        ranges[6] = 300;
+        ranges[7] = 800;
+        ranges[8] = 2000;
+        ranges[9] = 5000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 2);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "Native Token",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Fil.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Fil.sol
@@ -22,27 +22,31 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Fil {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](6);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 10 * Constants.decimals_factor;
-        ranges[2] = 30 * Constants.decimals_factor;
-        ranges[3] = 80 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 10;
+        ranges[2] = 30;
+        ranges[3] = 80;
+        ranges[4] = 200;
+        ranges[5] = 500;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x0d8ce2a99bb6e3b7db580ed848240e4a0f9ae153",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Grt.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Grt.sol
@@ -21,37 +21,41 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Grt {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x52ce071bd9b1c4b00a0b92d298c512478cad67e8",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Gtc.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Gtc.sol
@@ -22,31 +22,35 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Gtc {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Gusd.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Gusd.sol
@@ -22,31 +22,35 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Gusd {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Imx.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Imx.sol
@@ -22,29 +22,33 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Imx {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](8);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 10 * Constants.decimals_factor;
-        ranges[2] = 30 * Constants.decimals_factor;
-        ranges[3] = 80 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 1000 * Constants.decimals_factor;
-        ranges[7] = 2000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 10;
+        ranges[2] = 30;
+        ranges[3] = 80;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 1000;
+        ranges[7] = 2000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xf57e7e7c23978c3caec3c3548e3d615c346e79ff",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Inj.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Inj.sol
@@ -22,27 +22,31 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Inj {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](6);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 5 * Constants.decimals_factor;
-        ranges[3] = 20 * Constants.decimals_factor;
-        ranges[4] = 50 * Constants.decimals_factor;
-        ranges[5] = 80 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 5;
+        ranges[3] = 20;
+        ranges[4] = 50;
+        ranges[5] = 80;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Leo.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Leo.sol
@@ -22,26 +22,30 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Leo {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](6);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 10 * Constants.decimals_factor;
-        ranges[2] = 30 * Constants.decimals_factor;
-        ranges[3] = 80 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 10;
+        ranges[2] = 30;
+        ranges[3] = 80;
+        ranges[4] = 200;
+        ranges[5] = 500;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x2af5d2ad76741191d15dfe7bf6ac92d4bd912ca3",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Link.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Link.sol
@@ -22,36 +22,40 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Link {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x514910771af9ca656af840dff83e8264ecf986ca",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Lit.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Lit.sol
@@ -22,37 +22,41 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Lit {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Matic.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Matic.sol
@@ -22,37 +22,41 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Matic {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0xcc42724c6683b7e57334c4e856f4c9965ed682bd",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Mcrt.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Mcrt.sol
@@ -22,38 +22,42 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Mcrt {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](6);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 2000 * Constants.decimals_factor;
-        ranges[2] = 10000 * Constants.decimals_factor;
-        ranges[3] = 50000 * Constants.decimals_factor;
-        ranges[4] = 150000 * Constants.decimals_factor;
-        ranges[5] = 500000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 2000;
+        ranges[2] = 10000;
+        ranges[3] = 50000;
+        ranges[4] = 150000;
+        ranges[5] = 500000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](3);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](3);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xde16ce60804a881e9f8c4ebb3824646edecd478d",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x4b8285aB433D8f69CB48d5Ad62b415ed1a221e4f",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[2] = TokenInfo(
+        networks[2] = TokenInfoNetwork(
             Web3Networks.Solana,
             "FADm4QuSUF1K526LvTjvbJjKzeeipP6bj5bSzp3r6ipq",
             DataProviderTypes.MoralisClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Nfp.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Nfp.sol
@@ -22,31 +22,35 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Nfp {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x75e8ddb518bb757b4282cd5b83bb70d4101d12fb",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/People.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/People.sol
@@ -22,31 +22,35 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library People {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x7a58c0be72be218b41c608b7fe7c5bb630736c71",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Shib.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Shib.sol
@@ -22,28 +22,32 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Shib {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](8);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 400000 * Constants.decimals_factor;
-        ranges[2] = 2000000 * Constants.decimals_factor;
-        ranges[3] = 10000000 * Constants.decimals_factor;
-        ranges[4] = 20000000 * Constants.decimals_factor;
-        ranges[5] = 40000000 * Constants.decimals_factor;
-        ranges[6] = 100000000 * Constants.decimals_factor;
-        ranges[7] = 200000000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 400000;
+        ranges[2] = 2000000;
+        ranges[3] = 10000000;
+        ranges[4] = 20000000;
+        ranges[5] = 40000000;
+        ranges[6] = 100000000;
+        ranges[7] = 200000000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Sol.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Sol.sol
@@ -22,42 +22,46 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Sol {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](3);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](3);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x5288738df1aeb0894713de903e1d0c001eeb7644",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x570a5d26f7765ecb712c0924e4de545b89fd43df",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[2] = TokenInfo(
+        networks[2] = TokenInfoNetwork(
             Web3Networks.Solana,
             "Native Token",
             DataProviderTypes.MoralisClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/SpaceId.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/SpaceId.sol
@@ -22,36 +22,40 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library SpaceId {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x2dff88a56767223a5529ea5960da7a3f5f766406",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x2dff88a56767223a5529ea5960da7a3f5f766406",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Ton.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Ton.sol
@@ -22,36 +22,40 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Ton {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x582d872a1b094fc48f5de31d3b73f2d9be47def1",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x76a797a59ba2c17726896976b7b3747bfd1d220f",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Trx.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Trx.sol
@@ -22,36 +22,40 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Trx {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x50327c6c5a14dcade707abad2e27eb517df87ab5",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0xCE7de646e7208a4Ef112cb6ed5038FA6cC6b12e3",
             DataProviderTypes.NoderealClient,
             18
         );
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Tusd.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Tusd.sol
@@ -22,37 +22,41 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Tusd {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x0000000000085d4780b73119b644ae5ecd22b376",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x40af3827F39D0EAcBF4A168f8D4ee67c121D11c9",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Uni.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Uni.sol
@@ -22,42 +22,58 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Uni {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](9);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 10 * Constants.decimals_factor;
-        ranges[2] = 30 * Constants.decimals_factor;
-        ranges[3] = 80 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 1000 * Constants.decimals_factor;
-        ranges[7] = 2000 * Constants.decimals_factor;
-        ranges[8] = 5000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 10;
+        ranges[2] = 30;
+        ranges[3] = 80;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 1000;
+        ranges[7] = 2000;
+        ranges[8] = 5000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](3);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](5);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0xbf5140a22578168fd562dccf235e5d43a02ce9b1",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[2] = TokenInfo(
+        networks[2] = TokenInfoNetwork(
             Web3Networks.Solana,
             "8FU95xFJhUUkyyCLU13HSzDLs7oC4QZdXQHL6SCeab36",
             DataProviderTypes.MoralisClient,
             18
         );
+        networks[3] = TokenInfoNetwork(
+            Web3Networks.Arbitrum,
+            "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0",
+            DataProviderTypes.MoralisClient,
+            18
+        );
+        networks[4] = TokenInfoNetwork(
+            Web3Networks.Polygon,
+            "0xb33eaad8d922b1083446dc23f610c2567fb5180f",
+            DataProviderTypes.MoralisClient,
+            18
+        );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Usdc.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Usdc.sol
@@ -6,42 +6,58 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Usdc {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](9);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 10 * Constants.decimals_factor;
-        ranges[2] = 30 * Constants.decimals_factor;
-        ranges[3] = 80 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 1000 * Constants.decimals_factor;
-        ranges[7] = 2000 * Constants.decimals_factor;
-        ranges[8] = 5000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 10;
+        ranges[2] = 30;
+        ranges[3] = 80;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 1000;
+        ranges[7] = 2000;
+        ranges[8] = 5000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](3);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](5);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             DataProviderTypes.NoderealClient,
-            18
+            6
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
             DataProviderTypes.NoderealClient,
-            18
+            6
         );
-        tokenInfoList[2] = TokenInfo(
+        networks[2] = TokenInfoNetwork(
             Web3Networks.Solana,
             "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
             DataProviderTypes.MoralisClient,
-            18
+            6
+        );
+        networks[3] = TokenInfoNetwork(
+            Web3Networks.Arbitrum,
+            "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+            DataProviderTypes.MoralisClient,
+            6
+        );
+        networks[4] = TokenInfoNetwork(
+            Web3Networks.Polygon,
+            "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+            DataProviderTypes.MoralisClient,
+            6
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Usdd.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Usdd.sol
@@ -22,37 +22,41 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Usdd {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0xd17479997f34dd9156deef8f95a52d81d265be9c",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Usdt.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Usdt.sol
@@ -22,37 +22,41 @@ import "../../libraries/Identities.sol";
 import "../Constants.sol";
 
 library Usdt {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](10);
-        ranges[0] = 0 * Constants.decimals_factor;
-        ranges[1] = 1 * Constants.decimals_factor;
-        ranges[2] = 50 * Constants.decimals_factor;
-        ranges[3] = 100 * Constants.decimals_factor;
-        ranges[4] = 200 * Constants.decimals_factor;
-        ranges[5] = 500 * Constants.decimals_factor;
-        ranges[6] = 800 * Constants.decimals_factor;
-        ranges[7] = 1200 * Constants.decimals_factor;
-        ranges[8] = 1600 * Constants.decimals_factor;
-        ranges[9] = 3000 * Constants.decimals_factor;
+        ranges[0] = 0;
+        ranges[1] = 1;
+        ranges[2] = 50;
+        ranges[3] = 100;
+        ranges[4] = 200;
+        ranges[5] = 500;
+        ranges[6] = 800;
+        ranges[7] = 1200;
+        ranges[8] = 1600;
+        ranges[9] = 3000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 0);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](2);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](2);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0xdac17f958d2ee523a2206206994597c13d831ec7",
             DataProviderTypes.NoderealClient,
             18
         );
-        tokenInfoList[1] = TokenInfo(
+        networks[1] = TokenInfoNetwork(
             Web3Networks.Bsc,
             "0x55d398326f99059ff775485246999027b3197955",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Wbtc.sol
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/contracts/token_holding_amount/erc20/Wbtc.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.8;
 import "../../libraries/Identities.sol";
 import "../Constants.sol";
 library Wbtc {
-    function getTokenRanges() internal pure returns (uint256[] memory) {
+    function getTokenRanges() internal pure returns (TokenInfoRanges memory) {
         uint256[] memory ranges = new uint256[](14);
 
         // all ranges multiplied by decimals_factor(1000).
@@ -41,18 +41,22 @@ library Wbtc {
         ranges[12] = 40000;
         ranges[13] = 50000;
 
-        return ranges;
+        return TokenInfoRanges(ranges, 3);
     }
 
-    function getTokenInfo() internal pure returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokenInfoList = new TokenInfo[](1);
-        tokenInfoList[0] = TokenInfo(
+    function getTokenNetworks()
+        internal
+        pure
+        returns (TokenInfoNetwork[] memory)
+    {
+        TokenInfoNetwork[] memory networks = new TokenInfoNetwork[](1);
+        networks[0] = TokenInfoNetwork(
             Web3Networks.Ethereum,
             "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
             DataProviderTypes.NoderealClient,
             18
         );
 
-        return tokenInfoList;
+        return networks;
     }
 }

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/tests/string-cleaner.ts
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/tests/string-cleaner.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+
+describe('StringCleaner', () => {
+    let stringCleaner: any
+
+    before(async () => {
+        const StringCleaner =
+            await ethers.getContractFactory('StringCleanerTest')
+        stringCleaner = await StringCleaner.deploy()
+    })
+
+    it('should correctly identify visible and invisible characters', async () => {
+        const stringParis: Array<[string, string]> = [
+            ['Hello\u200BWorld', 'HelloWorld'],
+            ['Line1\nLine2', 'Line1Line2'],
+            ['Tab\tSeparated\tValues', 'TabSeparatedValues'],
+            ['Carriage\rReturn', 'CarriageReturn'],
+            ['Vertical\vTab', 'VerticalTab'],
+            ['Form\fFeed', 'FormFeed'],
+            ['Spaces    \u00A0\u2007\u202F', 'Spaces    '],
+            ['Unicode\uFEFFByteOrderMark', 'UnicodeByteOrderMark'],
+        ]
+        for (const stringPair of stringParis) {
+            const result = await stringCleaner.cleanString(stringPair[0])
+            expect(result).to.equal(stringPair[1])
+        }
+    })
+})

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/tests/string-comparison.ts
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/tests/string-comparison.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+
+describe('StringComparison', () => {
+    let stringComparison: any
+
+    before(async () => {
+        const StringComparison = await ethers.getContractFactory(
+            'StringComparisonTest'
+        )
+        stringComparison = await StringComparison.deploy()
+    })
+
+    it('should correctly compare strings ignoring case', async () => {
+        const stringTuples: Array<[string, string, boolean]> = [
+            ['Hello World', 'Hello World', true],
+            ['Hello World', 'Hello world', true],
+            ['hello World', 'Hello World', true],
+            ['hello World', 'hello world', true],
+            ['hello world', 'Hello World', true],
+            ['Hello World', 'Hello World', true],
+            ['HELLO WORLD', 'Hello World', true],
+            ['HELLO WORLD', 'Hello WORLD', true],
+            ['Hello World', 'Hello Worlds', false],
+        ]
+        for (const stringTuple of stringTuples) {
+            const result = await stringComparison.compareStringsIgnoreCase(
+                stringTuple[0],
+                stringTuple[1]
+            )
+            expect(result).to.equal(stringTuple[2])
+        }
+    })
+})

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/tests/token-holding-amount.ts
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/tests/token-holding-amount.ts
@@ -4,7 +4,7 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import {
     assembleSchemaUrl,
     deployContract,
-    deployMockContract,
+    deployAllMockContracts,
     expectAssertionResult,
     IdentityType,
     Web3Network,
@@ -13,10 +13,7 @@ import {
 
 describe('TokenHoldingAmount', () => {
     const deployFixture = async () => {
-        await deployMockContract('MockHttpGetString')
-        await deployMockContract('MockHttpGetI64')
-        await deployMockContract('MockIdentityToString')
-        await deployMockContract('MockParseDecimal')
+        await deployAllMockContracts()
         return await deployContract('TokenMapping')
     }
 
@@ -38,9 +35,33 @@ describe('TokenHoldingAmount', () => {
     const generateParams = (token: string) =>
         ethers.AbiCoder.defaultAbiCoder().encode(['string'], [token])
 
-    describe('BRC20', () => {
-        const secrets = ['0x12345', '0x12345']
+    const secrets = ['0x12345', '0x12345', '0x12345']
 
+    it('should throw error if token name not exist', async () => {
+        const { TokenMapping } = await loadFixture(deployFixture)
+        const val = TokenMapping.execute(
+            // identities
+            [
+                {
+                    identity_type: IdentityType.Bitcoin,
+                    value: ethers.toUtf8Bytes(
+                        '17fQAnS9FSUw5zBYY26DURYE4PXiemNKgb'
+                    ),
+                    networks: [Web3Network.BitcoinP2sh],
+                },
+            ],
+            // secrets
+            secrets,
+            // params
+            generateParams('not_exist_token_name')
+        )
+        await expect(val).to.be.rejectedWith(
+            Error,
+            `VM Exception while processing transaction: reverted with reason string 'Token not supported or not found'`
+        )
+    })
+
+    describe('BRC20', () => {
         const expectOrdiFalseResult = (contract: any, val: any) =>
             expectResult(
                 contract,
@@ -310,34 +331,9 @@ describe('TokenHoldingAmount', () => {
             )
             await expectOrdiFalseResult(TokenMapping, val)
         })
-
-        it('should throw error if token name not exist', async () => {
-            const { TokenMapping } = await loadFixture(deployFixture)
-            const val = TokenMapping.execute(
-                // identities
-                [
-                    {
-                        identity_type: IdentityType.Bitcoin,
-                        value: ethers.toUtf8Bytes(
-                            '17fQAnS9FSUw5zBYY26DURYE4PXiemNKgb'
-                        ),
-                        networks: [Web3Network.BitcoinP2sh],
-                    },
-                ],
-                // secrets
-                secrets,
-                // params
-                generateParams('not_exist_token_name')
-            )
-            await expect(val).to.be.rejectedWith(
-                Error,
-                `VM Exception while processing transaction: reverted with reason string 'Token not supported or not found'`
-            )
-        })
     })
 
     describe('Btc', () => {
-        const secrets = ['0x12345', '0x12345']
         it('should return result false when amount = 0', async () => {
             const { TokenMapping } = await loadFixture(deployFixture)
             const val = TokenMapping.execute(
@@ -423,6 +419,438 @@ describe('TokenHoldingAmount', () => {
                 },
                 true
             )
+        })
+    })
+
+    describe('ERC20', () => {
+        describe('Atom', () => {
+            const tokenName = 'atom'
+
+            it('should return result false when amount = 0', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0x50BcC2FEA4A95283b196bdEF4DEa5B27AFD6323c'
+                            ),
+                            networks: [Web3Network.Bsc],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>', dst: '0' },
+                        ],
+                    },
+                    false
+                )
+            })
+
+            it('should return result true when amount > 0 && amount < 1', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0xA7Ee59E733E613CC957FE203A2935E85cE39D08A'
+                            ),
+                            networks: [Web3Network.Ethereum],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>', dst: '0' },
+                            { src: '$holding_amount', op: '<', dst: '1' },
+                        ],
+                    },
+                    true
+                )
+            })
+
+            it('should return result true when amount = 2', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0xA7Ee59E733E613CC957FE203A2935E85cE39D08A'
+                            ),
+                            networks: [Web3Network.Bsc],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>=', dst: '1' },
+                            { src: '$holding_amount', op: '<', dst: '5' },
+                        ],
+                    },
+                    true
+                )
+            })
+
+            it('should return result true when amount = 30', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0x50BcC2FEA4A95283b196bdEF4DEa5B27AFD6323c'
+                            ),
+                            networks: [Web3Network.Polygon],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>=', dst: '20' },
+                            { src: '$holding_amount', op: '<', dst: '50' },
+                        ],
+                    },
+                    true
+                )
+            })
+
+            it('should return result true when amount = 50', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0x50BcC2FEA4A95283b196bdEF4DEa5B27AFD6323c'
+                            ),
+                            networks: [Web3Network.Ethereum],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>=', dst: '50' },
+                            { src: '$holding_amount', op: '<', dst: '80' },
+                        ],
+                    },
+                    true
+                )
+            })
+
+            it('should return result true when amount == 80', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0x50BcC2FEA4A95283b196bdEF4DEa5B27AFD6323c'
+                            ),
+                            networks: [
+                                Web3Network.Bsc,
+                                Web3Network.Ethereum,
+                                Web3Network.Polygon,
+                            ],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>=', dst: '80' },
+                        ],
+                    },
+                    true
+                )
+            })
+        })
+
+        describe('Bean', () => {
+            const tokenName = 'bean'
+
+            it('should return result false when amount = 0', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0xF4d1E80823D7b6BA4A041C58202039611B253590'
+                            ),
+                            networks: [Web3Network.Bsc, Web3Network.Combo],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>', dst: '0' },
+                        ],
+                    },
+                    false
+                )
+            })
+
+            it('should return result true when amount = 1500', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0xa298cA90a4aa6029e26Dacc33b85c3847875615e'
+                            ),
+                            networks: [Web3Network.Bsc, Web3Network.Combo],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>=', dst: '1500' },
+                            { src: '$holding_amount', op: '<', dst: '5000' },
+                        ],
+                    },
+                    true
+                )
+            })
+
+            it('should return result true when amount = 60000', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0x0d4E9A8E1c26747c3d62a883b0Af5a916D6985c5'
+                            ),
+                            networks: [Web3Network.Bsc, Web3Network.Combo],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>=', dst: '50000' },
+                        ],
+                    },
+                    true
+                )
+            })
+        })
+
+        describe('Dai', () => {
+            const tokenName = 'dai'
+
+            it('should return result false when amount = 0', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0xF4d1E80823D7b6BA4A041C58202039611B253590'
+                            ),
+                            networks: [Web3Network.Arbitrum],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>', dst: '0' },
+                        ],
+                    },
+                    false
+                )
+            })
+
+            it('should return result true when amount = 5', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0xbF98D4df371c2dE965a36E02b4c2E0DA89090818'
+                            ),
+                            networks: [Web3Network.Arbitrum],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>', dst: '0' },
+                            { src: '$holding_amount', op: '<', dst: '10' },
+                        ],
+                    },
+                    true
+                )
+            })
+        })
+
+        describe('Wbtc', () => {
+            const tokenName = 'wbtc'
+
+            it('should return result false when amount = 0', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0xF4d1E80823D7b6BA4A041C58202039611B253590'
+                            ),
+                            networks: [Web3Network.Ethereum],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>', dst: '0' },
+                        ],
+                    },
+                    false
+                )
+            })
+
+            it('should return result true when amount = 0.0001', async () => {
+                const { TokenMapping } = await loadFixture(deployFixture)
+                const val = TokenMapping.execute(
+                    // identities
+                    [
+                        {
+                            identity_type: IdentityType.Evm,
+                            value: ethers.toUtf8Bytes(
+                                '0x1C89Edd4FC080D71F92701C0794a16DbE573d4B8'
+                            ),
+                            networks: [Web3Network.Ethereum],
+                        },
+                    ],
+                    // secrets
+                    secrets,
+                    // params
+                    generateParams(tokenName)
+                )
+                await expectResult(
+                    TokenMapping,
+                    val,
+                    {
+                        and: [
+                            { src: '$token', op: '==', dst: tokenName },
+                            { src: '$holding_amount', op: '>', dst: '0' },
+                            { src: '$holding_amount', op: '<', dst: '0.001' },
+                        ],
+                    },
+                    true
+                )
+            })
         })
     })
 })

--- a/tee-worker/litentry/core/assertion-build/src/dynamic/tests/utils/helper.ts
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/tests/utils/helper.ts
@@ -52,19 +52,29 @@ export enum Op {
 }
 
 export enum PrecompileAddresses {
+    HTTP_GET = '0x00000000000000000000000000000000000003EE',
     HTTP_GET_STRING = '0x00000000000000000000000000000000000003EA',
-    IDENTITY_TO_STRING = '0x000000000000000000000000000000000000041C',
-    PARSE_DECIMAL = '0x000000000000000000000000000000000000041E',
+    HTTP_POST_STRING = '0x00000000000000000000000000000000000003ED',
     HTTP_GET_I64 = '0x00000000000000000000000000000000000003E8',
     HTTP_GET_BOOL = '0x00000000000000000000000000000000000003E9',
+    IDENTITY_TO_STRING = '0x000000000000000000000000000000000000041C',
+    HEX_TO_NUMBER = '0x000000000000000000000000000000000000041D',
+    PARSE_DECIMAL = '0x000000000000000000000000000000000000041E',
+    JSON_GET_ARRAY_LEN = '0x000000000000000000000000000000000000044F',
+    JSON_GET_STRING = '0x000000000000000000000000000000000000044C',
 }
 
 const mockContractAddressMapping: { [key: string]: string } = {
+    MockHttpGet: PrecompileAddresses.HTTP_GET,
     MockHttpGetString: PrecompileAddresses.HTTP_GET_STRING,
+    MockHttpPostString: PrecompileAddresses.HTTP_POST_STRING,
     MockHttpGetI64: PrecompileAddresses.HTTP_GET_I64,
-    MockIdentityToString: PrecompileAddresses.IDENTITY_TO_STRING,
-    MockParseDecimal: PrecompileAddresses.PARSE_DECIMAL,
     MockHttpGetBool: PrecompileAddresses.HTTP_GET_BOOL,
+    MockIdentityToString: PrecompileAddresses.IDENTITY_TO_STRING,
+    MockHexToNumber: PrecompileAddresses.HEX_TO_NUMBER,
+    MockParseDecimal: PrecompileAddresses.PARSE_DECIMAL,
+    MockJsonGetArrayLen: PrecompileAddresses.JSON_GET_ARRAY_LEN,
+    MockJsonGetString: PrecompileAddresses.JSON_GET_STRING,
 }
 
 export async function deployMockContract(
@@ -80,6 +90,18 @@ export async function deployMockContract(
         _contractAddress,
         await ethers.provider.getCode(contract.target),
     ])
+}
+
+export async function deployAllMockContracts(): Promise<void> {
+    await deployMockContract('MockHttpGet')
+    await deployMockContract('MockHttpGetString')
+    await deployMockContract('MockHttpPostString')
+    await deployMockContract('MockHttpGetI64')
+    await deployMockContract('MockIdentityToString')
+    await deployMockContract('MockHexToNumber')
+    await deployMockContract('MockParseDecimal')
+    await deployMockContract('MockJsonGetArrayLen')
+    await deployMockContract('MockJsonGetString')
 }
 
 export async function deployContract(contract: string) {

--- a/tee-worker/litentry/core/evm-dynamic-assertions/src/precompiles/parse_decimal.rs
+++ b/tee-worker/litentry/core/evm-dynamic-assertions/src/precompiles/parse_decimal.rs
@@ -49,19 +49,23 @@ pub fn parse_decimal(input: Vec<u8>) -> PrecompileResult {
 				},
 			};
 
-			let processed_decimal_string =
-				(decimal * Decimal::new(10_i64.pow(decimals), 0)).normalize().to_string();
-			match U256::from_dec_str(processed_decimal_string.as_str()) {
-				Ok(n) => n,
-				Err(e) => {
-					log::debug!(
-						"Cannot parse decimal {:?} to U256, reason: {:?}",
-						processed_decimal_string,
-						e
-					);
-					return Ok(failure_precompile_output(ethabi::Token::Uint(Default::default())))
-				},
-			}
+			// Split the decimal into integer and fractional parts
+			let integer_part = decimal.trunc();
+			let fractional_part = decimal.fract();
+
+			// Process the integer part
+			let integer_string = integer_part.to_string();
+			let integer_u256 = U256::from_dec_str(&integer_string).unwrap()
+				* U256::from(10).pow(U256::from(decimals));
+
+			// Process the fractional part
+			let fractional_string = (fractional_part * Decimal::new(10_i64.pow(decimals), 0))
+				.normalize()
+				.to_string();
+			let fractional_u256 = U256::from_dec_str(&fractional_string).unwrap();
+
+			// Combine the results
+			integer_u256 + fractional_u256
 		},
 		None => {
 			log::debug!("Could not decode input {:?}, reason: string value is invalid", input);


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

1 Mainly support network arbitrum, polygon and combo for erc20 token
with below refactoring too:
2 combine all token config to one mapping variable
3 add token config rangeDecimals instead of global decimals_factor
4 use maxDecimals from all networks of token as range decimals factor
5 add unit test for sol libraries: StringCleaner, StringComparison

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable

Atom from Polygon
./bin/litentry-cli trusted -d request-vc did:litentry:evm:0xac51C4c48Dc3116487eD4BC16542e27B5694Da1b -a "dynamic 6f57ad167c42951657685a5d9a874f02f9e96976 0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000461746f6d00000000000000000000000000000000000000000000000000000000"

>>> identity: Evm(Address20)
>>> nonce: 0
>>> assertions: [Dynamic(DynamicParams { smart_contract_id: 0x6f57ad167c42951657685a5d9a874f02f9e96976, smart_contract_params: Some(BoundedVec([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 97, 116, 111, 109, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 1024)), return_log: false })]
----Generated VC-----
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0x34ee470c6981191a4c04762db72ad5754325bd62d568a43872b35626d24b8f3c","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:evm:0xac51c4c48dc3116487ed4bc16542e27b5694da1b","description":"The amount of a particular token you are holding","type":"Token Holding Amount","assertionText":"","assertions":[{"and":[{"src":"$token","op":"==","dst":"atom"},{"src":"$holding_amount","op":">=","dst":"1"},{"src":"$holding_amount","op":"<","dst":"5"}]}],"values":[true],"endpoint":"http://localhost:9933"},"issuer":{"id":"did:litentry:substrate:0x0b9df679f406a51a2e53b87d8e3fc86e792e277fe932d9535b40692bec9e3789","name":"Litentry TEE Worker","mrenclave":"J8azBS97su2y9J9sUZGTgi6MAcvXR1GwVDeGCN5KagUQ","runtimeVersion":{"parachain":9192,"sidechain":109}},"issuanceDate":"2024-08-14T08:49:26.427469683+00:00","parachainBlockNumber":19,"sidechainBlockNumber":29,"proof":{"created":"2024-08-14T08:49:26.427661864+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"d789b2592d8d836903ea8ec2163f05b78aba0652f92065ab84e835ab812de99d9777238b97e83b7e6a7b3c20414749f8b1e3e79ec1216945bdd0906ed5e0ae06","verificationMethod":"0x44da3459814cb003846aece78984e0d064f6b7c1b4c3e4c7bf03b598ea550ba4"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/25-token-holding-amount/1-1-4.json","type":"JsonSchemaValidator2018"}}


Bean from Combo
./bin/litentry-cli trusted -d request-vc did:litentry:evm:0x6955512E5374D8fbD3ACF072e40bD4682ab2630a -a "dynamic 6f57ad167c42951657685a5d9a874f02f9e96976 000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046265616e00000000000000000000000000000000000000000000000000000000"

>>> identity: Evm(Address20)
>>> nonce: 0
>>> assertions: [Dynamic(DynamicParams { smart_contract_id: 0x6f57ad167c42951657685a5d9a874f02f9e96976, smart_contract_params: Some(BoundedVec([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 98, 101, 97, 110, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 1024)), return_log: false })]
----Generated VC-----
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0x4a5b09f24b4c87068e0267ceed81d34e819102bff0e57309916243f752c850ac","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:evm:0x6955512e5374d8fbd3acf072e40bd4682ab2630a","description":"The amount of a particular token you are holding","type":"Token Holding Amount","assertionText":"","assertions":[{"and":[{"src":"$token","op":"==","dst":"bean"},{"src":"$holding_amount","op":">","dst":"0"},{"src":"$holding_amount","op":"<","dst":"1500"}]}],"values":[true],"endpoint":"http://localhost:9933"},"issuer":{"id":"did:litentry:substrate:0x0b9df679f406a51a2e53b87d8e3fc86e792e277fe932d9535b40692bec9e3789","name":"Litentry TEE Worker","mrenclave":"J8azBS97su2y9J9sUZGTgi6MAcvXR1GwVDeGCN5KagUQ","runtimeVersion":{"parachain":9192,"sidechain":109}},"issuanceDate":"2024-08-14T08:54:37.515141848+00:00","parachainBlockNumber":45,"sidechainBlockNumber":80,"proof":{"created":"2024-08-14T08:54:37.515337340+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"d7e8bca09a197a0d331a44938a48cc7958ab512c28fb714fd553704529a66e256829ff1b8d21fad694ee6aad1ce88483dc2bec5f70dba397d76e128238c4bd09","verificationMethod":"0x44da3459814cb003846aece78984e0d064f6b7c1b4c3e4c7bf03b598ea550ba4"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/25-token-holding-amount/1-1-4.json","type":"JsonSchemaValidator2018"}}

Dai from Arbitrum
./bin/litentry-cli trusted -d request-vc did:litentry:evm:0xd85E038593d7A098614721EaE955EC2022B9B91B -a "dynamic 6f57ad167c42951657685a5d9a874f02f9e96976 000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000036461690000000000000000000000000000000000000000000000000000000000"

>>> identity: Evm(Address20)
>>> nonce: 0
>>> assertions: [Dynamic(DynamicParams { smart_contract_id: 0x6f57ad167c42951657685a5d9a874f02f9e96976, smart_contract_params: Some(BoundedVec([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 100, 97, 105, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 1024)), return_log: false })]
----Generated VC-----
{"@context":["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/suites/ed25519-2020/v1"],"id":"0x8f0a92182fb5ce2a723bb6001f123a9c18a104e645b1a0dbcbd6dd6e16194ba0","type":["VerifiableCredential"],"credentialSubject":{"id":"did:litentry:evm:0xd85e038593d7a098614721eae955ec2022b9b91b","description":"The amount of a particular token you are holding","type":"Token Holding Amount","assertionText":"","assertions":[{"and":[{"src":"$token","op":"==","dst":"dai"},{"src":"$holding_amount","op":">=","dst":"5000"}]}],"values":[true],"endpoint":"http://localhost:9933"},"issuer":{"id":"did:litentry:substrate:0x0b9df679f406a51a2e53b87d8e3fc86e792e277fe932d9535b40692bec9e3789","name":"Litentry TEE Worker","mrenclave":"6XVje1eZ1EpZg1RLb8TSrRotyPGrvrzBmnEnbAb8Ab68","runtimeVersion":{"parachain":9192,"sidechain":109}},"issuanceDate":"2024-08-14T08:32:49.655676395+00:00","parachainBlockNumber":18,"sidechainBlockNumber":27,"proof":{"created":"2024-08-14T08:32:49.655876494+00:00","type":"Ed25519Signature2020","proofPurpose":"assertionMethod","proofValue":"eb706d6c41f50112fafaf2f427e68558594bfacf8d20a18afb41224752727000b61f10cff6e9d1ae9cfb555edb320dbfce345c75379b636e22f07f51abf00507","verificationMethod":"0x44da3459814cb003846aece78984e0d064f6b7c1b4c3e4c7bf03b598ea550ba4"},"credentialSchema":{"id":"https://raw.githubusercontent.com/litentry/vc-jsonschema/main/dist/schemas/25-token-holding-amount/1-1-4.json","type":"JsonSchemaValidator2018"}}