### PR TITLE
disable default dcap feature for bitacross worker for the moment. 

### DIFF
--- a/tee-worker/bitacross/Makefile
+++ b/tee-worker/bitacross/Makefile
@@ -27,7 +27,7 @@ SGX_PRODUCTION ?= 0
 ######## Worker Feature Settings ########
 # Set offchain-worker as default feature mode
 WORKER_MODE ?= offchain-worker
-RA_METHOD ?= dcap
+RA_METHOD ?=
 
 SKIP_WASM_BUILD = 1
 # include the build settings from rust-sgx-sdk


### PR DESCRIPTION
There is still problem when running from docker image.
Should be merged before PR: https://github.com/litentry/litentry-parachain/pull/3087
