### PR TITLE
build flag is not passed inside enclave-runtime for bitacross

### DIFF
--- a/tee-worker/bitacross/Makefile
+++ b/tee-worker/bitacross/Makefile
@@ -223,7 +223,7 @@ endif
 enclave:
 	@echo
 	@echo "Building the enclave"
-	$(MAKE) -C ./enclave-runtime/
+	$(MAKE) -C ./enclave-runtime/ RA_METHOD=$(RA_METHOD) WORKER_DEV=$(WORKER_DEV)
 
 .git/hooks/pre-commit: .githooks/pre-commit
 	@echo "Installing git hooks"

--- a/tee-worker/bitacross/enclave-runtime/Makefile
+++ b/tee-worker/bitacross/enclave-runtime/Makefile
@@ -29,6 +29,8 @@
 ######## Worker Feature Settings ########
 # Set offchain-worker as default feature mode
 WORKER_MODE ?= offchain-worker
+WORKER_DEV ?= 0
+RA_METHOD ?= dcap
 
 Rust_Enclave_Name := libenclave.a
 Rust_Enclave_Files := $(wildcard src/*.rs) $(wildcard ../stf/src/*.rs)
@@ -46,6 +48,14 @@ ifeq ($(SGX_PRODUCTION), 1)
 	ENCLAVE_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 else
 	ENCLAVE_FEATURES = --features=test,development,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+endif
+
+ifeq ($(WORKER_DEV), 1)
+	ADDITIONAL_FEATURES := $(ADDITIONAL_FEATURES),development
+endif
+
+ifeq ($(RA_METHOD), dcap)
+    ADDITIONAL_FEATURES := $(ADDITIONAL_FEATURES),dcap
 endif
 
 .PHONY: all

--- a/tee-worker/bitacross/enclave-runtime/src/lib.rs
+++ b/tee-worker/bitacross/enclave-runtime/src/lib.rs
@@ -153,6 +153,11 @@ pub unsafe extern "C" fn init(
 		}
 	);
 
+	#[cfg(feature = "dcap")]
+	info!("  DCAP is enabled within enclave");
+	#[cfg(not(feature = "dcap"))]
+	info!("  DCAP is disabled within enclave");
+
 	let mu_ra_url =
 		match String::decode(&mut slice::from_raw_parts(mu_ra_addr, mu_ra_addr_size as usize))
 			.map_err(Error::Codec)

--- a/tee-worker/identity/enclave-runtime/Makefile
+++ b/tee-worker/identity/enclave-runtime/Makefile
@@ -30,6 +30,7 @@
 # Set sidechain as default feature mode
 WORKER_MODE ?= sidechain
 WORKER_DEV ?= 0
+RA_METHOD ?= dcap
 WORKER_ENV_DATA_PROVIDERS_CONFIG ?= 0
 
 Rust_Enclave_Name := libenclave.a


### PR DESCRIPTION
as title, a small, but important PR. Similar to #3138 . 


