### PR TITLE
replace omni-executor check with `TEEOrigin` check

### DIFF
--- a/parachain/pallets/omni-account/src/lib.rs
+++ b/parachain/pallets/omni-account/src/lib.rs
@@ -104,8 +104,6 @@ pub mod pallet {
 
 		/// Convert an `Identity` to OmniAccount type
 		type OmniAccountConverter: OmniAccountConverter<OmniAccount = Self::AccountId>;
-
-		type SetOmniExecutorOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 	}
 
 	pub type MemberAccounts<T> = BoundedVec<MemberAccount, <T as Config>::MaxAccountStoreLength>;
@@ -123,10 +121,6 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type MemberAccountHash<T: Config> =
 		StorageMap<Hasher = Blake2_128Concat, Key = H256, Value = T::AccountId>;
-
-	#[pallet::storage]
-	#[pallet::getter(fn omni_executor)]
-	pub type OmniExecutor<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -149,8 +143,6 @@ pub mod pallet {
 		IntentRequested { who: T::AccountId, intent: Intent },
 		/// Intent is executed
 		IntentExecuted { who: T::AccountId, intent: Intent, result: IntentExecutionResult },
-		/// Omni executor is set
-		OmniExecutorSet { omni_executor: T::AccountId },
 	}
 
 	#[pallet::error]
@@ -161,7 +153,6 @@ pub mod pallet {
 		InvalidAccount,
 		UnknownAccountStore,
 		EmptyAccount,
-		RequireOmniExecutor,
 	}
 
 	#[pallet::call]
@@ -363,20 +354,8 @@ pub mod pallet {
 			intent: Intent,
 			result: IntentExecutionResult,
 		) -> DispatchResult {
-			Self::ensure_omni_executor(origin)?;
+			let _ = T::TEECallOrigin::ensure_origin(origin.clone())?;
 			Self::deposit_event(Event::IntentExecuted { who, intent, result });
-			Ok(())
-		}
-
-		#[pallet::call_index(9)]
-		#[pallet::weight((195_000_000, DispatchClass::Normal,  Pays::No))]
-		pub fn set_omni_executor(
-			origin: OriginFor<T>,
-			new_omni_executor: T::AccountId,
-		) -> DispatchResult {
-			T::SetOmniExecutorOrigin::ensure_origin(origin)?;
-			OmniExecutor::<T>::put(new_omni_executor.clone());
-			Self::deposit_event(Event::OmniExecutorSet { omni_executor: new_omni_executor });
 			Ok(())
 		}
 	}
@@ -415,14 +394,6 @@ pub mod pallet {
 			});
 
 			Ok(member_accounts)
-		}
-
-		fn ensure_omni_executor(origin: OriginFor<T>) -> DispatchResult {
-			ensure!(
-				Some(ensure_signed(origin)?) == Self::omni_executor(),
-				Error::<T>::RequireOmniExecutor
-			);
-			Ok(())
 		}
 	}
 }

--- a/parachain/pallets/omni-account/src/mock.rs
+++ b/parachain/pallets/omni-account/src/mock.rs
@@ -187,7 +187,6 @@ impl pallet_omni_account::Config for TestRuntime {
 	type MaxAccountStoreLength = ConstU32<3>;
 	type OmniAccountOrigin = EnsureOmniAccount<Self::AccountId>;
 	type OmniAccountConverter = DefaultOmniAccountConverter;
-	type SetOmniExecutorOrigin = EnsureRoot<Self::AccountId>;
 }
 
 pub fn get_tee_signer() -> SystemAccountId {

--- a/parachain/runtime/litentry/src/lib.rs
+++ b/parachain/runtime/litentry/src/lib.rs
@@ -959,7 +959,6 @@ impl pallet_omni_account::Config for Runtime {
 	type MaxAccountStoreLength = ConstU32<64>;
 	type OmniAccountOrigin = EnsureOmniAccount;
 	type OmniAccountConverter = DefaultOmniAccountConverter;
-	type SetOmniExecutorOrigin = EnsureRootOrHalfCouncil;
 }
 
 impl pallet_bitacross::Config for Runtime {

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -1002,7 +1002,6 @@ impl pallet_omni_account::Config for Runtime {
 	type MaxAccountStoreLength = ConstU32<64>;
 	type OmniAccountOrigin = EnsureOmniAccount;
 	type OmniAccountConverter = DefaultOmniAccountConverter;
-	type SetOmniExecutorOrigin = EnsureRootOrAllCouncil;
 }
 
 impl pallet_bitacross::Config for Runtime {

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -1001,7 +1001,6 @@ impl pallet_omni_account::Config for Runtime {
 	type MaxAccountStoreLength = ConstU32<64>;
 	type OmniAccountOrigin = EnsureOmniAccount;
 	type OmniAccountConverter = DefaultOmniAccountConverter;
-	type SetOmniExecutorOrigin = EnsureRootOrAllCouncil;
 }
 
 impl pallet_bitacross::Config for Runtime {


### PR DESCRIPTION
Since `omni-executor` registers itself as an enclave we can simplify logic.