### PR TITLE
chore: remove all dynamic contract jobs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,14 +209,6 @@ jobs:
         working-directory: ./tee-worker/identity/ts-tests
         run: pnpm run check-format
 
-      - name: Dynamic-contract install npm deps
-        working-directory: ./tee-worker/identity/litentry/core/assertion-build/src/dynamic
-        run: pnpm install
-
-      - name: Dynamic-contract check code format
-        working-directory: ./tee-worker/identity/litentry/core/assertion-build/src/dynamic
-        run: pnpm run check-format
-
       - name: Fail early
         if: failure()
         uses: andymckay/cancel-action@0.5
@@ -657,26 +649,6 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.5
 
-  parachain-dynamic-contract-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Enable corepack and pnpm
-        run: corepack enable && corepack enable pnpm
-
-      - name: Install npm deps
-        working-directory: ./tee-worker/identity/litentry/core/assertion-build/src/dynamic
-        run: pnpm install
-
-      - name: Run all unittests
-        working-directory: ./tee-worker/identity/litentry/core/assertion-build/src/dynamic
-        run: pnpm run test
-
-      - name: Fail early
-        if: failure()
-        uses: andymckay/cancel-action@0.5
-
   parachain-unit-test:
     runs-on: ubuntu-latest
     needs:
@@ -763,7 +735,6 @@ jobs:
           - test_name: lit-test-failed-parentchain-extrinsic
           - test_name: lit-twitter-identity-test
           - test_name: lit-discord-identity-test
-          - test_name: lit-assertion-contracts-test
     name: ${{ matrix.test_name }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

need remove the ci job first in dev branch so the https://github.com/litentry/litentry-parachain/pull/3073 will pass ci test step.

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


