### PR TITLE
`omni-executor` path fix

### DIFF
--- a/tee-worker/omni-executor/docker-compose.yml
+++ b/tee-worker/omni-executor/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     depends_on:
       - ethereum-node
       - litentry-node
-    command: ["executor-worker", "ws://litentry-node:9944", "http://ethereum-node:8545"]
+    command: ["executor-worker", "ws://litentry-node:9944", "http://ethereum-node:8545", "0"]
     restart: always
   ethereum-node:
     image: ghcr.io/foundry-rs/foundry

--- a/tee-worker/omni-executor/parentchain/listener/src/lib.rs
+++ b/tee-worker/omni-executor/parentchain/listener/src/lib.rs
@@ -108,7 +108,7 @@ pub async fn create_listener<EthereumIntentExecutorT: IntentExecutor + Send + Sy
 
 	let metadata_provider =
 		Arc::new(SubxtMetadataProvider::new(SubxtClientFactory::new(ws_rpc_endpoint)));
-	let key_store = Arc::new(SubstrateKeyStore::new("/data/parentchain_key.bin".to_string()));
+	let key_store = Arc::new(SubstrateKeyStore::new("data/parentchain_key.bin".to_string()));
 	let secret_key_bytes = key_store
 		.read()
 		.map_err(|e| {


### PR DESCRIPTION
It should use relative path instead of absolute

