### PR TITLE
Rename heima to heima-network in packages

### DIFF
--- a/tee-worker/client-api/parachain-api/package.json
+++ b/tee-worker/client-api/parachain-api/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@heima/parachain-api",
+    "name": "@heima-network/parachain-api",
     "type": "module",
     "license": "ISC",
     "main": "dist/src/index.js",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/CHANGELOG.md
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add OmniAccount requestors for `createAccountStore`, `remark`, `transferNative`, `transferEthereum`, and `callEthereum`.
 -   Add `requestVerificationCode` requestor.
 -   Add `requestAuthToken` requestor.
--   Use `@heima/parachain-api` instead of `@litentry/parachain-api`.
+-   Use `@heima-network/parachain-api` instead of `@litentry/parachain-api`.
 
 ## 2024-10-14
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/README.md
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/README.md
@@ -11,7 +11,7 @@ This is a browser package, it may not work as-is on Node.js due to Crypto Subtle
 1. Install from NPM
 
     ```
-    npm install @heima/parachain-api @litentry/sidechain-api @litentry/client-sdk
+    npm install @heima-network/parachain-api @litentry/sidechain-api @litentry/client-sdk
     ```
 
 2. Set the right environment

--- a/tee-worker/identity/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/package.json
@@ -8,7 +8,7 @@
 		"@polkadot/rpc-provider": "^15.0.2"
 	},
 	"peerDependencies": {
-		"@heima/parachain-api": "0.9.24-next.0",
+		"@heima-network/parachain-api": "0.9.24-next.0",
 		"@litentry/sidechain-api": "0.9.20-next.8",
 		"@litentry/chaindata": "*",
 		"@polkadot/api": "^15.0.2",

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/index.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/index.ts
@@ -1,5 +1,5 @@
 import '@litentry/sidechain-api';
-import '@heima/parachain-api';
+import '@heima-network/parachain-api';
 
 export { enclave, Enclave } from './lib/enclave';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/__test__/id-graph-decoder.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/__test__/id-graph-decoder.test.ts
@@ -2,7 +2,7 @@ import { TypeRegistry, Metadata } from '@polkadot/types';
 import { cryptoWaitReady, decodeAddress } from '@polkadot/util-crypto';
 
 import metadataRpc from '@litentry/sidechain-api/prepare-build/litentry-sidechain-metadata.json';
-import { identity, sidechain } from '@heima/parachain-api';
+import { identity, sidechain } from '@heima-network/parachain-api';
 
 import { createIdGraphType } from '../type-creators/id-graph';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/__test__/payload-signing.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/__test__/payload-signing.test.ts
@@ -10,7 +10,7 @@ import {
   identity,
   sidechain,
   trusted_operations,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { getEnclaveNonce } from '../requests/get-enclave-nonce';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/enclave.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/enclave.ts
@@ -2,7 +2,7 @@ import type {
   RequestVcResultOrError,
   StfError,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 import { JsonRpcRequest, JsonRpcResponse } from './util/types';
 import { compactStripLength, hexToU8a, u8aToString } from '@polkadot/util';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/add-account.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/add-account.request.ts
@@ -6,7 +6,7 @@ import type {
   LitentryValidationData,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/call-ethereum.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/call-ethereum.request.ts
@@ -5,7 +5,7 @@ import type {
   LitentryIdentity,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/create-account-store.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/create-account-store.request.ts
@@ -5,7 +5,7 @@ import type {
   LitentryIdentity,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/get-enclave-nonce.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/get-enclave-nonce.ts
@@ -6,7 +6,7 @@ import { enclave } from '../enclave';
 
 import type { ApiPromise } from '@polkadot/api';
 import type { Index } from '@polkadot/types/interfaces';
-import type { LitentryIdentity } from '@heima/parachain-api';
+import type { LitentryIdentity } from '@heima-network/parachain-api';
 import type { JsonRpcRequest } from '../util/types';
 
 /**

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/get-id-graph-hash.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/get-id-graph-hash.ts
@@ -1,4 +1,4 @@
-import type { LitentryIdentity } from '@heima/parachain-api';
+import type { LitentryIdentity } from '@heima-network/parachain-api';
 import type { JsonRpcRequest } from '../util/types';
 
 import type { ApiPromise } from '@polkadot/api';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/get-id-graph.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/get-id-graph.request.ts
@@ -4,7 +4,7 @@ import { blake2AsHex } from '@polkadot/util-crypto';
 import type {
   LitentryIdentity,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 import type { JsonRpcRequest } from '../util/types';
 import type { ApiPromise } from '@polkadot/api';
 import { type IdGraph, ID_GRAPH_STRUCT } from '../type-creators/id-graph';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/link-identity-callback.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/link-identity-callback.request.ts
@@ -13,7 +13,7 @@ import type {
   LitentryIdentity,
   Web3Network,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 import type { JsonRpcRequest } from '../util/types';
 import type { ApiPromise } from '@polkadot/api';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/link-identity.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/link-identity.request.ts
@@ -14,7 +14,7 @@ import type {
   LitentryValidationData,
   Web3Network,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 import type { JsonRpcRequest } from '../util/types';
 import type { ApiPromise } from '@polkadot/api';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/publicize-account.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/publicize-account.request.ts
@@ -5,7 +5,7 @@ import type {
   LitentryIdentity,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remark.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remark.request.ts
@@ -5,7 +5,7 @@ import type {
   LitentryIdentity,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remove-accounts.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/remove-accounts.request.ts
@@ -5,7 +5,7 @@ import type {
   LitentryIdentity,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/request-batch-vc.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/request-batch-vc.request.ts
@@ -18,7 +18,7 @@ import type {
   Assertion,
   LitentryIdentity,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 /**
  * Request a Batch of Verifiable Credential (VC) from the Litentry Protocol.

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/request_auth_token.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/request_auth_token.request.ts
@@ -2,7 +2,7 @@ import type { ApiPromise } from '@polkadot/api';
 import type {
   LitentryIdentity,
   TrustedCallResult,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 import type { JsonRpcRequest } from '../util/types';
 
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/set-identity-networks.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/set-identity-networks.request.ts
@@ -14,7 +14,7 @@ import type {
   LitentryIdentity,
   Web3Network,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 import type { JsonRpcRequest } from '../util/types';
 import type { ApiPromise } from '@polkadot/api';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-ethereum.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-ethereum.request.ts
@@ -5,7 +5,7 @@ import type {
   LitentryIdentity,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-native.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-native.request.ts
@@ -5,7 +5,7 @@ import type {
   LitentryIdentity,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-solana.request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/requests/transfer-solana.request.ts
@@ -5,7 +5,7 @@ import type {
   LitentryIdentity,
   TrustedCallResult,
   WorkerRpcReturnValue,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { enclave } from '../enclave';
 import { codecToString } from '../util/codec-to-string';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/id-graph.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/id-graph.ts
@@ -5,7 +5,7 @@ import type { U8aLike } from '@polkadot/util/types';
 import type {
   IdentityContext,
   LitentryIdentity,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 /**
  * The Identity Graph type

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/key-aes-output.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/key-aes-output.ts
@@ -2,7 +2,7 @@ import { assert } from '@polkadot/util';
 
 import type { Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
-import type { AesOutput } from '@heima/parachain-api';
+import type { AesOutput } from '@heima-network/parachain-api';
 
 /**
  * Creates a KeyAesOutput sidechain type.

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/litentry-identity.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/litentry-identity.test.ts
@@ -2,7 +2,7 @@ import { u8aToHex } from '@polkadot/util';
 import { TypeRegistry } from '@polkadot/types';
 import { cryptoWaitReady, addressEq } from '@polkadot/util-crypto';
 
-import { identity } from '@heima/parachain-api';
+import { identity } from '@heima-network/parachain-api';
 
 import { createLitentryIdentityType } from './litentry-identity';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/litentry-identity.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/litentry-identity.ts
@@ -2,7 +2,7 @@ import { isHex, u8aToHex } from '@polkadot/util';
 import { base58Decode, decodeAddress } from '@polkadot/util-crypto';
 
 import type { Registry } from '@polkadot/types-codec/types';
-import type { LitentryIdentity } from '@heima/parachain-api';
+import type { LitentryIdentity } from '@heima-network/parachain-api';
 
 /**
  * Creates a LitentryIdentity chain type.

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/litentry-multi-signature.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/litentry-multi-signature.test.ts
@@ -5,7 +5,7 @@ import {
   randomAsHex,
 } from '@polkadot/util-crypto';
 
-import { identity } from '@heima/parachain-api';
+import { identity } from '@heima-network/parachain-api';
 
 import { createLitentryIdentityType } from './litentry-identity';
 import { createLitentryMultiSignature } from './litentry-multi-signature';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/litentry-multi-signature.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/litentry-multi-signature.ts
@@ -2,7 +2,7 @@ import type { Registry } from '@polkadot/types-codec/types';
 import type {
   LitentryIdentity,
   LitentryMultiSignature,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 import { decodeSignature } from '../util/decode-signature';
 
 /**

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/nonce.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/nonce.test.ts
@@ -2,7 +2,7 @@ import { TypeRegistry } from '@polkadot/types';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import { createNonceType } from './nonce';
-import { WorkerRpcReturnValue } from '@heima/parachain-api';
+import { WorkerRpcReturnValue } from '@heima-network/parachain-api';
 
 const types = {
   // No custom types are needed for Index

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/nonce.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/nonce.ts
@@ -1,5 +1,5 @@
 import type { Registry } from '@polkadot/types-codec/types';
-import type { WorkerRpcReturnValue } from '@heima/parachain-api';
+import type { WorkerRpcReturnValue } from '@heima-network/parachain-api';
 import { Index } from '@polkadot/types/interfaces';
 import { hexToU8a } from '@polkadot/util';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
@@ -8,7 +8,7 @@ import type {
   TrustedCall,
   AesRequest,
   AesOutput,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 import {
   encrypt,
   generateNonce12,

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/tc-authentication.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/tc-authentication.test.ts
@@ -1,6 +1,6 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { TypeRegistry } from '@polkadot/types';
-import { trusted_operations, identity } from '@heima/parachain-api';
+import { trusted_operations, identity } from '@heima-network/parachain-api';
 import { createTCAuthenticationType } from './tc-authentication';
 import { createLitentryIdentityType } from './litentry-identity';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/tc-authentication.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/tc-authentication.ts
@@ -1,4 +1,4 @@
-import { LitentryIdentity, TCAuthentication } from '@heima/parachain-api';
+import { LitentryIdentity, TCAuthentication } from '@heima-network/parachain-api';
 import { Registry } from '@polkadot/types-codec/types';
 import { createLitentryMultiSignature } from './litentry-multi-signature';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/trusted-call.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/trusted-call.test.ts
@@ -9,7 +9,7 @@ import {
   trusted_operations,
   type LitentryIdentity,
   type Assertion,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { createTrustedCallType } from './trusted-call';
 import { createLitentryIdentityType } from './litentry-identity';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/trusted-call.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/trusted-call.ts
@@ -2,7 +2,7 @@ import { compactAddLength } from '@polkadot/util';
 
 import type { Registry } from '@polkadot/types-codec/types';
 
-import { trusted_operations, type Intent } from '@heima/parachain-api';
+import { trusted_operations, type Intent } from '@heima-network/parachain-api';
 import type {
   TrustedCall,
   LitentryIdentity,
@@ -10,7 +10,7 @@ import type {
   AuthOptions,
   Web3Network,
   Assertion,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import * as shieldingKeyUtils from '../util/shielding-key';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/validation-data.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/validation-data.test.ts
@@ -5,7 +5,7 @@ import {
   base64Decode,
 } from '@polkadot/util-crypto';
 
-import { identity, trusted_operations } from '@heima/parachain-api';
+import { identity, trusted_operations } from '@heima-network/parachain-api';
 
 import { createLitentryValidationDataType } from './validation-data';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/validation-data.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/type-creators/validation-data.ts
@@ -4,7 +4,7 @@ import { assert, isHex, stringToHex } from '@polkadot/util';
 import type {
   LitentryIdentity,
   LitentryValidationData,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { decodeSignature } from '../util/decode-signature';
 import { getSignatureCryptoType } from '../util/get-signature-crypto-type';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/calculate-id-graph-hash.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/calculate-id-graph-hash.test.ts
@@ -2,7 +2,7 @@ import { TypeRegistry, Metadata } from '@polkadot/types';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import metadataRpc from '@litentry/sidechain-api/prepare-build/litentry-sidechain-metadata.json';
-import { identity } from '@heima/parachain-api';
+import { identity } from '@heima-network/parachain-api';
 
 import { calculateIdGraphHash } from './calculate-id-graph-hash';
 import { createIdGraphType } from '../type-creators/id-graph';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/create-payload-to-sign.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/create-payload-to-sign.test.ts
@@ -9,7 +9,7 @@ import {
   type LitentryIdentity,
   type TrustedCall,
   identity,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { createPayloadToSign } from './create-payload-to-sign';
 import { createLitentryIdentityType } from '../type-creators/litentry-identity';

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/create-payload-to-sign.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/create-payload-to-sign.ts
@@ -1,7 +1,7 @@
 import { stringToHex, u8aConcat } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
 
-import type { LitentryIdentity, TrustedCall } from '@heima/parachain-api';
+import type { LitentryIdentity, TrustedCall } from '@heima-network/parachain-api';
 import type { U8aLike } from '@polkadot/util/types';
 import type { Index } from '@polkadot/types/interfaces';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/decode-signature.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/decode-signature.ts
@@ -1,4 +1,4 @@
-import { LitentryIdentity } from '@heima/parachain-api';
+import { LitentryIdentity } from '@heima-network/parachain-api';
 import { hexToU8a, isHex } from '@polkadot/util';
 import { base58Decode, base64Decode } from '@polkadot/util-crypto';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/safely-decode-option.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/util/safely-decode-option.test.ts
@@ -1,5 +1,5 @@
 import { TypeRegistry } from '@polkadot/types';
-import { identity } from '@heima/parachain-api';
+import { identity } from '@heima-network/parachain-api';
 
 import { safelyDecodeOption } from './safely-decode-option';
 

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/vc-validator/__tests__/validate-enclave-registry.test.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/vc-validator/__tests__/validate-enclave-registry.test.ts
@@ -8,7 +8,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { Metadata, TypeRegistry } from '@polkadot/types';
 
-import metadataRpc from '@heima/parachain-api/prepare-build/litentry-parachain-metadata.json';
+import metadataRpc from '@heima-network/parachain-api/prepare-build/litentry-parachain-metadata.json';
 
 import {
   validateEnclaveRegistry,

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/vc-validator/validator.spec.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/vc-validator/validator.spec.ts
@@ -1,7 +1,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { TypeRegistry, Metadata } from '@polkadot/types';
 
-import metadataRpc from '@heima/parachain-api/prepare-build/litentry-parachain-metadata.json';
+import metadataRpc from '@heima-network/parachain-api/prepare-build/litentry-parachain-metadata.json';
 
 import {
   getIssuerAccount,

--- a/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/vc-validator/validator.ts
+++ b/tee-worker/identity/client-sdk/packages/client-sdk/src/lib/vc-validator/validator.ts
@@ -2,7 +2,7 @@ import { ApiPromise } from '@polkadot/api';
 import { hexToU8a, stringToU8a } from '@polkadot/util';
 import { base58Decode, signatureVerify } from '@polkadot/util-crypto';
 
-import type { CorePrimitivesTeebagTypesEnclave } from '@heima/parachain-api';
+import type { CorePrimitivesTeebagTypesEnclave } from '@heima-network/parachain-api';
 
 import { RUNTIME_ENCLAVE_REGISTRY } from './runtime-enclave-registry';
 

--- a/tee-worker/identity/client-sdk/pnpm-lock.yaml
+++ b/tee-worker/identity/client-sdk/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
 
   packages/client-sdk:
     dependencies:
-      '@heima/parachain-api':
+      '@heima-network/parachain-api':
         specifier: 0.9.24-next.0
         version: 0.9.24-next.0
       '@litentry/chaindata':
@@ -1520,7 +1520,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@heima/parachain-api@0.9.24-next.0:
+  /@heima-network/parachain-api@0.9.24-next.0:
     resolution: {integrity: sha512-+DoK68BJDEeK/TUL/ek1FynuutqyWWJF0znELRzum+tqoVurkDs/ATj0Z2gm5Wi16lBud2fCYnhTTbfH39WJrQ==}
     dependencies:
       '@polkadot/api': 15.8.1

--- a/tee-worker/omni-executor/client-sdk/README.md
+++ b/tee-worker/omni-executor/client-sdk/README.md
@@ -8,5 +8,5 @@ Learn more about it on [Heima's official documentation](https://docs.heima.netwo
 
 ## Packages
 
-- `@heima/client-sdk` ([go-to](packages/client-sdk/README.md)): provides helpers for dApps to interact with the Heima Protocol
-- `@heima/chaindata` ([go-to](packages/chaindata/README.md)): provides chain information of Heima networks.
+- `@heima-network/client-sdk` ([go-to](packages/client-sdk/README.md)): provides helpers for dApps to interact with the Heima Protocol
+- `@heima-network/chaindata` ([go-to](packages/chaindata/README.md)): provides chain information of Heima networks.

--- a/tee-worker/omni-executor/client-sdk/packages/chaindata/README.md
+++ b/tee-worker/omni-executor/client-sdk/packages/chaindata/README.md
@@ -1,4 +1,4 @@
-# @heima/chaindata
+# @heima-network/chaindata
 
 This library contains information about the available networks at Heima, including its testnets.
 
@@ -7,13 +7,13 @@ This library contains information about the available networks at Heima, includi
 1. Install from NPM
 
    ```
-   npm install @heima/chaindata
+   npm install @heima-network/chaindata
    ```
 
 2. Explore
 
    ```ts
-   import { all, byId } from '@heima/chaindata`;
+   import { all, byId } from '@heima-network/chaindata`;
 
    console.log(all);
 

--- a/tee-worker/omni-executor/client-sdk/packages/chaindata/package.json
+++ b/tee-worker/omni-executor/client-sdk/packages/chaindata/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@heima/chaindata",
+  "name": "@heima-network/chaindata",
   "version": "0.0.1",
   "dependencies": {
     "tslib": "^2.5.3"

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/.eslintrc.json
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/.eslintrc.json
@@ -23,8 +23,8 @@
           "error",
           {
             "ignoredDependencies": [
-              "@heima/chaindata",
-              "@heima/parachain-api",
+              "@heima-network/chaindata",
+              "@heima-network/parachain-api",
               "@polkadot/api",
               "@polkadot/types",
               "@polkadot/types-codec",

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/README.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/README.md
@@ -1,4 +1,4 @@
-# @heima/client-sdk
+# @heima-network/client-sdk
 
 This package provides helpers for dApps to interact with the Heima Protocol.
 
@@ -11,7 +11,7 @@ This is a browser package, it may not work as-is on Node.js due to Crypto Subtle
 1. Install from NPM
 
     ```
-    npm install @heima/parachain-api @heima/sidechain-api @heima/client-sdk
+    npm install @heima-network/parachain-api @heima-network/sidechain-api @heima-network/client-sdk
     ```
 
 2. Set the right environment
@@ -30,7 +30,7 @@ This is a browser package, it may not work as-is on Node.js due to Crypto Subtle
 
 This package is distributed under two main tags: `next` and `latest`.
 
-Versions in the pattern of `x.x.x-next.x` feature the most recent code version to work with `tee-dev`. E.g., `1.0.0-next.0`. Once stable and once the Heima Protocol is upgraded, the version will be tagged as `latest` and should be used against `tee-prod`. E.g., `1.0.0`. You can find all versions on https://www.npmjs.com/package/@heima/client-sdk?activeTab=versions
+Versions in the pattern of `x.x.x-next.x` feature the most recent code version to work with `tee-dev`. E.g., `1.0.0-next.0`. Once stable and once the Heima Protocol is upgraded, the version will be tagged as `latest` and should be used against `tee-prod`. E.g., `1.0.0`. You can find all versions on https://www.npmjs.com/package/@heima-network/client-sdk?activeTab=versions
 
 ## Examples & API documentation
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/README.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/README.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../README.md)
+[**@heima-network/client-sdk**](../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../README.md) / request
+[@heima-network/client-sdk](../../../README.md) / request
 
 # request
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/addAccount.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/addAccount.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / addAccount
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / addAccount
 
 # Function: addAccount()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/callEthereum.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/callEthereum.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / callEthereum
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / callEthereum
 
 # Function: callEthereum()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/getAccountNonce.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/getAccountNonce.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / getAccountNonce
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / getAccountNonce
 
 # Function: getAccountNonce()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/getAccountStore.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/getAccountStore.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / getAccountStore
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / getAccountStore
 
 # Function: getAccountStore()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/getOAuth2GoogleAuthorizationUrl.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/getOAuth2GoogleAuthorizationUrl.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / getOAuth2GoogleAuthorizationUrl
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / getOAuth2GoogleAuthorizationUrl
 
 # Function: getOAuth2GoogleAuthorizationUrl()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/getOmniAccountNonceWithIdentity.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/getOmniAccountNonceWithIdentity.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / getOmniAccountNonceWithIdentity
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / getOmniAccountNonceWithIdentity
 
 # Function: getOmniAccountNonceWithIdentity()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/publicizeAccount.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/publicizeAccount.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / publicizeAccount
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / publicizeAccount
 
 # Function: publicizeAccount()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/removeAccounts.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/removeAccounts.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / removeAccounts
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / removeAccounts
 
 # Function: removeAccounts()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/requestAuthToken.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/requestAuthToken.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / requestAuthToken
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / requestAuthToken
 
 # Function: requestAuthToken()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/setPermissions.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/setPermissions.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / setPermissions
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / setPermissions
 
 # Function: setPermissions()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/systemRemark.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/systemRemark.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / systemRemark
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / systemRemark
 
 # Function: systemRemark()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/transferEthereum.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/transferEthereum.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / transferEthereum
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / transferEthereum
 
 # Function: transferEthereum()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/transferNative.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/transferNative.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / transferNative
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / transferNative
 
 # Function: transferNative()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/transferSolana.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/@heima/namespaces/request/functions/transferSolana.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../../../../README.md)
+[**@heima-network/client-sdk**](../../../../README.md)
 
 ***
 
-[@heima/client-sdk](../../../../README.md) / [request](../README.md) / transferSolana
+[@heima-network/client-sdk](../../../../README.md) / [request](../README.md) / transferSolana
 
 # Function: transferSolana()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/README.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/README.md
@@ -1,8 +1,8 @@
-**@heima/client-sdk**
+**@heima-network/client-sdk**
 
 ***
 
-# @heima/client-sdk
+# @heima-network/client-sdk
 
 ## Namespaces
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/classes/Enclave.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/classes/Enclave.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / Enclave
+[@heima-network/client-sdk](../README.md) / Enclave
 
 # Class: Enclave
 
@@ -22,7 +22,7 @@ ensuring clients are connected to a trusted worker.
 ## Example
 
 ```ts
-import { enclave } from '@heima/client-sdk';
+import { enclave } from '@heima-network/client-sdk';
 
 const mrEnclave = await enclave.getMrEnclave(api);
 const key = await enclave.getShieldingKey();

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/enumerations/ConnectionState.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/enumerations/ConnectionState.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / ConnectionState
+[@heima-network/client-sdk](../README.md) / ConnectionState
 
 # Enumeration: ConnectionState
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createAuthentication.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createAuthentication.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / createAuthentication
+[@heima-network/client-sdk](../README.md) / createAuthentication
 
 # Function: createAuthentication()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createCallRequestType.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createCallRequestType.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / createCallRequestType
+[@heima-network/client-sdk](../README.md) / createCallRequestType
 
 # Function: createCallRequestType()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createIdentityType.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createIdentityType.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / createIdentityType
+[@heima-network/client-sdk](../README.md) / createIdentityType
 
 # Function: createIdentityType()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createKeyAesOutputType.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createKeyAesOutputType.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / createKeyAesOutputType
+[@heima-network/client-sdk](../README.md) / createKeyAesOutputType
 
 # Function: createKeyAesOutputType()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createNativeCallType.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createNativeCallType.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / createNativeCallType
+[@heima-network/client-sdk](../README.md) / createNativeCallType
 
 # Function: createNativeCallType()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createQueryRequestType.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createQueryRequestType.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / createQueryRequestType
+[@heima-network/client-sdk](../README.md) / createQueryRequestType
 
 # Function: createQueryRequestType()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createValidationDataType.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/createValidationDataType.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / createValidationDataType
+[@heima-network/client-sdk](../README.md) / createValidationDataType
 
 # Function: createValidationDataType()
 
@@ -58,8 +58,8 @@ The ownership proof
 ## Examples
 
 ```ts
-import { createValidationDataType } from '@heima/client-sdk';
-import type { Web3Proof } from '@heima/client-sdk';
+import { createValidationDataType } from '@heima-network/client-sdk';
+import type { Web3Proof } from '@heima-network/client-sdk';
 
 const userAddress = '0x123';
 
@@ -79,8 +79,8 @@ const validationData = createValidationDataType(
 ```
 
 ```ts
-import { createValidationDataType } from '@heima/client-sdk';
-import type { TwitterProof } from '@heima/client-sdk';
+import { createValidationDataType } from '@heima-network/client-sdk';
+import type { TwitterProof } from '@heima-network/client-sdk';
 
 const userHandle = '@heima';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/toPublicKey.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/functions/toPublicKey.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / toPublicKey
+[@heima-network/client-sdk](../README.md) / toPublicKey
 
 # Function: toPublicKey()
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/AuthenticationData.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/AuthenticationData.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / AuthenticationData
+[@heima-network/client-sdk](../README.md) / AuthenticationData
 
 # Type Alias: AuthenticationData
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/DiscordOAuth2Proof.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/DiscordOAuth2Proof.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / DiscordOAuth2Proof
+[@heima-network/client-sdk](../README.md) / DiscordOAuth2Proof
 
 # Type Alias: DiscordOAuth2Proof
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/DiscordProof.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/DiscordProof.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / DiscordProof
+[@heima-network/client-sdk](../README.md) / DiscordProof
 
 # Type Alias: DiscordProof
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/EmailProof.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/EmailProof.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / EmailProof
+[@heima-network/client-sdk](../README.md) / EmailProof
 
 # Type Alias: EmailProof
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/TwitterOAuth2Proof.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/TwitterOAuth2Proof.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / TwitterOAuth2Proof
+[@heima-network/client-sdk](../README.md) / TwitterOAuth2Proof
 
 # Type Alias: TwitterOAuth2Proof
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/TwitterProof.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/TwitterProof.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / TwitterProof
+[@heima-network/client-sdk](../README.md) / TwitterProof
 
 # Type Alias: TwitterProof
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/Web3Proof.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/type-aliases/Web3Proof.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / Web3Proof
+[@heima-network/client-sdk](../README.md) / Web3Proof
 
 # Type Alias: Web3Proof
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/variables/enclave.md
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/docs/variables/enclave.md
@@ -1,8 +1,8 @@
-[**@heima/client-sdk**](../README.md)
+[**@heima-network/client-sdk**](../README.md)
 
 ***
 
-[@heima/client-sdk](../README.md) / enclave
+[@heima-network/client-sdk](../README.md) / enclave
 
 # Variable: enclave
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/package.json
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@heima/client-sdk",
+	"name": "@heima-network/client-sdk",
 	"description": "This package provides helpers for dApps to interact with the Heima Protocol.",
 	"version": "1.0.0-next.0",
 	"license": "GPL-3.0-or-later",
@@ -10,8 +10,8 @@
 		"@types/ws": "^8.5.13"
 	},
 	"peerDependencies": {
-		"@heima/chaindata": "*",
-		"@heima/parachain-api": "0.9.24-next.0",
+		"@heima-network/chaindata": "*",
+		"@heima-network/parachain-api": "0.9.24-next.0",
 		"@polkadot/api": "^15.0.2",
 		"@polkadot/types": "^15.0.2",
 		"@polkadot/types-codec": "^15.0.2",

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/index.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import '@heima/parachain-api';
+import '@heima-network/parachain-api';
 
 export { Enclave, enclave, ConnectionState } from '@lib/enclave';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/config.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/config.ts
@@ -1,4 +1,4 @@
-import { type ChainId, getChain } from '@heima/chaindata';
+import { type ChainId, getChain } from '@heima-network/chaindata';
 
 const CURRENT_NETWORK =
   process.env.HEIMA_NETWORK ||

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/enclave.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/enclave.ts
@@ -36,7 +36,7 @@ const log = process.env.NODE_ENV !== 'production' ? console.log.bind(console) : 
  *
  * @example
  * ```ts
- * import { enclave } from '@heima/client-sdk';
+ * import { enclave } from '@heima-network/client-sdk';
  *
  * const mrEnclave = await enclave.getMrEnclave(api);
  * const key = await enclave.getShieldingKey();

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/account-store.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/account-store.request.test.ts
@@ -4,7 +4,7 @@ import { WsProvider } from '@polkadot/rpc-provider';
 import { u8aToHex } from '@polkadot/util';
 import { cryptoWaitReady, encodeAddress } from '@polkadot/util-crypto';
 
-import { getChain } from '@heima/chaindata';
+import { getChain } from '@heima-network/chaindata';
 import {
   identity,
   ValidationData,
@@ -13,7 +13,7 @@ import {
   Identity,
   sidechain,
   omniAccount,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 import { addAccount } from '@requests/add-account.request';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/get-nonce.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/get-nonce.request.test.ts
@@ -1,4 +1,4 @@
-import { ApiPromise, identity, WsProvider } from '@heima/parachain-api';
+import { ApiPromise, identity, WsProvider } from '@heima-network/parachain-api';
 
 import { getOmniAccountNonceWithIdentity } from '@requests/get-nonce.request';
 import { createIdentityType } from '@type-creators/identity';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/request-auth-token.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/request-auth-token.request.test.ts
@@ -3,8 +3,8 @@ import { WsProvider } from '@polkadot/rpc-provider';
 import { u8aToHex } from '@polkadot/util';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
-import { getChain } from '@heima/chaindata';
-import { identity, omniExecutor, sidechain } from '@heima/parachain-api';
+import { getChain } from '@heima-network/chaindata';
+import { identity, omniExecutor, sidechain } from '@heima-network/parachain-api';
 
 import { createAccountStore } from '@requests/create-account-store.request';
 import { requestAuthToken } from '@requests/request-auth-token.request';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/add-account.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/add-account.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { HexString } from '@polkadot/util/types';
 
-import type { Identity, ValidationData, OmniAccountPermission } from '@heima/parachain-api';
+import type { Identity, ValidationData, OmniAccountPermission } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 import { createNativeCallType } from '@type-creators/native-call';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/aes-call.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/aes-call.request.ts
@@ -2,7 +2,7 @@ import type { ApiPromise } from '@polkadot/api';
 import { hexToU8a } from '@polkadot/util';
 import { HexString } from '@polkadot/util/types';
 
-import type { Identity, NativeCall, NativeOperationResponse } from '@heima/parachain-api';
+import type { Identity, NativeCall, NativeOperationResponse } from '@heima-network/parachain-api';
 
 import { getOmniAccountNonceWithIdentity } from '@requests/get-nonce.request';
 import { AuthenticationData } from '@type-creators/authentication';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/aes-query.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/aes-query.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { hexToU8a } from '@polkadot/util';
 
-import type { Identity, NativeOperationResponse, NativeQuery, QueryResponse } from '@heima/parachain-api';
+import type { Identity, NativeOperationResponse, NativeQuery, QueryResponse } from '@heima-network/parachain-api';
 
 import { getOmniAccountNonceWithIdentity } from '@requests/get-nonce.request';
 import { AuthenticationData } from '@type-creators/authentication';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/create-account-store.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/create-account-store.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { HexString } from '@polkadot/util/types';
 
-import type { Identity } from '@heima/parachain-api';
+import type { Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 import { createNativeCallType } from '@type-creators/native-call';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/get-account-store.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/get-account-store.request.ts
@@ -1,6 +1,6 @@
 import type { ApiPromise } from '@polkadot/api';
 
-import type { Identity } from '@heima/parachain-api';
+import type { Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 import { createNativeQueryType } from '@type-creators/native-query';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/get-nonce.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/get-nonce.request.ts
@@ -1,6 +1,6 @@
 import { AccountId, Index } from '@polkadot/types/interfaces';
 
-import { ApiPromise, Identity } from '@heima/parachain-api';
+import { ApiPromise, Identity } from '@heima-network/parachain-api';
 
 import { toHash } from '@utils/identity';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/call-ethereum.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/call-ethereum.request.test.ts
@@ -2,8 +2,8 @@ import { ApiPromise, Keyring } from '@polkadot/api';
 import { WsProvider } from '@polkadot/rpc-provider';
 import { u8aToHex } from '@polkadot/util';
 
-import { getChain } from '@heima/chaindata';
-import { identity, omniExecutor, sidechain } from '@heima/parachain-api';
+import { getChain } from '@heima-network/chaindata';
+import { identity, omniExecutor, sidechain } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 import { callEthereum } from '@requests/intents/call-ethereum.request';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/system-remark.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/system-remark.request.test.ts
@@ -2,8 +2,8 @@ import { ApiPromise, Keyring } from '@polkadot/api';
 import { WsProvider } from '@polkadot/rpc-provider';
 import { u8aToHex } from '@polkadot/util';
 
-import { getChain } from '@heima/chaindata';
-import { identity, omniExecutor, sidechain } from '@heima/parachain-api';
+import { getChain } from '@heima-network/chaindata';
+import { identity, omniExecutor, sidechain } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 import { systemRemark } from '@requests/intents/system-remark.request';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/transfer-ethereum.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/transfer-ethereum.request.test.ts
@@ -2,8 +2,8 @@ import { ApiPromise, Keyring } from '@polkadot/api';
 import { WsProvider } from '@polkadot/rpc-provider';
 import { u8aToHex } from '@polkadot/util';
 
-import { getChain } from '@heima/chaindata';
-import { identity, omniExecutor, sidechain } from '@heima/parachain-api';
+import { getChain } from '@heima-network/chaindata';
+import { identity, omniExecutor, sidechain } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 import { transferEthereum } from '@requests/intents/transfer-ethereum.request';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/transfer-native.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/transfer-native.request.test.ts
@@ -2,8 +2,8 @@ import { ApiPromise, Keyring } from '@polkadot/api';
 import { WsProvider } from '@polkadot/rpc-provider';
 import { u8aToHex } from '@polkadot/util';
 
-import { getChain } from '@heima/chaindata';
-import { identity, omniExecutor, sidechain } from '@heima/parachain-api';
+import { getChain } from '@heima-network/chaindata';
+import { identity, omniExecutor, sidechain } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 import { transferNative } from '@requests/intents/transfer-native.request';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/transfer-solana.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/__test__/transfer-solana.request.test.ts
@@ -2,8 +2,8 @@ import { ApiPromise, Keyring } from '@polkadot/api';
 import { WsProvider } from '@polkadot/rpc-provider';
 import { u8aToHex } from '@polkadot/util';
 
-import { getChain } from '@heima/chaindata';
-import { identity, omniExecutor, sidechain } from '@heima/parachain-api';
+import { getChain } from '@heima-network/chaindata';
+import { identity, omniExecutor, sidechain } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 import { transferSolana } from '@requests/intents/transfer-solana.request';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/call-ethereum.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/call-ethereum.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import type { HexString, U8aLike } from '@polkadot/util/types';
 
-import type { Intent, IntentCallEthereum, Identity } from '@heima/parachain-api';
+import type { Intent, IntentCallEthereum, Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/intent.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/intent.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { HexString } from '@polkadot/util/types';
 
-import type { Intent, Identity } from '@heima/parachain-api';
+import type { Intent, Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 import { createNativeCallType } from '@type-creators/native-call';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/system-remark.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/system-remark.request.ts
@@ -2,7 +2,7 @@ import type { ApiPromise } from '@polkadot/api';
 import { stringToHex } from '@polkadot/util';
 import { HexString } from '@polkadot/util/types';
 
-import type { Intent, Identity } from '@heima/parachain-api';
+import type { Intent, Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/transfer-ethereum.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/transfer-ethereum.request.ts
@@ -2,7 +2,7 @@ import type { ApiPromise } from '@polkadot/api';
 import { hexToU8a } from '@polkadot/util';
 import { HexString } from '@polkadot/util/types';
 
-import type { Intent, IntentTransferEthereum, Identity } from '@heima/parachain-api';
+import type { Intent, IntentTransferEthereum, Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/transfer-native.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/transfer-native.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { HexString } from '@polkadot/util/types';
 
-import type { Intent, IntentTransferNative, Identity } from '@heima/parachain-api';
+import type { Intent, IntentTransferNative, Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/transfer-solana.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/intents/transfer-solana.request.ts
@@ -2,7 +2,7 @@ import type { ApiPromise } from '@polkadot/api';
 import { HexString } from '@polkadot/util/types';
 import { base58 } from '@scure/base';
 
-import type { Intent, IntentTransferSolana, Identity } from '@heima/parachain-api';
+import type { Intent, IntentTransferSolana, Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/publicize-account.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/publicize-account.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { HexString } from '@polkadot/util/types';
 
-import type { Identity } from '@heima/parachain-api';
+import type { Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 import { createNativeCallType } from '@type-creators/native-call';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/remove-accounts.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/remove-accounts.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { HexString } from '@polkadot/util/types';
 
-import type { Identity } from '@heima/parachain-api';
+import type { Identity } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 import { createNativeCallType } from '@type-creators/native-call';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/request-auth-token.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/request-auth-token.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { hexToU8a } from '@polkadot/util';
 
-import type { Identity, NativeOperationResponse } from '@heima/parachain-api';
+import type { Identity, NativeOperationResponse } from '@heima-network/parachain-api';
 
 import { getOmniAccountNonceWithIdentity } from '@requests/get-nonce.request';
 import { AuthenticationData } from '@type-creators/authentication';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/set-permissions.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/set-permissions.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { HexString } from '@polkadot/util/types';
 
-import type { Identity, OmniAccountPermission } from '@heima/parachain-api';
+import type { Identity, OmniAccountPermission } from '@heima-network/parachain-api';
 
 import { AuthenticationData } from '@type-creators/authentication';
 import { createNativeCallType } from '@type-creators/native-call';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/test-utils/helpers.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/test-utils/helpers.ts
@@ -2,7 +2,7 @@ import { ApiPromise } from '@polkadot/api';
 import { Option, Vec } from '@polkadot/types-codec';
 import { AccountId32 } from '@polkadot/types/interfaces';
 
-import { CorePrimitivesOmniAccountMemberAccount } from '@heima/parachain-api';
+import { CorePrimitivesOmniAccountMemberAccount } from '@heima-network/parachain-api';
 
 /**
  * Retrieves and waits for the account store to be created for the specified account.

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/__test__/identity.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/__test__/identity.test.ts
@@ -2,7 +2,7 @@ import { TypeRegistry } from '@polkadot/types';
 import { u8aToHex } from '@polkadot/util';
 import { cryptoWaitReady, addressEq } from '@polkadot/util-crypto';
 
-import { identity } from '@heima/parachain-api';
+import { identity } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/__test__/multi-signature.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/__test__/multi-signature.test.ts
@@ -1,7 +1,7 @@
 import { TypeRegistry } from '@polkadot/types';
 import { base64Decode, cryptoWaitReady, randomAsHex } from '@polkadot/util-crypto';
 
-import { identity } from '@heima/parachain-api';
+import { identity } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 import { createMultiSignature } from '@type-creators/multi-signature';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/__test__/native-call.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/__test__/native-call.test.ts
@@ -2,7 +2,7 @@ import { Keyring } from '@polkadot/api';
 import { TypeRegistry } from '@polkadot/types';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
-import { identity, Identity, omniExecutor, sidechain } from '@heima/parachain-api';
+import { identity, Identity, omniExecutor, sidechain } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@type-creators/identity';
 import { createNativeCallType } from '@type-creators/native-call';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/__test__/validation-data.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/__test__/validation-data.test.ts
@@ -1,7 +1,7 @@
 import { TypeRegistry } from '@polkadot/types';
 import { base58Encode, cryptoWaitReady, base64Decode } from '@polkadot/util-crypto';
 
-import { identity } from '@heima/parachain-api';
+import { identity } from '@heima-network/parachain-api';
 
 import { createValidationDataType } from '@type-creators/validation-data';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/authentication.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/authentication.ts
@@ -1,4 +1,4 @@
-import { Authentication, Identity } from '@heima/parachain-api';
+import { Authentication, Identity } from '@heima-network/parachain-api';
 import { Registry } from '@polkadot/types-codec/types';
 import { createMultiSignature } from './multi-signature';
 import { createOAuth2Data, type OAuth2DataType } from './oauth2';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/identity.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/identity.ts
@@ -2,7 +2,7 @@ import type { Registry } from '@polkadot/types-codec/types';
 import { isHex, u8aToHex } from '@polkadot/util';
 import { base58Decode, decodeAddress } from '@polkadot/util-crypto';
 
-import type { Identity } from '@heima/parachain-api';
+import type { Identity } from '@heima-network/parachain-api';
 
 /**
  * Creates a Identity chain type.

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/key-aes-output.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/key-aes-output.ts
@@ -2,7 +2,7 @@ import type { Registry } from '@polkadot/types-codec/types';
 import { assert } from '@polkadot/util';
 import type { HexString } from '@polkadot/util/types';
 
-import type { AesOutput } from '@heima/parachain-api';
+import type { AesOutput } from '@heima-network/parachain-api';
 
 /**
  * Creates a KeyAesOutput sidechain type.

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/multi-signature.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/multi-signature.ts
@@ -1,6 +1,6 @@
 import type { Registry } from '@polkadot/types-codec/types';
 
-import type { Identity, MultiSignature } from '@heima/parachain-api';
+import type { Identity, MultiSignature } from '@heima-network/parachain-api';
 
 import { decodeSignature } from '@utils/decode-signature';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/native-call.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/native-call.ts
@@ -6,7 +6,7 @@ import {
   NativeCall,
   OmniAccountPermission,
   omniExecutor,
-} from '@heima/parachain-api';
+} from '@heima-network/parachain-api';
 
 const NativeCallEnum = omniExecutor.types.NativeCall._enum;
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/native-query.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/native-query.ts
@@ -1,5 +1,5 @@
 import { Registry } from '@polkadot/types-codec/types';
-import { Identity, NativeQuery, omniExecutor } from '@heima/parachain-api';
+import { Identity, NativeQuery, omniExecutor } from '@heima-network/parachain-api';
 
 const NativeQueryEnum = omniExecutor.types.NativeQuery._enum;
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/oauth2.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/oauth2.ts
@@ -1,5 +1,5 @@
 import type { Registry } from '@polkadot/types-codec/types';
-import { OAuth2Data, OAuth2Provider } from '@heima/parachain-api';
+import { OAuth2Data, OAuth2Provider } from '@heima-network/parachain-api';
 
 export type OAuth2DataType = {
   provider: 'Google';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/request.ts
@@ -2,7 +2,7 @@ import type { Index } from '@polkadot/types/interfaces';
 import type { ApiPromise } from '@polkadot/api';
 import { compactAddLength, u8aToHex } from '@polkadot/util';
 
-import type { AesOutput, NativeCall, NativeQuery, OmniAesRequest as AesRequest, PlainRequest } from '@heima/parachain-api';
+import type { AesOutput, NativeCall, NativeQuery, OmniAesRequest as AesRequest, PlainRequest } from '@heima-network/parachain-api';
 import { encrypt, generateNonce12, generate, exportKey } from '@utils/shielding-key';
 import { createKeyAesOutputType } from './key-aes-output';
 import { createAuthentication, AuthenticationData } from './authentication';

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/validation-data.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/validation-data.ts
@@ -1,7 +1,7 @@
 import type { Registry } from '@polkadot/types-codec/types';
 import { assert, isHex, stringToHex } from '@polkadot/util';
 
-import type { Identity, ValidationData } from '@heima/parachain-api';
+import type { Identity, ValidationData } from '@heima-network/parachain-api';
 
 import { createIdentityType } from '@lib/type-creators/identity';
 import { decodeSignature } from '@utils/decode-signature';
@@ -77,8 +77,8 @@ export type EmailProof = {
  *
  * @example Web3
  * ```ts
- * import { createValidationDataType } from '@heima/client-sdk';
- * import type { Web3Proof } from '@heima/client-sdk';
+ * import { createValidationDataType } from '@heima-network/client-sdk';
+ * import type { Web3Proof } from '@heima-network/client-sdk';
  *
  * const userAddress = '0x123';
  *
@@ -99,8 +99,8 @@ export type EmailProof = {
  *
  * @example Twitter
  * ```ts
- * import { createValidationDataType } from '@heima/client-sdk';
- * import type { TwitterProof } from '@heima/client-sdk';
+ * import { createValidationDataType } from '@heima-network/client-sdk';
+ * import type { TwitterProof } from '@heima-network/client-sdk';
  *
  * const userHandle = '@heima';
  *

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/utils/create-payload-to-sign.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/utils/create-payload-to-sign.ts
@@ -2,7 +2,7 @@ import { stringToHex, u8aConcat } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
 import type { Index } from '@polkadot/types/interfaces';
 
-import type { Identity, NativeCall, NativeQuery } from '@heima/parachain-api';
+import type { Identity, NativeCall, NativeQuery } from '@heima-network/parachain-api';
 
 type Operation = NativeCall | NativeQuery;
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/utils/create-verification-message.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/utils/create-verification-message.ts
@@ -4,7 +4,7 @@ import { stringToHex, u8aConcat } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
 import { HexString } from '@polkadot/util/types';
 
-import { Identity } from '@heima/parachain-api';
+import { Identity } from '@heima-network/parachain-api';
 
 /**
  * Creates a verification message for adding a new member to an Omni account

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/utils/decode-signature.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/utils/decode-signature.ts
@@ -1,4 +1,4 @@
-import { Identity } from '@heima/parachain-api';
+import { Identity } from '@heima-network/parachain-api';
 import { hexToU8a, isHex } from '@polkadot/util';
 import { base58Decode, base64Decode } from '@polkadot/util-crypto';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/utils/identity.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/utils/identity.ts
@@ -1,5 +1,5 @@
 import { blake2AsHex } from '@polkadot/util-crypto';
-import { Identity } from '@heima/parachain-api';
+import { Identity } from '@heima-network/parachain-api';
 import { HexString } from '@polkadot/util/types';
 
 /**

--- a/tee-worker/omni-executor/client-sdk/pnpm-lock.yaml
+++ b/tee-worker/omni-executor/client-sdk/pnpm-lock.yaml
@@ -114,10 +114,10 @@ importers:
 
   packages/client-sdk:
     dependencies:
-      '@heima/chaindata':
+      '@heima-network/chaindata':
         specifier: '*'
         version: link:../chaindata
-      '@heima/parachain-api':
+      '@heima-network/parachain-api':
         specifier: 0.9.24-next.0
         version: 0.9.24-next.0
       '@polkadot/api':
@@ -1575,7 +1575,7 @@ packages:
       '@shikijs/vscode-textmate': 10.0.2
     dev: true
 
-  /@heima/parachain-api@0.9.24-next.0:
+  /@heima-network/parachain-api@0.9.24-next.0:
     resolution: {integrity: sha512-cPS8ThoQPSr5oKsXuppFYIXb9LoJI8UKyAop4rRzjpzV7DdJmMbapbQ6Wprn/EHSGFwaWSjv97WvhkbZtNFWZQ==}
     dependencies:
       '@polkadot/api': 15.8.1

--- a/tee-worker/omni-executor/client-sdk/tsconfig.base.json
+++ b/tee-worker/omni-executor/client-sdk/tsconfig.base.json
@@ -18,10 +18,10 @@
 		"skipDefaultLibCheck": true,
 		"baseUrl": ".",
 		"paths": {
-			"@heima/chaindata": [
+			"@heima-network/chaindata": [
 				"packages/chaindata/src/index.ts"
 			],
-			"@heima/client-sdk": [
+			"@heima-network/client-sdk": [
 				"packages/client-sdk/src/index.ts"
 			],
 		}


### PR DESCRIPTION
heima has been registered by other organizations on npmjs, so we need to rename the packages name; otherwise, it cannot be published to the organization through the scope.