### PR TITLE
Adding OmniAccount core primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
+ "sp-core-hashing",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -13,7 +13,7 @@ strum_macros = { workspace = true }
 frame-support = { workspace = true }
 pallet-evm = { workspace = true }
 scale-info = { workspace = true }
-sp-core = { workspace = true }
+sp-core = { workspace = true, features = ["full_crypto"] }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -13,7 +13,8 @@ strum_macros = { workspace = true }
 frame-support = { workspace = true }
 pallet-evm = { workspace = true }
 scale-info = { workspace = true }
-sp-core = { workspace = true, features = ["full_crypto"] }
+sp-core = { workspace = true }
+sp-core-hashing = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }

--- a/primitives/core/src/identity.rs
+++ b/primitives/core/src/identity.rs
@@ -451,9 +451,8 @@ impl Identity {
 		))
 	}
 
-	pub fn hash(&self) -> Result<H256, &'static str> {
-		let did = self.to_did()?;
-		Ok(H256::from(blake2_256(&did.encode())))
+	pub fn hash(&self) -> H256 {
+		self.using_encoded(blake2_256).into()
 	}
 }
 
@@ -751,13 +750,5 @@ mod tests {
 		let did = format!("did:litentry:solana:{}", address);
 		assert_eq!(identity.to_did().unwrap(), did.as_str());
 		assert_eq!(Identity::from_did(did.as_str()).unwrap(), identity);
-	}
-
-	#[test]
-	fn test_identity_hash() {
-		let identity = Identity::Substrate([0; 32].into());
-		let did_str = "did:litentry:substrate:0x0000000000000000000000000000000000000000000000000000000000000000";
-		let hash = identity.hash().unwrap();
-		assert_eq!(hash, H256::from(blake2_256(&did_str.encode())));
 	}
 }

--- a/primitives/core/src/identity.rs
+++ b/primitives/core/src/identity.rs
@@ -13,9 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
-
-pub extern crate alloc;
-
 use crate::{
 	assertion::network::{
 		all_bitcoin_web3networks, all_evm_web3networks, all_solana_web3networks,
@@ -33,7 +30,7 @@ use parity_scale_codec::{Decode, Encode, Error, Input, MaxEncodedLen};
 use scale_info::{meta_type, Type, TypeDefSequence, TypeInfo};
 use sp_core::{
 	crypto::{AccountId32, ByteArray},
-	ecdsa, ed25519, sr25519, H160,
+	ecdsa, ed25519, sr25519, H160, H256,
 };
 use sp_io::hashing::blake2_256;
 use sp_runtime::{
@@ -453,6 +450,11 @@ impl Identity {
 			}
 		))
 	}
+
+	pub fn hash(&self) -> Result<H256, &'static str> {
+		let did = self.to_did()?;
+		Ok(H256::from(blake2_256(&did.encode())))
+	}
 }
 
 impl From<ed25519::Public> for Identity {
@@ -749,5 +751,13 @@ mod tests {
 		let did = format!("did:litentry:solana:{}", address);
 		assert_eq!(identity.to_did().unwrap(), did.as_str());
 		assert_eq!(Identity::from_did(did.as_str()).unwrap(), identity);
+	}
+
+	#[test]
+	fn test_identity_hash() {
+		let identity = Identity::Substrate([0; 32].into());
+		let did_str = "did:litentry:substrate:0x0000000000000000000000000000000000000000000000000000000000000000";
+		let hash = identity.hash().unwrap();
+		assert_eq!(hash, H256::from(blake2_256(&did_str.encode())));
 	}
 }

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -17,6 +17,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::identity_op)]
 
+extern crate alloc;
+
 mod error;
 pub use error::*;
 
@@ -28,6 +30,9 @@ pub use assertion::Assertion;
 
 pub mod identity;
 pub use identity::*;
+
+pub mod omni_account;
+pub use omni_account::*;
 
 use sp_runtime::{traits::ConstU32, BoundedVec};
 

--- a/primitives/core/src/omni_account.rs
+++ b/primitives/core/src/omni_account.rs
@@ -1,0 +1,48 @@
+use crate::{Hash, Identity};
+use alloc::vec::Vec;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_core::blake2_256;
+use sp_runtime::{BoundedVec, RuntimeDebug};
+
+#[derive(Encode, Decode, TypeInfo, Clone, PartialEq, Eq, RuntimeDebug)]
+pub struct MemberAccount {
+	pub id: MemberIdentity,
+	pub hash: Hash,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, PartialEq, Eq, RuntimeDebug)]
+pub enum MemberIdentity {
+	Public(Identity),
+	Private(Vec<u8>),
+}
+
+impl MemberIdentity {
+	pub fn is_public(&self) -> bool {
+		matches!(self, Self::Public(..))
+	}
+}
+
+impl From<Identity> for MemberIdentity {
+	fn from(identity: Identity) -> Self {
+		Self::Public(identity)
+	}
+}
+
+pub trait GetAccountStoreHash {
+	fn hash(&self) -> Hash;
+}
+
+impl<T> GetAccountStoreHash for BoundedVec<MemberAccount, T> {
+	fn hash(&self) -> Hash {
+		let hashes: Vec<Hash> = self.iter().map(|member| member.hash).collect();
+		hashes.using_encoded(blake2_256).into()
+	}
+}
+
+impl GetAccountStoreHash for Vec<MemberAccount> {
+	fn hash(&self) -> Hash {
+		let hashes: Vec<Hash> = self.iter().map(|member| member.hash).collect();
+		hashes.using_encoded(blake2_256).into()
+	}
+}

--- a/primitives/core/src/omni_account.rs
+++ b/primitives/core/src/omni_account.rs
@@ -2,7 +2,7 @@ use crate::{Hash, Identity};
 use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
-use sp_core::blake2_256;
+use sp_core_hashing::blake2_256;
 use sp_runtime::{BoundedVec, RuntimeDebug};
 
 #[derive(Encode, Decode, TypeInfo, Clone, PartialEq, Eq, RuntimeDebug)]


### PR DESCRIPTION
These types will be shared between the omni-account pallet and the identity worker