### PR TITLE
Remove unneeded chain spec criteria

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -5842,7 +5842,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "litentry-collator"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "async-trait",
  "clap",

--- a/parachain/node/Cargo.toml
+++ b/parachain/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://litentry.com/'
 license = 'GPL-3.0'
 name = 'litentry-collator'
 repository = 'https://github.com/litentry/litentry-parachain'
-version = '0.9.22'
+version = '0.9.23'
 
 [[bin]]
 name = 'litentry-collator'


### PR DESCRIPTION
### Context

As topic, it seems `is_litentry()` and `is_paseo()` are unneeded now


