### PR TITLE
change the max heap size from 512MB to 2GB

### DIFF
--- a/tee-worker/identity/enclave-runtime/Enclave.config.production.xml
+++ b/tee-worker/identity/enclave-runtime/Enclave.config.production.xml
@@ -3,7 +3,7 @@
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
-  <HeapMaxSize>0x20000000</HeapMaxSize>
+  <HeapMaxSize>0x80000000</HeapMaxSize>
   <TCSNum>1024</TCSNum>
   <TCSPolicy>0</TCSPolicy> <!-- 0 = Thread Control Structure (TCS) is bound to the untrusted thread -->
   <DisableDebug>1</DisableDebug>


### PR DESCRIPTION
as title, a minor PR to address recent identity hub worker crash issue (because of memory overflow). 
For our servers, it's safe to extend it to 2GB.

Some ref docs:
https://www.intel.com/content/www/us/en/support/articles/000089548/software/intel-security-products.html
https://www.intel.com/content/www/us/en/support/articles/000089551/software/intel-security-products.html
https://www.intel.com/content/www/us/en/support/articles/000088062/software/intel-security-products.html


