### PR TITLE
Optimize parachain events handling

### DIFF
--- a/tee-worker/common/core-primitives/types/src/parentchain/mod.rs
+++ b/tee-worker/common/core-primitives/types/src/parentchain/mod.rs
@@ -98,31 +98,34 @@ pub trait IdentifyParentchain {
 pub trait FilterEvents {
 	type Error: From<ParentchainEventProcessingError> + Debug;
 
-	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error>;
+	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error>;
 
-	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error>;
+	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error>;
 
 	fn get_deactivate_identity_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error>;
 
-	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error>;
+	fn get_activate_identity_events(
+		&mut self,
+	) -> Result<Vec<ActivateIdentityRequested>, Self::Error>;
 
-	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error>;
+	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error>;
 
-	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error>;
+	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error>;
 
-	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error>;
+	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error>;
 
 	fn get_parentchain_block_proccessed_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error>;
 
-	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error>;
+	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error>;
 
-	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error>;
+	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error>;
 
-	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error>;
+	fn get_account_store_updated_events(&mut self)
+		-> Result<Vec<AccountStoreUpdated>, Self::Error>;
 }
 
 #[derive(Debug)]
@@ -143,7 +146,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		executor: &Executor,
-		events: impl FilterEvents,
+		events: &mut impl FilterEvents,
 		block_number: <<Block as ParentchainBlock>::Header as ParentchainHeader>::Number,
 	) -> Result<Self::Output, Error>
 	where

--- a/tee-worker/common/core-primitives/types/src/parentchain/mod.rs
+++ b/tee-worker/common/core-primitives/types/src/parentchain/mod.rs
@@ -98,34 +98,31 @@ pub trait IdentifyParentchain {
 pub trait FilterEvents {
 	type Error: From<ParentchainEventProcessingError> + Debug;
 
-	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error>;
+	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error>;
 
-	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error>;
+	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error>;
 
 	fn get_deactivate_identity_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error>;
 
-	fn get_activate_identity_events(
-		&mut self,
-	) -> Result<Vec<ActivateIdentityRequested>, Self::Error>;
+	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error>;
 
-	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error>;
+	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error>;
 
-	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error>;
+	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error>;
 
-	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error>;
+	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error>;
 
 	fn get_parentchain_block_proccessed_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error>;
 
-	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error>;
+	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error>;
 
-	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error>;
+	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error>;
 
-	fn get_account_store_updated_events(&mut self)
-		-> Result<Vec<AccountStoreUpdated>, Self::Error>;
+	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error>;
 }
 
 #[derive(Debug)]
@@ -146,7 +143,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		executor: &Executor,
-		events: &mut impl FilterEvents,
+		events: impl FilterEvents,
 		block_number: <<Block as ParentchainBlock>::Header as ParentchainHeader>::Number,
 	) -> Result<Self::Output, Error>
 	where

--- a/tee-worker/common/core-primitives/types/src/parentchain/mod.rs
+++ b/tee-worker/common/core-primitives/types/src/parentchain/mod.rs
@@ -32,8 +32,6 @@ use sp_runtime::{
 	MultiAddress, MultiSignature,
 };
 
-use self::events::ParentchainBlockProcessed;
-
 pub type StorageProof = Vec<Vec<u8>>;
 
 // Basic Types.
@@ -113,10 +111,6 @@ pub trait FilterEvents {
 	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error>;
 
 	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error>;
-
-	fn get_parentchain_block_proccessed_events(
-		&self,
-	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error>;
 
 	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error>;
 

--- a/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_filter.rs
@@ -16,25 +16,58 @@
 */
 //! Various way to filter Parentchain events
 
-use itc_parentchain_indirect_calls_executor::event_filter::ToEvents;
-use itp_api_client_types::Events;
-
+use itp_api_client_types::{EventDetails, Events};
 use itp_node_api::api_client::StaticEvent;
 use itp_types::{
 	parentchain::{events::*, FilterEvents},
 	H256,
 };
-use std::vec::Vec;
+use std::{vec, vec::Vec};
 
 #[derive(Clone)]
-pub struct FilterableEvents(pub Events<H256>);
+pub struct FilterableEvents {
+	events: Vec<EventDetails<H256>>,
+}
 
 impl FilterableEvents {
-	fn filter<T: StaticEvent, E>(&self) -> Result<Vec<T>, E> {
+	pub fn new(events: Events<H256>) -> Self {
+		let mut interesting_events = vec![];
+		events.iter().flatten().for_each(|ev| {
+			// lets keep only events worker is interested in
+			if ev.pallet_name() == LinkIdentityRequested::PALLET
+				&& ev.variant_name() == LinkIdentityRequested::EVENT
+				|| ev.pallet_name() == VCRequested::PALLET
+					&& ev.variant_name() == VCRequested::EVENT
+				|| ev.pallet_name() == DeactivateIdentityRequested::PALLET
+					&& ev.variant_name() == DeactivateIdentityRequested::EVENT
+				|| ev.pallet_name() == ActivateIdentityRequested::PALLET
+					&& ev.variant_name() == ActivateIdentityRequested::EVENT
+				|| ev.pallet_name() == EnclaveUnauthorized::PALLET
+					&& ev.variant_name() == EnclaveUnauthorized::EVENT
+				|| ev.pallet_name() == OpaqueTaskPosted::PALLET
+					&& ev.variant_name() == OpaqueTaskPosted::EVENT
+				|| ev.pallet_name() == AssertionCreated::PALLET
+					&& ev.variant_name() == AssertionCreated::EVENT
+				|| ev.pallet_name() == ParentchainBlockProcessed::PALLET
+					&& ev.variant_name() == ParentchainBlockProcessed::EVENT
+				|| ev.pallet_name() == EnclaveAdded::PALLET
+					&& ev.variant_name() == EnclaveAdded::EVENT
+				|| ev.pallet_name() == EnclaveRemoved::PALLET
+					&& ev.variant_name() == EnclaveRemoved::EVENT
+				|| ev.pallet_name() == AccountStoreUpdated::PALLET
+					&& ev.variant_name() == AccountStoreUpdated::EVENT
+			{
+				interesting_events.push(ev)
+			}
+		});
+
+		Self { events: interesting_events }
+	}
+
+	fn filter<T: StaticEvent, E>(&mut self) -> Result<Vec<T>, E> {
 		Ok(self
-			.to_events()
+			.events
 			.iter()
-			.flatten()
 			.filter_map(|ev| match ev.as_event::<T>() {
 				Ok(maybe_event) => maybe_event,
 				Err(e) => {
@@ -46,67 +79,64 @@ impl FilterableEvents {
 	}
 }
 
-// todo: improve: https://github.com/integritee-network/worker/pull/1378#discussion_r1393933766
-impl ToEvents<Events<H256>> for FilterableEvents {
-	fn to_events(&self) -> &Events<H256> {
-		&self.0
-	}
-}
-
 impl From<Events<H256>> for FilterableEvents {
 	fn from(ev: Events<H256>) -> Self {
-		Self(ev)
+		Self::new(ev)
 	}
 }
 
 impl FilterEvents for FilterableEvents {
 	type Error = itc_parentchain_indirect_calls_executor::Error;
 
-	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
+	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error> {
+	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_deactivate_identity_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
+	fn get_activate_identity_events(
+		&mut self,
+	) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
+	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
+	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
+	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_parentchain_block_proccessed_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
+	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
+	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
+	fn get_account_store_updated_events(
+		&mut self,
+	) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
 		self.filter()
 	}
 }

--- a/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_filter.rs
@@ -48,8 +48,6 @@ impl FilterableEvents {
 					&& ev.variant_name() == OpaqueTaskPosted::EVENT
 				|| ev.pallet_name() == AssertionCreated::PALLET
 					&& ev.variant_name() == AssertionCreated::EVENT
-				|| ev.pallet_name() == ParentchainBlockProcessed::PALLET
-					&& ev.variant_name() == ParentchainBlockProcessed::EVENT
 				|| ev.pallet_name() == EnclaveAdded::PALLET
 					&& ev.variant_name() == EnclaveAdded::EVENT
 				|| ev.pallet_name() == EnclaveRemoved::PALLET
@@ -115,12 +113,6 @@ impl FilterEvents for FilterableEvents {
 	}
 
 	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
-		self.filter()
-	}
-
-	fn get_parentchain_block_proccessed_events(
-		&self,
-	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		self.filter()
 	}
 

--- a/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_filter.rs
@@ -64,7 +64,7 @@ impl FilterableEvents {
 		Self { events: interesting_events }
 	}
 
-	fn filter<T: StaticEvent, E>(&mut self) -> Result<Vec<T>, E> {
+	fn filter<T: StaticEvent, E>(&self) -> Result<Vec<T>, E> {
 		Ok(self
 			.events
 			.iter()
@@ -88,55 +88,51 @@ impl From<Events<H256>> for FilterableEvents {
 impl FilterEvents for FilterableEvents {
 	type Error = itc_parentchain_indirect_calls_executor::Error;
 
-	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
+	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error> {
+	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_deactivate_identity_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_activate_identity_events(
-		&mut self,
-	) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
+	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
+	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
+	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error> {
+	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_parentchain_block_proccessed_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error> {
+	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
+	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_account_store_updated_events(
-		&mut self,
-	) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
+	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
 		self.filter()
 	}
 }

--- a/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_handler.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_handler.rs
@@ -255,7 +255,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		executor: &Executor,
-		events: impl FilterEvents,
+		events: &mut impl FilterEvents,
 		block_number: <<Block as ParentchainBlockTrait>::Header as ParentchainHeader>::Number,
 	) -> Result<ProcessedEventsArtifacts, Error>
 	where

--- a/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_handler.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_handler.rs
@@ -255,7 +255,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		executor: &Executor,
-		events: &mut impl FilterEvents,
+		events: impl FilterEvents,
 		block_number: <<Block as ParentchainBlockTrait>::Header as ParentchainHeader>::Number,
 	) -> Result<ProcessedEventsArtifacts, Error>
 	where

--- a/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_handler.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/integritee/event_handler.rs
@@ -372,15 +372,6 @@ where
 				.map_err(|_| ParentchainEventProcessingError::AssertionCreatedFailure)?;
 		}
 
-		if let Ok(events) = events.get_parentchain_block_proccessed_events() {
-			debug!("Handling ParentchainBlockProcessed events");
-			events.iter().for_each(|event| {
-				debug!("found ParentchainBlockProcessed event: {:?}", event);
-				// This is for monitoring purposes
-				handled_events.push(hash_of(&event));
-			});
-		}
-
 		if let Ok(events) = events.get_account_store_updated_events() {
 			debug!("Handling AccountStoreUpdated events");
 			events

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_filter.rs
@@ -60,51 +60,55 @@ impl From<Events<H256>> for FilterableEvents {
 impl FilterEvents for FilterableEvents {
 	type Error = itc_parentchain_indirect_calls_executor::Error;
 
-	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
+	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error> {
+	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_deactivate_identity_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
+	fn get_activate_identity_events(
+		&mut self,
+	) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
+	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
+	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
+	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_parentchain_block_proccessed_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
+	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
+	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
+	fn get_account_store_updated_events(
+		&mut self,
+	) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
 		self.filter()
 	}
 }

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_filter.rs
@@ -60,55 +60,51 @@ impl From<Events<H256>> for FilterableEvents {
 impl FilterEvents for FilterableEvents {
 	type Error = itc_parentchain_indirect_calls_executor::Error;
 
-	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
+	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error> {
+	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_deactivate_identity_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_activate_identity_events(
-		&mut self,
-	) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
+	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
+	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
+	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error> {
+	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_parentchain_block_proccessed_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error> {
+	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
+	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_account_store_updated_events(
-		&mut self,
-	) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
+	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
 		self.filter()
 	}
 }

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_filter.rs
@@ -90,12 +90,6 @@ impl FilterEvents for FilterableEvents {
 		self.filter()
 	}
 
-	fn get_parentchain_block_proccessed_events(
-		&self,
-	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
-		Ok(Vec::new())
-	}
-
 	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		self.filter()
 	}

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_handler.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_handler.rs
@@ -36,7 +36,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		_executor: &Executor,
-		_events: &mut impl FilterEvents,
+		_events: impl FilterEvents,
 		_block_number: <<Block as ParentchainBlock>::Header as ParentchainHeader>::Number,
 	) -> Result<ProcessedEventsArtifacts, Error>
 	where

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_handler.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_a/event_handler.rs
@@ -36,7 +36,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		_executor: &Executor,
-		_events: impl FilterEvents,
+		_events: &mut impl FilterEvents,
 		_block_number: <<Block as ParentchainBlock>::Header as ParentchainHeader>::Number,
 	) -> Result<ProcessedEventsArtifacts, Error>
 	where

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_filter.rs
@@ -60,51 +60,55 @@ impl From<Events<H256>> for FilterableEvents {
 impl FilterEvents for FilterableEvents {
 	type Error = itc_parentchain_indirect_calls_executor::Error;
 
-	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
+	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error> {
+	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_deactivate_identity_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
+	fn get_activate_identity_events(
+		&mut self,
+	) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
+	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
+	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
+	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_parentchain_block_proccessed_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
+	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
+	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
+	fn get_account_store_updated_events(
+		&mut self,
+	) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
 		self.filter()
 	}
 }

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_filter.rs
@@ -60,55 +60,51 @@ impl From<Events<H256>> for FilterableEvents {
 impl FilterEvents for FilterableEvents {
 	type Error = itc_parentchain_indirect_calls_executor::Error;
 
-	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
+	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error> {
+	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_deactivate_identity_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_activate_identity_events(
-		&mut self,
-	) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
+	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
+	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
+	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error> {
+	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
 		self.filter()
 	}
 
 	fn get_parentchain_block_proccessed_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error> {
+	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
+	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
 		self.filter()
 	}
 
-	fn get_account_store_updated_events(
-		&mut self,
-	) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
+	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
 		self.filter()
 	}
 }

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_filter.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_filter.rs
@@ -90,12 +90,6 @@ impl FilterEvents for FilterableEvents {
 		self.filter()
 	}
 
-	fn get_parentchain_block_proccessed_events(
-		&self,
-	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
-		Ok(Vec::new())
-	}
-
 	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		self.filter()
 	}

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_handler.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_handler.rs
@@ -36,7 +36,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		_executor: &Executor,
-		_events: &mut impl FilterEvents,
+		_events: impl FilterEvents,
 		_block_number: <<Block as ParentchainBlock>::Header as ParentchainHeader>::Number,
 	) -> Result<ProcessedEventsArtifacts, Error>
 	where

--- a/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_handler.rs
+++ b/tee-worker/identity/app-libs/parentchain-interface/src/target_b/event_handler.rs
@@ -36,7 +36,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		_executor: &Executor,
-		_events: impl FilterEvents,
+		_events: &mut impl FilterEvents,
 		_block_number: <<Block as ParentchainBlock>::Header as ParentchainHeader>::Number,
 	) -> Result<ProcessedEventsArtifacts, Error>
 	where

--- a/tee-worker/identity/core/parentchain/indirect-calls-executor/src/executor.rs
+++ b/tee-worker/identity/core/parentchain/indirect-calls-executor/src/executor.rs
@@ -164,7 +164,7 @@ impl<
 
 		trace!("Scanning block {:?} for relevant events", block_number);
 
-		let events = self
+		let mut events = self
 			.node_meta_data_provider
 			.get_from_metadata(|metadata| {
 				EventCreator::create_from_metadata(metadata.clone(), block_hash, events)
@@ -173,7 +173,7 @@ impl<
 
 		let (processed_events, successful_assertion_ids, failed_assertion_ids) = self
 			.parentchain_event_handler
-			.handle_events::<ParentchainBlock>(self, events, block_number)?;
+			.handle_events::<ParentchainBlock>(self, &mut events, block_number)?;
 		let mut calls: Vec<OpaqueCall> = Vec::new();
 		if !successful_assertion_ids.is_empty() {
 			calls.extend(self.create_assertion_stored_call(successful_assertion_ids)?);

--- a/tee-worker/identity/core/parentchain/indirect-calls-executor/src/executor.rs
+++ b/tee-worker/identity/core/parentchain/indirect-calls-executor/src/executor.rs
@@ -164,7 +164,7 @@ impl<
 
 		trace!("Scanning block {:?} for relevant events", block_number);
 
-		let mut events = self
+		let events = self
 			.node_meta_data_provider
 			.get_from_metadata(|metadata| {
 				EventCreator::create_from_metadata(metadata.clone(), block_hash, events)
@@ -173,7 +173,7 @@ impl<
 
 		let (processed_events, successful_assertion_ids, failed_assertion_ids) = self
 			.parentchain_event_handler
-			.handle_events::<ParentchainBlock>(self, &mut events, block_number)?;
+			.handle_events::<ParentchainBlock>(self, events, block_number)?;
 		let mut calls: Vec<OpaqueCall> = Vec::new();
 		if !successful_assertion_ids.is_empty() {
 			calls.extend(self.create_assertion_stored_call(successful_assertion_ids)?);

--- a/tee-worker/identity/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/tee-worker/identity/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -60,12 +60,6 @@ impl FilterEvents for MockEvents {
 		Ok(Vec::new())
 	}
 
-	fn get_parentchain_block_proccessed_events(
-		&self,
-	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
-		Ok(Vec::new())
-	}
-
 	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		Ok(Vec::new())
 	}

--- a/tee-worker/identity/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/tee-worker/identity/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -28,53 +28,57 @@ pub struct MockEvents;
 impl FilterEvents for MockEvents {
 	type Error = ();
 
-	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
+	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
 		let opaque_task_posted_event =
 			OpaqueTaskPosted { request: RsaRequest::new(H256::default(), Vec::from([0u8; 32])) };
 		Ok(Vec::from([opaque_task_posted_event]))
 	}
 
-	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
+	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error> {
+	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error> {
 		Ok(Vec::new())
 	}
 
 	fn get_deactivate_identity_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
+	fn get_activate_identity_events(
+		&mut self,
+	) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
+	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
+	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error> {
 		Ok(Vec::new())
 	}
 
 	fn get_parentchain_block_proccessed_events(
-		&self,
+		&mut self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
+	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
+	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
+	fn get_account_store_updated_events(
+		&mut self,
+	) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
 		Ok(Vec::new())
 	}
 }
@@ -90,7 +94,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		_: &Executor,
-		_: impl FilterEvents,
+		_: &mut impl FilterEvents,
 		_block_number: <<Block as ParentchainBlock>::Header as ParentchainHeader>::Number,
 	) -> Result<ProcessedEventsArtifacts, Error>
 	where

--- a/tee-worker/identity/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/tee-worker/identity/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -28,57 +28,53 @@ pub struct MockEvents;
 impl FilterEvents for MockEvents {
 	type Error = ();
 
-	fn get_opaque_task_posted_events(&mut self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
+	fn get_opaque_task_posted_events(&self) -> Result<Vec<OpaqueTaskPosted>, Self::Error> {
 		let opaque_task_posted_event =
 			OpaqueTaskPosted { request: RsaRequest::new(H256::default(), Vec::from([0u8; 32])) };
 		Ok(Vec::from([opaque_task_posted_event]))
 	}
 
-	fn get_link_identity_events(&mut self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
+	fn get_link_identity_events(&self) -> Result<Vec<LinkIdentityRequested>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_vc_requested_events(&mut self) -> Result<Vec<VCRequested>, Self::Error> {
+	fn get_vc_requested_events(&self) -> Result<Vec<VCRequested>, Self::Error> {
 		Ok(Vec::new())
 	}
 
 	fn get_deactivate_identity_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<DeactivateIdentityRequested>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_activate_identity_events(
-		&mut self,
-	) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
+	fn get_activate_identity_events(&self) -> Result<Vec<ActivateIdentityRequested>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_unauthorized_events(&mut self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
+	fn get_enclave_unauthorized_events(&self) -> Result<Vec<EnclaveUnauthorized>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_assertion_created_events(&mut self) -> Result<Vec<AssertionCreated>, Self::Error> {
+	fn get_assertion_created_events(&self) -> Result<Vec<AssertionCreated>, Self::Error> {
 		Ok(Vec::new())
 	}
 
 	fn get_parentchain_block_proccessed_events(
-		&mut self,
+		&self,
 	) -> Result<Vec<ParentchainBlockProcessed>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_added_events(&mut self) -> Result<Vec<EnclaveAdded>, Self::Error> {
+	fn get_enclave_added_events(&self) -> Result<Vec<EnclaveAdded>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_enclave_removed_events(&mut self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
+	fn get_enclave_removed_events(&self) -> Result<Vec<EnclaveRemoved>, Self::Error> {
 		Ok(Vec::new())
 	}
 
-	fn get_account_store_updated_events(
-		&mut self,
-	) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
+	fn get_account_store_updated_events(&self) -> Result<Vec<AccountStoreUpdated>, Self::Error> {
 		Ok(Vec::new())
 	}
 }
@@ -94,7 +90,7 @@ where
 	fn handle_events<Block>(
 		&self,
 		_: &Executor,
-		_: &mut impl FilterEvents,
+		_: impl FilterEvents,
 		_block_number: <<Block as ParentchainBlock>::Header as ParentchainHeader>::Number,
 	) -> Result<ProcessedEventsArtifacts, Error>
 	where


### PR DESCRIPTION
Iterate parachain's events only once and keep only events worker is interested in.

This should reduce time spent by event handler during parachain's event processing. It doesn't guarantee that sidechain block events will come out every 6 s.