### PR TITLE
ts-tests: avoid hardcoded runtime version

### DIFF
--- a/tee-worker/enclave-runtime/src/rpc/common_api.rs
+++ b/tee-worker/enclave-runtime/src/rpc/common_api.rs
@@ -9,7 +9,7 @@ use crate::{
 use base58::FromBase58;
 use codec::{Decode, Encode};
 use core::result::Result;
-use ita_sgx_runtime::{Runtime, System};
+use ita_sgx_runtime::{Runtime, System, VERSION};
 use ita_stf::{aes_encrypt_default, AesOutput, Getter, TrustedCallSigned};
 use itc_parentchain::light_client::{concurrent_access::ValidatorAccess, ExtrinsicSender};
 use itp_ocall_api::EnclaveAttestationOCallApi;
@@ -233,8 +233,18 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OcallApi, Stat
 
 	io_handler.add_sync_method("state_getRuntimeVersion", |_: Params| {
 		debug!("worker_api_direct rpc was called: state_getRuntimeVersion");
-		let parsed = "world";
-		Ok(Value::String(format!("hello, {}", parsed)))
+		let runtime_version = VERSION;
+
+		Ok(json!({
+			// "specName": runtime_version.spec_name,
+			// "implName": runtime_version.impl_name,
+			"authoringVersion": runtime_version.authoring_version,
+			"specVersion": runtime_version.spec_version,
+			"implVersion": runtime_version.impl_version,
+			"apis": runtime_version.apis,
+			"transactionVersion": runtime_version.transaction_version,
+			"stateVersion": runtime_version.state_version,
+		}))
 	});
 
 	// TODO: deprecate

--- a/tee-worker/enclave-runtime/src/rpc/common_api.rs
+++ b/tee-worker/enclave-runtime/src/rpc/common_api.rs
@@ -235,16 +235,10 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OcallApi, Stat
 		debug!("worker_api_direct rpc was called: state_getRuntimeVersion");
 		let runtime_version = VERSION;
 
-		Ok(json!({
-			// "specName": runtime_version.spec_name,
-			// "implName": runtime_version.impl_name,
-			"authoringVersion": runtime_version.authoring_version,
-			"specVersion": runtime_version.spec_version,
-			"implVersion": runtime_version.impl_version,
-			"apis": runtime_version.apis,
-			"transactionVersion": runtime_version.transaction_version,
-			"stateVersion": runtime_version.state_version,
-		}))
+		let json_value =
+			RpcReturnValue::new(runtime_version.encode(), false, DirectRequestStatus::Ok);
+
+		Ok(json!(json_value.to_hex()))
 	});
 
 	// TODO: deprecate

--- a/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/assertion.ts
@@ -11,11 +11,10 @@ import colors from 'colors';
 import { WorkerRpcReturnValue, StfError } from 'parachain-api';
 import { Bytes } from '@polkadot/types-codec';
 import { decryptWithAes } from './crypto';
-import { blake2AsHex } from '@polkadot/util-crypto';
+import { base58Encode, blake2AsHex } from '@polkadot/util-crypto';
 import { validateVcSchema } from '@litentry/vc-schema-validator';
 import { PalletIdentityManagementTeeIdentityContext } from 'sidechain-api';
 import { KeyObject } from 'crypto';
-import * as base58 from 'micro-base58';
 import { fail } from 'assert';
 
 export function assertIdGraph(
@@ -134,7 +133,7 @@ export async function assertVc(context: IntegrationTestContext, subject: CorePri
 
     assert.equal(
         vcPayloadJson.issuer.mrenclave,
-        base58.encode(registeredEnclave.mrenclave),
+        base58Encode(registeredEnclave.mrenclave),
         "Check VC mrenclave: it should equal enclave's mrenclave from parachains enclave registry"
     );
 


### PR DESCRIPTION
update the vc assertions to check the runtime version dynamically instead.