### PR TITLE
use tmp dir in tests

### DIFF
--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -7914,6 +7914,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.8",
+ "tempfile",
  "tokio",
 ]
 

--- a/tee-worker/omni-executor/Cargo.toml
+++ b/tee-worker/omni-executor/Cargo.toml
@@ -75,6 +75,7 @@ subxt-core = "0.38.0"
 subxt-signer = { version = "0.38.0", features = ["subxt"] }
 tokio = "1.43.0"
 url = "2.5.4"
+tempfile = "3.19.1"
 
 # Local dependencies
 accounting-contract-client = { path = "accounting-contract-client" }

--- a/tee-worker/omni-executor/rpc-server/Cargo.toml
+++ b/tee-worker/omni-executor/rpc-server/Cargo.toml
@@ -34,6 +34,9 @@ oauth-providers = { workspace = true }
 parentchain-rpc-client = { workspace = true }
 pumpx = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_health.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_health.rs
@@ -35,14 +35,16 @@ mod test {
 	use pumpx::PumpxApi;
 	use rsa::{pkcs1::EncodeRsaPrivateKey, RsaPrivateKey};
 	use std::sync::Arc;
+	use tempfile::tempdir;
 	use tokio::sync::mpsc;
 
 	#[tokio::test]
 	pub async fn get_health_works() {
+		let tmp_dir = tempdir().unwrap();
 		let port = 2000;
 		let shielding_key = ShieldingKey::new();
 		let (sender, _) = mpsc::channel::<NativeTaskChannelType>(1);
-		let db = StorageDB::open_default("test_get_health_storage_db").unwrap();
+		let db = StorageDB::open_default(tmp_dir.path()).unwrap();
 
 		let mut rng = rand::thread_rng();
 		let rsa_private_key =

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_shielding_key.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_shielding_key.rs
@@ -28,14 +28,16 @@ mod test {
 	use pumpx::PumpxApi;
 	use rsa::{pkcs1::EncodeRsaPrivateKey, RsaPrivateKey};
 	use std::sync::Arc;
+	use tempfile::tempdir;
 	use tokio::sync::mpsc;
 
 	#[tokio::test]
 	pub async fn get_shielding_key_works() {
+		let tmp_dir = tempdir().unwrap();
 		let port: u16 = 2005;
 		let shielding_key = ShieldingKey::new();
 		let (sender, _) = mpsc::channel::<NativeTaskChannelType>(1);
-		let db = StorageDB::open_default("test_get_shielding_key_storage_db").unwrap();
+		let db = StorageDB::open_default(tmp_dir.path()).unwrap();
 		let mut rng = rand::thread_rng();
 		let rsa_private_key =
 			RsaPrivateKey::new(&mut rng, 2048).expect("Failed to generate private key");


### PR DESCRIPTION
Some tests are leaving directiories with storage db files. Let's assign them temp directiories which are automatically cleaned.