### PR TITLE
Use custom txpool to workaround the invalid tx

### DIFF
--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -168,11 +168,11 @@ sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sta
 sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
 sc-tracing = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
 sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
 
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
 substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
 substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
 
 # wasm

--- a/parachain/node/src/custom_txpool.rs
+++ b/parachain/node/src/custom_txpool.rs
@@ -1,0 +1,100 @@
+use futures::Future;
+use sc_transaction_pool_api::{
+	ImportNotificationStream, PoolFuture, PoolStatus, ReadyTransactions, TransactionFor,
+	TransactionPool, TransactionSource, TransactionStatusStreamFor, TxHash,
+};
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
+
+pub struct CustomPool<I> {
+	inner_pool: Arc<I>,
+}
+
+impl<I> CustomPool<I> {
+	pub fn new(inner_pool: Arc<I>) -> Self {
+		Self { inner_pool }
+	}
+}
+
+impl<I> TransactionPool for CustomPool<I>
+where
+	I: TransactionPool,
+{
+	type Block = I::Block;
+	type Hash = I::Hash;
+	type InPoolTransaction = I::InPoolTransaction;
+	type Error = I::Error;
+
+	fn submit_at(
+		&self,
+		at: <Self::Block as BlockT>::Hash,
+		source: TransactionSource,
+		xts: Vec<TransactionFor<Self>>,
+	) -> PoolFuture<Vec<Result<TxHash<Self>, Self::Error>>, Self::Error> {
+		self.inner_pool.submit_at(at, source, xts)
+	}
+
+	fn submit_one(
+		&self,
+		at: <Self::Block as BlockT>::Hash,
+		source: TransactionSource,
+		xt: TransactionFor<Self>,
+	) -> PoolFuture<TxHash<Self>, Self::Error> {
+		self.inner_pool.submit_one(at, source, xt)
+	}
+
+	fn submit_and_watch(
+		&self,
+		at: <Self::Block as BlockT>::Hash,
+		source: TransactionSource,
+		xt: TransactionFor<Self>,
+	) -> PoolFuture<Pin<Box<TransactionStatusStreamFor<Self>>>, Self::Error> {
+		self.inner_pool.submit_and_watch(at, source, xt)
+	}
+
+	fn remove_invalid(&self, _: &[TxHash<Self>]) -> Vec<Arc<Self::InPoolTransaction>> {
+		// Don't do anything on purpose.
+		Vec::new()
+	}
+
+	fn status(&self) -> PoolStatus {
+		self.inner_pool.status()
+	}
+
+	fn import_notification_stream(&self) -> ImportNotificationStream<TxHash<Self>> {
+		self.inner_pool.import_notification_stream()
+	}
+
+	fn hash_of(&self, xt: &TransactionFor<Self>) -> TxHash<Self> {
+		self.inner_pool.hash_of(xt)
+	}
+
+	fn on_broadcasted(&self, propagations: HashMap<TxHash<Self>, Vec<String>>) {
+		self.inner_pool.on_broadcasted(propagations)
+	}
+
+	fn ready_transaction(&self, hash: &TxHash<Self>) -> Option<Arc<Self::InPoolTransaction>> {
+		self.inner_pool.ready_transaction(hash)
+	}
+
+	fn ready_at(
+		&self,
+		at: NumberFor<Self::Block>,
+	) -> Pin<
+		Box<
+			dyn Future<
+					Output = Box<dyn ReadyTransactions<Item = Arc<Self::InPoolTransaction>> + Send>,
+				> + Send,
+		>,
+	> {
+		self.inner_pool.ready_at(at)
+	}
+
+	fn ready(&self) -> Box<dyn ReadyTransactions<Item = Arc<Self::InPoolTransaction>> + Send> {
+		self.inner_pool.ready()
+	}
+
+	fn futures(&self) -> Vec<Self::InPoolTransaction> {
+		self.inner_pool.futures()
+	}
+}

--- a/parachain/node/src/main.rs
+++ b/parachain/node/src/main.rs
@@ -19,6 +19,7 @@
 mod chain_specs;
 mod cli;
 mod command;
+mod custom_txpool;
 mod evm_tracing_types;
 mod rpc;
 mod service;

--- a/parachain/node/src/service.rs
+++ b/parachain/node/src/service.rs
@@ -749,11 +749,17 @@ where
 	let select_chain = maybe_select_chain
 		.expect("In `standalone` mode, `new_partial` will return some `select_chain`; qed");
 
+	// TODO: use fork-aware txpool when paritytech/polkadot-sdk#4639 is included in a stable release
+	//       presumably in stable2412
+	//       This is a workaround mentioned in https://github.com/paritytech/polkadot-sdk/issues/1202
+	let custom_txpool =
+		std::sync::Arc::new(crate::custom_txpool::CustomPool::new(transaction_pool.clone()));
+
 	if role.is_authority() {
 		let proposer_factory = sc_basic_authorship::ProposerFactory::new(
 			task_manager.spawn_handle(),
 			client.clone(),
-			transaction_pool.clone(),
+			custom_txpool,
 			None,
 			None,
 		);
@@ -1059,10 +1065,16 @@ where
 		+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>,
 {
+	// TODO: use fork-aware txpool when paritytech/polkadot-sdk#4639 is included in a stable release
+	//       presumably in stable2412
+	//       This is a workaround mentioned in https://github.com/paritytech/polkadot-sdk/issues/1202
+	let custom_txpool =
+		std::sync::Arc::new(crate::custom_txpool::CustomPool::new(transaction_pool.clone()));
+
 	let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
 		task_manager.spawn_handle(),
 		client.clone(),
-		transaction_pool,
+		custom_txpool,
 		prometheus_registry,
 		telemetry.clone(),
 	);

--- a/parachain/zombienet/config.toml
+++ b/parachain/zombienet/config.toml
@@ -31,7 +31,7 @@ args = [
   "--force-authoring",
   "--enable-evm-rpc",
   "--state-pruning=archive",
-  "--delayed-best-block",
+  # "--delayed-best-block",
   "-l=parachain=debug,txpool=trace"
 ]
 ws_port = {{COLLATOR_WS_PORT}}

--- a/parachain/zombienet/config.toml
+++ b/parachain/zombienet/config.toml
@@ -31,7 +31,6 @@ args = [
   "--force-authoring",
   "--enable-evm-rpc",
   "--state-pruning=archive",
-  # "--delayed-best-block",
   "-l=parachain=debug,txpool=trace"
 ]
 ws_port = {{COLLATOR_WS_PORT}}


### PR DESCRIPTION
### Context

As topic.

A proper fix is using fork-aware txpool as done here: https://github.com/paritytech/polkadot-sdk/pull/4639

However we are using `stable2407`  branch which means direct cherry-picking will result in many incompatible issues. I also tried ported versions [from tanssi](https://github.com/moondance-labs/polkadot-sdk/tree/tanssi-polkadot-stable2407-tx-pool-fix-wip) and it didn't work so well.

The workaround is taken from the comment in https://github.com/paritytech/polkadot-sdk/issues/1202 (from Frequency) - in my tests it looked good without `--delayed-best-block`