### PR TITLE
update bitacross rpc types definitions

### DIFF
--- a/tee-worker/bitacross/example/client/definitions.json
+++ b/tee-worker/bitacross/example/client/definitions.json
@@ -95,6 +95,13 @@
       ["SigningError", "()"]
     ]
   },
+  "SignTonError": {
+    "type": "enum",
+    "type_mapping": [
+      ["InvalidSigner", "()"],
+      ["SigningError", "()"]
+    ]
+  },
   "PrehashedEthereumMessage": "[u8; 32]",
   "PlainRequest": {
     "type": "struct",


### PR DESCRIPTION
* adds `SignTonError` to rpc type definitions



