### PR TITLE
Fixing A20 assertion (identity worker crashing)

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/a20.rs
+++ b/tee-worker/litentry/core/assertion-build/src/a20.rs
@@ -60,7 +60,7 @@ pub fn build(
 		Identity::Substrate(account) => account_id_to_string(&account),
 		Identity::Evm(account) => account_id_to_string(&account),
 		Identity::Bitcoin(account) => account_id_to_string(&account),
-		_ => unreachable!(),
+		_ => return Err(Error::RequestVCFailed(Assertion::A20, ErrorDetail::NoEligibleIdentity)),
 	};
 	debug!("Assertion A20 build, who: {:?}", who);
 

--- a/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
+++ b/tee-worker/litentry/core/vc-task/receiver/src/lib.rs
@@ -435,7 +435,7 @@ where
 
 	// The `call` should always be `TrustedCall:request_vc`. Once decided to remove 'request_vc', this part can be refactored regarding the parameters.
 	if let TrustedCall::request_vc(signer, who, assertion, maybe_key, req_ext_hash) = call {
-		info!(
+		debug!(
 			"Processing vc request for {}, assertion: {:?}",
 			who.to_did().unwrap_or_default(),
 			assertion


### PR DESCRIPTION
This is a small change to prevent the worker from crashing when the identity sent is not eligible for the assertion A20.

Also the log level has been changed not to leak sensible info on production

