### PR TITLE
Adjust weight consumption in parachain-staking

### DIFF
--- a/parachain/runtime/litentry/src/lib.rs
+++ b/parachain/runtime/litentry/src/lib.rs
@@ -1008,9 +1008,9 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Minimum collators selected per round, default at genesis and minimum forever after
 	type MinSelectedCandidates = ConstU32<1>;
 	/// Maximum top delegations per candidate
-	type MaxTopDelegationsPerCandidate = ConstU32<1000>;
+	type MaxTopDelegationsPerCandidate = ConstU32<300>;
 	/// Maximum bottom delegations per candidate
-	type MaxBottomDelegationsPerCandidate = ConstU32<200>;
+	type MaxBottomDelegationsPerCandidate = ConstU32<100>;
 	/// Maximum delegations per delegator
 	type MaxDelegationsPerDelegator = ConstU32<100>;
 	type DefaultCollatorCommission = DefaultCollatorCommission;

--- a/parachain/runtime/litentry/src/lib.rs
+++ b/parachain/runtime/litentry/src/lib.rs
@@ -1025,7 +1025,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MinDelegatorStk = MinDelegatorStk;
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
-	type WeightInfo = weights::pallet_parachain_staking::WeightInfo<Runtime>;
+	type WeightInfo = ();
 	type IssuanceAdapter = AssetsHandler;
 	type OnAllDelegationRemoved = ScoreStaking;
 }

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -1053,9 +1053,9 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Minimum collators selected per round, default at genesis and minimum forever after
 	type MinSelectedCandidates = ConstU32<1>;
 	/// Maximum top delegations per candidate
-	type MaxTopDelegationsPerCandidate = ConstU32<1000>;
+	type MaxTopDelegationsPerCandidate = ConstU32<300>;
 	/// Maximum bottom delegations per candidate
-	type MaxBottomDelegationsPerCandidate = ConstU32<200>;
+	type MaxBottomDelegationsPerCandidate = ConstU32<100>;
 	/// Maximum delegations per delegator
 	type MaxDelegationsPerDelegator = ConstU32<100>;
 	type DefaultCollatorCommission = DefaultCollatorCommission;

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -1070,7 +1070,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MinDelegatorStk = MinDelegatorStk;
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
-	type WeightInfo = weights::pallet_parachain_staking::WeightInfo<Runtime>;
+	type WeightInfo = ();
 	type IssuanceAdapter = AssetsHandler;
 	type OnAllDelegationRemoved = ScoreStaking;
 }

--- a/parachain/scripts/benchmark-weight-remote.sh
+++ b/parachain/scripts/benchmark-weight-remote.sh
@@ -23,9 +23,9 @@ docker pull litentry/litentry-parachain:runtime-benchmarks
 # clone the repo
 TMPDIR=/tmp
 cd "$TMPDIR"
-[ -d litentry-parachain ] && rm -rf litentry-parachain
-git clone https://github.com/litentry/litentry-parachain
-cd litentry-parachain/parachain
+[ -d heima ] && rm -rf heima
+git clone https://github.com/litentry/heima
+cd heima/parachain
 git checkout "$2"
 
 # copy binary out


### PR DESCRIPTION
### Context

To work around a problem reported by one collator.

This PR reduces the max top/bottom candidate delegations to be more practical.

It also uses the default pallet weights for parachain-staking - I wanted to rerun the benchmarking, but it seems we have problems with remote instances.

I verified the extrinsic with chopsticks - it should work now