### PR TITLE
chore: P-1044 remove all di identity ts tests from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,15 +709,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_name: lit-di-substrate-identity-test
-          - test_name: lit-di-evm-identity-test
-          - test_name: lit-di-bitcoin-identity-test
-          - test_name: lit-di-solana-identity-test
           - test_name: lit-dr-vc-test
           - test_name: lit-parentchain-nonce
           - test_name: lit-test-failed-parentchain-extrinsic
-          - test_name: lit-twitter-identity-test
-          - test_name: lit-discord-identity-test
     name: ${{ matrix.test_name }}
     steps:
       - uses: actions/checkout@v4
@@ -785,10 +779,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_name: lit-di-bitcoin-identity-multiworker-test
-          - test_name: lit-di-evm-identity-multiworker-test
-          - test_name: lit-di-solana-identity-multiworker-test
-          - test_name: lit-di-substrate-identity-multiworker-test
           - test_name: lit-dr-vc-multiworker-test
           - test_name: lit-resume-worker
     name: ${{ matrix.test_name }}


### PR DESCRIPTION
so the followup [PR](https://github.com/litentry/litentry-parachain/pull/3113) to remove these ts tests will pass ci checks.


### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


