### PR TITLE
prefund omni-exeuctor ethereum account

### DIFF
--- a/tee-worker/omni-executor/docker-compose.yml
+++ b/tee-worker/omni-executor/docker-compose.yml
@@ -14,6 +14,12 @@ services:
       - "anvil --host 0.0.0.0 --block-time 1"
     ports:
       - "8545:8545"
+  fund-eth-account:
+    image: ghcr.io/foundry-rs/foundry
+    command:
+      - "cast send --private-key 0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 0xf8d392519239c01a3a7a7a85d23abc2094d0ce53 --value 0.1ether -r http://ethereum-node:8545"
+    depends_on:
+      - ethereum-node
   litentry-node:
     image: litentry/litentry-parachain
     ports: 


### PR DESCRIPTION
Adds a service for prefunding `omni-executor`'s ethereum account so foreign intents can be executed without extra preparations in locally run env.

