### PR TITLE
Add option to specify start block

### DIFF
--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -4724,6 +4724,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/tee-worker/omni-executor/executor-core/src/listener.rs
+++ b/tee-worker/omni-executor/executor-core/src/listener.rs
@@ -147,8 +147,9 @@ impl<
 							{
 								if checkpoint.lt(&event.get_event_id().clone().into()) {
 									log::info!("Handling event: {:?}", event_id);
-									if let Err(e) =
-										self.handle.block_on(self.intent_event_handler.handle(event))
+									if let Err(e) = self
+										.handle
+										.block_on(self.intent_event_handler.handle(event))
 									{
 										log::error!("Could not handle event: {:?}", e);
 										match e {
@@ -184,9 +185,9 @@ impl<
 										},
 										Error::RecoverableError => {
 											error!(
-											"Recoverable intent handling error, event: {:?}",
-											event_id
-										);
+												"Recoverable intent handling error, event: {:?}",
+												event_id
+											);
 											continue 'main;
 										},
 									}
@@ -206,7 +207,7 @@ impl<
 					Err(e) => {
 						log::error!("Could not get block {} events: {:?}", block_number_to_sync, e);
 						sync_error = true;
-					}
+					},
 				}
 			} else {
 				log::trace!("Block: {} not yet finalized", block_number_to_sync);

--- a/tee-worker/omni-executor/executor-worker/Cargo.toml
+++ b/tee-worker/omni-executor/executor-worker/Cargo.toml
@@ -14,7 +14,7 @@ log = { workspace = true }
 parentchain-listener = { path = "../parentchain/listener" }
 scale-encode = { workspace = true }
 serde_json = "1.0.127"
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 
 [lints]
 workspace = true

--- a/tee-worker/omni-executor/executor-worker/src/cli.rs
+++ b/tee-worker/omni-executor/executor-worker/src/cli.rs
@@ -5,4 +5,5 @@ use clap::Parser;
 pub struct Cli {
 	pub parentchain_url: String,
 	pub ethereum_url: String,
+	pub start_block: u64
 }

--- a/tee-worker/omni-executor/executor-worker/src/cli.rs
+++ b/tee-worker/omni-executor/executor-worker/src/cli.rs
@@ -5,5 +5,5 @@ use clap::Parser;
 pub struct Cli {
 	pub parentchain_url: String,
 	pub ethereum_url: String,
-	pub start_block: u64
+	pub start_block: u64,
 }

--- a/tee-worker/omni-executor/executor-worker/src/main.rs
+++ b/tee-worker/omni-executor/executor-worker/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), ()> {
 		error!("Could not create data dir: {:?}", e);
 	})?;
 
-	listen_to_parentchain(cli.parentchain_url, cli.ethereum_url)
+	listen_to_parentchain(cli.parentchain_url, cli.ethereum_url, cli.start_block)
 		.await
 		.unwrap()
 		.join()
@@ -59,6 +59,7 @@ async fn main() -> Result<(), ()> {
 async fn listen_to_parentchain(
 	parentchain_url: String,
 	ethereum_url: String,
+	start_block: u64
 ) -> Result<JoinHandle<()>, ()> {
 	let (_sub_stop_sender, sub_stop_receiver) = oneshot::channel();
 	let ethereum_intent_executor =
@@ -75,6 +76,6 @@ async fn listen_to_parentchain(
 
 	Ok(thread::Builder::new()
 		.name("litentry_rococo_sync".to_string())
-		.spawn(move || parentchain_listener.sync(0))
+		.spawn(move || parentchain_listener.sync(start_block))
 		.unwrap())
 }

--- a/tee-worker/omni-executor/parentchain/listener/src/rpc_client.rs
+++ b/tee-worker/omni-executor/parentchain/listener/src/rpc_client.rs
@@ -16,7 +16,7 @@
 
 use crate::primitives::{BlockEvent, EventId};
 use async_trait::async_trait;
-use log::error;
+use log::{info, error};
 use parity_scale_codec::Encode;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -67,9 +67,16 @@ impl<ChainConfig: Config<AccountId = AccountId32>> SubstrateRpcClient<ChainConfi
 		}
 	}
 	async fn get_block_events(&mut self, block_num: u64) -> Result<Vec<BlockEvent>, ()> {
-		match self.legacy.chain_get_block_hash(Some(block_num.into())).await.map_err(|_| ())? {
+		info!("Getting block {} events", block_num);
+		match self.legacy.chain_get_block_hash(Some(block_num.into())).await
+			.map_err(|e|
+				{
+					error!("Error getting block {} hash: {:?}", block_num, e);
+				})? {
 			Some(hash) => {
-				let events = self.events.at(BlockRef::from_hash(hash)).await.map_err(|_| ())?;
+				let events = self.events.at(BlockRef::from_hash(hash)).await.map_err(|e| {
+					error!("Error getting block {} events: {:?}", block_num, e);
+				})?;
 				Ok(events
 					.iter()
 					.enumerate()

--- a/tee-worker/omni-executor/parentchain/listener/src/rpc_client.rs
+++ b/tee-worker/omni-executor/parentchain/listener/src/rpc_client.rs
@@ -16,7 +16,7 @@
 
 use crate::primitives::{BlockEvent, EventId};
 use async_trait::async_trait;
-use log::{info, error};
+use log::{error, info};
 use parity_scale_codec::Encode;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -68,11 +68,9 @@ impl<ChainConfig: Config<AccountId = AccountId32>> SubstrateRpcClient<ChainConfi
 	}
 	async fn get_block_events(&mut self, block_num: u64) -> Result<Vec<BlockEvent>, ()> {
 		info!("Getting block {} events", block_num);
-		match self.legacy.chain_get_block_hash(Some(block_num.into())).await
-			.map_err(|e|
-				{
-					error!("Error getting block {} hash: {:?}", block_num, e);
-				})? {
+		match self.legacy.chain_get_block_hash(Some(block_num.into())).await.map_err(|e| {
+			error!("Error getting block {} hash: {:?}", block_num, e);
+		})? {
 			Some(hash) => {
 				let events = self.events.at(BlockRef::from_hash(hash)).await.map_err(|e| {
 					error!("Error getting block {} events: {:?}", block_num, e);


### PR DESCRIPTION
Adds option to specify `start_block` for `omni-executor`'s parentchain listener. 

also:
* rpc client errors are logged
* wait 1s in case of sync error
* system signal handling