### PR TITLE
Only Initialize AccountStore in-memory state when starting the worker

### DIFF
--- a/tee-worker/identity/service/src/main_impl.rs
+++ b/tee-worker/identity/service/src/main_impl.rs
@@ -162,11 +162,6 @@ pub(crate) fn main() {
 		enclave_metrics_receiver,
 	)));
 
-	// init in-memory store, it should be done after the o-call bridge is initialized
-	if let Err(e) = enclave.init_in_memory_state() {
-		error!("Failed to initialize in-memory state: {:?}", e);
-	}
-
 	#[cfg(feature = "dcap")]
 	let quoting_enclave_target_info = match enclave.qe_get_target_info() {
 		Ok(target_info) => Some(target_info),
@@ -190,6 +185,11 @@ pub(crate) fn main() {
 	let quote_size = None;
 
 	if let Some(run_config) = config.run_config() {
+		// init in-memory store, it should be done after the o-call bridge is initialized
+		if let Err(e) = enclave.init_in_memory_state() {
+			error!("Failed to initialize in-memory state: {:?}", e);
+		}
+
 		let shard = extract_shard(run_config.shard(), enclave.as_ref());
 
 		info!("Worker Config: {:?}", config);


### PR DESCRIPTION
As topic, we don't need to initialize the in-memory state when running other commands, e.g: `migrate-shard`
