### PR TITLE
Shorten parachain-staking schedule delay

### DIFF
--- a/parachain/runtime/litentry/src/lib.rs
+++ b/parachain/runtime/litentry/src/lib.rs
@@ -810,15 +810,15 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Blocks per round
 	type DefaultBlocksPerRound = Period;
 	/// Rounds before the collator leaving the candidates request can be executed
-	type LeaveCandidatesDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type LeaveCandidatesDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the candidate bond increase/decrease can be executed
-	type CandidateBondLessDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type CandidateBondLessDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator exit can be executed
-	type LeaveDelegatorsDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type LeaveDelegatorsDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator revocation can be executed
-	type RevokeDelegationDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type RevokeDelegationDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator bond increase/decrease can be executed
-	type DelegationBondLessDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type DelegationBondLessDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the reward is paid
 	type RewardPaymentDelay = ConstU32<2>;
 	/// Minimum collators selected per round, default at genesis and minimum forever after

--- a/parachain/runtime/litentry/src/lib.rs
+++ b/parachain/runtime/litentry/src/lib.rs
@@ -221,7 +221,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("litentry-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9201,
+	spec_version: 9202,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -854,15 +854,15 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Blocks per round
 	type DefaultBlocksPerRound = ConstU32<{ prod_or_fast!(2 * MINUTES, 2) }>;
 	/// Rounds before the collator leaving the candidates request can be executed
-	type LeaveCandidatesDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type LeaveCandidatesDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the candidate bond increase/decrease can be executed
-	type CandidateBondLessDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type CandidateBondLessDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator exit can be executed
-	type LeaveDelegatorsDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type LeaveDelegatorsDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator revocation can be executed
-	type RevokeDelegationDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type RevokeDelegationDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator bond increase/decrease can be executed
-	type DelegationBondLessDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type DelegationBondLessDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the reward is paid
 	type RewardPaymentDelay = ConstU32<2>;
 	/// Minimum collators selected per round, default at genesis and minimum forever after

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -227,7 +227,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("paseo-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9201,
+	spec_version: 9202,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -853,15 +853,15 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Blocks per round
 	type DefaultBlocksPerRound = ConstU32<{ prod_or_fast!(2 * MINUTES, 2) }>;
 	/// Rounds before the collator leaving the candidates request can be executed
-	type LeaveCandidatesDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type LeaveCandidatesDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the candidate bond increase/decrease can be executed
-	type CandidateBondLessDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type CandidateBondLessDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator exit can be executed
-	type LeaveDelegatorsDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type LeaveDelegatorsDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator revocation can be executed
-	type RevokeDelegationDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type RevokeDelegationDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the delegator bond increase/decrease can be executed
-	type DelegationBondLessDelay = ConstU32<{ prod_or_fast!(28, 1) }>;
+	type DelegationBondLessDelay = ConstU32<{ prod_or_fast!(8, 1) }>;
 	/// Rounds before the reward is paid
 	type RewardPaymentDelay = ConstU32<2>;
 	/// Minimum collators selected per round, default at genesis and minimum forever after

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -226,7 +226,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("rococo-parachain"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9201,
+	spec_version: 9202,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
### Context

We shorten the parachain-staking schedule delay to 2 days (was: 7 days) after talking with Hanwen. It will help achieve a stronger liquidity.

It's primarily related to bondLess, revoke(unstake) from users' perspective.

The already in-schedule requests aren't affected.

