### PR TITLE
Parametrize `sgx.debug`

### DIFF
--- a/tee-worker/omni-executor/omni-executor.manifest.template
+++ b/tee-worker/omni-executor/omni-executor.manifest.template
@@ -24,7 +24,7 @@ fs.mounts = [
   { path = "/storage_db", uri = "file:storage_db" },
 ]
 
-sgx.debug = true
+sgx.debug = {{ 'true' if env.get('SGX_DEBUG', '0') == '1' else 'false' }}
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 


### PR DESCRIPTION
Parametrizes `sgx.debug` in Gramine manifest.
This should be set to `false` for prod deployments.
Changing this flag requires fresh deployment (for example enclave will be unable to unseal existing files).
