### PR TITLE
adding email identity to core primitives

### DIFF
--- a/primitives/core/src/assertion/mod.rs
+++ b/primitives/core/src/assertion/mod.rs
@@ -201,11 +201,11 @@ impl Assertion {
 			// any web3 network is allowed
 			Self::A1 | Self::A13(..) | Self::A20 => all_web3networks(),
 			// no web3 network is allowed
-			Self::A2(..)
-			| Self::A3(..)
-			| Self::A6
-			| Self::GenericDiscordRole(..)
-			| Self::LinkedIdentities => vec![],
+			Self::A2(..) |
+			Self::A3(..) |
+			Self::A6 |
+			Self::GenericDiscordRole(..) |
+			Self::LinkedIdentities => vec![],
 			Self::TokenHoldingAmount(t_type) => t_type.get_supported_networks(),
 			Self::PlatformUser(p_type) => p_type.get_supported_networks(),
 			Self::NftHolder(t_type) => t_type.get_supported_networks(),

--- a/primitives/core/src/identity.rs
+++ b/primitives/core/src/identity.rs
@@ -295,11 +295,14 @@ pub enum Identity {
 
 	#[codec(index = 6)]
 	Solana(Address32),
+
+	#[codec(index = 7)]
+	Email(IdentityString),
 }
 
 impl Identity {
 	pub fn is_web2(&self) -> bool {
-		matches!(self, Self::Twitter(..) | Self::Discord(..) | Self::Github(..))
+		matches!(self, Self::Twitter(..) | Self::Discord(..) | Self::Github(..) | Self::Email(..))
 	}
 
 	pub fn is_web3(&self) -> bool {
@@ -328,7 +331,10 @@ impl Identity {
 			Identity::Evm(_) => all_evm_web3networks(),
 			Identity::Bitcoin(_) => all_bitcoin_web3networks(),
 			Identity::Solana(_) => all_solana_web3networks(),
-			Identity::Twitter(_) | Identity::Discord(_) | Identity::Github(_) => Vec::new(),
+			Identity::Twitter(_) |
+			Identity::Discord(_) |
+			Identity::Github(_) |
+			Identity::Email(_) => Vec::new(),
 		}
 	}
 
@@ -340,8 +346,10 @@ impl Identity {
 			Identity::Evm(_) => !networks.is_empty() && networks.iter().all(|n| n.is_evm()),
 			Identity::Bitcoin(_) => !networks.is_empty() && networks.iter().all(|n| n.is_bitcoin()),
 			Identity::Solana(_) => !networks.is_empty() && networks.iter().all(|n| n.is_solana()),
-			Identity::Twitter(_) | Identity::Discord(_) | Identity::Github(_) =>
-				networks.is_empty(),
+			Identity::Twitter(_) |
+			Identity::Discord(_) |
+			Identity::Github(_) |
+			Identity::Email(_) => networks.is_empty(),
 		}
 	}
 
@@ -352,7 +360,10 @@ impl Identity {
 			Identity::Evm(address) =>
 				Some(HashedAddressMapping::into_account_id(H160::from_slice(address.as_ref()))),
 			Identity::Bitcoin(address) => Some(blake2_256(address.as_ref()).into()),
-			Identity::Twitter(_) | Identity::Discord(_) | Identity::Github(_) => None,
+			Identity::Twitter(_) |
+			Identity::Discord(_) |
+			Identity::Github(_) |
+			Identity::Email(_) => None,
 		}
 	}
 
@@ -397,6 +408,8 @@ impl Identity {
 					return Ok(Identity::Discord(IdentityString::new(v[1].as_bytes().to_vec())))
 				} else if v[0] == "twitter" {
 					return Ok(Identity::Twitter(IdentityString::new(v[1].as_bytes().to_vec())))
+				} else if v[0] == "email" {
+					return Ok(Identity::Email(IdentityString::new(v[1].as_bytes().to_vec())))
 				} else {
 					return Err("Unknown did type")
 				}
@@ -431,6 +444,11 @@ impl Identity {
 					"github:{}",
 					str::from_utf8(handle.inner_ref())
 						.map_err(|_| "github handle conversion error")?
+				),
+				Identity::Email(handle) => format!(
+					"email:{}",
+					str::from_utf8(handle.inner_ref())
+						.map_err(|_| "email handle conversion error")?
 				),
 			}
 		))
@@ -507,6 +525,7 @@ mod tests {
 					Identity::Twitter(..) => true,
 					Identity::Discord(..) => true,
 					Identity::Github(..) => true,
+					Identity::Email(..) => true,
 					Identity::Substrate(..) => false,
 					Identity::Evm(..) => false,
 					Identity::Bitcoin(..) => false,
@@ -525,6 +544,7 @@ mod tests {
 					Identity::Twitter(..) => false,
 					Identity::Discord(..) => false,
 					Identity::Github(..) => false,
+					Identity::Email(..) => false,
 					Identity::Substrate(..) => true,
 					Identity::Evm(..) => true,
 					Identity::Bitcoin(..) => true,
@@ -543,6 +563,7 @@ mod tests {
 					Identity::Twitter(..) => false,
 					Identity::Discord(..) => false,
 					Identity::Github(..) => false,
+					Identity::Email(..) => false,
 					Identity::Substrate(..) => true,
 					Identity::Evm(..) => false,
 					Identity::Bitcoin(..) => false,
@@ -561,6 +582,7 @@ mod tests {
 					Identity::Twitter(..) => false,
 					Identity::Discord(..) => false,
 					Identity::Github(..) => false,
+					Identity::Email(..) => false,
 					Identity::Substrate(..) => false,
 					Identity::Evm(..) => true,
 					Identity::Bitcoin(..) => false,
@@ -579,6 +601,7 @@ mod tests {
 					Identity::Twitter(..) => false,
 					Identity::Discord(..) => false,
 					Identity::Github(..) => false,
+					Identity::Email(..) => false,
 					Identity::Substrate(..) => false,
 					Identity::Evm(..) => false,
 					Identity::Bitcoin(..) => true,
@@ -597,6 +620,7 @@ mod tests {
 					Identity::Twitter(..) => false,
 					Identity::Discord(..) => false,
 					Identity::Github(..) => false,
+					Identity::Email(..) => false,
 					Identity::Substrate(..) => false,
 					Identity::Evm(..) => false,
 					Identity::Bitcoin(..) => false,
@@ -705,6 +729,14 @@ mod tests {
 	fn test_github_did() {
 		let identity = Identity::Github(IdentityString::new("github_handle".as_bytes().to_vec()));
 		let did_str = "did:litentry:github:github_handle";
+		assert_eq!(identity.to_did().unwrap(), did_str);
+		assert_eq!(Identity::from_did(did_str).unwrap(), identity);
+	}
+
+	#[test]
+	fn test_email_did() {
+		let identity = Identity::Email(IdentityString::new("test@test.com".as_bytes().to_vec()));
+		let did_str = "did:litentry:email:test@test.com";
 		assert_eq!(identity.to_did().unwrap(), did_str);
 		assert_eq!(Identity::from_did(did_str).unwrap(), identity);
 	}


### PR DESCRIPTION
This PR updates the `Identity` primitive type by adding `Email` variant.

