### PR TITLE
client-sdk: add OmniAccount helpers

### DIFF
--- a/tee-worker/identity/client-api/parachain-api/README.md
+++ b/tee-worker/identity/client-api/parachain-api/README.md
@@ -15,9 +15,15 @@ These types were auto generated using [Polkadot.js Type Generation](https://polk
 2. Extend and decorate the API's types with:
 
     ```typescript
-    import { identity, vc, trusted_operations, sidechain } from "parachain-api";
+    import { identity, vc, trusted_operations, sidechain, omniAccount } from "parachain-api";
 
-    const types = { ...identity.types, ...vc.types, ...trusted_operations.types, ...sidechain.types };
+    const types = {
+        ...identity.types,
+        ...vc.types,
+        ...omniAccount.types,
+        ...trusted_operations.types,
+        ...sidechain.types,
+    };
 
     const api = await ApiPromise.create({
         provider,

--- a/tee-worker/identity/client-sdk/packages/client-sdk/CHANGELOG.md
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--   Add OmniAccount requestors for `remark`, `transferNative`
+-   Add OmniAccount requestors for `createAccountStore`, `remark`, `transferNative`, `transferEthereum`, and `callEthereum`.
 
 ## 2024-10-14
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/CHANGELOG.md
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--   Add a request method for OmniAccount's `Intent` requests.
+-   Add OmniAccount requestors for `remark`, `transferNative`
 
 ## 2024-10-14
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/CHANGELOG.md
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   Add a request method for OmniAccount's `Intent` requests.
+
 ## 2024-10-14
 
 Initial version. Merge [@litentry/enclave](https://www.npmjs.com/package/@litentry/enclave) and [@litentry/vc-sdk](https://www.npmjs.com/package/@litentry/vc-sdk) into this one.

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@litentry/client-sdk",
   "description": "This package provides helpers for dApps to interact with the Litentry Protocol.",
-  "version": "1.0.0",
+  "version": "1.0.0-next.0",
   "license": "GPL-3.0-or-later",
   "dependencies": {},
   "devDependencies": {

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -8,8 +8,8 @@
     "@polkadot/rpc-provider": "^10.9.1"
   },
   "peerDependencies": {
-    "@litentry/parachain-api": "0.9.20-next.3",
-    "@litentry/sidechain-api": "0.9.20-next.3",
+    "@litentry/parachain-api": "0.9.20-next.4",
+    "@litentry/sidechain-api": "0.9.20-next.4",
     "@litentry/chaindata": "*",
     "@polkadot/api": "^10.9.1",
     "@polkadot/types": "^10.9.1",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -8,8 +8,8 @@
     "@polkadot/rpc-provider": "^10.9.1"
   },
   "peerDependencies": {
-    "@litentry/parachain-api": "0.9.20-4.1",
-    "@litentry/sidechain-api": "0.9.20-4",
+    "@litentry/parachain-api": "0.9.20-next.3",
+    "@litentry/sidechain-api": "0.9.20-next.3",
     "@litentry/chaindata": "*",
     "@polkadot/api": "^10.9.1",
     "@polkadot/types": "^10.9.1",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -8,8 +8,8 @@
     "@polkadot/rpc-provider": "^10.9.1"
   },
   "peerDependencies": {
-    "@litentry/parachain-api": "0.9.20-next.4",
-    "@litentry/sidechain-api": "0.9.20-next.4",
+    "@litentry/parachain-api": "0.9.20-next.5",
+    "@litentry/sidechain-api": "0.9.20-next.5",
     "@litentry/chaindata": "*",
     "@polkadot/api": "^10.9.1",
     "@polkadot/types": "^10.9.1",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/index.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/index.ts
@@ -19,9 +19,9 @@ export { ID_GRAPH_STRUCT } from './lib/type-creators/id-graph';
 // vc
 export {
   validateVc,
-  VerifiableCredentialLike,
+  type VerifiableCredentialLike,
 } from './lib/vc-validator/validator';
-export {
+export type {
   ValidationResultDetail,
   ValidationResult,
 } from './lib/vc-validator/validator.types';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/call-ethereum.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/call-ethereum.request.ts
@@ -1,0 +1,108 @@
+import { assert, hexToU8a } from '@polkadot/util';
+import { randomAsHex } from '@polkadot/util-crypto';
+
+import type { ApiPromise } from '@polkadot/api';
+import type {
+  LitentryIdentity,
+  WorkerRpcReturnValue,
+} from '@litentry/parachain-api';
+
+import { enclave } from '../enclave';
+import { createPayloadToSign } from '../util/create-payload-to-sign';
+import { createTrustedCallType } from '../type-creators/trusted-call';
+import { createRequestType } from '../type-creators/request';
+
+import type { JsonRpcRequest } from '../util/types';
+import type { U8aLike } from '@polkadot/util/types';
+
+/**
+ * OmniAccount: Call an Ethereum contract.
+ */
+export async function callEthereum(
+  /** Litentry Parachain API instance from Polkadot.js */
+  api: ApiPromise,
+  data: {
+    /** The user's omniAccount.  Use `createLitentryIdentityType` helper to create this struct */
+    omniAccount: LitentryIdentity;
+    /** The user's account.  Use `createLitentryIdentityType` helper to create this struct */
+    who: LitentryIdentity;
+    /** Ethereum contract address */
+    address: string;
+    /** Contract input data */
+    input: U8aLike;
+  }
+): Promise<{
+  payloadToSign: string;
+  txHash: string;
+  send: (args: { signedPayload: string }) => Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }>;
+}> {
+  const { who, omniAccount } = data;
+
+  assert(omniAccount.isSubstrate, 'OmniAccount must be a Substrate identity');
+
+  const shard = await enclave.getShard(api);
+  const shardU8 = hexToU8a(shard);
+  const txHash = randomAsHex();
+
+  const { call } = await createTrustedCallType(api.registry, {
+    method: 'request_intent',
+    params: {
+      who,
+      intent: api.createType('Intent', {
+        CallEthereum: api.createType('IntentCallEthereum', {
+          address: data.address,
+          input: data.input,
+        }),
+      }),
+    },
+  });
+
+  const nonce = await api.rpc.system.accountNextIndex(omniAccount.asSubstrate);
+
+  const payloadToSign = createPayloadToSign({
+    who,
+    call,
+    nonce,
+    shard: shardU8,
+  });
+
+  const send = async (args: {
+    signedPayload: string;
+  }): Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }> => {
+    // prepare and encrypt request
+
+    const request = await createRequestType(api, {
+      signer: who,
+      signature: args.signedPayload,
+      call,
+      nonce,
+      shard: shardU8,
+    });
+
+    // send the request to the Enclave
+    const rpcRequest: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      method: 'author_submitNativeRequest',
+      params: [request.toHex()],
+    };
+
+    const enclaveResult = await enclave.send(api, rpcRequest);
+
+    return {
+      txHash,
+      response: enclaveResult,
+    };
+  };
+
+  return {
+    txHash,
+    payloadToSign,
+    send,
+  };
+}

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/create-account-store.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/create-account-store.request.ts
@@ -1,0 +1,97 @@
+import { hexToU8a } from '@polkadot/util';
+import { randomAsHex } from '@polkadot/util-crypto';
+
+import type { ApiPromise } from '@polkadot/api';
+import type {
+  LitentryIdentity,
+  WorkerRpcReturnValue,
+} from '@litentry/parachain-api';
+
+import { enclave } from '../enclave';
+import { createPayloadToSign } from '../util/create-payload-to-sign';
+import { createTrustedCallType } from '../type-creators/trusted-call';
+import { createRequestType } from '../type-creators/request';
+
+import type { JsonRpcRequest } from '../util/types';
+
+/**
+ * OmniAccount: Create the OmniAccount for the given Identity
+ */
+export async function createAccountStore(
+  /** Litentry Parachain API instance from Polkadot.js */
+  api: ApiPromise,
+  data: {
+    /** The user's OmniAccount.  Use `createLitentryIdentityType` helper to create this struct */
+    omniAccount: LitentryIdentity;
+    /** The user's account.  Use `createLitentryIdentityType` helper to create this struct */
+    who: LitentryIdentity;
+  }
+): Promise<{
+  payloadToSign: string;
+  txHash: string;
+  send: (args: { signedPayload: string }) => Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }>;
+}> {
+  const { who, omniAccount } = data;
+
+  const shard = await enclave.getShard(api);
+  const shardU8 = hexToU8a(shard);
+  const txHash = randomAsHex();
+
+  const { call } = await createTrustedCallType(api.registry, {
+    method: 'create_account_store',
+    params: {
+      who,
+    },
+  });
+
+  const nonce = await api.rpc.system.accountNextIndex(
+    omniAccount.asSubstrate.toHex()
+  );
+
+  const payloadToSign = createPayloadToSign({
+    who,
+    call,
+    nonce,
+    shard: shardU8,
+  });
+
+  const send = async (args: {
+    signedPayload: string;
+  }): Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }> => {
+    // prepare and encrypt request
+
+    const request = await createRequestType(api, {
+      signer: who,
+      signature: args.signedPayload,
+      call,
+      nonce,
+      shard: shardU8,
+    });
+
+    // send the request to the Enclave
+    const rpcRequest: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      method: 'author_submitNativeRequest',
+      params: [request.toHex()],
+    };
+
+    const enclaveResult = await enclave.send(api, rpcRequest);
+
+    return {
+      txHash,
+      response: enclaveResult,
+    };
+  };
+
+  return {
+    txHash,
+    payloadToSign,
+    send,
+  };
+}

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/get-last-registered-enclave.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/get-last-registered-enclave.ts
@@ -1,8 +1,8 @@
 import type { ApiPromise } from '@polkadot/api';
 import { AccountId32 } from '@polkadot/types/interfaces';
 import type {
-  PalletTeebagEnclave,
-  PalletTeebagWorkerType,
+  CorePrimitivesTeebagTypesEnclave,
+  CorePrimitivesTeebagTypesWorkerType,
 } from '@polkadot/types/lookup';
 
 /**
@@ -10,8 +10,11 @@ import type {
  */
 export async function getLastRegisteredEnclave(
   api: ApiPromise,
-  workerType: PalletTeebagWorkerType['type'] = 'Identity'
-): Promise<{ account: AccountId32; enclave: PalletTeebagEnclave }> {
+  workerType: CorePrimitivesTeebagTypesWorkerType['type'] = 'Identity'
+): Promise<{
+  account: AccountId32;
+  enclave: CorePrimitivesTeebagTypesEnclave;
+}> {
   const identifiers = await api.query.teebag.enclaveIdentifier(workerType);
   const latestEnclaveId = identifiers[identifiers.length - 1];
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
@@ -4,6 +4,7 @@ export { setIdentityNetworks } from './set-identity-networks.request';
 export { requestBatchVC } from './request-batch-vc.request';
 export { remark } from './remark.request';
 export { transferNative } from './transfer-native.request';
+export { transferEthereum } from './transfer-ethereum.request';
 
 export { createAccountStore } from './create-account-store.request';
 export { getIdGraph } from './get-id-graph.request';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
@@ -5,6 +5,7 @@ export { requestBatchVC } from './request-batch-vc.request';
 export { remark } from './remark.request';
 export { transferNative } from './transfer-native.request';
 export { transferEthereum } from './transfer-ethereum.request';
+export { callEthereum } from './call-ethereum.request';
 
 export { createAccountStore } from './create-account-store.request';
 export { getIdGraph } from './get-id-graph.request';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
@@ -3,6 +3,7 @@ export { linkIdentityCallback } from './link-identity-callback.request';
 export { setIdentityNetworks } from './set-identity-networks.request';
 export { requestBatchVC } from './request-batch-vc.request';
 export { remark } from './remark.request';
+export { createAccountStore } from './create-account-store.request';
 export { getIdGraph } from './get-id-graph.request';
 export { getIdGraphHash } from './get-id-graph-hash';
 export { getLastRegisteredEnclave } from './get-last-registered-enclave';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
@@ -2,6 +2,7 @@ export { createChallengeCode, linkIdentity } from './link-identity.request';
 export { linkIdentityCallback } from './link-identity-callback.request';
 export { setIdentityNetworks } from './set-identity-networks.request';
 export { requestBatchVC } from './request-batch-vc.request';
+export { remark } from './remark.request';
 export { getIdGraph } from './get-id-graph.request';
 export { getIdGraphHash } from './get-id-graph-hash';
 export { getLastRegisteredEnclave } from './get-last-registered-enclave';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/index.ts
@@ -3,6 +3,8 @@ export { linkIdentityCallback } from './link-identity-callback.request';
 export { setIdentityNetworks } from './set-identity-networks.request';
 export { requestBatchVC } from './request-batch-vc.request';
 export { remark } from './remark.request';
+export { transferNative } from './transfer-native.request';
+
 export { createAccountStore } from './create-account-store.request';
 export { getIdGraph } from './get-id-graph.request';
 export { getIdGraphHash } from './get-id-graph-hash';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remark.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remark.request.ts
@@ -1,4 +1,4 @@
-import { hexToU8a, stringToHex } from '@polkadot/util';
+import { assert, hexToU8a, stringToHex } from '@polkadot/util';
 import { randomAsHex } from '@polkadot/util-crypto';
 
 import type { ApiPromise } from '@polkadot/api';
@@ -21,6 +21,8 @@ export async function remark(
   /** Litentry Parachain API instance from Polkadot.js */
   api: ApiPromise,
   data: {
+    /** The user's omniAccount.  Use `createLitentryIdentityType` helper to create this struct */
+    omniAccount: LitentryIdentity;
     /** The user's account.  Use `createLitentryIdentityType` helper to create this struct */
     who: LitentryIdentity;
     /** the message to be sent */
@@ -34,7 +36,7 @@ export async function remark(
     txHash: string;
   }>;
 }> {
-  const { who, message } = data;
+  const { who, message, omniAccount } = data;
 
   const shard = await enclave.getShard(api);
   const shardU8 = hexToU8a(shard);
@@ -50,8 +52,10 @@ export async function remark(
     },
   });
 
+  assert(omniAccount.isSubstrate, 'OmniAccount must be a Substrate identity');
+
   const nonce = await api.rpc.system.accountNextIndex(
-    who.asSubstrate.toHex() // who is OmniAccount, thus substrate
+    omniAccount.asSubstrate.toHex()
   );
 
   const payloadToSign = createPayloadToSign({

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remark.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remark.request.ts
@@ -21,8 +21,6 @@ export async function remark(
   /** Litentry Parachain API instance from Polkadot.js */
   api: ApiPromise,
   data: {
-    /** The signer's account.  Use `createLitentryIdentityType` helper to create this struct */
-    signer?: LitentryIdentity;
     /** The user's account.  Use `createLitentryIdentityType` helper to create this struct */
     who: LitentryIdentity;
     /** the message to be sent */
@@ -42,10 +40,7 @@ export async function remark(
   const shardU8 = hexToU8a(shard);
   const txHash = randomAsHex();
 
-  // identity to sign the requests
-  const signer = data.signer || who;
-
-  const { call, key } = await createTrustedCallType(api.registry, {
+  const { call } = await createTrustedCallType(api.registry, {
     method: 'request_intent',
     params: {
       who,

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remark.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remark.request.ts
@@ -1,0 +1,105 @@
+import { hexToU8a, stringToHex } from '@polkadot/util';
+import { randomAsHex } from '@polkadot/util-crypto';
+
+import type { ApiPromise } from '@polkadot/api';
+import type {
+  LitentryIdentity,
+  WorkerRpcReturnValue,
+} from '@litentry/parachain-api';
+
+import { enclave } from '../enclave';
+import { createPayloadToSign } from '../util/create-payload-to-sign';
+import { createTrustedCallType } from '../type-creators/trusted-call';
+import { createRequestType } from '../type-creators/request';
+
+import type { JsonRpcRequest } from '../util/types';
+
+/**
+ * OmniAccount: Make a remark
+ */
+export async function remark(
+  /** Litentry Parachain API instance from Polkadot.js */
+  api: ApiPromise,
+  data: {
+    /** The signer's account.  Use `createLitentryIdentityType` helper to create this struct */
+    signer?: LitentryIdentity;
+    /** The user's account.  Use `createLitentryIdentityType` helper to create this struct */
+    who: LitentryIdentity;
+    /** the message to be sent */
+    message: string;
+  }
+): Promise<{
+  payloadToSign: string;
+  txHash: string;
+  send: (args: { signedPayload: string }) => Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }>;
+}> {
+  const { who, message } = data;
+
+  const shard = await enclave.getShard(api);
+  const shardU8 = hexToU8a(shard);
+  const txHash = randomAsHex();
+
+  // identity to sign the requests
+  const signer = data.signer || who;
+
+  const { call, key } = await createTrustedCallType(api.registry, {
+    method: 'request_intent',
+    params: {
+      who,
+      intent: api.createType('Intent', {
+        SystemRemark: stringToHex(message),
+      }),
+    },
+  });
+
+  const nonce = await api.rpc.system.accountNextIndex(
+    who.asSubstrate.toHex() // who is OmniAccount, thus substrate
+  );
+
+  const payloadToSign = createPayloadToSign({
+    who,
+    call,
+    nonce,
+    shard: shardU8,
+  });
+
+  const send = async (args: {
+    signedPayload: string;
+  }): Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }> => {
+    // prepare and encrypt request
+
+    const request = await createRequestType(api, {
+      signer: who,
+      signature: args.signedPayload,
+      call,
+      nonce,
+      shard: shardU8,
+    });
+
+    // send the request to the Enclave
+    const rpcRequest: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      method: 'author_submitNativeRequest',
+      params: [request.toHex()],
+    };
+
+    const enclaveResult = await enclave.send(api, rpcRequest);
+
+    return {
+      txHash,
+      response: enclaveResult,
+    };
+  };
+
+  return {
+    txHash,
+    payloadToSign,
+    send,
+  };
+}

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-ethereum.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-ethereum.request.ts
@@ -1,0 +1,107 @@
+import { assert, hexToU8a } from '@polkadot/util';
+import { randomAsHex } from '@polkadot/util-crypto';
+
+import type { ApiPromise } from '@polkadot/api';
+import type {
+  LitentryIdentity,
+  WorkerRpcReturnValue,
+} from '@litentry/parachain-api';
+
+import { enclave } from '../enclave';
+import { createPayloadToSign } from '../util/create-payload-to-sign';
+import { createTrustedCallType } from '../type-creators/trusted-call';
+import { createRequestType } from '../type-creators/request';
+
+import type { JsonRpcRequest } from '../util/types';
+
+/**
+ * OmniAccount: Transfer funds to Ethereum Network.
+ */
+export async function transferEthereum(
+  /** Litentry Parachain API instance from Polkadot.js */
+  api: ApiPromise,
+  data: {
+    /** The user's omniAccount.  Use `createLitentryIdentityType` helper to create this struct */
+    omniAccount: LitentryIdentity;
+    /** The user's account.  Use `createLitentryIdentityType` helper to create this struct */
+    who: LitentryIdentity;
+    /** Ethereum address destination */
+    to: string;
+    /** Amount to send */
+    amount: bigint;
+  }
+): Promise<{
+  payloadToSign: string;
+  txHash: string;
+  send: (args: { signedPayload: string }) => Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }>;
+}> {
+  const { who, omniAccount } = data;
+
+  assert(omniAccount.isSubstrate, 'OmniAccount must be a Substrate identity');
+
+  const shard = await enclave.getShard(api);
+  const shardU8 = hexToU8a(shard);
+  const txHash = randomAsHex();
+
+  const { call } = await createTrustedCallType(api.registry, {
+    method: 'request_intent',
+    params: {
+      who,
+      intent: api.createType('Intent', {
+        TransferEthereum: api.createType('IntentTransferEthereum', {
+          to: data.to,
+          value: data.amount,
+        }),
+      }),
+    },
+  });
+
+  const nonce = await api.rpc.system.accountNextIndex(omniAccount.asSubstrate);
+
+  const payloadToSign = createPayloadToSign({
+    who,
+    call,
+    nonce,
+    shard: shardU8,
+  });
+
+  const send = async (args: {
+    signedPayload: string;
+  }): Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }> => {
+    // prepare and encrypt request
+
+    const request = await createRequestType(api, {
+      signer: who,
+      signature: args.signedPayload,
+      call,
+      nonce,
+      shard: shardU8,
+    });
+
+    // send the request to the Enclave
+    const rpcRequest: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      method: 'author_submitNativeRequest',
+      params: [request.toHex()],
+    };
+
+    const enclaveResult = await enclave.send(api, rpcRequest);
+
+    return {
+      txHash,
+      response: enclaveResult,
+    };
+  };
+
+  return {
+    txHash,
+    payloadToSign,
+    send,
+  };
+}

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-native.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-native.request.ts
@@ -28,7 +28,7 @@ export async function transferNative(
     /** Account destination in hex or ss58 formatted address */
     to: string;
     /** Amount to send */
-    value: bigint;
+    amount: bigint;
   }
 ): Promise<{
   payloadToSign: string;
@@ -53,7 +53,7 @@ export async function transferNative(
       intent: api.createType('Intent', {
         TransferNative: api.createType('IntentTransferNative', {
           to: data.to,
-          value: data.value,
+          value: data.amount,
         }),
       }),
     },

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-native.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-native.request.ts
@@ -1,0 +1,107 @@
+import { assert, hexToU8a } from '@polkadot/util';
+import { randomAsHex } from '@polkadot/util-crypto';
+
+import type { ApiPromise } from '@polkadot/api';
+import type {
+  LitentryIdentity,
+  WorkerRpcReturnValue,
+} from '@litentry/parachain-api';
+
+import { enclave } from '../enclave';
+import { createPayloadToSign } from '../util/create-payload-to-sign';
+import { createTrustedCallType } from '../type-creators/trusted-call';
+import { createRequestType } from '../type-creators/request';
+
+import type { JsonRpcRequest } from '../util/types';
+
+/**
+ * OmniAccount: Transfer funds within the Litentry Network.
+ */
+export async function transferNative(
+  /** Litentry Parachain API instance from Polkadot.js */
+  api: ApiPromise,
+  data: {
+    /** The user's omniAccount.  Use `createLitentryIdentityType` helper to create this struct */
+    omniAccount: LitentryIdentity;
+    /** The user's account.  Use `createLitentryIdentityType` helper to create this struct */
+    who: LitentryIdentity;
+    /** Account destination in hex or ss58 formatted address */
+    to: string;
+    /** Amount to send */
+    value: bigint;
+  }
+): Promise<{
+  payloadToSign: string;
+  txHash: string;
+  send: (args: { signedPayload: string }) => Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }>;
+}> {
+  const { who, omniAccount } = data;
+
+  assert(omniAccount.isSubstrate, 'OmniAccount must be a Substrate identity');
+
+  const shard = await enclave.getShard(api);
+  const shardU8 = hexToU8a(shard);
+  const txHash = randomAsHex();
+
+  const { call } = await createTrustedCallType(api.registry, {
+    method: 'request_intent',
+    params: {
+      who,
+      intent: api.createType('Intent', {
+        TransferNative: api.createType('IntentTransferNative', {
+          to: data.to,
+          value: data.value,
+        }),
+      }),
+    },
+  });
+
+  const nonce = await api.rpc.system.accountNextIndex(omniAccount.asSubstrate);
+
+  const payloadToSign = createPayloadToSign({
+    who,
+    call,
+    nonce,
+    shard: shardU8,
+  });
+
+  const send = async (args: {
+    signedPayload: string;
+  }): Promise<{
+    response: Array<WorkerRpcReturnValue>;
+    txHash: string;
+  }> => {
+    // prepare and encrypt request
+
+    const request = await createRequestType(api, {
+      signer: who,
+      signature: args.signedPayload,
+      call,
+      nonce,
+      shard: shardU8,
+    });
+
+    // send the request to the Enclave
+    const rpcRequest: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      method: 'author_submitNativeRequest',
+      params: [request.toHex()],
+    };
+
+    const enclaveResult = await enclave.send(api, rpcRequest);
+
+    return {
+      txHash,
+      response: enclaveResult,
+    };
+  };
+
+  return {
+    txHash,
+    payloadToSign,
+    send,
+  };
+}

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
@@ -50,7 +50,7 @@ export async function createRequestType(
 
   let operationU8a = new Uint8Array();
 
-  if (call.isRequestIntent) {
+  if (isNativeRequest(call)) {
     const callAuthenticated = api.createType('TrustedCallAuthenticated', {
       call,
       nonce,
@@ -105,4 +105,8 @@ export async function createRequestType(
     key: compactAddLength(encryptedKey),
     payload: encryptedPayload,
   });
+}
+
+function isNativeRequest(call: TrustedCall): boolean {
+  return call.isRequestIntent || call.isCreateAccountStore;
 }

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
@@ -48,21 +48,41 @@ export async function createRequestType(
     signature: signedPayload,
   });
 
-  const signedCall = api.createType('TrustedCallSigned', {
-    call,
-    index: nonce,
-    signature: signature,
-  });
+  let operationU8a = new Uint8Array();
 
-  const operation = api.createType('TrustedOperation', {
-    direct_call: signedCall,
-  });
+  if (call.isRequestIntent) {
+    const callAuthenticated = api.createType('TrustedCallAuthenticated', {
+      call,
+      nonce,
+      authentication: api.createType('TCAuthentication', {
+        Web3: signature,
+      }),
+    });
+
+    const operation = api.createType('TrustedOperation', {
+      direct_call: callAuthenticated,
+    });
+
+    operationU8a = operation.toU8a();
+  } else {
+    const signedCall = api.createType('TrustedCallSigned', {
+      call,
+      index: nonce,
+      signature: signature,
+    });
+
+    const operation = api.createType('TrustedOperation', {
+      direct_call: signedCall,
+    });
+
+    operationU8a = operation.toU8a();
+  }
 
   // Encrypt the operation call using the client shielding key
   const encryptionNonce = generateNonce12();
   const { ciphertext: encryptedOperation } = await encrypt(
     {
-      cleartext: operation.toU8a(),
+      cleartext: operationU8a,
       nonce: encryptionNonce,
     },
     encryptionKey

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/trusted-call.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/trusted-call.ts
@@ -72,6 +72,11 @@ type RequestIntentParams = {
   intent: Intent;
 };
 
+// LitentryIdentity
+type RequestCreateAccountStoreParams = {
+  who: LitentryIdentity;
+};
+
 /**
  * Creates the TrustedCall for the given method and provide the `param's` types expected for them.
  *
@@ -115,6 +120,13 @@ export async function createTrustedCallType(
   data: {
     method: 'request_intent';
     params: RequestIntentParams;
+  }
+): Promise<{ call: TrustedCall; key: CryptoKey }>;
+export async function createTrustedCallType(
+  registry: Registry,
+  data: {
+    method: 'create_account_store';
+    params: RequestCreateAccountStoreParams;
   }
 ): Promise<{ call: TrustedCall; key: CryptoKey }>;
 export async function createTrustedCallType(
@@ -245,6 +257,19 @@ export async function createTrustedCallType(
     return { call, key };
   }
 
+  if (isRequestCreateAccountStoreParams(method, params)) {
+    const { who } = params;
+
+    const call = registry.createType('TrustedCall', {
+      [trustedCallMethodsMap.create_account_store]: registry.createType(
+        trusted_operations.types.TrustedCall._enum.create_account_store,
+        who
+      ),
+    }) as TrustedCall;
+
+    return { call, key };
+  }
+
   throw new Error(`trusted call method: ${data.method} is not supported`);
 }
 
@@ -284,4 +309,10 @@ function isRequestIntentCall(
   params: Record<string, unknown>
 ): params is RequestIntentParams {
   return method === 'request_intent';
+}
+function isRequestCreateAccountStoreParams(
+  method: TrustedCallMethod,
+  params: Record<string, unknown>
+): params is RequestCreateAccountStoreParams {
+  return method === 'create_account_store';
 }

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/vc-validator/validator.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/vc-validator/validator.ts
@@ -2,7 +2,7 @@ import { ApiPromise } from '@polkadot/api';
 import { hexToU8a, stringToU8a } from '@polkadot/util';
 import { base58Decode, signatureVerify } from '@polkadot/util-crypto';
 
-import type { PalletTeebagEnclave } from '@litentry/parachain-api';
+import type { CorePrimitivesTeebagTypesEnclave } from '@litentry/parachain-api';
 
 import { RUNTIME_ENCLAVE_REGISTRY } from './runtime-enclave-registry';
 
@@ -298,8 +298,8 @@ export function validateVcWithTrustedTeeDevEnclave(
   api: ApiPromise,
   vc: VerifiableCredentialLike
 ): true | string {
-  const enclave: PalletTeebagEnclave = api.createType(
-    'PalletTeebagEnclave',
+  const enclave: CorePrimitivesTeebagTypesEnclave = api.createType(
+    'CorePrimitivesTeebagTypesEnclave',
     RUNTIME_ENCLAVE_REGISTRY
   );
 

--- a/tee-worker/identity/client-sdk/pnpm-lock.yaml
+++ b/tee-worker/identity/client-sdk/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
   packages/client-sdk:
     specifiers:
       '@litentry/chaindata': '*'
-      '@litentry/parachain-api': 0.9.20-next.3
-      '@litentry/sidechain-api': 0.9.20-next.3
+      '@litentry/parachain-api': 0.9.20-next.4
+      '@litentry/sidechain-api': 0.9.20-next.4
       '@polkadot/api': ^10.9.1
       '@polkadot/rpc-provider': ^10.9.1
       '@polkadot/types': ^10.9.1
@@ -101,8 +101,8 @@ importers:
       tslib: ^2.3.0
     dependencies:
       '@litentry/chaindata': link:../chaindata
-      '@litentry/parachain-api': 0.9.20-next.3
-      '@litentry/sidechain-api': 0.9.20-next.3
+      '@litentry/parachain-api': 0.9.20-next.4
+      '@litentry/sidechain-api': 0.9.20-next.4
       '@polkadot/api': 10.13.1
       '@polkadot/types': 10.13.1
       '@polkadot/types-codec': 10.13.1
@@ -1741,8 +1741,8 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@litentry/parachain-api/0.9.20-next.3:
-    resolution: {integrity: sha512-7C6RsxTec7rp6kxiQOoNipUS5Gr839is3Z7C/bHiOsA1CXyeYa1V0TtUqkPS5TU7ctNpxx5tZZcwS8nS5DF0VQ==}
+  /@litentry/parachain-api/0.9.20-next.4:
+    resolution: {integrity: sha512-qMHw4IPhhNrmoL7TXl6EDailkirXL3u3v3RRUMUBjmBHKbpN2XX/2d3c9ITCWkFCIMgKB+E7j6SOQ4AyjWD4hA==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1
@@ -1764,8 +1764,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@litentry/sidechain-api/0.9.20-next.3:
-    resolution: {integrity: sha512-Uv2DpQQWhGt/jy1I+ZdAVb9butti11ZujEUMn3r40qULSBUiUZEUcxGy06KnaUkqqD7stLvNxTEgWMeABUPqzQ==}
+  /@litentry/sidechain-api/0.9.20-next.4:
+    resolution: {integrity: sha512-YQ2Ivmzl0v3jElK8sChayLrREcApT3piI4KixNZrjoGwbqz8qeN8OV4GJa6HjAgXGawo2VA9oy6uskZLBkWM1g==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1

--- a/tee-worker/identity/client-sdk/pnpm-lock.yaml
+++ b/tee-worker/identity/client-sdk/pnpm-lock.yaml
@@ -87,11 +87,11 @@ importers:
     dependencies:
       tslib: 2.6.2
 
-  packages/enclave:
+  packages/client-sdk:
     specifiers:
       '@litentry/chaindata': '*'
-      '@litentry/parachain-api': 0.9.20-4.1
-      '@litentry/sidechain-api': 0.9.20-4
+      '@litentry/parachain-api': 0.9.20-next.3
+      '@litentry/sidechain-api': 0.9.20-next.3
       '@polkadot/api': ^10.9.1
       '@polkadot/rpc-provider': ^10.9.1
       '@polkadot/types': ^10.9.1
@@ -101,8 +101,8 @@ importers:
       tslib: ^2.3.0
     dependencies:
       '@litentry/chaindata': link:../chaindata
-      '@litentry/parachain-api': 0.9.20-4.1
-      '@litentry/sidechain-api': 0.9.20-4
+      '@litentry/parachain-api': 0.9.20-next.3
+      '@litentry/sidechain-api': 0.9.20-next.3
       '@polkadot/api': 10.13.1
       '@polkadot/types': 10.13.1
       '@polkadot/types-codec': 10.13.1
@@ -111,25 +111,6 @@ importers:
       tslib: 2.6.2
     devDependencies:
       '@polkadot/rpc-provider': 10.13.1
-
-  packages/vc-sdk:
-    specifiers:
-      '@litentry/parachain-api': 0.9.20-4.1
-      '@litentry/sidechain-api': 0.9.20-4
-      '@polkadot/api': ^10.9.1
-      '@polkadot/util': ^12.5.1
-      '@polkadot/util-crypto': ^12.5.1
-      fast-glob: ^3.3.2
-      tslib: ^2.3.0
-    dependencies:
-      '@litentry/parachain-api': 0.9.20-4.1
-      '@litentry/sidechain-api': 0.9.20-4
-      '@polkadot/api': 10.13.1
-      '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.6.2_@polkadot+util@12.6.2
-      tslib: 2.6.2
-    devDependencies:
-      fast-glob: 3.3.2
 
 packages:
 
@@ -1760,8 +1741,8 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@litentry/parachain-api/0.9.20-4.1:
-    resolution: {integrity: sha512-IL3E86EXlc3YdzHghxHwy0+a+1cWAjyQ8Ynyku4BtD6lL5b/bLgS3tFRmAYhkmmIFfJnx9vLRw2gZ3LVEudcJg==}
+  /@litentry/parachain-api/0.9.20-next.3:
+    resolution: {integrity: sha512-7C6RsxTec7rp6kxiQOoNipUS5Gr839is3Z7C/bHiOsA1CXyeYa1V0TtUqkPS5TU7ctNpxx5tZZcwS8nS5DF0VQ==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1
@@ -1783,8 +1764,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@litentry/sidechain-api/0.9.20-4:
-    resolution: {integrity: sha512-wYIS8FStKL7Nw/ViRlRMijSpZgVxJr2OKQlSRO1j9rBdNiCiOw0M5Y5Uo3eeSO7y4R04gPaSm7q0FvjByvGEMw==}
+  /@litentry/sidechain-api/0.9.20-next.3:
+    resolution: {integrity: sha512-Uv2DpQQWhGt/jy1I+ZdAVb9butti11ZujEUMn3r40qULSBUiUZEUcxGy06KnaUkqqD7stLvNxTEgWMeABUPqzQ==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1

--- a/tee-worker/identity/client-sdk/pnpm-lock.yaml
+++ b/tee-worker/identity/client-sdk/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
   packages/client-sdk:
     specifiers:
       '@litentry/chaindata': '*'
-      '@litentry/parachain-api': 0.9.20-next.4
-      '@litentry/sidechain-api': 0.9.20-next.4
+      '@litentry/parachain-api': 0.9.20-next.5
+      '@litentry/sidechain-api': 0.9.20-next.5
       '@polkadot/api': ^10.9.1
       '@polkadot/rpc-provider': ^10.9.1
       '@polkadot/types': ^10.9.1
@@ -101,8 +101,8 @@ importers:
       tslib: ^2.3.0
     dependencies:
       '@litentry/chaindata': link:../chaindata
-      '@litentry/parachain-api': 0.9.20-next.4
-      '@litentry/sidechain-api': 0.9.20-next.4
+      '@litentry/parachain-api': 0.9.20-next.5
+      '@litentry/sidechain-api': 0.9.20-next.5
       '@polkadot/api': 10.13.1
       '@polkadot/types': 10.13.1
       '@polkadot/types-codec': 10.13.1
@@ -1741,8 +1741,8 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@litentry/parachain-api/0.9.20-next.4:
-    resolution: {integrity: sha512-qMHw4IPhhNrmoL7TXl6EDailkirXL3u3v3RRUMUBjmBHKbpN2XX/2d3c9ITCWkFCIMgKB+E7j6SOQ4AyjWD4hA==}
+  /@litentry/parachain-api/0.9.20-next.5:
+    resolution: {integrity: sha512-FnK4Jb/i2+sV0V0qy4iT7aswk8JzOXDtyW76VGVFva5vb7IXEz9TC4CmEKFTVE1o0mvBB8+eRbu2HYliq/3i4w==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1
@@ -1764,8 +1764,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@litentry/sidechain-api/0.9.20-next.4:
-    resolution: {integrity: sha512-YQ2Ivmzl0v3jElK8sChayLrREcApT3piI4KixNZrjoGwbqz8qeN8OV4GJa6HjAgXGawo2VA9oy6uskZLBkWM1g==}
+  /@litentry/sidechain-api/0.9.20-next.5:
+    resolution: {integrity: sha512-wJTsPq9DJGSD2PSpR4AFdAmta/RDR/L2iAUnMQxYd49H/a1Pl/X6X7Ml50QR9OIftJLfah0SIwlKhdsMaOenvg==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1


### PR DESCRIPTION
Add helpers to build requests for: 
- `createAccountStore`
- `remark`
- `transferNative`
- `transferEthereum`
- `callEthereum`

Other changes
- Use the latest client-api preview version of [0.9.20-next.4](https://www.npmjs.com/package/@litentry/parachain-api/v/0.9.20-next.4)

Published packages
- client-sdk: https://www.npmjs.com/package/@litentry/client-sdk/v/1.0.0-next.0