### PR TITLE
fix: wrong line break for multiple secrets in deploy script

### DIFF
--- a/tee-worker/litentry/core/assertion-build/src/dynamic/scripts/run_deploy.sh
+++ b/tee-worker/litentry/core/assertion-build/src/dynamic/scripts/run_deploy.sh
@@ -52,7 +52,7 @@ fi
 
 if [ ${#SECRET_VALUES[@]} -gt 0 ]; then
 	# Join array elements with line break for the environment variable
-    export SECRETS=$(IFS=$'\n'; echo ${SECRET_VALUES[*]})
+    export SECRETS=$(printf "%s\n" ${SECRET_VALUES[*]})
 else
     unset SECRETS
 fi


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


