### PR TITLE
P 1328 check runtime upgrade ci fails

### DIFF
--- a/.github/workflows/check-runtime-upgrade.yml
+++ b/.github/workflows/check-runtime-upgrade.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3.0.0
         with:
-          version: "3.6.1"
+          version: "23.x"
 
       - name: Add wasm32-unknown-unknown target
         run: rustup target add wasm32-unknown-unknown

--- a/parachain/scripts/runtime-upgrade.sh
+++ b/parachain/scripts/runtime-upgrade.sh
@@ -27,7 +27,7 @@ if [ -f "$new_wasm" ] && [ -s "$new_wasm" ]; then
   ls -l "$new_wasm"
 else
   echo "Cannot find $new_wasm or it has 0 bytes, quit"
-  exit 0
+  exit 1
 fi
 
 # Install tools


### PR DESCRIPTION
- upgrade protobuff version: 
   Only heima succeeds, because Paseo has already been updated. https://github.com/litentry/heima/actions/runs/13482675672

- minor bugfix: when release image not found, CI job should return failure. 

