### PR TITLE
Only trigger multi-worker test manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ on:
         description: rebuild-bitacross-docker
         required: true
         default: true
+      run-multi-worker-test:
+        type: boolean
+        description: run-multi-worker-test
+        required: true
+        default: false
       push-docker:
         type: boolean
         description: push-docker
@@ -813,6 +818,7 @@ jobs:
   identity-multi-worker-test:
     runs-on: ubuntu-latest
     continue-on-error: true
+    if: ${{ github.event.inputs.run-multi-worker-test == 'true' }} # only if triggered manually
     needs:
       - set-condition
       - parachain-build-dev


### PR DESCRIPTION
### Context

As topic.
Multi-worker is not our current focus right now, and probably not in the near future.

To save CI time and keep us focused, the multi-worker CI test is set to be triggered manually only.