### PR TITLE
Refactoring ts integration tests to get worker url from the parachain

### DIFF
--- a/tee-worker/ts-tests/integration-tests/.env.local.example
+++ b/tee-worker/ts-tests/integration-tests/.env.local.example
@@ -1,5 +1,4 @@
 NODE_ENV = local
-WORKER_ENDPOINT = ws://localhost:2000
 NODE_ENDPOINT = ws://localhost:9944
 BINARY_DIR=../../bin
 LITENTRY_CLI_DIR=../../bin/litentry-cli

--- a/tee-worker/ts-tests/integration-tests/.env.staging
+++ b/tee-worker/ts-tests/integration-tests/.env.staging
@@ -1,5 +1,4 @@
 NODE_ENV = staging
-WORKER_ENDPOINT = ws://litentry-worker-1:2011
 NODE_ENDPOINT = "ws://litentry-node:9912"
 BINARY_DIR=/usr/local/bin
 LITENTRY_CLI_DIR=/usr/local/bin/litentry-cli

--- a/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
+++ b/tee-worker/ts-tests/integration-tests/assertion_contracts.test.ts
@@ -40,7 +40,6 @@ describe('Test Vc (direct request)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/common/utils/context.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/context.ts
@@ -1,4 +1,4 @@
-import { WsProvider, ApiPromise } from 'parachain-api';
+import { WsProvider, ApiPromise, PalletTeebagEnclave } from 'parachain-api';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { hexToString } from '@polkadot/util';
 import WebSocketAsPromised from 'websocket-as-promised';
@@ -27,10 +27,7 @@ export async function initWorkerConnection(endpoint: string): Promise<WebSocketA
     return wsp;
 }
 
-export async function initIntegrationTestContext(
-    workerEndpoint: string,
-    substrateEndpoint: string
-): Promise<IntegrationTestContext> {
+export async function initIntegrationTestContext(substrateEndpoint: string): Promise<IntegrationTestContext> {
     const provider = new WsProvider(substrateEndpoint);
     await cryptoWaitReady();
 
@@ -45,6 +42,7 @@ export async function initIntegrationTestContext(
 
     const chainIdentifier = api.registry.chainSS58 as number;
 
+    const workerEndpoint = await getWorkerEndpoint(api);
     const wsp = await initWorkerConnection(workerEndpoint);
     const requestId = 1;
 
@@ -61,6 +59,22 @@ export async function initIntegrationTestContext(
         chainIdentifier,
         requestId,
     };
+}
+
+async function getWorkerEndpoint(api: ApiPromise): Promise<string> {
+    const registry = await api.query.teebag.enclaveRegistry.entries();
+    const identityEnclaves = registry.reduce((enclaves, [, enclave]) => {
+        if (enclave.isEmpty || !enclave.unwrap().workerType.isIdentity) {
+            return enclaves;
+        }
+        return [...enclaves, enclave.unwrap()];
+    }, [] as PalletTeebagEnclave[]);
+
+    if (identityEnclaves.length === 0) {
+        throw new Error('No identity worker found');
+    }
+
+    return identityEnclaves[Math.floor(Math.random() * identityEnclaves.length)].url.toHuman() as string;
 }
 
 export async function getEnclave(api: ApiPromise): Promise<{

--- a/tee-worker/ts-tests/integration-tests/common/utils/integration-setup.ts
+++ b/tee-worker/ts-tests/integration-tests/common/utils/integration-setup.ts
@@ -27,7 +27,7 @@ export function describeLitentry(title: string, cb: (context: IntegrationTestCon
         before('Starting Litentry(parachain&tee)', async function () {
             //env url
 
-            const tmp = await initIntegrationTestContext(process.env.WORKER_ENDPOINT!, process.env.NODE_ENDPOINT!);
+            const tmp = await initIntegrationTestContext(process.env.NODE_ENDPOINT!);
             context.mrEnclave = tmp.mrEnclave;
             context.api = tmp.api;
             context.tee = tmp.tee;

--- a/tee-worker/ts-tests/integration-tests/di_bitcoin_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_bitcoin_identity.test.ts
@@ -60,7 +60,6 @@ describe('Test Identity (bitcoin direct invocation)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/di_evm_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_evm_identity.test.ts
@@ -48,7 +48,6 @@ describe('Test Identity (evm direct invocation)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/di_solana_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_solana_identity.test.ts
@@ -46,7 +46,6 @@ describe('Test Identity (solana direct invocation)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_substrate_identity.test.ts
@@ -57,7 +57,6 @@ describe('Test Identity (direct invocation)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/di_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/di_vc.test.ts
@@ -40,7 +40,6 @@ describe('Test Vc (direct invocation)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/discord_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/discord_identity.test.ts
@@ -51,7 +51,6 @@ describe('Test Discord Identity (direct invocation)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/dr_vc.test.ts
+++ b/tee-worker/ts-tests/integration-tests/dr_vc.test.ts
@@ -41,7 +41,6 @@ describe('Test Vc (direct request)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/twitter_identity.test.ts
+++ b/tee-worker/ts-tests/integration-tests/twitter_identity.test.ts
@@ -54,7 +54,6 @@ describe('Test Twitter Identity (direct invocation)', function () {
 
     before(async () => {
         context = await initIntegrationTestContext(
-            process.env.WORKER_ENDPOINT!, // @fixme evil assertion; centralize env access
             process.env.NODE_ENDPOINT! // @fixme evil assertion; centralize env access
         );
         teeShieldingKey = await getTeeShieldingKey(context);

--- a/tee-worker/ts-tests/integration-tests/vc_correctness.test.ts
+++ b/tee-worker/ts-tests/integration-tests/vc_correctness.test.ts
@@ -43,7 +43,7 @@ describe('Test Vc (direct invocation)', function () {
     const errorArray: { id: string; index: number; assertion: any; error: any }[] = [];
     this.timeout(6000000);
     before(async () => {
-        context = await initIntegrationTestContext(enclaveEndpoint, nodeEndpoint);
+        context = await initIntegrationTestContext(nodeEndpoint);
         teeShieldingKey = await getTeeShieldingKey(context);
     });
 


### PR DESCRIPTION
The key changes in this PR are:

- We no longer use a hardcoded worker url, instead we get the url from the registered enclaves in the parachain.
- We select a random enclave from the registry.

More context in the linear issue