### PR TITLE
Email identity verification improvement

### DIFF
--- a/tee-worker/identity/enclave-runtime/src/rpc/common_api.rs
+++ b/tee-worker/identity/enclave-runtime/src/rpc/common_api.rs
@@ -481,7 +481,11 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OcallApi, Stat
 				);
 				let verification_code = email::generate_verification_code();
 
-				match email::VerificationCodeStore::insert(account_id, verification_code.clone()) {
+				match email::VerificationCodeStore::insert(
+					account_id,
+					email.clone(),
+					verification_code.clone(),
+				) {
 					Ok(_) => {
 						if email::send_verification_email(&mut mailer, email, verification_code)
 							.is_err()

--- a/tee-worker/identity/litentry/core/identity-verification/src/web2/email/verification_code_store.rs
+++ b/tee-worker/identity/litentry/core/identity-verification/src/web2/email/verification_code_store.rs
@@ -45,20 +45,24 @@ pub struct VerificationCodeStore;
 impl VerificationCodeStore {
 	pub fn insert(
 		account_id: AccountId,
+		email: String,
 		verification_code: String,
 	) -> Result<(), VerificationCodeStoreError> {
 		STORE
 			.write()
 			.map_err(|_| VerificationCodeStoreError::LockPoisoning)?
-			.put(hex::encode(account_id.encode()), verification_code);
+			.put(hex::encode((account_id, email).encode()), verification_code);
 		Ok(())
 	}
 
-	pub fn get(account_id: &AccountId) -> Result<Option<String>, VerificationCodeStoreError> {
+	pub fn get(
+		account_id: &AccountId,
+		email: &str,
+	) -> Result<Option<String>, VerificationCodeStoreError> {
 		let code = STORE
 			.write()
 			.map_err(|_| VerificationCodeStoreError::LockPoisoning)?
-			.pop(hex::encode(account_id.encode()).as_str());
+			.pop(hex::encode((account_id, email).encode()).as_str());
 		Ok(code)
 	}
 }

--- a/tee-worker/identity/litentry/core/identity-verification/src/web2/mod.rs
+++ b/tee-worker/identity/litentry/core/identity-verification/src/web2/mod.rs
@@ -220,19 +220,22 @@ pub fn verify(
 			let Some(account_id) = who.to_account_id() else {
 					return Err(Error::LinkIdentityFailed(ErrorDetail::ParseError));
 				};
-			let stored_verification_code = match email::VerificationCodeStore::get(&account_id) {
-				Ok(data) => data.ok_or_else(|| {
-					Error::LinkIdentityFailed(ErrorDetail::StfError(ErrorString::truncate_from(
-						std::format!(
-							"no verification code found for {}",
-							account_id_to_string(&account_id)
-						)
-						.as_bytes()
-						.to_vec(),
-					)))
-				})?,
-				Err(e) => return Err(Error::LinkIdentityFailed(e.into_error_detail())),
-			};
+			let stored_verification_code =
+				match email::VerificationCodeStore::get(&account_id, &email) {
+					Ok(data) => data.ok_or_else(|| {
+						Error::LinkIdentityFailed(ErrorDetail::StfError(
+							ErrorString::truncate_from(
+								std::format!(
+									"no verification code found for {}",
+									account_id_to_string(&account_id)
+								)
+								.as_bytes()
+								.to_vec(),
+							),
+						))
+					})?,
+					Err(e) => return Err(Error::LinkIdentityFailed(e.into_error_detail())),
+				};
 
 			ensure!(
 				verification_code == stored_verification_code,

--- a/tee-worker/identity/litentry/core/identity-verification/src/web2/mod.rs
+++ b/tee-worker/identity/litentry/core/identity-verification/src/web2/mod.rs
@@ -226,8 +226,8 @@ pub fn verify(
 						Error::LinkIdentityFailed(ErrorDetail::StfError(
 							ErrorString::truncate_from(
 								std::format!(
-									"no verification code found for {}",
-									account_id_to_string(&account_id)
+									"no verification code found for {}:{}",
+									account_id_to_string(&account_id, &email)
 								)
 								.as_bytes()
 								.to_vec(),

--- a/tee-worker/identity/litentry/core/identity-verification/src/web2/mod.rs
+++ b/tee-worker/identity/litentry/core/identity-verification/src/web2/mod.rs
@@ -227,7 +227,8 @@ pub fn verify(
 							ErrorString::truncate_from(
 								std::format!(
 									"no verification code found for {}:{}",
-									account_id_to_string(&account_id, &email)
+									account_id_to_string(&account_id),
+									&email
 								)
 								.as_bytes()
 								.to_vec(),


### PR DESCRIPTION
it makes sure that the verification code is only valid for the email that requested it and not just the prime identity.

Thanks to @jonalvarezz for finding the issue.