### PR TITLE
Add omni account origin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,7 +581,7 @@ jobs:
           - litentry
           - rococo
           - paseo
-    name: ${{ matrix.chain }}
+    name: ${{ matrix.chain || github.job }}
     steps:
       - uses: actions/checkout@v4
 
@@ -718,7 +718,7 @@ jobs:
           - test_name: lit-test-failed-parentchain-extrinsic
           - test_name: lit-twitter-identity-test
           - test_name: lit-discord-identity-test
-    name: ${{ matrix.test_name }}
+    name: ${{ matrix.test_name || github.job }}
     steps:
       - uses: actions/checkout@v4
 
@@ -791,7 +791,7 @@ jobs:
           - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-dr-vc-multiworker-test
           - test_name: lit-resume-worker
-    name: ${{ matrix.test_name || 'identity-multi-worker-test' }}
+    name: ${{ matrix.test_name || github.job }}
     steps:
       - uses: actions/checkout@v4
 
@@ -857,7 +857,7 @@ jobs:
       matrix:
         include:
           - test_name: lit-sign-bitcoin
-    name: ${{ matrix.test_name }}
+    name: ${{ matrix.test_name || github.job }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,7 +581,7 @@ jobs:
           - litentry
           - rococo
           - paseo
-    name: ${{ matrix.chain || 'parachain-ts-test' }}
+    name: ${{ matrix.chain }} || 'parachain-ts-test'
     steps:
       - uses: actions/checkout@v4
 
@@ -718,7 +718,7 @@ jobs:
           - test_name: lit-test-failed-parentchain-extrinsic
           - test_name: lit-twitter-identity-test
           - test_name: lit-discord-identity-test
-    name: ${{ matrix.test_name || 'identity-single-worker-test' }}
+    name: ${{ matrix.test_name }} || 'identity-single-worker-test'
     steps:
       - uses: actions/checkout@v4
 
@@ -791,7 +791,7 @@ jobs:
           - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-dr-vc-multiworker-test
           - test_name: lit-resume-worker
-    name: ${{ matrix.test_name || 'identity-multi-worker-test' }}
+    name: ${{ matrix.test_name }} || 'identity-multi-worker-test'
     steps:
       - uses: actions/checkout@v4
 
@@ -857,7 +857,7 @@ jobs:
       matrix:
         include:
           - test_name: lit-sign-bitcoin
-    name: ${{ matrix.test_name || 'bitacross-worker-test' }}
+    name: ${{ matrix.test_name }} || 'bitacross-worker-test'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,7 +581,7 @@ jobs:
           - litentry
           - rococo
           - paseo
-    name: ${{ matrix.chain }} || 'parachain-ts-test'
+    name: ${{ matrix.chain }}
     steps:
       - uses: actions/checkout@v4
 
@@ -718,7 +718,7 @@ jobs:
           - test_name: lit-test-failed-parentchain-extrinsic
           - test_name: lit-twitter-identity-test
           - test_name: lit-discord-identity-test
-    name: ${{ matrix.test_name }} || 'identity-single-worker-test'
+    name: ${{ matrix.test_name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -791,7 +791,7 @@ jobs:
           - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-dr-vc-multiworker-test
           - test_name: lit-resume-worker
-    name: ${{ matrix.test_name }} || 'identity-multi-worker-test'
+    name: ${{ matrix.test_name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -857,7 +857,7 @@ jobs:
       matrix:
         include:
           - test_name: lit-sign-bitcoin
-    name: ${{ matrix.test_name }} || 'bitacross-worker-test'
+    name: ${{ matrix.test_name }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,7 +581,7 @@ jobs:
           - litentry
           - rococo
           - paseo
-    name: ${{ matrix.chain || github.job }}
+    name: ${{ matrix.chain || 'parachain-ts-test' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -718,7 +718,7 @@ jobs:
           - test_name: lit-test-failed-parentchain-extrinsic
           - test_name: lit-twitter-identity-test
           - test_name: lit-discord-identity-test
-    name: ${{ matrix.test_name || github.job }}
+    name: ${{ matrix.test_name || 'identity-single-worker-test' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -791,7 +791,7 @@ jobs:
           - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-dr-vc-multiworker-test
           - test_name: lit-resume-worker
-    name: ${{ matrix.test_name || github.job }}
+    name: ${{ matrix.test_name || 'identity-multi-worker-test' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -857,7 +857,7 @@ jobs:
       matrix:
         include:
           - test_name: lit-sign-bitcoin
-    name: ${{ matrix.test_name || github.job }}
+    name: ${{ matrix.test_name || 'bitacross-worker-test' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -11061,6 +11061,7 @@ dependencies = [
  "pallet-membership",
  "pallet-message-queue",
  "pallet-multisig",
+ "pallet-omni-account",
  "pallet-teebag",
  "pallet-transaction-payment",
  "pallet-treasury",

--- a/parachain/pallets/omni-account/src/lib.rs
+++ b/parachain/pallets/omni-account/src/lib.rs
@@ -86,10 +86,11 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		/// The runtime origin type.
-		type RuntimeOrigin: From<RawOrigin<Self::AccountId>>;
+		/// The runtime origin type
+		type RuntimeOrigin: From<RawOrigin<Self::AccountId>>
+			+ From<frame_system::RawOrigin<Self::AccountId>>;
 
-		/// The overarching call type.
+		/// The overarching call type
 		type RuntimeCall: Parameter
 			+ Dispatchable<
 				RuntimeOrigin = <Self as Config>::RuntimeOrigin,
@@ -100,16 +101,22 @@ pub mod pallet {
 			+ IsSubType<Call<Self>>
 			+ IsType<<Self as frame_system::Config>::RuntimeCall>;
 
-		/// The event type of this pallet.
+		/// The event type of this pallet
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-		/// The origin which can manage the pallet.
+		/// The origin that represents the off-chain worker
 		type TEECallOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 		/// The maximum number of identities an id graph can have.
 		#[pallet::constant]
 		type MaxIDGraphLength: Get<u32>;
 		/// AccountId converter
 		type AccountIdConverter: AccountIdConverter<Self>;
+		/// The origin that represents the customised OmniAccount type
+		type OmniAccountOrigin: EnsureOrigin<
+			<Self as frame_system::Config>::RuntimeOrigin,
+			Success = Self::AccountId,
+		>;
 	}
+
 	pub type IDGraph<T> = BoundedVec<IDGraphMember, <T as Config>::MaxIDGraphLength>;
 
 	#[pallet::origin]
@@ -117,7 +124,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	pub type LinkedIdentityHashes<T: Config> =
-		StorageMap<Hasher = Blake2_128Concat, Key = H256, Value = ()>;
+		StorageMap<Hasher = Blake2_128Concat, Key = H256, Value = T::AccountId>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn id_graphs)]
@@ -138,6 +145,10 @@ pub mod pallet {
 		IdentityRemoved { who: T::AccountId, identity_hashes: Vec<H256> },
 		/// Identity made public
 		IdentityMadePublic { who: T::AccountId, identity_hash: H256 },
+		/// Some call is dispatched as omni-account origin
+		DispatchedAsOmniAccount { who: T::AccountId, result: DispatchResult },
+		/// Some call is dispatched as signed origin
+		DispatchedAsSigned { who: T::AccountId, result: DispatchResult },
 	}
 
 	#[pallet::error]
@@ -164,18 +175,47 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		// dispatch the `call` as RawOrigin::OmniAccount
 		#[pallet::call_index(0)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn dispatch_as_omni_account(
 			origin: OriginFor<T>,
-			who_hash: H256,
+			account_hash: H256,
 			call: Box<<T as Config>::RuntimeCall>,
 		) -> DispatchResult {
 			let _ = T::TEECallOrigin::ensure_origin(origin)?;
+			let omni_account =
+				LinkedIdentityHashes::<T>::get(account_hash).ok_or(Error::<T>::IdentityNotFound)?;
+			let result = call.dispatch(RawOrigin::OmniAccount(omni_account.clone()).into());
+			Self::deposit_event(Event::DispatchedAsOmniAccount {
+				who: omni_account,
+				result: result.map(|_| ()).map_err(|e| e.error),
+			});
 			Ok(())
 		}
 
+		// dispatch the `call` as the standard (frame_system) signed origin
+		// TODO: what about other customised origin like collective?
 		#[pallet::call_index(1)]
+		#[pallet::weight((195_000_000, DispatchClass::Normal))]
+		pub fn dispatch_as_signed(
+			origin: OriginFor<T>,
+			account_hash: H256,
+			call: Box<<T as Config>::RuntimeCall>,
+		) -> DispatchResult {
+			let _ = T::TEECallOrigin::ensure_origin(origin)?;
+			let omni_account =
+				LinkedIdentityHashes::<T>::get(account_hash).ok_or(Error::<T>::IdentityNotFound)?;
+			let result =
+				call.dispatch(frame_system::RawOrigin::Signed(omni_account.clone()).into());
+			Self::deposit_event(Event::DispatchedAsSigned {
+				who: omni_account,
+				result: result.map(|_| ()).map_err(|e| e.error),
+			});
+			Ok(())
+		}
+
+		#[pallet::call_index(2)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn link_identity(
 			origin: OriginFor<T>,
@@ -183,6 +223,8 @@ pub mod pallet {
 			member_account: IDGraphMember,
 			maybe_id_graph_hash: Option<H256>,
 		) -> DispatchResult {
+			// We can't use `T::OmniAccountOrigin` here as the ownership of member account needs to
+			// be firstly validated by the TEE-worker before dispatching the extrinsic
 			let _ = T::TEECallOrigin::ensure_origin(origin)?;
 			ensure!(
 				!LinkedIdentityHashes::<T>::contains_key(member_account.hash),
@@ -202,7 +244,7 @@ pub mod pallet {
 				.try_push(member_account)
 				.map_err(|_| Error::<T>::IDGraphLenLimitReached)?;
 
-			LinkedIdentityHashes::<T>::insert(identity_hash, ());
+			LinkedIdentityHashes::<T>::insert(identity_hash, who_account_id.clone());
 			IDGraphHashes::<T>::insert(who_account_id.clone(), id_graph.graph_hash());
 			IDGraphs::<T>::insert(who_account_id.clone(), id_graph);
 
@@ -214,23 +256,17 @@ pub mod pallet {
 			Ok(())
 		}
 
-		#[pallet::call_index(2)]
+		#[pallet::call_index(3)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn remove_identities(
 			origin: OriginFor<T>,
-			who: Identity,
 			identity_hashes: Vec<H256>,
 		) -> DispatchResult {
-			let _ = T::TEECallOrigin::ensure_origin(origin)?;
+			let who = T::OmniAccountOrigin::ensure_origin(origin)?;
 			ensure!(!identity_hashes.is_empty(), Error::<T>::IdentitiesEmpty);
 
-			let who_account_id = match T::AccountIdConverter::convert(&who) {
-				Some(account_id) => account_id,
-				None => return Err(Error::<T>::InvalidIdentity.into()),
-			};
-
 			let mut id_graph_members =
-				IDGraphs::<T>::get(&who_account_id).ok_or(Error::<T>::UnknownIDGraph)?;
+				IDGraphs::<T>::get(&who).ok_or(Error::<T>::UnknownIDGraph)?;
 
 			id_graph_members.retain(|member| {
 				if identity_hashes.contains(&member.hash) {
@@ -242,43 +278,37 @@ pub mod pallet {
 			});
 
 			if id_graph_members.is_empty() {
-				IDGraphs::<T>::remove(&who_account_id);
+				IDGraphs::<T>::remove(&who);
 			} else {
-				IDGraphs::<T>::insert(who_account_id.clone(), id_graph_members);
+				IDGraphs::<T>::insert(who.clone(), id_graph_members);
 			}
 
-			Self::deposit_event(Event::IdentityRemoved { who: who_account_id, identity_hashes });
+			Self::deposit_event(Event::IdentityRemoved { who, identity_hashes });
 
 			Ok(())
 		}
 
-		#[pallet::call_index(3)]
+		#[pallet::call_index(4)]
 		#[pallet::weight((195_000_000, DispatchClass::Normal))]
 		pub fn make_identity_public(
 			origin: OriginFor<T>,
-			who: Identity,
 			identity_hash: H256,
 			public_identity: MemberIdentity,
 		) -> DispatchResult {
-			let _ = T::TEECallOrigin::ensure_origin(origin)?;
+			let who = T::OmniAccountOrigin::ensure_origin(origin)?;
 			ensure!(public_identity.is_public(), Error::<T>::IdentityIsPrivate);
 
-			let who_account_id = match T::AccountIdConverter::convert(&who) {
-				Some(account_id) => account_id,
-				None => return Err(Error::<T>::InvalidIdentity.into()),
-			};
-
 			let mut id_graph_members =
-				IDGraphs::<T>::get(&who_account_id).ok_or(Error::<T>::UnknownIDGraph)?;
+				IDGraphs::<T>::get(&who).ok_or(Error::<T>::UnknownIDGraph)?;
 			let id_graph_link = id_graph_members
 				.iter_mut()
 				.find(|member| member.hash == identity_hash)
 				.ok_or(Error::<T>::IdentityNotFound)?;
 			id_graph_link.id = public_identity;
 
-			IDGraphs::<T>::insert(who_account_id.clone(), id_graph_members);
+			IDGraphs::<T>::insert(who.clone(), id_graph_members);
 
-			Self::deposit_event(Event::IdentityMadePublic { who: who_account_id, identity_hash });
+			Self::deposit_event(Event::IdentityMadePublic { who, identity_hash });
 
 			Ok(())
 		}
@@ -334,7 +364,7 @@ pub mod pallet {
 					hash: owner_identity_hash,
 				})
 				.map_err(|_| Error::<T>::IDGraphLenLimitReached)?;
-			LinkedIdentityHashes::<T>::insert(owner_identity_hash, ());
+			LinkedIdentityHashes::<T>::insert(owner_identity_hash, owner_account_id.clone());
 			IDGraphs::<T>::insert(owner_account_id.clone(), id_graph_members.clone());
 
 			Ok(id_graph_members)

--- a/parachain/pallets/omni-account/src/lib.rs
+++ b/parachain/pallets/omni-account/src/lib.rs
@@ -34,6 +34,7 @@ use frame_system::pallet_prelude::*;
 use sp_core::H256;
 use sp_core_hashing::blake2_256;
 use sp_runtime::traits::Dispatchable;
+use sp_std::boxed::Box;
 use sp_std::vec::Vec;
 
 #[derive(Encode, Decode, TypeInfo, Clone, PartialEq, Eq, RuntimeDebug)]

--- a/parachain/pallets/omni-account/src/mock.rs
+++ b/parachain/pallets/omni-account/src/mock.rs
@@ -182,11 +182,12 @@ pub fn get_tee_signer() -> SystemAccountId {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let system = frame_system::GenesisConfig::<TestRuntime>::default();
-	let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig { system, ..Default::default() }
-		.build_storage()
-		.unwrap()
-		.into();
+	let mut t = frame_system::GenesisConfig::<TestRuntime>::default().build_storage().unwrap();
+	pallet_balances::GenesisConfig::<TestRuntime> { balances: vec![(alice(), 10)] }
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+	let mut ext: sp_io::TestExternalities = t.into();
 	ext.execute_with(|| {
 		System::set_block_number(1);
 		let signer = get_tee_signer();

--- a/parachain/pallets/omni-account/src/mock.rs
+++ b/parachain/pallets/omni-account/src/mock.rs
@@ -1,3 +1,19 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{self as pallet_omni_account};
 use core_primitives::Identity;
 use frame_support::{
@@ -152,6 +168,8 @@ impl pallet_omni_account::AccountIdConverter<TestRuntime> for IdentityToAccountI
 }
 
 impl pallet_omni_account::Config for TestRuntime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type TEECallOrigin = EnsureEnclaveSigner<Self>;
 	type MaxIDGraphLength = ConstU32<3>;

--- a/parachain/pallets/omni-account/src/mock.rs
+++ b/parachain/pallets/omni-account/src/mock.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{self as pallet_omni_account};
+use crate::{self as pallet_omni_account, EnsureOmniAccount};
 use core_primitives::Identity;
 use frame_support::{
 	assert_ok,
@@ -174,6 +174,7 @@ impl pallet_omni_account::Config for TestRuntime {
 	type TEECallOrigin = EnsureEnclaveSigner<Self>;
 	type MaxIDGraphLength = ConstU32<3>;
 	type AccountIdConverter = IdentityToAccountIdConverter;
+	type OmniAccountOrigin = EnsureOmniAccount<Self::AccountId>;
 }
 
 pub fn get_tee_signer() -> SystemAccountId {

--- a/parachain/pallets/omni-account/src/tests.rs
+++ b/parachain/pallets/omni-account/src/tests.rs
@@ -1,3 +1,19 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{mock::*, IDGraphs, LinkedIdentityHashes, *};
 use core_primitives::Identity;
 use frame_support::{assert_noop, assert_ok};

--- a/parachain/pallets/omni-account/src/tests.rs
+++ b/parachain/pallets/omni-account/src/tests.rs
@@ -17,8 +17,21 @@
 use crate::{mock::*, IDGraphs, LinkedIdentityHashes, *};
 use core_primitives::Identity;
 use frame_support::{assert_noop, assert_ok};
-use sp_runtime::traits::BadOrigin;
+use sp_runtime::{traits::BadOrigin, ModuleError};
 use sp_std::vec;
+
+fn remove_identity_call(hashes: Vec<H256>) -> Box<RuntimeCall> {
+	let call = RuntimeCall::OmniAccount(crate::Call::remove_identities { identity_hashes: hashes });
+	Box::new(call)
+}
+
+fn make_identity_public_call(hash: H256, id: MemberIdentity) -> Box<RuntimeCall> {
+	let call = RuntimeCall::OmniAccount(crate::Call::make_identity_public {
+		identity_hash: hash,
+		public_identity: id,
+	});
+	Box::new(call)
+}
 
 #[test]
 fn link_identity_works() {
@@ -342,12 +355,38 @@ fn remove_identity_works() {
 			member_account.clone(),
 			None
 		));
-		assert_ok!(OmniAccount::remove_identities(
+
+		// normal signed origin should give `BadOrigin`, no matter
+		// it's from TEE-worker, or omni-account itself
+		assert_noop!(
+			OmniAccount::remove_identities(
+				RuntimeOrigin::signed(tee_signer.clone()),
+				identities_to_remove.clone()
+			),
+			sp_runtime::DispatchError::BadOrigin
+		);
+
+		assert_noop!(
+			OmniAccount::remove_identities(
+				RuntimeOrigin::signed(who.clone()),
+				identities_to_remove.clone()
+			),
+			sp_runtime::DispatchError::BadOrigin
+		);
+
+		let call = remove_identity_call(identities_to_remove.clone());
+		assert_ok!(OmniAccount::dispatch_as_omni_account(
 			RuntimeOrigin::signed(tee_signer.clone()),
-			who_identity.clone(),
-			identities_to_remove.clone()
+			who_identity_hash,
+			call
 		));
-		System::assert_last_event(
+
+		System::assert_has_event(
+			Event::DispatchedAsOmniAccount { who: who.clone(), result: DispatchResult::Ok(()) }
+				.into(),
+		);
+
+		System::assert_has_event(
 			Event::IdentityRemoved { who: who.clone(), identity_hashes: identities_to_remove }
 				.into(),
 		);
@@ -361,15 +400,12 @@ fn remove_identity_works() {
 		assert_eq!(IDGraphs::<TestRuntime>::get(&who).unwrap(), expected_id_graph);
 		assert!(!LinkedIdentityHashes::<TestRuntime>::contains_key(identity_hash));
 
-		assert_ok!(OmniAccount::remove_identities(
+		let call = remove_identity_call(vec![who_identity_hash]);
+		assert_ok!(OmniAccount::dispatch_as_omni_account(
 			RuntimeOrigin::signed(tee_signer.clone()),
-			who_identity.clone(),
-			vec![who_identity_hash],
+			who_identity_hash,
+			call
 		));
-		System::assert_last_event(
-			Event::IdentityRemoved { who: who.clone(), identity_hashes: vec![who_identity_hash] }
-				.into(),
-		);
 
 		assert!(!IDGraphs::<TestRuntime>::contains_key(&who));
 	});
@@ -379,33 +415,37 @@ fn remove_identity_works() {
 fn remove_identity_empty_identity_check_works() {
 	new_test_ext().execute_with(|| {
 		let tee_signer = get_tee_signer();
-		let who = Identity::from(alice());
+		let who = alice();
+		let who_identity = Identity::from(who.clone());
+		let who_identity_hash = who_identity.hash().unwrap();
 
 		assert_ok!(OmniAccount::link_identity(
 			RuntimeOrigin::signed(tee_signer.clone()),
-			who.clone(),
+			who_identity,
 			IDGraphMember {
 				id: MemberIdentity::Private(vec![1, 2, 3]),
 				hash: H256::from(blake2_256(&[1, 2, 3])),
 			},
 			None
 		));
-		assert_noop!(
-			OmniAccount::remove_identities(RuntimeOrigin::signed(tee_signer.clone()), who, vec![],),
-			Error::<TestRuntime>::IdentitiesEmpty
-		);
-	});
-}
 
-#[test]
-fn remove_identity_origin_check_works() {
-	new_test_ext().execute_with(|| {
-		let who = Identity::from(alice());
-		let identities_to_remove = vec![H256::from(blake2_256(&[1, 2, 3]))];
-
-		assert_noop!(
-			OmniAccount::remove_identities(RuntimeOrigin::signed(bob()), who, identities_to_remove),
-			BadOrigin
+		let call = remove_identity_call(vec![]);
+		// execution itself is ok, but error is shown in the dispatch result
+		assert_ok!(OmniAccount::dispatch_as_omni_account(
+			RuntimeOrigin::signed(tee_signer.clone()),
+			who_identity_hash,
+			call
+		));
+		System::assert_has_event(
+			Event::DispatchedAsOmniAccount {
+				who,
+				result: Err(DispatchError::Module(ModuleError {
+					index: 5,
+					error: [6, 0, 0, 0],
+					message: Some("IdentitiesEmpty"),
+				})),
+			}
+			.into(),
 		);
 	});
 }
@@ -416,6 +456,7 @@ fn make_identity_public_works() {
 		let tee_signer = get_tee_signer();
 		let who = alice();
 		let who_identity = Identity::from(who.clone());
+		let who_identity_hash = who_identity.hash().unwrap();
 
 		let private_identity = MemberIdentity::Private(vec![1, 2, 3]);
 		let public_identity = MemberIdentity::Public(Identity::from(bob()));
@@ -438,13 +479,19 @@ fn make_identity_public_works() {
 		]);
 		assert_eq!(IDGraphs::<TestRuntime>::get(&who).unwrap(), expected_id_graph);
 
-		assert_ok!(OmniAccount::make_identity_public(
+		let call = make_identity_public_call(identity_hash, public_identity.clone());
+		assert_ok!(OmniAccount::dispatch_as_omni_account(
 			RuntimeOrigin::signed(tee_signer.clone()),
-			who_identity.clone(),
-			identity_hash,
-			public_identity.clone()
+			who_identity_hash,
+			call
 		));
-		System::assert_last_event(
+
+		System::assert_has_event(
+			Event::DispatchedAsOmniAccount { who: who.clone(), result: DispatchResult::Ok(()) }
+				.into(),
+		);
+
+		System::assert_has_event(
 			Event::IdentityMadePublic { who: who.clone(), identity_hash }.into(),
 		);
 
@@ -460,30 +507,12 @@ fn make_identity_public_works() {
 }
 
 #[test]
-fn make_identity_public_origin_check_works() {
-	new_test_ext().execute_with(|| {
-		let who = Identity::from(alice());
-		let identity = Identity::from(bob());
-		let identity_hash = identity.hash().unwrap();
-		let public_identity = MemberIdentity::Public(identity.clone());
-
-		assert_noop!(
-			OmniAccount::make_identity_public(
-				RuntimeOrigin::signed(bob()),
-				who,
-				identity_hash,
-				public_identity
-			),
-			BadOrigin
-		);
-	});
-}
-
-#[test]
 fn make_identity_public_identity_not_found_works() {
 	new_test_ext().execute_with(|| {
 		let tee_signer = get_tee_signer();
-		let who = Identity::from(alice());
+		let who = alice();
+		let who_identity = Identity::from(who.clone());
+		let who_identity_hash = who_identity.hash().unwrap();
 
 		let private_identity = MemberIdentity::Private(vec![1, 2, 3]);
 		let identity = Identity::from(bob());
@@ -491,19 +520,19 @@ fn make_identity_public_identity_not_found_works() {
 		let identity_hash =
 			H256::from(blake2_256(&Identity::from(bob()).to_did().unwrap().encode()));
 
+		let call = make_identity_public_call(identity_hash, public_identity.clone());
 		assert_noop!(
-			OmniAccount::make_identity_public(
+			OmniAccount::dispatch_as_omni_account(
 				RuntimeOrigin::signed(tee_signer.clone()),
-				who.clone(),
-				identity_hash,
-				public_identity.clone()
+				who_identity_hash,
+				call
 			),
-			Error::<TestRuntime>::UnknownIDGraph
+			Error::<TestRuntime>::IdentityNotFound
 		);
 
 		assert_ok!(OmniAccount::link_identity(
 			RuntimeOrigin::signed(tee_signer.clone()),
-			who.clone(),
+			who_identity,
 			IDGraphMember { id: private_identity.clone(), hash: identity_hash },
 			None
 		));
@@ -513,14 +542,22 @@ fn make_identity_public_identity_not_found_works() {
 		let other_identity_hash =
 			H256::from(blake2_256(&charlie_identity.to_did().unwrap().encode()));
 
-		assert_noop!(
-			OmniAccount::make_identity_public(
-				RuntimeOrigin::signed(tee_signer),
+		let call = make_identity_public_call(other_identity_hash, other_identity);
+		assert_ok!(OmniAccount::dispatch_as_omni_account(
+			RuntimeOrigin::signed(tee_signer.clone()),
+			who_identity_hash,
+			call
+		));
+		System::assert_has_event(
+			Event::DispatchedAsOmniAccount {
 				who,
-				other_identity_hash,
-				other_identity,
-			),
-			Error::<TestRuntime>::IdentityNotFound
+				result: Err(DispatchError::Module(ModuleError {
+					index: 5,
+					error: [2, 0, 0, 0],
+					message: Some("IdentityNotFound"),
+				})),
+			}
+			.into(),
 		);
 	});
 }
@@ -529,26 +566,36 @@ fn make_identity_public_identity_not_found_works() {
 fn make_identity_public_identity_is_private_check_works() {
 	new_test_ext().execute_with(|| {
 		let tee_signer = get_tee_signer();
-		let who = Identity::from(alice());
+		let who = alice();
+		let who_identity = Identity::from(who.clone());
+		let who_identity_hash = who_identity.hash().unwrap();
 
 		let private_identity = MemberIdentity::Private(vec![1, 2, 3]);
 		let identity_hash = Identity::from(bob()).hash().unwrap();
 
 		assert_ok!(OmniAccount::link_identity(
 			RuntimeOrigin::signed(tee_signer.clone()),
-			who.clone(),
+			who_identity,
 			IDGraphMember { id: private_identity.clone(), hash: identity_hash },
 			None
 		));
 
-		assert_noop!(
-			OmniAccount::make_identity_public(
-				RuntimeOrigin::signed(tee_signer),
+		let call = make_identity_public_call(identity_hash, private_identity);
+		assert_ok!(OmniAccount::dispatch_as_omni_account(
+			RuntimeOrigin::signed(tee_signer.clone()),
+			who_identity_hash,
+			call
+		));
+		System::assert_has_event(
+			Event::DispatchedAsOmniAccount {
 				who,
-				identity_hash,
-				private_identity,
-			),
-			Error::<TestRuntime>::IdentityIsPrivate
+				result: Err(DispatchError::Module(ModuleError {
+					index: 5,
+					error: [5, 0, 0, 0],
+					message: Some("IdentityIsPrivate"),
+				})),
+			}
+			.into(),
 		);
 	});
 }

--- a/parachain/runtime/common/Cargo.toml
+++ b/parachain/runtime/common/Cargo.toml
@@ -50,6 +50,7 @@ cumulus-test-relay-sproof-builder = { workspace = true, optional = true }
 pallet-asset-manager = { workspace = true }
 pallet-extrinsic-filter = { workspace = true }
 pallet-group = { workspace = true }
+pallet-omni-account = { workspace = true }
 pallet-teebag = { workspace = true }
 
 [features]
@@ -89,6 +90,7 @@ std = [
     "core-primitives/std",
     "pallet-asset-manager/std",
     "pallet-extrinsic-filter/std",
+    "pallet-omni-account/std",
     "pallet-teebag/std",
     "orml-xtokens/std",
 ]

--- a/parachain/runtime/common/src/lib.rs
+++ b/parachain/runtime/common/src/lib.rs
@@ -327,3 +327,5 @@ where
 		Ok(frame_system::RawOrigin::Signed(signer).into())
 	}
 }
+
+pub type EnsureOmniAccount = pallet_omni_account::EnsureOmniAccount<AccountId>;

--- a/parachain/runtime/litentry/Cargo.toml
+++ b/parachain/runtime/litentry/Cargo.toml
@@ -170,6 +170,7 @@ runtime-benchmarks = [
     "cumulus-pallet-parachain-system/runtime-benchmarks",
     "cumulus-pallet-xcmp-queue/runtime-benchmarks",
     "pallet-score-staking/runtime-benchmarks",
+    "pallet-omni-account/runtime-benchmarks",
 ]
 std = [
     "parity-scale-codec/std",
@@ -255,6 +256,7 @@ std = [
     "pallet-bridge-transfer/std",
     "pallet-extrinsic-filter/std",
     "pallet-bitacross/std",
+    "pallet-omni-account/std",
     "pallet-identity-management/std",
     "pallet-score-staking/std",
     "pallet-teebag/std",
@@ -315,4 +317,5 @@ try-runtime = [
     "pallet-xcm/try-runtime",
     "parachain-info/try-runtime",
     "pallet-score-staking/try-runtime",
+    "pallet-omni-account/try-runtime",
 ]

--- a/parachain/runtime/litentry/src/lib.rs
+++ b/parachain/runtime/litentry/src/lib.rs
@@ -1319,7 +1319,8 @@ impl Contains<RuntimeCall> for NormalModeFilter {
 			RuntimeCall::AssetsHandler(_) |
 			RuntimeCall::Bitacross(_) |
 			RuntimeCall::EvmAssertions(_) |
-			RuntimeCall::ScoreStaking(_)
+			RuntimeCall::ScoreStaking(_) |
+			RuntimeCall::OmniAccount(_)
 		)
 	}
 }

--- a/parachain/runtime/litentry/src/lib.rs
+++ b/parachain/runtime/litentry/src/lib.rs
@@ -66,13 +66,13 @@ pub use runtime_common::currency::*;
 use runtime_common::{
 	impl_runtime_transaction_payment_fees, prod_or_fast, BlockHashCount, BlockLength,
 	CouncilInstance, CouncilMembershipInstance, DeveloperCommitteeInstance,
-	DeveloperCommitteeMembershipInstance, EnsureEnclaveSigner, EnsureRootOrAllCouncil,
-	EnsureRootOrAllTechnicalCommittee, EnsureRootOrHalfCouncil, EnsureRootOrHalfTechnicalCommittee,
-	EnsureRootOrTwoThirdsCouncil, EnsureRootOrTwoThirdsTechnicalCommittee,
-	IMPExtrinsicWhitelistInstance, NegativeImbalance, RuntimeBlockWeights, SlowAdjustingFeeUpdate,
-	TechnicalCommitteeInstance, TechnicalCommitteeMembershipInstance,
-	VCMPExtrinsicWhitelistInstance, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, WEIGHT_PER_GAS,
-	WEIGHT_TO_FEE_FACTOR,
+	DeveloperCommitteeMembershipInstance, EnsureEnclaveSigner, EnsureOmniAccount,
+	EnsureRootOrAllCouncil, EnsureRootOrAllTechnicalCommittee, EnsureRootOrHalfCouncil,
+	EnsureRootOrHalfTechnicalCommittee, EnsureRootOrTwoThirdsCouncil,
+	EnsureRootOrTwoThirdsTechnicalCommittee, IMPExtrinsicWhitelistInstance, NegativeImbalance,
+	RuntimeBlockWeights, SlowAdjustingFeeUpdate, TechnicalCommitteeInstance,
+	TechnicalCommitteeMembershipInstance, VCMPExtrinsicWhitelistInstance, MAXIMUM_BLOCK_WEIGHT,
+	NORMAL_DISPATCH_RATIO, WEIGHT_PER_GAS, WEIGHT_TO_FEE_FACTOR,
 };
 use xcm_config::{XcmConfig, XcmOriginToTransactDispatchOrigin};
 
@@ -960,10 +960,13 @@ impl pallet_omni_account::AccountIdConverter<Runtime> for IdentityToAccountIdCon
 }
 
 impl pallet_omni_account::Config for Runtime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type TEECallOrigin = EnsureEnclaveSigner<Runtime>;
 	type MaxIDGraphLength = ConstU32<64>;
 	type AccountIdConverter = IdentityToAccountIdConverter;
+	type OmniAccountOrigin = EnsureOmniAccount;
 }
 
 impl pallet_bitacross::Config for Runtime {

--- a/parachain/runtime/paseo/Cargo.toml
+++ b/parachain/runtime/paseo/Cargo.toml
@@ -173,6 +173,7 @@ runtime-benchmarks = [
     "pallet-vc-management/runtime-benchmarks",
     "pallet-account-fix/runtime-benchmarks",
     "pallet-score-staking/runtime-benchmarks",
+    "pallet-omni-account/runtime-benchmarks",
 ]
 std = [
     "parity-scale-codec/std",
@@ -266,6 +267,7 @@ std = [
     "pallet-extrinsic-filter/std",
     "pallet-group/std",
     "pallet-identity-management/std",
+    "pallet-omni-account/std",
     "pallet-score-staking/std",
     "pallet-teebag/std",
     "pallet-vc-management/std",
@@ -327,4 +329,5 @@ try-runtime = [
     "pallet-vesting/try-runtime",
     "pallet-xcm/try-runtime",
     "parachain-info/try-runtime",
+    "pallet-omni-account/try-runtime",
 ]

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -77,7 +77,7 @@ pub use runtime_common::currency::*;
 use runtime_common::{
 	impl_runtime_transaction_payment_fees, prod_or_fast, BlockHashCount, BlockLength,
 	CouncilInstance, CouncilMembershipInstance, DeveloperCommitteeInstance,
-	DeveloperCommitteeMembershipInstance, EnsureRootOrAllCouncil,
+	DeveloperCommitteeMembershipInstance, EnsureOmniAccount, EnsureRootOrAllCouncil,
 	EnsureRootOrAllTechnicalCommittee, EnsureRootOrHalfCouncil, EnsureRootOrHalfTechnicalCommittee,
 	EnsureRootOrTwoThirdsCouncil, EnsureRootOrTwoThirdsTechnicalCommittee,
 	IMPExtrinsicWhitelistInstance, NegativeImbalance, RuntimeBlockWeights, SlowAdjustingFeeUpdate,
@@ -1003,10 +1003,13 @@ impl pallet_omni_account::AccountIdConverter<Runtime> for IdentityToAccountIdCon
 }
 
 impl pallet_omni_account::Config for Runtime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type TEECallOrigin = EnsureEnclaveSigner<Runtime>;
 	type MaxIDGraphLength = ConstU32<64>;
 	type AccountIdConverter = IdentityToAccountIdConverter;
+	type OmniAccountOrigin = EnsureOmniAccount;
 }
 
 impl pallet_bitacross::Config for Runtime {

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -1380,7 +1380,8 @@ impl Contains<RuntimeCall> for NormalModeFilter {
 			RuntimeCall::AssetsHandler(_) |
 			RuntimeCall::Bitacross(_) |
 			RuntimeCall::EvmAssertions(_) |
-			RuntimeCall::ScoreStaking(_)
+			RuntimeCall::ScoreStaking(_) |
+			RuntimeCall::OmniAccount(_)
 		)
 	}
 }

--- a/parachain/runtime/rococo/Cargo.toml
+++ b/parachain/runtime/rococo/Cargo.toml
@@ -173,6 +173,7 @@ runtime-benchmarks = [
     "pallet-vc-management/runtime-benchmarks",
     "pallet-account-fix/runtime-benchmarks",
     "pallet-score-staking/runtime-benchmarks",
+    "pallet-omni-account/runtime-benchmarks",
 ]
 std = [
     "parity-scale-codec/std",
@@ -266,6 +267,7 @@ std = [
     "pallet-extrinsic-filter/std",
     "pallet-group/std",
     "pallet-identity-management/std",
+    "pallet-omni-account/std",
     "pallet-score-staking/std",
     "pallet-teebag/std",
     "pallet-vc-management/std",
@@ -327,4 +329,5 @@ try-runtime = [
     "pallet-vesting/try-runtime",
     "pallet-xcm/try-runtime",
     "parachain-info/try-runtime",
+    "pallet-omni-account/try-runtime",
 ]

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -76,7 +76,7 @@ pub use runtime_common::currency::*;
 use runtime_common::{
 	impl_runtime_transaction_payment_fees, prod_or_fast, BlockHashCount, BlockLength,
 	CouncilInstance, CouncilMembershipInstance, DeveloperCommitteeInstance,
-	DeveloperCommitteeMembershipInstance, EnsureRootOrAllCouncil,
+	DeveloperCommitteeMembershipInstance, EnsureOmniAccount, EnsureRootOrAllCouncil,
 	EnsureRootOrAllTechnicalCommittee, EnsureRootOrHalfCouncil, EnsureRootOrHalfTechnicalCommittee,
 	EnsureRootOrTwoThirdsCouncil, EnsureRootOrTwoThirdsTechnicalCommittee,
 	IMPExtrinsicWhitelistInstance, NegativeImbalance, RuntimeBlockWeights, SlowAdjustingFeeUpdate,
@@ -1002,10 +1002,13 @@ impl pallet_omni_account::AccountIdConverter<Runtime> for IdentityToAccountIdCon
 }
 
 impl pallet_omni_account::Config for Runtime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type TEECallOrigin = EnsureEnclaveSigner<Runtime>;
 	type MaxIDGraphLength = ConstU32<64>;
 	type AccountIdConverter = IdentityToAccountIdConverter;
+	type OmniAccountOrigin = EnsureOmniAccount;
 }
 
 impl pallet_bitacross::Config for Runtime {

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -1379,7 +1379,8 @@ impl Contains<RuntimeCall> for NormalModeFilter {
 			RuntimeCall::AssetsHandler(_) |
 			RuntimeCall::Bitacross(_) |
 			RuntimeCall::EvmAssertions(_) |
-			RuntimeCall::ScoreStaking(_)
+			RuntimeCall::ScoreStaking(_) |
+			RuntimeCall::OmniAccount(_)
 		)
 	}
 }


### PR DESCRIPTION
### Context

As topic, other with two extra extrinsics:
- `dispatch_as_omni_account`
- `dispatch_as_signed`

```
// 1. to decouple `TEECallOrigin` and extrinsic that should be sent from `OmniAccount` origin only
// 2. allow other pallets to specify ensure_origin using this origin
// 3. leave room for more delicate control over OmniAccount in the future (e.g. multisig-like control)
```