### PR TITLE
client-sdk: decode the result of native trusted operations

### DIFF
--- a/tee-worker/identity/client-api/parachain-api/package.json
+++ b/tee-worker/identity/client-api/parachain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.20-next.6",
+    "version": "0.9.20-next.7",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "curl -s -H \"Content-Type: application/json\" -d '{\"id\":\"1\", \"jsonrpc\":\"2.0\", \"method\": \"state_getMetadata\", \"params\":[]}' http://localhost:9944 > prepare-build/litentry-parachain-metadata.json",

--- a/tee-worker/identity/client-api/parachain-api/package.json
+++ b/tee-worker/identity/client-api/parachain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.20-next.5",
+    "version": "0.9.20-next.6",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "curl -s -H \"Content-Type: application/json\" -d '{\"id\":\"1\", \"jsonrpc\":\"2.0\", \"method\": \"state_getMetadata\", \"params\":[]}' http://localhost:9944 > prepare-build/litentry-parachain-metadata.json",

--- a/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
+++ b/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
@@ -142,27 +142,29 @@ export default {
             },
         },
         NativeTaskError: {
-            UnexpectedCall: "Text",
-            ShieldingKeyRetrievalFailed: "Text", // Stringified itp_sgx_crypto::Error
-            RequestPayloadDecodingFailed: "Null",
-            ParentchainDataRetrievalFailed: "Text", // Stringified itp_stf_state_handler::Error
-            InvalidSignerAccount: "Null",
-            UnauthorizedSigner: "Null",
-            InvalidMemberIdentity: "Null",
-            MissingAesKey: "Null",
-            MrEnclaveRetrievalFailed: "Null",
-            EnclaveSignerRetrievalFailed: "Null",
-            AuthenticationVerificationFailed: "Null",
-            ValidationDataVerificationFailed: "Null",
-            ConnectionHashNotFound: "Text",
-            MetadataRetrievalFailed: "Text", // Stringified itp_node_api_metadata_provider::Error
-            InvalidMetadata: "Text", // Stringified itp_node_api_metadata::Error
-            TrustedCallSendingFailed: "Text", // Stringified mpsc::SendError<(H256, TrustedCall)>
-            CallSendingFailed: "Text",
-            ExtrinsicConstructionFailed: "Text", // Stringified itp_extrinsics_factory::Error
-            ExtrinsicSendingFailed: "Text", // Stringified sgx_status_t
-            InvalidRequest: "Null",
-            NativeRequestSendFailed: "Null",
+            _enum: {
+                UnexpectedCall: "Text",
+                ShieldingKeyRetrievalFailed: "Text", // Stringified itp_sgx_crypto::Error
+                RequestPayloadDecodingFailed: "Null",
+                ParentchainDataRetrievalFailed: "Text", // Stringified itp_stf_state_handler::Error
+                InvalidSignerAccount: "Null",
+                UnauthorizedSigner: "Null",
+                InvalidMemberIdentity: "Null",
+                MissingAesKey: "Null",
+                MrEnclaveRetrievalFailed: "Null",
+                EnclaveSignerRetrievalFailed: "Null",
+                AuthenticationVerificationFailed: "Null",
+                ValidationDataVerificationFailed: "Null",
+                ConnectionHashNotFound: "Text",
+                MetadataRetrievalFailed: "Text", // Stringified itp_node_api_metadata_provider::Error
+                InvalidMetadata: "Text", // Stringified itp_node_api_metadata::Error
+                TrustedCallSendingFailed: "Text", // Stringified mpsc::SendError<(H256, TrustedCall)>
+                CallSendingFailed: "Text",
+                ExtrinsicConstructionFailed: "Text", // Stringified itp_extrinsics_factory::Error
+                ExtrinsicSendingFailed: "Text", // Stringified sgx_status_t
+                InvalidRequest: "Null",
+                NativeRequestSendFailed: "Null",
+            },
         },
     },
 };

--- a/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
+++ b/tee-worker/identity/client-api/parachain-api/prepare-build/interfaces/trusted_operations/definitions.ts
@@ -142,10 +142,10 @@ export default {
             },
         },
         NativeTaskError: {
-            UnexpectedCall: "String",
-            ShieldingKeyRetrievalFailed: "String", // Stringified itp_sgx_crypto::Error
+            UnexpectedCall: "Text",
+            ShieldingKeyRetrievalFailed: "Text", // Stringified itp_sgx_crypto::Error
             RequestPayloadDecodingFailed: "Null",
-            ParentchainDataRetrievalFailed: "String", // Stringified itp_stf_state_handler::Error
+            ParentchainDataRetrievalFailed: "Text", // Stringified itp_stf_state_handler::Error
             InvalidSignerAccount: "Null",
             UnauthorizedSigner: "Null",
             InvalidMemberIdentity: "Null",
@@ -154,13 +154,13 @@ export default {
             EnclaveSignerRetrievalFailed: "Null",
             AuthenticationVerificationFailed: "Null",
             ValidationDataVerificationFailed: "Null",
-            ConnectionHashNotFound: "String",
-            MetadataRetrievalFailed: "String", // Stringified itp_node_api_metadata_provider::Error
-            InvalidMetadata: "String", // Stringified itp_node_api_metadata::Error
-            TrustedCallSendingFailed: "String", // Stringified mpsc::SendError<(H256, TrustedCall)>
-            CallSendingFailed: "String",
-            ExtrinsicConstructionFailed: "String", // Stringified itp_extrinsics_factory::Error
-            ExtrinsicSendingFailed: "String", // Stringified sgx_status_t
+            ConnectionHashNotFound: "Text",
+            MetadataRetrievalFailed: "Text", // Stringified itp_node_api_metadata_provider::Error
+            InvalidMetadata: "Text", // Stringified itp_node_api_metadata::Error
+            TrustedCallSendingFailed: "Text", // Stringified mpsc::SendError<(H256, TrustedCall)>
+            CallSendingFailed: "Text",
+            ExtrinsicConstructionFailed: "Text", // Stringified itp_extrinsics_factory::Error
+            ExtrinsicSendingFailed: "Text", // Stringified sgx_status_t
             InvalidRequest: "Null",
             NativeRequestSendFailed: "Null",
         },

--- a/tee-worker/identity/client-api/sidechain-api/package.json
+++ b/tee-worker/identity/client-api/sidechain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.20-next.6",
+    "version": "0.9.20-next.7",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "../../bin/litentry-cli print-sgx-metadata-raw > prepare-build/litentry-sidechain-metadata.json",

--- a/tee-worker/identity/client-api/sidechain-api/package.json
+++ b/tee-worker/identity/client-api/sidechain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.20-next.5",
+    "version": "0.9.20-next.6",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "../../bin/litentry-cli print-sgx-metadata-raw > prepare-build/litentry-sidechain-metadata.json",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -8,8 +8,8 @@
     "@polkadot/rpc-provider": "^10.9.1"
   },
   "peerDependencies": {
-    "@litentry/parachain-api": "0.9.20-next.5",
-    "@litentry/sidechain-api": "0.9.20-next.5",
+    "@litentry/parachain-api": "0.9.20-next.7",
+    "@litentry/sidechain-api": "0.9.20-next.7",
     "@litentry/chaindata": "*",
     "@polkadot/api": "^10.9.1",
     "@polkadot/types": "^10.9.1",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@litentry/client-sdk",
   "description": "This package provides helpers for dApps to interact with the Litentry Protocol.",
-  "version": "1.0.0-next.0",
+  "version": "1.0.0-next.1",
   "license": "GPL-3.0-or-later",
   "dependencies": {},
   "devDependencies": {

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/call-ethereum.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/call-ethereum.request.ts
@@ -1,13 +1,14 @@
 import { assert, hexToU8a } from '@polkadot/util';
-import { randomAsHex } from '@polkadot/util-crypto';
 
 import type { ApiPromise } from '@polkadot/api';
 import type {
   LitentryIdentity,
+  TrustedCallResult,
   WorkerRpcReturnValue,
 } from '@litentry/parachain-api';
 
 import { enclave } from '../enclave';
+import { codecToString } from '../util/codec-to-string';
 import { createPayloadToSign } from '../util/create-payload-to-sign';
 import { createTrustedCallType } from '../type-creators/trusted-call';
 import { createRequestType } from '../type-creators/request';
@@ -33,10 +34,10 @@ export async function callEthereum(
   }
 ): Promise<{
   payloadToSign: string;
-  txHash: string;
   send: (args: { signedPayload: string }) => Promise<{
-    response: Array<WorkerRpcReturnValue>;
-    txHash: string;
+    response: WorkerRpcReturnValue;
+    blockHash: string;
+    extrinsicHash: string;
   }>;
 }> {
   const { who, omniAccount } = data;
@@ -45,7 +46,6 @@ export async function callEthereum(
 
   const shard = await enclave.getShard(api);
   const shardU8 = hexToU8a(shard);
-  const txHash = randomAsHex();
 
   const { call } = await createTrustedCallType(api.registry, {
     method: 'request_intent',
@@ -72,8 +72,9 @@ export async function callEthereum(
   const send = async (args: {
     signedPayload: string;
   }): Promise<{
-    response: Array<WorkerRpcReturnValue>;
-    txHash: string;
+    response: WorkerRpcReturnValue;
+    blockHash: string;
+    extrinsicHash: string;
   }> => {
     // prepare and encrypt request
 
@@ -92,16 +93,27 @@ export async function callEthereum(
       params: [request.toHex()],
     };
 
-    const enclaveResult = await enclave.send(api, rpcRequest);
+    const [response] = await enclave.send(api, rpcRequest); // we expect 1 response only
+
+    const result: TrustedCallResult = api.createType(
+      'TrustedCallResult',
+      response.value
+    );
+
+    if (result.isErr) {
+      throw new Error(codecToString(result.asErr));
+    }
+
+    const { extrinsic_hash, block_hash } = result.asOk;
 
     return {
-      txHash,
-      response: enclaveResult,
+      response,
+      extrinsicHash: extrinsic_hash.toString(),
+      blockHash: block_hash.toString(),
     };
   };
 
   return {
-    txHash,
     payloadToSign,
     send,
   };

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/create-account-store.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/create-account-store.request.ts
@@ -1,13 +1,14 @@
 import { hexToU8a } from '@polkadot/util';
-import { randomAsHex } from '@polkadot/util-crypto';
 
 import type { ApiPromise } from '@polkadot/api';
 import type {
   LitentryIdentity,
+  TrustedCallResult,
   WorkerRpcReturnValue,
 } from '@litentry/parachain-api';
 
 import { enclave } from '../enclave';
+import { codecToString } from '../util/codec-to-string';
 import { createPayloadToSign } from '../util/create-payload-to-sign';
 import { createTrustedCallType } from '../type-creators/trusted-call';
 import { createRequestType } from '../type-creators/request';
@@ -28,17 +29,16 @@ export async function createAccountStore(
   }
 ): Promise<{
   payloadToSign: string;
-  txHash: string;
   send: (args: { signedPayload: string }) => Promise<{
-    response: Array<WorkerRpcReturnValue>;
-    txHash: string;
+    response: WorkerRpcReturnValue;
+    blockHash: string;
+    extrinsicHash: string;
   }>;
 }> {
   const { who, omniAccount } = data;
 
   const shard = await enclave.getShard(api);
   const shardU8 = hexToU8a(shard);
-  const txHash = randomAsHex();
 
   const { call } = await createTrustedCallType(api.registry, {
     method: 'create_account_store',
@@ -61,8 +61,9 @@ export async function createAccountStore(
   const send = async (args: {
     signedPayload: string;
   }): Promise<{
-    response: Array<WorkerRpcReturnValue>;
-    txHash: string;
+    response: WorkerRpcReturnValue;
+    blockHash: string;
+    extrinsicHash: string;
   }> => {
     // prepare and encrypt request
 
@@ -81,16 +82,27 @@ export async function createAccountStore(
       params: [request.toHex()],
     };
 
-    const enclaveResult = await enclave.send(api, rpcRequest);
+    const [response] = await enclave.send(api, rpcRequest); // we expect 1 response only
+
+    const result: TrustedCallResult = api.createType(
+      'TrustedCallResult',
+      response.value
+    );
+
+    if (result.isErr) {
+      throw new Error(codecToString(result.asErr));
+    }
+
+    const { extrinsic_hash, block_hash } = result.asOk;
 
     return {
-      txHash,
-      response: enclaveResult,
+      response,
+      extrinsicHash: extrinsic_hash.toString(),
+      blockHash: block_hash.toString(),
     };
   };
 
   return {
-    txHash,
     payloadToSign,
     send,
   };

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-ethereum.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-ethereum.request.ts
@@ -1,13 +1,14 @@
 import { assert, hexToU8a } from '@polkadot/util';
-import { randomAsHex } from '@polkadot/util-crypto';
 
 import type { ApiPromise } from '@polkadot/api';
 import type {
   LitentryIdentity,
+  TrustedCallResult,
   WorkerRpcReturnValue,
 } from '@litentry/parachain-api';
 
 import { enclave } from '../enclave';
+import { codecToString } from '../util/codec-to-string';
 import { createPayloadToSign } from '../util/create-payload-to-sign';
 import { createTrustedCallType } from '../type-creators/trusted-call';
 import { createRequestType } from '../type-creators/request';
@@ -32,10 +33,10 @@ export async function transferEthereum(
   }
 ): Promise<{
   payloadToSign: string;
-  txHash: string;
   send: (args: { signedPayload: string }) => Promise<{
-    response: Array<WorkerRpcReturnValue>;
-    txHash: string;
+    response: WorkerRpcReturnValue;
+    blockHash: string;
+    extrinsicHash: string;
   }>;
 }> {
   const { who, omniAccount } = data;
@@ -44,7 +45,6 @@ export async function transferEthereum(
 
   const shard = await enclave.getShard(api);
   const shardU8 = hexToU8a(shard);
-  const txHash = randomAsHex();
 
   const { call } = await createTrustedCallType(api.registry, {
     method: 'request_intent',
@@ -71,8 +71,9 @@ export async function transferEthereum(
   const send = async (args: {
     signedPayload: string;
   }): Promise<{
-    response: Array<WorkerRpcReturnValue>;
-    txHash: string;
+    response: WorkerRpcReturnValue;
+    blockHash: string;
+    extrinsicHash: string;
   }> => {
     // prepare and encrypt request
 
@@ -91,16 +92,27 @@ export async function transferEthereum(
       params: [request.toHex()],
     };
 
-    const enclaveResult = await enclave.send(api, rpcRequest);
+    const [response] = await enclave.send(api, rpcRequest); // we expect 1 response only
+
+    const result: TrustedCallResult = api.createType(
+      'TrustedCallResult',
+      response.value
+    );
+
+    if (result.isErr) {
+      throw new Error(codecToString(result.asErr));
+    }
+
+    const { extrinsic_hash, block_hash } = result.asOk;
 
     return {
-      txHash,
-      response: enclaveResult,
+      response,
+      extrinsicHash: extrinsic_hash.toString(),
+      blockHash: block_hash.toString(),
     };
   };
 
   return {
-    txHash,
     payloadToSign,
     send,
   };

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/codec-to-string.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/codec-to-string.ts
@@ -1,0 +1,17 @@
+import type { Enum } from '@polkadot/types';
+
+export function codecToString(codec: Enum): string {
+  const output = codec.type;
+
+  const value = codec.value?.toHuman();
+
+  if (value == null) {
+    return output;
+  }
+
+  if (value.toString() === '[object Object]') {
+    return `${output}: ${JSON.stringify(value)}`;
+  }
+
+  return `${output}: ${value}`;
+}

--- a/tee-worker/identity/client-sdk/pnpm-lock.yaml
+++ b/tee-worker/identity/client-sdk/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
   packages/client-sdk:
     specifiers:
       '@litentry/chaindata': '*'
-      '@litentry/parachain-api': 0.9.20-next.5
-      '@litentry/sidechain-api': 0.9.20-next.5
+      '@litentry/parachain-api': 0.9.20-next.7
+      '@litentry/sidechain-api': 0.9.20-next.7
       '@polkadot/api': ^10.9.1
       '@polkadot/rpc-provider': ^10.9.1
       '@polkadot/types': ^10.9.1
@@ -101,8 +101,8 @@ importers:
       tslib: ^2.3.0
     dependencies:
       '@litentry/chaindata': link:../chaindata
-      '@litentry/parachain-api': 0.9.20-next.5
-      '@litentry/sidechain-api': 0.9.20-next.5
+      '@litentry/parachain-api': 0.9.20-next.7
+      '@litentry/sidechain-api': 0.9.20-next.7
       '@polkadot/api': 10.13.1
       '@polkadot/types': 10.13.1
       '@polkadot/types-codec': 10.13.1
@@ -1741,8 +1741,8 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@litentry/parachain-api/0.9.20-next.5:
-    resolution: {integrity: sha512-FnK4Jb/i2+sV0V0qy4iT7aswk8JzOXDtyW76VGVFva5vb7IXEz9TC4CmEKFTVE1o0mvBB8+eRbu2HYliq/3i4w==}
+  /@litentry/parachain-api/0.9.20-next.7:
+    resolution: {integrity: sha512-wlDrEutgh7c4CgTyUkYUPjr4+9OEGltU+gY97e7WADVX9kOn4pEDtkUQlIPcyY6yes28UUnT5eM7Gbab6cwoeQ==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1
@@ -1764,8 +1764,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@litentry/sidechain-api/0.9.20-next.5:
-    resolution: {integrity: sha512-wJTsPq9DJGSD2PSpR4AFdAmta/RDR/L2iAUnMQxYd49H/a1Pl/X6X7Ml50QR9OIftJLfah0SIwlKhdsMaOenvg==}
+  /@litentry/sidechain-api/0.9.20-next.7:
+    resolution: {integrity: sha512-oZmQdkQNMSN+Ti1wiWiYGA1PawRjsrS908+Bp5pMlFsVBriURSYUIOI93d8oLvOGfIMZ50OfEoAliX5OmONMvw==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1


### PR DESCRIPTION
as topic

client follow-up of https://github.com/litentry/litentry-parachain/pull/3155 now that the native responses include results.

Published packages
- client-sdk: https://www.npmjs.com/package/@litentry/client-sdk/v/1.0.0-next.1
- parachain-api: https://www.npmjs.com/package/@litentry/parachain-api/v/0.9.20-next.7
- sidechain-api: https://www.npmjs.com/package/@litentry/sidechain-api/v/0.9.20-next.7