### PR TITLE
`bitacross_getPublicKeys` return ton public key

### DIFF
--- a/tee-worker/bitacross/enclave-runtime/src/initialization/mod.rs
+++ b/tee-worker/bitacross/enclave-runtime/src/initialization/mod.rs
@@ -259,6 +259,7 @@ pub(crate) fn init_enclave(
 		signing_key_repository,
 		bitcoin_key_repository,
 		ethereum_key_repository,
+		ton_key_repository,
 		signer_registry,
 	);
 	let rpc_handler = Arc::new(RpcWsHandler::new(io_handler, watch_extractor, connection_registry));

--- a/tee-worker/bitacross/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/tee-worker/bitacross/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -22,6 +22,7 @@ use crate::{
 	},
 	initialization::global_components::{
 		EnclaveBitcoinKeyRepository, EnclaveEthereumKeyRepository, EnclaveSigningKeyRepository,
+		EnclaveTonKeyRepository,
 	},
 	std::string::ToString,
 	utils::get_validator_accessor_from_integritee_solo_or_parachain,
@@ -80,6 +81,7 @@ pub fn public_api_rpc_handler<Author, GetterExecutor, AccessShieldingKey, OcallA
 	signing_key_repository: Arc<EnclaveSigningKeyRepository>,
 	bitcoin_key_repository: Arc<EnclaveBitcoinKeyRepository>,
 	ethereum_key_repository: Arc<EnclaveEthereumKeyRepository>,
+	ton_key_repository: Arc<EnclaveTonKeyRepository>,
 	signer_lookup: Arc<SR>,
 ) -> IoHandler
 where
@@ -237,10 +239,16 @@ where
 			Err(_e) => compute_hex_encoded_return_error("Can not obtain ethereum key"),
 		};
 
+		let ton_key = match ton_key_repository.retrieve_key() {
+			Ok(pair) => pair.public().0.to_hex(),
+			Err(_e) => compute_hex_encoded_return_error("Can not obtain ton key"),
+		};
+
 		Ok(json!({
 			"signer": signer,
 			"bitcoin_key": bitcoin_key,
-			"ethereum_key": ethereum_key
+			"ethereum_key": ethereum_key,
+			"ton_key": ton_key
 		}))
 	});
 

--- a/tee-worker/bitacross/enclave-runtime/src/test/direct_rpc_tests.rs
+++ b/tee-worker/bitacross/enclave-runtime/src/test/direct_rpc_tests.rs
@@ -19,7 +19,7 @@
 use crate::{
 	initialization::global_components::{
 		GLOBAL_BITCOIN_KEY_REPOSITORY_COMPONENT, GLOBAL_ETHEREUM_KEY_REPOSITORY_COMPONENT,
-		GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT,
+		GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT, GLOBAL_TON_KEY_REPOSITORY_COMPONENT,
 	},
 	rpc::worker_api_direct::public_api_rpc_handler,
 	test::{
@@ -89,6 +89,7 @@ pub fn state_get_mrenclave_works() {
 		GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT.get().unwrap(),
 		GLOBAL_BITCOIN_KEY_REPOSITORY_COMPONENT.get().unwrap(),
 		GLOBAL_ETHEREUM_KEY_REPOSITORY_COMPONENT.get().unwrap(),
+		GLOBAL_TON_KEY_REPOSITORY_COMPONENT.get().unwrap(),
 		signer_lookup,
 	);
 	let rpc_handler = Arc::new(RpcWsHandler::new(io_handler, watch_extractor, connection_registry));
@@ -143,6 +144,7 @@ pub fn get_state_request_works() {
 		GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT.get().unwrap(),
 		GLOBAL_BITCOIN_KEY_REPOSITORY_COMPONENT.get().unwrap(),
 		GLOBAL_ETHEREUM_KEY_REPOSITORY_COMPONENT.get().unwrap(),
+		GLOBAL_TON_KEY_REPOSITORY_COMPONENT.get().unwrap(),
 		signer_lookup,
 	);
 	let rpc_handler = Arc::new(RpcWsHandler::new(io_handler, watch_extractor, connection_registry));


### PR DESCRIPTION
Adds TON public key to returned key set from `bitacross_getPublicKeys` rpc method