### PR TITLE
Temporarily ignoring failing tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,8 +707,9 @@ jobs:
           - test_name: lit-dr-vc-test
           - test_name: lit-parentchain-nonce
           - test_name: lit-test-failed-parentchain-extrinsic
-          - test_name: lit-omni-account-test
-          - test_name: lit-native-request-vc-test
+          # TODO: enable these tests once we use polkadot-sdk branch stable2412
+          # - test_name: lit-omni-account-test
+          # - test_name: lit-native-request-vc-test
     name: ${{ matrix.test_name }}
     steps:
       - uses: actions/checkout@v4
@@ -793,8 +794,9 @@ jobs:
           - test_name: lit-di-identity-multiworker-test
           - test_name: lit-dr-vc-multiworker-test
           - test_name: lit-resume-worker
-          - test_name: lit-omni-account-multiworker-test
-          - test_name: lit-native-request-vc-multiworker-test
+          # TODO: enable these tests once we use polkadot-sdk branch stable2412
+          # - test_name: lit-omni-account-multiworker-test
+          # - test_name: lit-native-request-vc-multiworker-test
     name: ${{ matrix.test_name }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As mentioned [here](https://linear.app/litentry/issue/P-1246/native-request-error-in-ts-tests#comment-0f510ff9), we are disabling the failing tests on CI until we upgrade the polkadot-sdk version to `stable2412` branch. Hopefully the tx pool issue will be resolved


