### PR TITLE
remove default-dcap-feature

### DIFF
--- a/tee-worker/Makefile
+++ b/tee-worker/Makefile
@@ -30,7 +30,7 @@ SGX_PRODUCTION ?= 0
 WORKER_MODE ?= sidechain
 WORKER_DEV ?= 0
 WORKER_MOCK_SERVER ?= 0
-RA_METHOD ?= dcap
+RA_METHOD ?=
 
 SKIP_WASM_BUILD = 1
 # include the build settings from rust-sgx-sdk


### PR DESCRIPTION
as title. A tiny PR. 
DCAP feature is not possible to run on id-worker prod env. Roll-back to IAS for the moment. Investigate and get it back in another PR.

