### PR TITLE
client-api: add type definitions for TrustedCallResult and update TrustedCall

### DIFF
--- a/tee-worker/identity/client-api/parachain-api/CHANGELOG.md
+++ b/tee-worker/identity/client-api/parachain-api/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 -   Type definitions for the new OmniAccount Pallet under the name of `omniAccount`.
--   Expose getter to get the derived `omniaccount` address from a given identity
--   Expose the OmniAccount's `request_intent` and `create_account_store` trusted calls.
+-   Expose getter to get the derived `omniaccount` address from a given identity.
+-   Expose the OmniAccount's trusted calls: `request_intent`, `create_account_store`, `add_account`, and `remove_accounts`.
 -   Add `TrustedCallAuthenticated` and `TCAuthentication` trusted call structs.
+-   Add `TrustedCallResult` to handle OmniAccount's call results.
 
 ## [0.9.20-4.1] - 2024-09-30
 

--- a/tee-worker/identity/client-api/parachain-api/package.json
+++ b/tee-worker/identity/client-api/parachain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.20-next.4",
+    "version": "0.9.20-next.5",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "curl -s -H \"Content-Type: application/json\" -d '{\"id\":\"1\", \"jsonrpc\":\"2.0\", \"method\": \"state_getMetadata\", \"params\":[]}' http://localhost:9944 > prepare-build/litentry-parachain-metadata.json",

--- a/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/omniAccount/definitions.ts
+++ b/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/omniAccount/definitions.ts
@@ -20,5 +20,16 @@ export default {
             to: "AccountId32",
             value: "u128",
         },
+
+        /**
+         * AccountStore
+         * @see common/primitives/core/src/omni_account.rs
+         */
+        MemberAccount: {
+            _enum: {
+                Public: "LitentryIdentity",
+                Private: "(Bytes,H256)",
+            },
+        },
     },
 };

--- a/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
+++ b/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
@@ -40,7 +40,7 @@ export default {
                 id_graph: "(LitentryIdentity)",
             },
         },
-        //important
+
         TrustedCall: {
             _enum: {
                 link_identity:
@@ -96,6 +96,70 @@ export default {
                 Invalid: null,
                 TopExecuted: "Bytes",
             },
+        },
+
+        /**
+         * Native tasks (OmniAccount) results
+         * @see tee-worker/identity/litentry/core/native-task/receiver/src/lib.rs
+         */
+        TrustedCallResult: "Result<ExtrinsicReport, NativeTaskError>",
+        ExtrinsicReport: {
+            // Hash of the extrinsic.
+            extrinsic_hash: "H256",
+            // Block hash of the block the extrinsic was included in.
+            // Only available if watched until at least `InBlock`.
+            block_hash: "Option<H256>",
+            // Last known Transaction Status.
+            status: "TransactionStatus",
+        },
+        TransactionStatus: {
+            _enum: {
+                /// Transaction is part of the future queue.
+                Future: "Null",
+                /// Transaction is part of the ready queue.
+                Ready: "Null",
+                /// The transaction has been broadcast to the given peers.
+                Broadcasted: "Null",
+                /// Transaction has been included in block with given hash.
+                InBlock: "H256",
+                /// The block this transaction was included in has been retracted.
+                Retracted: "H256",
+                /// Maximum number of finality watchers has been reached,
+                /// old watchers are being removed.
+                FinalityTimeout: "H256",
+                /// Transaction has been finalized by a finality-gadget, e.g GRANDPA
+                Finalized: "H256",
+                /// Transaction has been replaced in the pool, by another transaction
+                /// that provides the same tags. (e.g. same (sender, nonce)).
+                Usurped: "H256",
+                /// Transaction has been dropped from the pool because of the limit.
+                Dropped: "Null",
+                /// Transaction is no longer valid in the current state.
+                Invalid: "Null",
+            },
+        },
+        NativeTaskError: {
+            UnexpectedCall: "String",
+            ShieldingKeyRetrievalFailed: "String", // Stringified itp_sgx_crypto::Error
+            RequestPayloadDecodingFailed: "Null",
+            ParentchainDataRetrievalFailed: "String", // Stringified itp_stf_state_handler::Error
+            InvalidSignerAccount: "Null",
+            UnauthorizedSigner: "Null",
+            InvalidMemberIdentity: "Null",
+            MissingAesKey: "Null",
+            MrEnclaveRetrievalFailed: "Null",
+            EnclaveSignerRetrievalFailed: "Null",
+            AuthenticationVerificationFailed: "Null",
+            ValidationDataVerificationFailed: "Null",
+            ConnectionHashNotFound: "String",
+            MetadataRetrievalFailed: "String", // Stringified itp_node_api_metadata_provider::Error
+            InvalidMetadata: "String", // Stringified itp_node_api_metadata::Error
+            TrustedCallSendingFailed: "String", // Stringified mpsc::SendError<(H256, TrustedCall)>
+            CallSendingFailed: "String",
+            ExtrinsicConstructionFailed: "String", // Stringified itp_extrinsics_factory::Error
+            ExtrinsicSendingFailed: "String", // Stringified sgx_status_t
+            InvalidRequest: "Null",
+            NativeRequestSendFailed: "Null",
         },
     },
 };

--- a/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
+++ b/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
@@ -79,6 +79,9 @@ export default {
                 clean_id_graphs: "(LitentryIdentity)",
                 request_intent: "(LitentryIdentity, Intent)",
                 create_account_store: "(LitentryIdentity)",
+                add_account: "(LitentryIdentity, LitentryIdentity, LitentryValidationData, bool)",
+                remove_accounts: "(LitentryIdentity, Vec<LitentryIdentity>)",
+                publicize_account: "(LitentryIdentity, LitentryIdentity)",
             },
         },
         TrustedOperationStatus: {

--- a/tee-worker/identity/client-api/sidechain-api/package.json
+++ b/tee-worker/identity/client-api/sidechain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.20-next.4",
+    "version": "0.9.20-next.5",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "../../bin/litentry-cli print-sgx-metadata-raw > prepare-build/litentry-sidechain-metadata.json",


### PR DESCRIPTION
Add new type definitions:
- `TrustedCallResult`.
- `MemberAccount`.
- Update TrustedCall methods.

Published packages:
- parachain-api: https://www.npmjs.com/package/@litentry/parachain-api/v/0.9.20-next.5 
- sidechain-api: https://www.npmjs.com/package/@litentry/sidechain-api/v/0.9.20-next.5
