### PR TITLE
Fix post-checks test script environment variable

### DIFF
--- a/tee-worker/identity/ts-tests/post-checks/config.ts
+++ b/tee-worker/identity/ts-tests/post-checks/config.ts
@@ -1,7 +1,8 @@
-import { byId } from '@litentry/chaindata';
+import { byId, ChainId } from '@litentry/chaindata';
 
 // Change this to the environment you want to test
-const chain = byId['litentry-prod'];
+const network = process.env.LITENTRY_NETWORK;
+const chain = byId[network as ChainId];
 
 export const nodeEndpoint: string = chain.rpcs[0].url;
 export const enclaveEndpoint: string = chain.enclaveRpcs[0].url;

--- a/tee-worker/identity/ts-tests/post-checks/package.json
+++ b/tee-worker/identity/ts-tests/post-checks/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "LITENTRY_NETWORK='litentry-dev' mocha --timeout 20000 --exit --sort -r ts-node/register --loader=ts-node/esm ./tests/**/*.test.ts"
+    "start": "LITENTRY_NETWORK=${LITENTRY_NETWORK:-litentry-dev} mocha --timeout 20000 --exit --sort -r ts-node/register --loader=ts-node/esm ./tests/**/*.test.ts"
   },
   "dependencies": {
     "@litentry/chaindata": "^0.2.0",


### PR DESCRIPTION
The start script always uses the config's settings, causing the script's environment variables to not work.