### PR TITLE
Clear the score when the user fully unstakes

### DIFF
--- a/pallets/score-staking/src/lib.rs
+++ b/pallets/score-staking/src/lib.rs
@@ -242,11 +242,36 @@ pub mod pallet {
 			let round_reward_u128 = round_reward.saturated_into::<u128>();
 
 			let total_stake_u128 = ParaStaking::Pallet::<T>::total().saturated_into::<u128>();
-			let total_score = Self::total_score();
 			let n = Self::round_config().stake_coef_n;
 			let m = Self::round_config().stake_coef_m;
 
 			let mut all_user_reward = BalanceOf::<T>::zero();
+
+			// the score of the user who has 0 staking should be cleared, so that they don't
+			// participate in any reward calculation, nor should they affect others (`total_score`)
+			// we can't simply delete the entry as there might still be unclaimed reward
+			//
+			// TODO: optimise this, both in a structural (e.g. separate `Score` and `Payment`) and
+			// algorithmetic way
+			//
+			// TODO: when can we remove an entry from `Scores`programmatically?
+			for (a, mut p) in Scores::<T>::iter() {
+				let user_stake_u128 = ParaStaking::Pallet::<T>::delegator_state(&a)
+					.map(|s| s.total)
+					.unwrap_or_default()
+					.saturated_into::<u128>();
+
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 0));
+
+				if user_stake_u128 == 0 {
+					let _ = Self::update_total_score(p.score, 0);
+					p.score = 0;
+					Scores::<T>::insert(&a, p);
+					weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 1));
+				}
+			}
+
+			let total_score = Self::total_score();
 
 			for (a, mut p) in Scores::<T>::iter() {
 				let user_stake_u128 = ParaStaking::Pallet::<T>::delegator_state(&a)
@@ -375,6 +400,7 @@ pub mod pallet {
 			Ok(Pays::No.into())
 		}
 
+		// please use it with care, it will clear the unpaid_reward too
 		#[pallet::call_index(5)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn remove_score(origin: OriginFor<T>, user: Identity) -> DispatchResultWithPostInfo {

--- a/pallets/score-staking/src/lib.rs
+++ b/pallets/score-staking/src/lib.rs
@@ -378,8 +378,10 @@ pub mod pallet {
 		#[pallet::call_index(5)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn remove_score(origin: OriginFor<T>, user: Identity) -> DispatchResultWithPostInfo {
-			// only admin can remove entries in `Scores`
-			T::AdminOrigin::ensure_origin(origin)?;
+			ensure!(
+				Some(ensure_signed(origin)?) == Self::score_feeder(),
+				Error::<T>::UnauthorizedOrigin
+			);
 			let account = T::AccountIdConvert::convert(
 				user.to_account_id().ok_or(Error::<T>::ConvertIdentityFailed)?,
 			);

--- a/pallets/score-staking/src/tests.rs
+++ b/pallets/score-staking/src/tests.rs
@@ -264,6 +264,45 @@ fn score_staking_works() {
 			Error::<Test>::MaxScoreUserCountReached
 		);
 
+		run_to_block(23);
+
+		// bob unstakes
+		pallet_parachain_staking::DelegatorState::<Test>::insert(
+			bob(),
+			Delegator::new(alice(), alice(), 0),
+		);
+		pallet_parachain_staking::Total::<Test>::put(900);
+
+		run_to_block(27);
+
+		// alice should get all rewards
+		assert_eq!(
+			ScoreStaking::scores(alice()).unwrap(),
+			ScorePayment {
+				score: 2000,
+				total_reward: 3 * round_reward() +
+					round_reward() * 3 / 4 +
+					round_reward() * 2 * 3 / (3 * 5),
+				last_round_reward: round_reward(),
+				unpaid_reward: 3 * round_reward() +
+					round_reward() * 3 / 4 +
+					round_reward() * 2 * 3 / (3 * 5),
+			}
+		);
+
+		// bob should not participate in the reward calculation
+		assert_eq!(
+			ScoreStaking::scores(bob()).unwrap(),
+			ScorePayment {
+				score: 0, // bob's score should be cleared
+				total_reward: round_reward() * 1 * 4 / (3 * 5),
+				last_round_reward: 0,
+				unpaid_reward: round_reward() * 1 * 4 / (3 * 5),
+			}
+		);
+		assert_eq!(ScoreStaking::total_score(), 2000);
+		assert_eq!(ScoreStaking::score_user_count(), 2); // entry is not yet removed
+
 		// remove_score works
 		assert_ok!(ScoreStaking::remove_score(RuntimeOrigin::signed(alice()), bob().into()));
 		assert_eq!(ScoreStaking::total_score(), 2000);

--- a/pallets/score-staking/src/tests.rs
+++ b/pallets/score-staking/src/tests.rs
@@ -229,10 +229,6 @@ fn score_staking_works() {
 		assert_eq!(ScoreStaking::score_user_count(), 2);
 
 		run_to_block(22);
-		// System::assert_last_event(RuntimeEvent::ScoreStaking(Event::<Test>::RewardCalculated {
-		// 	total: round_reward(),
-		// 	distributed: round_reward() * 2 * 3 / (3 * 5) + round_reward() * 1 * 4 / (3 * 5),
-		// }));
 
 		assert_eq!(
 			ScoreStaking::scores(alice()).unwrap(),
@@ -267,6 +263,11 @@ fn score_staking_works() {
 			ScoreStaking::update_score(RuntimeOrigin::signed(alice()), charlie().into(), 1000),
 			Error::<Test>::MaxScoreUserCountReached
 		);
+
+		// remove_score works
+		assert_ok!(ScoreStaking::remove_score(RuntimeOrigin::signed(alice()), bob().into()));
+		assert_eq!(ScoreStaking::total_score(), 2000);
+		assert_eq!(ScoreStaking::score_user_count(), 1);
 	});
 }
 

--- a/runtime/litentry/src/lib.rs
+++ b/runtime/litentry/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litentry-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9193,
+	spec_version: 9194,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/litmus/src/lib.rs
+++ b/runtime/litmus/src/lib.rs
@@ -151,7 +151,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litmus-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9193,
+	spec_version: 9194,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -223,7 +223,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("rococo-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9193,
+	spec_version: 9194,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -148,7 +148,7 @@ export async function assertVc(context: IntegrationTestContext, subject: CorePri
     // check runtime version is present
     assert.deepEqual(
         vcPayloadJson.issuer.runtimeVersion,
-        { parachain: 9193, sidechain: 109 },
+        { parachain: 9194, sidechain: 109 },
         'Check VC runtime version: it should equal the current defined versions'
     );
 

--- a/ts-tests/integration-tests/precompile-contract.test.ts
+++ b/ts-tests/integration-tests/precompile-contract.test.ts
@@ -237,18 +237,22 @@ describeLitentry('Test Parachain Precompile Contract', ``, (context) => {
         const autoCompoundPercent = 20;
 
         let collator = (await context.api.query.parachainStaking.candidateInfo(context.alice.address)).toHuman();
-        console.log("Candidates Info:", collator);
-        const staking_status = (await context.api.query.parachainStaking.delegatorState(evmAccountRaw.mappedAddress)).toHuman();
-        console.log("EVM Account Delegator State:", staking_status);
+        console.log('Candidates Info:', collator);
+        const staking_status = (
+            await context.api.query.parachainStaking.delegatorState(evmAccountRaw.mappedAddress)
+        ).toHuman();
+        console.log('EVM Account Delegator State:', staking_status);
 
         if (collator === null) {
-            console.log("Alice not candidate? Try joining");
+            console.log('Alice not candidate? Try joining');
             // 5001 will be big enough for both Litentry and Rococo
-            let join_extrinsic = context.api.tx.parachainStaking.joinCandidates(ethers.utils.parseUnits('5001', 18).toString());
+            let join_extrinsic = context.api.tx.parachainStaking.joinCandidates(
+                ethers.utils.parseUnits('5001', 18).toString()
+            );
             await signAndSend(join_extrinsic, context.alice);
         }
         collator = (await context.api.query.parachainStaking.candidateInfo(context.alice.address)).toHuman();
-        console.log("Candidates Info:", collator);
+        console.log('Candidates Info:', collator);
 
         // delegateWithAutoCompound(collator, amount, percent)
         const delegateWithAutoCompound = precompileStakingContract.interface.encodeFunctionData(


### PR DESCRIPTION
### Context

A small adjustment based on the new requirement.

When a user fully unstakes, his reward will become 0 according to the current logic, which is fine. However, his score shouldn't participate in the reward calculation, which is unfair to other users.

This PR fixes it in a brutal way - there's room to improve: both structural and algorithmetic way - but the time is limited, we can do the improvement later.

This PR simply clears the user's score for whoever has 0 staking when we calculate the rewards.
We can't simply remove the entry from `Scores` as the user might still have unclaimed reward.

