### PR TITLE
fix: set a default name for job identity-multi-worker-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,7 +791,7 @@ jobs:
           - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-dr-vc-multiworker-test
           - test_name: lit-resume-worker
-    name: ${{ matrix.test_name }}
+    name: ${{ matrix.test_name || 'identity-multi-worker-test' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
set a default name for job identity-multi-worker-test  while identity-multi-worker-test is skipped, so  we don't see ${{ matrix.test_name }}


### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


