### PR TITLE
change sidechain block slot duration from 6s to 12s

### DIFF
--- a/tee-worker/core-primitives/settings/src/lib.rs
+++ b/tee-worker/core-primitives/settings/src/lib.rs
@@ -90,5 +90,5 @@ pub mod worker {
 pub mod sidechain {
 	use core::time::Duration;
 
-	pub static SLOT_DURATION: Duration = Duration::from_millis(6000);
+	pub static SLOT_DURATION: Duration = Duration::from_millis(12000);
 }


### PR DESCRIPTION
tiny PR as title
We are suffering not enough time to sync parachain block and produce sidechain block.

