### PR TITLE
Fix omni-executor ci checks

### DIFF
--- a/tee-worker/omni-executor/docker/docker-compose.yml
+++ b/tee-worker/omni-executor/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       litentry-node:
         condition: service_healthy
         restart: true
-    command: ["executor-worker", "run", "ws://litentry-node:9944", "http://ethereum-node:8545", "https://api.devnet.solana.com", "2100"]
+    command: ["executor-worker", "run", "ws://litentry-node:9944", "http://ethereum-node:8545", "https://api.devnet.solana.com", "ws://omni-executor:2100"]
     privileged: true
     restart: unless-stopped
     networks:

--- a/tee-worker/omni-executor/rpc-server/src/methods/get_health.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/get_health.rs
@@ -28,7 +28,7 @@ mod test {
 
 	#[tokio::test]
 	pub async fn get_health_works() {
-		let port = "2000";
+		let port = 2000;
 		let shielding_key = ShieldingKey::new();
 		let (sender, _) = mpsc::channel::<NativeTask>(1);
 		let client_factory = SubxtClientFactory::<CustomConfig>::new("ws://localhost:9944");


### PR DESCRIPTION
The last PR was automatically merged but the omni-executor check was failing due to a recent change. This PR fixes it.

