### PR TITLE
pass `AccountId` to intent executor

### DIFF
--- a/tee-worker/omni-executor/executor-core/src/intent_executor.rs
+++ b/tee-worker/omni-executor/executor-core/src/intent_executor.rs
@@ -19,10 +19,12 @@ use tokio::sync::mpsc;
 
 use executor_primitives::intent::Intent;
 
+pub type AccountId = [u8; 32];
+
 /// Used to perform intent on destination chain
 #[async_trait]
 pub trait IntentExecutor: Send {
-	async fn execute(&self, intent: Intent) -> Result<(), ()>;
+	async fn execute(&self, account_id: &AccountId, intent: Intent) -> Result<(), ()>;
 }
 
 pub struct MockedIntentExecutor {
@@ -38,7 +40,7 @@ impl MockedIntentExecutor {
 
 #[async_trait]
 impl IntentExecutor for MockedIntentExecutor {
-	async fn execute(&self, _intent: Intent) -> Result<(), ()> {
+	async fn execute(&self, _account_id: &AccountId, _intent: Intent) -> Result<(), ()> {
 		self.sender.send(()).map_err(|_| ())
 	}
 }

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -15,6 +15,7 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
+use executor_core::intent_executor::AccountId;
 use executor_core::intent_executor::IntentExecutor;
 use executor_primitives::intent::Intent;
 
@@ -28,7 +29,7 @@ impl CrossChainIntentExecutor {
 
 #[async_trait]
 impl IntentExecutor for CrossChainIntentExecutor {
-	async fn execute(&self, intent: Intent) -> Result<(), ()> {
+	async fn execute(&self, _account_id: &AccountId, intent: Intent) -> Result<(), ()> {
 		match intent {
 			Intent::CrossChainSwap(_swap_order) => {
 				// TODO:

--- a/tee-worker/omni-executor/intent/executors/ethereum/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/ethereum/src/lib.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 
 use alloy::primitives::Address;
 use async_trait::async_trait;
-use executor_core::intent_executor::IntentExecutor;
+use executor_core::intent_executor::{AccountId, IntentExecutor};
 use executor_primitives::intent::Intent;
 use log::{error, info};
 use rpc::AlloyRpcProviderFactory;
@@ -46,7 +46,7 @@ impl EthereumIntentExecutor {
 
 #[async_trait]
 impl IntentExecutor for EthereumIntentExecutor {
-	async fn execute(&self, intent: Intent) -> Result<(), ()> {
+	async fn execute(&self, _account_id: &AccountId, intent: Intent) -> Result<(), ()> {
 		info!("Executing intent: {:?}", intent);
 
 		let omni_account_signer = get_omni_account_signer();

--- a/tee-worker/omni-executor/intent/executors/solana/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/solana/src/lib.rs
@@ -15,7 +15,7 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
-use executor_core::intent_executor::IntentExecutor;
+use executor_core::intent_executor::{AccountId, IntentExecutor};
 use executor_primitives::intent::Intent;
 use log::{error, info};
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -42,7 +42,7 @@ impl SolanaIntentExecutor {
 
 #[async_trait]
 impl IntentExecutor for SolanaIntentExecutor {
-	async fn execute(&self, intent: Intent) -> Result<(), ()> {
+	async fn execute(&self, _account_id: &AccountId, intent: Intent) -> Result<(), ()> {
 		info!("Executing intent: {:?}", intent);
 		// TODO: get key from key store
 		let signer_key_pair = Keypair::read_from_file("dev-key.json")

--- a/tee-worker/omni-executor/native-task-handler/src/native_call_handlers.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/native_call_handlers.rs
@@ -175,7 +175,11 @@ pub async fn handle_native_call<
 					ctx.transaction_signer.sign(dispatch_as_omni_account_call, Some(nonce)).await
 				},
 				Intent::CallEthereum(_) | Intent::TransferEthereum(_) => {
-					if let Err(e) = ctx.ethereum_intent_executor.execute(intent.clone()).await {
+					if let Err(e) = ctx
+						.ethereum_intent_executor
+						.execute(omni_account.as_ref(), intent.clone())
+						.await
+					{
 						log::error!("Error executing intent: {:?}", e);
 						execution_result = IntentExecutionResult::Failure;
 					}
@@ -188,7 +192,11 @@ pub async fn handle_native_call<
 					ctx.transaction_signer.sign(intent_executed_call, Some(nonce)).await
 				},
 				Intent::TransferSolana(_) => {
-					if let Err(e) = ctx.solana_intent_executor.execute(intent.clone()).await {
+					if let Err(e) = ctx
+						.solana_intent_executor
+						.execute(omni_account.as_ref(), intent.clone())
+						.await
+					{
 						log::error!("Error executing intent: {:?}", e);
 						execution_result = IntentExecutionResult::Failure;
 					}
@@ -201,7 +209,11 @@ pub async fn handle_native_call<
 					ctx.transaction_signer.sign(intent_executed_call, Some(nonce)).await
 				},
 				Intent::CrossChainSwap(_) => {
-					if let Err(e) = ctx.cross_chain_intent_executor.execute(intent.clone()).await {
+					if let Err(e) = ctx
+						.cross_chain_intent_executor
+						.execute(omni_account.as_ref(), intent.clone())
+						.await
+					{
 						log::error!("Error executing intent: {:?}", e);
 						execution_result = IntentExecutionResult::Failure;
 					}


### PR DESCRIPTION
All intents are executed in context of Heima's account.
We need account information for multiple purposes:
* omni-account key derivation
* derived account's assets balance tracing & locking

