### PR TITLE
feat: fix/edit missing migration

### DIFF
--- a/parachain/pallets/collab-ai/curator/src/lib.rs
+++ b/parachain/pallets/collab-ai/curator/src/lib.rs
@@ -52,7 +52,7 @@ pub mod pallet {
 	use super::*;
 
 	/// The current storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/parachain/pallets/collab-ai/guardian/src/lib.rs
+++ b/parachain/pallets/collab-ai/guardian/src/lib.rs
@@ -52,7 +52,7 @@ pub mod pallet {
 	use super::*;
 
 	/// The current storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/parachain/pallets/collab-ai/pool-proposal/src/lib.rs
+++ b/parachain/pallets/collab-ai/pool-proposal/src/lib.rs
@@ -71,7 +71,7 @@ pub mod pallet {
 	/// CollabAI investing pool proposal
 	const MODULE_ID: PalletId = PalletId(*b"cbai/ipp");
 	/// The current storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
 	pub type BalanceOf<T> =
 		<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;

--- a/parachain/runtime/litentry/src/migration/mod.rs
+++ b/parachain/runtime/litentry/src/migration/mod.rs
@@ -332,10 +332,10 @@ where
 				"StorageVersion".as_bytes(),
 			));
 
-			// Set storage version to `4`.
-			StorageVersion::new(4).put::<pallet_democracy::Pallet<T>>();
+			// Set storage version to `1`.
+			StorageVersion::new(1).put::<pallet_democracy::Pallet<T>>();
 
-			log::info!(target: DEMOCRACY_LOG_TARGET, "Storage to version 4");
+			log::info!(target: DEMOCRACY_LOG_TARGET, "Storage to version 1");
 			T::DbWeight::get().reads_writes(1, 3)
 		} else {
 			log::info!(
@@ -348,7 +348,7 @@ where
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		ensure!(StorageVersion::get::<pallet_democracy::Pallet<T>>() == 4, "Must upgrade");
+		ensure!(StorageVersion::get::<pallet_democracy::Pallet<T>>() == 1, "Must upgrade");
 		Ok(())
 	}
 }

--- a/parachain/runtime/paseo/src/migration/mod.rs
+++ b/parachain/runtime/paseo/src/migration/mod.rs
@@ -29,6 +29,13 @@
 
 // In try-runtime, current implementation, the storage version is not checked,
 // Pallet version is used instead.
+#[cfg(feature = "try-runtime")]
+use frame_support::ensure;
+use frame_support::traits::{
+	Get, GetStorageVersion, OnRuntimeUpgrade, PalletInfoAccess, StorageVersion,
+};
+use sp_std::marker::PhantomData;
+use sp_std::vec::Vec;
 
 pub type Migrations<Runtime> = (
 	// Identity V0 => V1
@@ -78,11 +85,11 @@ where
 			// Set storage version to `1`.
 			StorageVersion::new(1).put::<pallet_identity::Pallet<T>>();
 
-			log::info!(target: BOUNTIES_LOG_TARGET, "Storage to version 1");
+			log::info!(target: IDENTITY_LOG_TARGET, "Storage to version 1");
 			T::DbWeight::get().reads_writes(1, 3)
 		} else {
 			log::info!(
-				target: BOUNTIES_LOG_TARGET,
+				target: IDENTITY_LOG_TARGET,
 				"Migration did not execute. This probably should be removed"
 			);
 			T::DbWeight::get().reads(1)

--- a/parachain/runtime/paseo/src/migration/mod.rs
+++ b/parachain/runtime/paseo/src/migration/mod.rs
@@ -35,7 +35,6 @@ use frame_support::traits::{
 	Get, GetStorageVersion, OnRuntimeUpgrade, PalletInfoAccess, StorageVersion,
 };
 use sp_std::marker::PhantomData;
-use sp_std::vec::Vec;
 
 pub type Migrations<Runtime> = (
 	// Identity V0 => V1

--- a/parachain/runtime/paseo/src/migration/mod.rs
+++ b/parachain/runtime/paseo/src/migration/mod.rs
@@ -35,6 +35,8 @@ use frame_support::traits::{
 	Get, GetStorageVersion, OnRuntimeUpgrade, PalletInfoAccess, StorageVersion,
 };
 use sp_std::marker::PhantomData;
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
 
 pub type Migrations<Runtime> = (
 	// Identity V0 => V1


### PR DESCRIPTION
For Litentry: We have an ongoing democracy. So just bump storage version.
For Paseo: For collabAI pallets, decrease some storage version since it is not neccessary to be non-zero.
                 Add pallet_identity bump version.


