### PR TITLE
Use debug log level for block syncing

### DIFF
--- a/tee-worker/omni-executor/executor-core/src/listener.rs
+++ b/tee-worker/omni-executor/executor-core/src/listener.rs
@@ -137,7 +137,7 @@ impl<
 			let mut sync_error = false;
 
 			if last_finalized_block >= block_number_to_sync {
-				log::info!("Syncing block: {}", block_number_to_sync);
+				log::debug!("Syncing block: {}", block_number_to_sync);
 				match self.handle.block_on(self.fetcher.get_block_events(block_number_to_sync)) {
 					Ok(events) => {
 						for event in events {
@@ -152,7 +152,7 @@ impl<
 									continue;
 								}
 							}
-							log::info!("Handling event: {:?}", event_id);
+							log::debug!("Handling event: {:?}", event_id);
 							if let Err(e) = self.handle.block_on(self.event_handler.handle(event)) {
 								log::error!("Could not handle event: {:?}", e);
 								match e {
@@ -180,7 +180,7 @@ impl<
 						self.checkpoint_repository
 							.save(CheckpointT::from(block_number_to_sync))
 							.expect("Could not save checkpoint");
-						log::info!("Finished syncing block: {}", block_number_to_sync);
+						log::debug!("Finished syncing block: {}", block_number_to_sync);
 						block_number_to_sync += 1;
 					},
 					Err(e) => {

--- a/tee-worker/omni-executor/executor-worker/src/main.rs
+++ b/tee-worker/omni-executor/executor-worker/src/main.rs
@@ -188,7 +188,7 @@ async fn listen_to_parentchain(
 	let (_sub_stop_sender, sub_stop_receiver) = oneshot::channel();
 
 	let mut parentchain_listener = parentchain_listener::create_listener(
-		"litentry_rococo",
+		"heima",
 		Handle::current(),
 		&args.parentchain_url,
 		sub_stop_receiver,
@@ -198,7 +198,7 @@ async fn listen_to_parentchain(
 	.await?;
 
 	Ok(thread::Builder::new()
-		.name("litentry_rococo_sync".to_string())
+		.name("heima_sync".to_string())
 		.spawn(move || parentchain_listener.sync(args.start_block))
 		.unwrap())
 }

--- a/tee-worker/omni-executor/parentchain/rpc-client/src/lib.rs
+++ b/tee-worker/omni-executor/parentchain/rpc-client/src/lib.rs
@@ -24,7 +24,7 @@ pub use subxt_core::utils::AccountId32;
 
 use async_trait::async_trait;
 use executor_primitives::{AccountId, BlockEvent, BlockNumber, EventId, Hash};
-use log::{error, info};
+use log::{debug, error};
 use parity_scale_codec::{Decode, Encode};
 use scale_encode::EncodeAsType;
 use std::marker::PhantomData;
@@ -156,7 +156,7 @@ impl<ChainConfig: Config<AccountId = AccountId32, Header = RpcClientHeader>>
 		Ok(latest_block.number())
 	}
 	async fn get_block_events(&mut self, block_num: u64) -> Result<Vec<BlockEvent>, ()> {
-		info!("Getting block {} events", block_num);
+		debug!("Getting block {} events", block_num);
 		match self.legacy.chain_get_block_hash(Some(block_num.into())).await.map_err(|e| {
 			error!("Error getting block {} hash: {:?}", block_num, e);
 		})? {


### PR DESCRIPTION
### Context

As topic - the motivation is the worker log seems to be flooded with block syncing logs

@kziemianek does the change make sense?

