### PR TITLE
Add missing `tokio` features

### DIFF
--- a/tee-worker/omni-executor/executor-core/Cargo.toml
+++ b/tee-worker/omni-executor/executor-core/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = { workspace = true }
 log = { workspace = true }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 regex = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt"] }
 
 # Local dependencies
 executor-primitives = { workspace = true }


### PR DESCRIPTION
`executor-core` package cannot compile alone without them being listed explicitly.