### PR TITLE
client packages: use `TrustedOperationAuthenticated`

### DIFF
--- a/tee-worker/identity/client-api/parachain-api/CHANGELOG.md
+++ b/tee-worker/identity/client-api/parachain-api/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Expose the OmniAccount's trusted calls: `request_intent`, `create_account_store`, `add_account`, and `remove_accounts`.
 -   Add `TrustedCallAuthenticated` and `TCAuthentication` trusted call structs.
 -   Add `TrustedCallResult` to handle OmniAccount's call results.
+-   Add `TrustedOperationAuthenticated` type definition.
 
 ## [0.9.20-4.1] - 2024-09-30
 

--- a/tee-worker/identity/client-api/parachain-api/package.json
+++ b/tee-worker/identity/client-api/parachain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.20-next.7",
+    "version": "0.9.20-next.8",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "curl -s -H \"Content-Type: application/json\" -d '{\"id\":\"1\", \"jsonrpc\":\"2.0\", \"method\": \"state_getMetadata\", \"params\":[]}' http://localhost:9944 > prepare-build/litentry-parachain-metadata.json",

--- a/tee-worker/identity/client-api/sidechain-api/package.json
+++ b/tee-worker/identity/client-api/sidechain-api/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "module": "dist/src/index.js",
     "sideEffects": false,
-    "version": "0.9.20-next.7",
+    "version": "0.9.20-next.8",
     "scripts": {
         "clean": "rm -rf dist build node_modules",
         "update-metadata": "../../bin/litentry-cli print-sgx-metadata-raw > prepare-build/litentry-sidechain-metadata.json",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@litentry/client-sdk",
   "description": "This package provides helpers for dApps to interact with the Litentry Protocol.",
-  "version": "1.0.0-next.1",
+  "version": "1.0.0-next.2",
   "license": "GPL-3.0-or-later",
   "dependencies": {},
   "devDependencies": {

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -8,8 +8,8 @@
     "@polkadot/rpc-provider": "^10.9.1"
   },
   "peerDependencies": {
-    "@litentry/parachain-api": "0.9.20-next.7",
-    "@litentry/sidechain-api": "0.9.20-next.7",
+    "@litentry/parachain-api": "0.9.20-next.8",
+    "@litentry/sidechain-api": "0.9.20-next.8",
     "@litentry/chaindata": "*",
     "@polkadot/api": "^10.9.1",
     "@polkadot/types": "^10.9.1",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
@@ -59,7 +59,7 @@ export async function createRequestType(
       }),
     });
 
-    const operation = api.createType('TrustedOperation', {
+    const operation = api.createType('TrustedOperationAuthenticated', {
       direct_call: callAuthenticated,
     });
 

--- a/tee-worker/identity/client-sdk/pnpm-lock.yaml
+++ b/tee-worker/identity/client-sdk/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
   packages/client-sdk:
     specifiers:
       '@litentry/chaindata': '*'
-      '@litentry/parachain-api': 0.9.20-next.7
-      '@litentry/sidechain-api': 0.9.20-next.7
+      '@litentry/parachain-api': 0.9.20-next.8
+      '@litentry/sidechain-api': 0.9.20-next.8
       '@polkadot/api': ^10.9.1
       '@polkadot/rpc-provider': ^10.9.1
       '@polkadot/types': ^10.9.1
@@ -101,8 +101,8 @@ importers:
       tslib: ^2.3.0
     dependencies:
       '@litentry/chaindata': link:../chaindata
-      '@litentry/parachain-api': 0.9.20-next.7
-      '@litentry/sidechain-api': 0.9.20-next.7
+      '@litentry/parachain-api': 0.9.20-next.8
+      '@litentry/sidechain-api': 0.9.20-next.8
       '@polkadot/api': 10.13.1
       '@polkadot/types': 10.13.1
       '@polkadot/types-codec': 10.13.1
@@ -1741,8 +1741,8 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@litentry/parachain-api/0.9.20-next.7:
-    resolution: {integrity: sha512-wlDrEutgh7c4CgTyUkYUPjr4+9OEGltU+gY97e7WADVX9kOn4pEDtkUQlIPcyY6yes28UUnT5eM7Gbab6cwoeQ==}
+  /@litentry/parachain-api/0.9.20-next.8:
+    resolution: {integrity: sha512-ilkKo902aSX7ouXhpwPX7D1iC0GNX/qLAYd87bC/4ziU+yXmHpnaRCTq1dXumPl2DDRkLQgPwnXkVPX2WLmPsQ==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1
@@ -1764,8 +1764,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@litentry/sidechain-api/0.9.20-next.7:
-    resolution: {integrity: sha512-oZmQdkQNMSN+Ti1wiWiYGA1PawRjsrS908+Bp5pMlFsVBriURSYUIOI93d8oLvOGfIMZ50OfEoAliX5OmONMvw==}
+  /@litentry/sidechain-api/0.9.20-next.8:
+    resolution: {integrity: sha512-QOy9rDUZYvk2k+cIBkIOzBCEDr/ncq1Tc4NypB9+kX68d9ET9gwX1tqIX/A0HpRFh4WCuj+J2XEngFeeeB4Q8Q==}
     dependencies:
       '@polkadot/api': 10.13.1
       '@polkadot/api-augment': 10.13.1


### PR DESCRIPTION
This is a client follow-up pull request of https://github.com/litentry/litentry-parachain/pull/3173

Use `TrustedOperationAuthenticated` instead of `TrustedOperation` for native calls.

Published packages:
- client-sdk: https://www.npmjs.com/package/@litentry/client-sdk/v/1.0.0-next.2
- parachain-api: https://www.npmjs.com/package/@litentry/parachain-api/v/0.9.20-next.8
- sidechain-api: https://www.npmjs.com/package/@litentry/sidechain-api/v/0.9.20-next.8 