### PR TITLE
fix: support aes encrypted response from omni-executor in omni-client…

### DIFF
--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/pumpx-request-jwt.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/pumpx-request-jwt.request.test.ts
@@ -34,29 +34,37 @@ describe('pumpx-request-jwt', () => {
     });
 
     // This test is just an example. It requires receiving email verification codes, which cannot be done by running this unit test.
-    it.skip('web2 identity (email) authentication', async () => {
-        const email = 'test@test.com';
+    describe.skip('web2 identity (email) authentication', () => {
+        // Update the email address to your own email address
+        const email = 'xxx@xxx.com';
 
-        // Request email verification code for next account store creation
-        await requestEmailVerificationCode({ email });
-        // Get the email verification code from the email inbox
-        const verificationCode = 'emailVerificationCodeYouReceivedInEmail';
-
-        const member = createIdentityType(api.registry, {
-            addressOrHandle: email,
-            type: 'Email',
+        // Step 1
+        it('request email verification code', async () => {
+            await requestEmailVerificationCode({ email });
         });
 
-        const { send } = await requestPumpxJwt(api, { 
-            member,
-            // inviteCode: 'inviteCode',
-            // googleCode: 'googleCode',
-            // lang: 'en',
+        // Step 2
+        it('request pumpx jwt', async () => {
+            // Update the email verification code from the email inbox that requested in step 1
+            const verificationCode = 'emailVerificationCodeYouReceivedInEmail';
+
+            const member = createIdentityType(api.registry, {
+                addressOrHandle: email,
+                type: 'Email',
+            });
+
+            const { send } = await requestPumpxJwt(api, {
+                member,
+                // inviteCode: 'inviteCode',
+                // googleCode: 'googleCode',
+                // lang: 'en',
+            });
+
+            const { jwt } = await send({ authData: { type: 'Email', verificationCode } });
+
+            expect(jwt).toBeDefined();
+            expect(jwt.access_token).toBeDefined();
+            console.log(JSON.stringify(jwt.toJSON(), null, 2));
         });
-
-        const { jwt } = await send({ authData: { type: 'Email', verificationCode } });
-
-        expect(jwt).toBeDefined();
-        expect(jwt.access_token).toBeDefined();
     });
 });

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/aes-task.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/aes-task.request.ts
@@ -2,7 +2,7 @@ import type { ApiPromise } from '@polkadot/api';
 import { hexToU8a } from '@polkadot/util';
 import { HexString } from '@polkadot/util/types';
 
-import type { Identity, NativeTask, NativeTaskResponse } from '@heima-network/parachain-api';
+import type { AesOutput, Identity, NativeTask, NativeTaskResponse } from '@heima-network/parachain-api';
 
 import { getOmniAccountNonceWithIdentity } from '@requests/get-nonce.request';
 import { OmniAuthData } from '@type-creators/omni-auth';
@@ -13,6 +13,7 @@ import { isWeb3 } from '@utils/identity';
 import type { JsonRpcRequest } from '@utils/types';
 
 import { enclave } from '@lib/enclave';
+import { decrypt } from '@lib/utils';
 
 /**
  * Sends an AES task to Enclave.
@@ -56,7 +57,7 @@ export async function aesTask(
     status: HexString;
   }> => {
     // prepare and encrypt task
-    const rawTask = await createRawTaskType(api, {
+    const { rawTask, encryptionKey } = await createRawTaskType(api, {
       task,
       nonce,
       authData: args.authData,
@@ -70,8 +71,10 @@ export async function aesTask(
     };
 
     const data = await enclave.send(request);
+    const aesOutput = api.createType<AesOutput>('AesOutput', data)
+    const { cleartext } = await decrypt({ ciphertext: aesOutput.ciphertext, nonce: aesOutput.nonce }, encryptionKey);
 
-    const response = api.createType<NativeTaskResponse>('NativeTaskResponse', data);
+    const response = api.createType<NativeTaskResponse>('NativeTaskResponse', cleartext);
 
     if (response.isErr) {
       throw new Error(response.asErr.toString());

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/pumpx-request-jwt.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/pumpx-request-jwt.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { hexToU8a } from '@polkadot/util';
 
-import type { Identity, NativeTaskResponse, PumpxJwt } from '@heima-network/parachain-api';
+import type { AesOutput, Identity, NativeTaskResponse, PumpxJwt } from '@heima-network/parachain-api';
 
 import { getOmniAccountNonceWithIdentity } from '@requests/get-nonce.request';
 import { OmniAuthData } from '@type-creators/omni-auth';
@@ -13,6 +13,7 @@ import { isWeb3 } from '@utils/identity';
 import type { JsonRpcRequest } from '@utils/types';
 
 import { enclave } from '@lib/enclave';
+import { decrypt } from '@lib/utils';
 
 /**
  * Requests a pumpx JWT from the Enclave.
@@ -64,7 +65,7 @@ export async function requestPumpxJwt(
         jwt: PumpxJwt;
     }> => {
         // prepare and encrypt task
-        const rawTask = await createRawTaskType(api, {
+        const { rawTask, encryptionKey } = await createRawTaskType(api, {
             task,
             nonce,
             authData: args.authData,
@@ -78,8 +79,10 @@ export async function requestPumpxJwt(
         };
 
         const data = await enclave.send(request);
+        const aesOutput = api.createType<AesOutput>('AesOutput', data)
+        const { cleartext } = await decrypt({ ciphertext: aesOutput.ciphertext, nonce: aesOutput.nonce }, encryptionKey);
 
-        const response = api.createType<NativeTaskResponse>('NativeTaskResponse', data);
+        const response = api.createType<NativeTaskResponse>('NativeTaskResponse', cleartext);
 
         if (response.isErr) {
             throw new Error(response.asErr.toString());

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/request-auth-token.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/request-auth-token.request.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import { hexToU8a } from '@polkadot/util';
 
-import type { Identity, NativeTaskResponse } from '@heima-network/parachain-api';
+import type { AesOutput, Identity, NativeTaskResponse } from '@heima-network/parachain-api';
 
 import { getOmniAccountNonceWithIdentity } from '@requests/get-nonce.request';
 import { OmniAuthData } from '@type-creators/omni-auth';
@@ -13,6 +13,7 @@ import { isWeb3 } from '@utils/identity';
 import type { JsonRpcRequest } from '@utils/types';
 
 import { enclave } from '@lib/enclave';
+import { decrypt } from '@lib/utils';
 
 /**
  * Requests an auth token from the Enclave.
@@ -57,7 +58,7 @@ export async function requestAuthToken(
         token: string;
     }> => {
         // prepare and encrypt task
-        const rawTask = await createRawTaskType(api, {
+        const { rawTask, encryptionKey } = await createRawTaskType(api, {
             task,
             nonce,
             authData: args.authData,
@@ -71,8 +72,10 @@ export async function requestAuthToken(
         };
 
         const data = await enclave.send(request);
+        const aesOutput = api.createType<AesOutput>('AesOutput', data)
+        const { cleartext } = await decrypt({ ciphertext: aesOutput.ciphertext, nonce: aesOutput.nonce }, encryptionKey);
 
-        const response = api.createType<NativeTaskResponse>('NativeTaskResponse', data);
+        const response = api.createType<NativeTaskResponse>('NativeTaskResponse', cleartext);
 
         if (response.isErr) {
             throw new Error(response.asErr.toString());

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/raw-task.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/type-creators/raw-task.ts
@@ -9,12 +9,74 @@ import { createAesOutputType } from './aes-output';
 import { createOmniAuth, OmniAuthData } from './omni-auth';
 
 /**
- * Creates a RawTask struct type for the `NativeTask`.
- *
- * A shielding key is generated and used to encrypt the `NativeTask` and communicated
- * to the enclave to protect the data for transportation.
- *
- * The shielding key is encrypted using the Enclave's shielding key and attached in the Task.
+ * Creates a raw task type for unencrypted NativeTask.
+ * 
+ * @param api - Polkadot API instance
+ * @param data - Task configuration
+ * @param data.task - Native task to be wrapped
+ * @param data.nonce - Optional nonce value
+ * @param data.authData - Optional authentication data
+ * @param data.plain - Flag to return unencrypted raw task
+ * @returns Promise resolving to RawTask
+ */
+export async function createRawTaskType(
+  api: ApiPromise,
+  data: {
+    task: NativeTask;
+    nonce?: Index;
+    authData?: OmniAuthData;
+    plain: true;
+  },
+): Promise<RawTask>;
+
+/**
+ * Creates an encrypted raw task type.
+ * 
+ * @param api - Polkadot API instance
+ * @param data - Task configuration
+ * @param data.task - Native task to be wrapped
+ * @param data.nonce - Optional nonce value
+ * @param data.authData - Optional authentication data
+ * @param data.plain - Flag to return encrypted raw task (default)
+ * @returns Promise resolving to object containing encrypted RawTask and encryption key
+ */
+export async function createRawTaskType(
+  api: ApiPromise,
+  data: {
+    task: NativeTask;
+    nonce?: Index;
+    authData?: OmniAuthData;
+    plain?: false;
+  },
+): Promise<{ rawTask: RawTask, encryptionKey: CryptoKey }>;
+
+/**
+ * Creates a RawTask wrapper for NativeTask with optional encryption.
+ * 
+ * When plain=true:
+ * - Returns unencrypted RawTask directly
+ * 
+ * When plain=false or omitted:
+ * 1. Generates ephemeral shielding key
+ * 2. Encrypts the task using client shielding key
+ * 3. Encrypts the shielding key using Enclave's public key
+ * 4. Packages as AES task
+ * 
+ * @param api - Polkadot API instance
+ * @param data - Task configuration
+ * @param data.task - Native task to be wrapped
+ * @param data.nonce - Optional nonce value
+ * @param data.authData - Optional authentication data
+ * @param data.plain - Whether to skip encryption, defaults to false
+ * @returns Either RawTask or object with encrypted RawTask and encryption key
+ * 
+ * @example
+ * // Get unencrypted raw task
+ * const rawTask = await createRawTaskType(api, { task, plain: true });
+ * 
+ * @example
+ * // Get encrypted raw task with key
+ * const { rawTask, encryptionKey } = await createRawTaskType(api, { task });
  */
 export async function createRawTaskType(
   api: ApiPromise,
@@ -24,7 +86,7 @@ export async function createRawTaskType(
     authData?: OmniAuthData;
     plain?: boolean;
   },
-): Promise<RawTask> {
+): Promise<RawTask | { rawTask: RawTask, encryptionKey: CryptoKey }> {
   const { authData, task, nonce, plain = false } = data;
 
   const auth = authData ? createOmniAuth(api.registry, authData) : undefined;
@@ -69,7 +131,10 @@ export async function createRawTaskType(
     payload: encryptedPayload,
   });
 
-  return api.createType<RawTask>('RawTask', {
-    Aes: aesTask,
-  });
+  return {
+    rawTask: api.createType<RawTask>('RawTask', {
+      Aes: aesTask,
+    }),
+    encryptionKey,
+  };
 }


### PR DESCRIPTION
…-sdk


### Context

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


