### PR TITLE
Use new pumpx API for market order transfer tx

### DIFF
--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -33,12 +33,12 @@ use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
 use parity_scale_codec::Encode;
 use pumpx::signer_client::ChainType;
 use pumpx::signer_client::SignerClient;
-use pumpx::types::CreateCrossOrderData;
+use pumpx::types::CreateCrossOrderBody;
+use pumpx::types::CreateLimitOrderBody;
+use pumpx::types::CreateMarketOrderTxBody;
 use pumpx::types::CrossOrderInfo;
 use pumpx::types::GasType;
-use pumpx::types::MarketOrderTx;
-use pumpx::types::NewLimitOrder;
-use pumpx::types::NewMarketOrder;
+use pumpx::types::SendOrderTxBody;
 use pumpx::types::SwapType;
 use pumpx::PumpxApi;
 use pumpx::{pubkey_to_evm_address, pubkey_to_solana_address};
@@ -254,7 +254,7 @@ impl<
 
 					let order_response = match pumpx_config.order_type {
 						PumpxOrderType::Market => {
-							let new_market_order = NewMarketOrder {
+							let new_market_order = CreateMarketOrderTxBody {
 								request_id: intent_id,
 								chain_id: pumpx_config.to_chain_id,
 								token_ca: to_token_ca.clone(),
@@ -343,7 +343,7 @@ impl<
 								.map(|signature| signature.to_hex())
 								.collect();
 
-							let market_order_tx = MarketOrderTx {
+							let market_order_tx = SendOrderTxBody {
 								order_id: market_order_unsigned_tx_res.data.order_id,
 								chain_id: market_order_unsigned_tx_res.data.chain_id,
 								tx_data: signed_tx_data,
@@ -379,7 +379,7 @@ impl<
 								None => None,
 							};
 
-							let new_limit_order = NewLimitOrder {
+							let new_limit_order = CreateLimitOrderBody {
 								request_id: intent_id,
 								chain_id: pumpx_config.to_chain_id,
 								token_ca: to_token_ca,
@@ -478,7 +478,7 @@ impl<
 							log::error!("Could not get to_wallet from pumpx-signer: {:?}", e)
 						})?;
 
-					let cross_order_data = CreateCrossOrderData {
+					let cross_order_data = CreateCrossOrderBody {
 						request_id: intent_id,
 						chain_id: pumpx_config.to_chain_id,
 						token_ca: to_token_ca,

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -16,7 +16,6 @@
 
 use async_trait::async_trait;
 use executor_core::intent_executor::IntentExecutor;
-use executor_primitives::utils::hex::ToHexPrefixed;
 use executor_primitives::Intent;
 use executor_primitives::IntentId;
 use executor_primitives::PumpxOrderType;
@@ -38,7 +37,6 @@ use pumpx::types::CreateLimitOrderBody;
 use pumpx::types::CreateMarketOrderTxBody;
 use pumpx::types::CrossOrderInfo;
 use pumpx::types::GasType;
-use pumpx::types::SendOrderTxBody;
 use pumpx::types::SwapType;
 use pumpx::PumpxApi;
 use pumpx::{pubkey_to_evm_address, pubkey_to_solana_address};
@@ -297,65 +295,15 @@ impl<
 								slippage: pumpx_config.slippage,
 								wallet_index: pumpx_config.wallet_index,
 							};
-							let market_order_unsigned_tx_res = self
+							let res = self
 								.pumpx_api
-								.create_market_order_unsigned_tx(&access_token, new_market_order)
+								.create_market_order_tx(&access_token, new_market_order)
 								.await
 								.map_err(|_| {
-									log::error!("Failed to create market order unsigned tx");
+									log::error!("Failed to create market order tx");
 								})?;
 
-							let tx_data = market_order_unsigned_tx_res.data.tx_data;
-							let mut messages_to_sign = Vec::new();
-							for tx in tx_data {
-								let tx_cleaned = tx.strip_prefix("0x").unwrap_or(&tx);
-								let tx_bytes = match hex::decode(tx_cleaned) {
-									Ok(bytes) => bytes,
-									Err(e) => {
-										log::error!("Failed to decode hex string: {:?}", e);
-										return Err(());
-									},
-								};
-								messages_to_sign.push(tx_bytes);
-							}
-
-							let signatures = match self
-								.pumpx_signer_client
-								.request_signatures(
-									chain_type,
-									pumpx_config.wallet_index,
-									*account_id.as_ref(),
-									messages_to_sign,
-								)
-								.await
-							{
-								Ok(sigs) => sigs,
-								Err(e) => {
-									log::error!(
-										"Failed to get signatures from pumpx-signer: {:?}",
-										e
-									);
-									return Err(());
-								},
-							};
-							let signed_tx_data: Vec<String> = signatures
-								.into_iter()
-								.map(|signature| signature.to_hex())
-								.collect();
-
-							let market_order_tx = SendOrderTxBody {
-								order_id: market_order_unsigned_tx_res.data.order_id,
-								chain_id: market_order_unsigned_tx_res.data.chain_id,
-								tx_data: signed_tx_data,
-							};
-							let market_order_tx_res = self
-								.pumpx_api
-								.send_order_tx(&access_token, market_order_tx)
-								.await
-								.map_err(|_| {
-									log::error!("Failed to send market order tx");
-								})?;
-							market_order_tx_res.encode()
+							res.encode()
 						},
 						PumpxOrderType::Limit => {
 							let token_cap = match pumpx_config.token_cap {

--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -832,117 +832,25 @@ async fn handle_native_task<
 				return;
 			}
 
-			// 3. Create an unsigned tx with Pumpx backend
-			let unsigned_tx = CreateTransferUnsignedTxBody {
+			// 3. Create a transfer tx and send to backend
+			let body = CreateTransferTxBody {
 				request_id,
 				chain_id,
 				wallet_index,
-				recipient_address: recipient_address.to_string(),
-				token_ca: token_ca.to_string(),
-				amount: amount.to_string(),
+				recipient_address,
+				token_ca,
+				amount,
 			};
-			let create_transfer_res = match ctx
-				.pumpx_api
-				.create_transfer_unsigned_tx(&access_token, unsigned_tx, language.clone())
-				.await
-			{
-				Ok(res) => res,
-				Err(e) => {
-					send_error(
-						format!("Failed to create_transfer_unsigned_tx: {:?}", e),
-						response_sender,
-						NativeTaskError::PumpxApiError(
-							PumpxApiError::CreateTransferUnsignedTxFailed,
-						),
-					);
-					return;
-				},
-			};
-
-			let transfer_id = create_transfer_res.data.transfer_id;
-			let tx_data = create_transfer_res.data.tx_data;
-			let tx_data = match tx_data {
-				Some(data) => data,
-				None => {
-					send_error(
-						"No tx_data in create_transfer_unsigned_tx response".to_string(),
-						response_sender,
-						NativeTaskError::PumpxApiError(
-							PumpxApiError::CreateTransferUnsignedTxFailed,
-						),
-					);
-					return;
-				},
-			};
-
-			let Some(chain_type) = ChainType::from_pumpx_chain_id(chain_id) else {
-				send_error(
-					format!("Failed to map pumpx chain_id {}", chain_id),
-					response_sender,
-					NativeTaskError::InternalError,
-				);
-				return;
-			};
-
-			// 4. Use the pumpx_signer_client to sign all tx_data entries at once
-			let mut messages_to_sign = Vec::new();
-			for tx in tx_data {
-				let tx_cleaned = tx.strip_prefix("0x").unwrap_or(&tx);
-				let tx_bytes = match hex::decode(tx_cleaned) {
-					Ok(bytes) => bytes,
-					Err(e) => {
-						send_error(
-							format!("Failed to decode tx_data (hex): {:?}", e),
-							response_sender,
-							NativeTaskError::InternalError,
-						);
-						return;
-					},
-				};
-				messages_to_sign.push(tx_bytes);
-			}
-
-			let signatures = match ctx
-				.pumpx_signer_client
-				.request_signatures(
-					chain_type,
-					wallet_index,
-					sender.to_omni_account().into(),
-					messages_to_sign,
-				)
-				.await
-			{
-				Ok(sigs) => sigs,
-				Err(e) => {
-					send_error(
-						format!("Failed to sign transfer tx: {:?}", e),
-						response_sender,
-						NativeTaskError::PumpxSignerError(PumpxSignerError::RequestSignatureFailed),
-					);
-					return;
-				},
-			};
-
-			let signed_tx_data: Vec<String> =
-				signatures.into_iter().map(|sig| sig.to_hex()).collect();
-
-			// 5. Send the signed tx to the Pumpx backend
-			let signed_transfer_tx =
-				SendTransferTxBody { chain_id, tx_data: signed_tx_data, transfer_id };
-			match ctx
-				.pumpx_api
-				.send_transfer_tx(&access_token, signed_transfer_tx, language)
-				.await
-			{
+			match ctx.pumpx_api.create_transfer_tx(&access_token, body, language.clone()).await {
 				Ok(res) => {
 					send_ok(response_sender, NativeTaskOk::PumpxTransferWithdraw(res));
 					return;
 				},
 				Err(e) => {
 					send_error(
-						format!("Failed to send_transfer_tx: {:?}", e),
+						format!("Failed to create_transfer_tx: {:?}", e),
 						response_sender,
-						NativeTaskError::PumpxApiError(PumpxApiError::SendTransferTxFailed),
+						NativeTaskError::PumpxApiError(PumpxApiError::CreateTransferTxFailed),
 					);
 					return;
 				},

--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -32,7 +32,7 @@ use parentchain_signer::TxSigner;
 use parity_scale_codec::{Decode, Encode};
 use pumpx::{
 	signer_client::{ChainType, SignerClient},
-	types::{TransferTx, TransferUnsignedTx},
+	types::*,
 	PumpxApi,
 };
 use std::{marker::PhantomData, sync::Arc};
@@ -833,7 +833,7 @@ async fn handle_native_task<
 			}
 
 			// 3. Create an unsigned tx with Pumpx backend
-			let unsigned_tx = TransferUnsignedTx {
+			let unsigned_tx = CreateTransferUnsignedTxBody {
 				request_id,
 				chain_id,
 				wallet_index,
@@ -927,7 +927,8 @@ async fn handle_native_task<
 				signatures.into_iter().map(|sig| sig.to_hex()).collect();
 
 			// 5. Send the signed tx to the Pumpx backend
-			let signed_transfer_tx = TransferTx { chain_id, tx_data: signed_tx_data, transfer_id };
+			let signed_transfer_tx =
+				SendTransferTxBody { chain_id, tx_data: signed_tx_data, transfer_id };
 			match ctx
 				.pumpx_api
 				.send_transfer_tx(&access_token, signed_transfer_tx, language)

--- a/tee-worker/omni-executor/native-task-handler/src/types.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/types.rs
@@ -1,7 +1,7 @@
 use executor_primitives::Hash;
 use parentchain_rpc_client::TransactionStatus;
 use parity_scale_codec::{Decode, Encode};
-use pumpx::types::{AddWalletResponse, SendTransferTxResponse, UserConnectResponse};
+use pumpx::types::{AddWalletResponse, CreateTransferTxResponse, UserConnectResponse};
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq)]
 pub enum NativeTaskOk {
@@ -16,14 +16,13 @@ pub enum NativeTaskOk {
 		access_token: String,
 		/// Used for user's identity verification before making sensitive operations
 		id_token: String,
-
 		backend_response: UserConnectResponse,
 	},
 	IntentSwapResponse(Vec<u8>),
 	PumpxExportWallet(Vec<u8>),
 	PumpxAddWallet(AddWalletResponse),
 	PumpxSignLimitOrder(Vec<Vec<u8>>),
-	PumpxTransferWithdraw(SendTransferTxResponse),
+	PumpxTransferWithdraw(CreateTransferTxResponse),
 	PumpxNotifyLimitOrderResult,
 }
 
@@ -45,10 +44,11 @@ pub enum PumpxApiError {
 	GoogleCodeVerificationFailed,
 	UserConnectionFailed,
 	UnknownError,
+	InvalidInput,
 	AddWalletFailed,
 	CreateTransferUnsignedTxFailed,
 	SendTransferTxFailed,
-	InvalidInput,
+	CreateTransferTxFailed,
 }
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]

--- a/tee-worker/omni-executor/pumpx/src/pumpx_api/mod.rs
+++ b/tee-worker/omni-executor/pumpx/src/pumpx_api/mod.rs
@@ -2,11 +2,11 @@ pub mod types;
 
 use reqwest::{Client, Error};
 use types::{
-	AddWalletResponse, ConnectUser, CreateCrossOrderData, CreateTransferUnsignedTxResponse,
-	CrossOrderFailData, GoogleCode, MarketOrderTx, MarketOrderTxResponse,
-	MarketOrderUnsignedTxResponse, NewLimitOrder, NewMarketOrder, OrderInfoResponse,
-	SendTransferTxResponse, TransferTx, TransferUnsignedTx, UserConnectResponse,
-	UserTradeInfoResponse, VerifyGoogleCodeResponse,
+	AddWalletResponse, CreateCrossOrderBody, CreateLimitOrderBody, CreateMarketOrderTxBody,
+	CreateMarketOrderUnsignedTxResponse, CreateTransferUnsignedTxBody,
+	CreateTransferUnsignedTxResponse, CrossFailBody, GoogleCode, OrderInfoResponse,
+	SendOrderTxBody, SendOrderTxResponse, SendTransferTxBody, SendTransferTxResponse,
+	UserConnectBody, UserConnectResponse, UserTradeInfoResponse, VerifyGoogleCodeResponse,
 };
 use url::Url;
 
@@ -41,14 +41,14 @@ impl PumpxApi {
 		language: Option<String>,
 	) -> Result<UserConnectResponse, Error> {
 		let endpoint = format!("{}/v3/account/user_connect", self.base_url);
-		let user_connect = ConnectUser { email: email.clone(), invite_code, google_code };
+		let body = UserConnectBody { email: email.clone(), invite_code, google_code };
 
 		let response = self
 			.http_client
 			.post(&endpoint)
 			.header("X-Language", language.unwrap_or("en".to_string()))
 			.bearer_auth(access_token)
-			.json(&user_connect)
+			.json(&body)
 			.send()
 			.await
 			.map_err(|e| {
@@ -140,11 +140,41 @@ impl PumpxApi {
 			.await
 	}
 
+	pub async fn create_market_order_tx(
+		&self,
+		access_token: &str,
+		body: CreateMarketOrderTxBody,
+	) -> Result<CreateMarketOrderUnsignedTxResponse, Error> {
+		let endpoint = format!("{}/v3/trade/create_market_order_tx", self.base_url);
+		let response = self
+			.http_client
+			.post(&endpoint)
+			.bearer_auth(access_token)
+			.json(&body)
+			.send()
+			.await
+			.map_err(|e| {
+				log::error!("Failed to send market order creation request: {:?}", e);
+				e
+			})?;
+
+		let status = response.status();
+		let response = response.error_for_status().map_err(|e| {
+			log::error!("Market order creation failed with status: {}, error: {:?}", status, e);
+			e
+		})?;
+
+		response.json().await.map_err(|e| {
+			log::error!("Failed to parse market order creation response: {:?}", e);
+			e
+		})
+	}
+
 	pub async fn create_market_order_unsigned_tx(
 		&self,
 		access_token: &str,
-		new_market_order: NewMarketOrder,
-	) -> Result<MarketOrderUnsignedTxResponse, Error> {
+		new_market_order: CreateMarketOrderTxBody,
+	) -> Result<CreateMarketOrderUnsignedTxResponse, Error> {
 		let endpoint = format!("{}/v3/trade/create_market_order_unsigned_tx", self.base_url);
 		let response = self
 			.http_client
@@ -173,14 +203,14 @@ impl PumpxApi {
 	pub async fn send_order_tx(
 		&self,
 		access_token: &str,
-		market_order_tx: MarketOrderTx,
-	) -> Result<MarketOrderTxResponse, Error> {
+		body: SendOrderTxBody,
+	) -> Result<SendOrderTxResponse, Error> {
 		let endpoint = format!("{}/v3/trade/send_order_tx", self.base_url);
 		let response = self
 			.http_client
 			.post(&endpoint)
 			.bearer_auth(access_token)
-			.json(&market_order_tx)
+			.json(&body)
 			.send()
 			.await
 			.map_err(|e| {
@@ -203,13 +233,13 @@ impl PumpxApi {
 	pub async fn create_limit_order(
 		&self,
 		access_token: &str,
-		new_limit_order: NewLimitOrder,
+		body: CreateLimitOrderBody,
 	) -> Result<OrderInfoResponse, Error> {
 		let endpoint = format!("{}/v3/trade/create_limit_order", self.base_url);
 		self.http_client
 			.post(&endpoint)
 			.bearer_auth(access_token)
-			.json(&new_limit_order)
+			.json(&body)
 			.send()
 			.await?
 			.json()
@@ -219,7 +249,7 @@ impl PumpxApi {
 	pub async fn create_cross_order(
 		&self,
 		access_token: &str,
-		data: CreateCrossOrderData,
+		data: CreateCrossOrderBody,
 	) -> Result<OrderInfoResponse, Error> {
 		let endpoint = format!("{}/v3/trade/create_cross_order", self.base_url);
 		let response = self
@@ -245,7 +275,7 @@ impl PumpxApi {
 	pub async fn cross_fail(
 		&self,
 		access_token: &str,
-		data: CrossOrderFailData,
+		data: CrossFailBody,
 	) -> Result<OrderInfoResponse, Error> {
 		let endpoint = format!("{}/v3/trade/cross_fail", self.base_url);
 		let response = self
@@ -272,7 +302,7 @@ impl PumpxApi {
 	pub async fn create_transfer_unsigned_tx(
 		&self,
 		access_token: &str,
-		unsigned_tx: TransferUnsignedTx,
+		body: CreateTransferUnsignedTxBody,
 		language: Option<String>,
 	) -> Result<CreateTransferUnsignedTxResponse, Error> {
 		let endpoint = format!("{}/v3/trade/create_transfer_unsigned_tx", self.base_url);
@@ -281,7 +311,7 @@ impl PumpxApi {
 			.post(&endpoint)
 			.header("X-Language", language.unwrap_or("en".to_string()))
 			.bearer_auth(access_token)
-			.json(&unsigned_tx)
+			.json(&body)
 			.send()
 			.await
 			.map_err(|e| {
@@ -308,7 +338,7 @@ impl PumpxApi {
 	pub async fn send_transfer_tx(
 		&self,
 		access_token: &str,
-		signed_transfer_tx: TransferTx,
+		body: SendTransferTxBody,
 		language: Option<String>,
 	) -> Result<SendTransferTxResponse, Error> {
 		let endpoint = format!("{}/v3/trade/send_transfer_tx", self.base_url);
@@ -317,7 +347,7 @@ impl PumpxApi {
 			.post(&endpoint)
 			.header("X-Language", language.unwrap_or("en".to_string()))
 			.bearer_auth(access_token)
-			.json(&signed_transfer_tx)
+			.json(&body)
 			.send()
 			.await
 			.map_err(|e| {

--- a/tee-worker/omni-executor/pumpx/src/pumpx_api/mod.rs
+++ b/tee-worker/omni-executor/pumpx/src/pumpx_api/mod.rs
@@ -3,10 +3,12 @@ pub mod types;
 use reqwest::{Client, Error};
 use types::{
 	AddWalletResponse, CreateCrossOrderBody, CreateLimitOrderBody, CreateMarketOrderTxBody,
-	CreateMarketOrderUnsignedTxResponse, CreateTransferUnsignedTxBody,
-	CreateTransferUnsignedTxResponse, CrossFailBody, GoogleCode, OrderInfoResponse,
-	SendOrderTxBody, SendOrderTxResponse, SendTransferTxBody, SendTransferTxResponse,
-	UserConnectBody, UserConnectResponse, UserTradeInfoResponse, VerifyGoogleCodeResponse,
+	CreateMarketOrderTxResponse, CreateMarketOrderUnsignedTxBody,
+	CreateMarketOrderUnsignedTxResponse, CreateTransferTxBody, CreateTransferTxResponse,
+	CreateTransferUnsignedTxBody, CreateTransferUnsignedTxResponse, CrossFailBody, GoogleCode,
+	OrderInfoResponse, SendOrderTxBody, SendOrderTxResponse, SendTransferTxBody,
+	SendTransferTxResponse, UserConnectBody, UserConnectResponse, UserTradeInfoResponse,
+	VerifyGoogleCodeResponse,
 };
 use url::Url;
 
@@ -140,12 +142,12 @@ impl PumpxApi {
 			.await
 	}
 
-	pub async fn create_market_order_tx(
+	pub async fn create_market_order_unsigned_tx(
 		&self,
 		access_token: &str,
-		body: CreateMarketOrderTxBody,
+		body: CreateMarketOrderUnsignedTxBody,
 	) -> Result<CreateMarketOrderUnsignedTxResponse, Error> {
-		let endpoint = format!("{}/v3/trade/create_market_order_tx", self.base_url);
+		let endpoint = format!("{}/v3/trade/create_market_order_unsigned_tx", self.base_url);
 		let response = self
 			.http_client
 			.post(&endpoint)
@@ -154,48 +156,22 @@ impl PumpxApi {
 			.send()
 			.await
 			.map_err(|e| {
-				log::error!("Failed to send market order creation request: {:?}", e);
+				log::error!("Failed to send create_market_order_unsigned_tx request: {:?}", e);
 				e
 			})?;
 
 		let status = response.status();
 		let response = response.error_for_status().map_err(|e| {
-			log::error!("Market order creation failed with status: {}, error: {:?}", status, e);
-			e
-		})?;
-
-		response.json().await.map_err(|e| {
-			log::error!("Failed to parse market order creation response: {:?}", e);
-			e
-		})
-	}
-
-	pub async fn create_market_order_unsigned_tx(
-		&self,
-		access_token: &str,
-		new_market_order: CreateMarketOrderTxBody,
-	) -> Result<CreateMarketOrderUnsignedTxResponse, Error> {
-		let endpoint = format!("{}/v3/trade/create_market_order_unsigned_tx", self.base_url);
-		let response = self
-			.http_client
-			.post(&endpoint)
-			.bearer_auth(access_token)
-			.json(&new_market_order)
-			.send()
-			.await
-			.map_err(|e| {
-				log::error!("Failed to send market order creation request: {:?}", e);
+			log::error!(
+				"create_market_order_unsigned_tx failed with status: {}, error: {:?}",
+				status,
 				e
-			})?;
-
-		let status = response.status();
-		let response = response.error_for_status().map_err(|e| {
-			log::error!("Market order creation failed with status: {}, error: {:?}", status, e);
+			);
 			e
 		})?;
 
 		response.json().await.map_err(|e| {
-			log::error!("Failed to parse market order creation response: {:?}", e);
+			log::error!("Failed to parse create_market_order_unsigned_tx response: {:?}", e);
 			e
 		})
 	}
@@ -363,6 +339,73 @@ impl PumpxApi {
 
 		response.json().await.map_err(|e| {
 			log::error!("Failed to parse send_transfer_tx response: {:?}", e);
+			e
+		})
+	}
+
+	pub async fn create_market_order_tx(
+		&self,
+		access_token: &str,
+		body: CreateMarketOrderTxBody,
+	) -> Result<CreateMarketOrderTxResponse, Error> {
+		let endpoint = format!("{}/v3/trade/create_market_order_tx", self.base_url);
+		let response = self
+			.http_client
+			.post(&endpoint)
+			.bearer_auth(access_token)
+			.json(&body)
+			.send()
+			.await
+			.map_err(|e| {
+				log::error!("Failed to send create_market_order_tx request: {:?}", e);
+				e
+			})?;
+
+		let status = response.status();
+		let response = response.error_for_status().map_err(|e| {
+			log::error!("create_market_order_tx failed with status: {}, error: {:?}", status, e);
+			e
+		})?;
+
+		response.json().await.map_err(|e| {
+			log::error!("Failed to parse create_market_order_tx response: {:?}", e);
+			e
+		})
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	pub async fn create_transfer_tx(
+		&self,
+		access_token: &str,
+		body: CreateTransferTxBody,
+		language: Option<String>,
+	) -> Result<CreateTransferTxResponse, Error> {
+		let endpoint = format!("{}/v3/trade/create_transfer_tx", self.base_url);
+		let response = self
+			.http_client
+			.post(&endpoint)
+			.header("X-Language", language.unwrap_or("en".to_string()))
+			.bearer_auth(access_token)
+			.json(&body)
+			.send()
+			.await
+			.map_err(|e| {
+				log::error!("Failed to send create_transfer_tx request: {:?}", e);
+				e
+			})?;
+
+		let status = response.status();
+		let response = response.error_for_status().map_err(|e| {
+			log::error!(
+				"create_transfer_tx request failed with status: {}, error: {:?}",
+				status,
+				e
+			);
+			e
+		})?;
+
+		response.json().await.map_err(|e| {
+			log::error!("Failed to parse create_transfer_tx response: {:?}", e);
 			e
 		})
 	}

--- a/tee-worker/omni-executor/pumpx/src/pumpx_api/types.rs
+++ b/tee-worker/omni-executor/pumpx/src/pumpx_api/types.rs
@@ -10,22 +10,18 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 // TODO: split this file to individual file per API
 
 pub type UserConnectResponse = ApiResponse<UserConnectResponseData>;
-
 pub type CreateMarketOrderUnsignedTxResponse = ApiResponse<CreateMarketOrderUnsignedTxResponseData>;
-
 pub type SendOrderTxResponse = ApiResponse<SendOrderTxResponseData>;
-
 pub type UserTradeInfoResponse = ApiResponse<UserTradeInfoResponseData>;
-
 pub type OrderInfoResponse = ApiResponse<OrderInfoResponseData>;
-
 pub type VerifyGoogleCodeResponse = ApiResponse<VerifyGoogleCodeResponseData>;
-
 pub type AddWalletResponse = ApiResponse<()>;
-
 pub type CreateTransferUnsignedTxResponse = ApiResponse<CreateTransferUnsignedTxResponseData>;
-
 pub type SendTransferTxResponse = ApiResponse<SendTransferTxResponseData>;
+
+// new API
+pub type CreateMarketOrderTxResponse = ApiResponse<CreateMarketOrderTxResponseData>;
+pub type CreateTransferTxResponse = ApiResponse<CreateTransferTxResponseData>;
 
 #[derive(Deserialize_repr, Serialize_repr, Debug)]
 #[allow(clippy::upper_case_acronyms)]
@@ -185,6 +181,26 @@ pub struct CreateMarketOrderTxResponseData {
 	pub chain_id: u32,
 	pub order_id: u32,
 	pub tx_hash: Vec<String>,
+}
+
+// /v3/trade/create_transfer_tx
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTransferTxBody {
+	pub request_id: Option<u32>,
+	pub chain_id: u32,
+	pub wallet_index: u32,
+	pub recipient_address: String,
+	pub token_ca: String,
+	pub amount: String,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTransferTxResponseData {
+	pub tx_hash: String,
+	pub transfer_id: u32,
+	pub chain_id: u32,
 }
 
 // /v3/trade/send_order_tx

--- a/tee-worker/omni-executor/pumpx/src/pumpx_api/types.rs
+++ b/tee-worker/omni-executor/pumpx/src/pumpx_api/types.rs
@@ -2,88 +2,30 @@ use parity_scale_codec::{Codec, Decode, Encode};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-pub type UserConnectResponse = ApiResponse<ConnectedUser>;
+// This file contains the type and struct definitions of pumpx-API (backend).
+// For each API, we define the struct of:
+// - (optional) request body: ...Body
+// - response `data` section: ...ResponseData
+//
+// TODO: split this file to individual file per API
 
-pub type MarketOrderUnsignedTxResponse = ApiResponse<MarketOrderUnsignedTx>;
+pub type UserConnectResponse = ApiResponse<UserConnectResponseData>;
 
-pub type MarketOrderTxResponse = ApiResponse<TxData>;
+pub type CreateMarketOrderUnsignedTxResponse = ApiResponse<CreateMarketOrderUnsignedTxResponseData>;
 
-pub type UserTradeInfoResponse = ApiResponse<UserTradeInfo>;
+pub type SendOrderTxResponse = ApiResponse<SendOrderTxResponseData>;
 
-pub type OrderInfoResponse = ApiResponse<OrderInfo>;
+pub type UserTradeInfoResponse = ApiResponse<UserTradeInfoResponseData>;
 
-pub type VerifyGoogleCodeResponse = ApiResponse<DataResult>;
+pub type OrderInfoResponse = ApiResponse<OrderInfoResponseData>;
 
-pub type AddWalletResponse = ApiResponse<EmptyResponse>;
+pub type VerifyGoogleCodeResponse = ApiResponse<VerifyGoogleCodeResponseData>;
 
-pub type CreateTransferUnsignedTxResponse = ApiResponse<TransferUnsignedTxData>;
+pub type AddWalletResponse = ApiResponse<()>;
 
-pub type SendTransferTxResponse = ApiResponse<TransferTxData>;
+pub type CreateTransferUnsignedTxResponse = ApiResponse<CreateTransferUnsignedTxResponseData>;
 
-#[derive(Deserialize, Serialize, Encode, Decode, PartialEq, Eq, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct TransferUnsignedTxData {
-	pub tx_data: Option<Vec<String>>,
-	pub transfer_id: u32,
-	pub chain_id: u32,
-}
-
-#[derive(Deserialize, Serialize, Encode, Decode, PartialEq, Eq, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct TransferTxData {
-	pub tx_hash: Option<Vec<String>>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TransferUnsignedTx {
-	pub request_id: Option<u32>,
-	pub chain_id: u32,
-	pub wallet_index: u32,
-	pub recipient_address: String,
-	pub token_ca: String,
-	pub amount: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TransferTx {
-	pub chain_id: u32,
-	pub tx_data: Vec<String>,
-	pub transfer_id: u32,
-}
-
-#[derive(Deserialize, Serialize, Encode, Decode, PartialEq, Eq, Debug, Clone, Default)]
-pub struct EmptyResponse {}
-
-#[derive(Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ConnectUser {
-	pub email: String,
-	pub invite_code: Option<String>,
-	pub google_code: String,
-}
-
-#[derive(Deserialize, Serialize, Encode, Decode, PartialEq, Eq, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct ConnectedUser {
-	pub user_id: String,
-	pub google_auth_check: bool,
-}
-
-#[derive(Deserialize, Serialize, Encode, Decode, PartialEq, Eq, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct ApiResponse<T: Codec> {
-	code: u32,
-	message: String,
-	pub data: T,
-}
-
-impl<T: Codec> ApiResponse<T> {
-	pub fn data(&self) -> &T {
-		&self.data
-	}
-}
+pub type SendTransferTxResponse = ApiResponse<SendTransferTxResponseData>;
 
 #[derive(Deserialize_repr, Serialize_repr, Debug)]
 #[allow(clippy::upper_case_acronyms)]
@@ -102,7 +44,7 @@ impl SwapType {
 	}
 }
 
-#[derive(Deserialize_repr, Serialize_repr, Encode, Decode)]
+#[derive(Deserialize_repr, Serialize_repr, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 #[repr(u8)]
 pub enum GasType {
@@ -121,9 +63,80 @@ impl GasType {
 	}
 }
 
+// the generic (standard) JSON-RPC response
+#[derive(Deserialize, Serialize, Encode, Decode, PartialEq, Eq, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiResponse<T: Codec> {
+	code: u32,
+	message: String,
+	pub data: T,
+}
+
+impl<T: Codec> ApiResponse<T> {
+	pub fn data(&self) -> &T {
+		&self.data
+	}
+}
+
+// /v3/trade/create_transfer_unsigned_tx
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct NewMarketOrder {
+pub struct CreateTransferUnsignedTxBody {
+	pub request_id: Option<u32>,
+	pub chain_id: u32,
+	pub wallet_index: u32,
+	pub recipient_address: String,
+	pub token_ca: String,
+	pub amount: String,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTransferUnsignedTxResponseData {
+	pub tx_data: Option<Vec<String>>,
+	pub transfer_id: u32,
+	pub chain_id: u32,
+}
+
+// /v3/trade/send_transfer_tx
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendTransferTxBody {
+	pub chain_id: u32,
+	pub tx_data: Vec<String>,
+	pub transfer_id: u32,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SendTransferTxResponseData {
+	pub tx_hash: Option<Vec<String>>,
+}
+
+// /v3/account/user_connect
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserConnectBody {
+	pub email: String,
+	pub invite_code: Option<String>,
+	pub google_code: String,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UserConnectResponseData {
+	pub user_id: String,
+	pub google_auth_check: bool,
+}
+
+// /v3/trade/create_market_order_unsigned_tx
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateMarketOrderUnsignedTxBody {
 	pub request_id: u32,
 	pub chain_id: u32,
 	pub token_ca: String,
@@ -139,31 +152,61 @@ pub struct NewMarketOrder {
 	pub wallet_index: u32,
 }
 
-#[derive(Deserialize, Encode, Decode)]
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct MarketOrderUnsignedTx {
+pub struct CreateMarketOrderUnsignedTxResponseData {
 	pub chain_id: u32,
 	pub order_id: u32,
 	pub tx_data: Vec<String>,
 }
 
+// /v3/trade/create_market_order_tx
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct MarketOrderTx {
+pub struct CreateMarketOrderTxBody {
+	pub request_id: u32,
+	pub chain_id: u32,
+	pub token_ca: String,
+	pub swap_type: SwapType,
+	pub amount_in: String,
+	pub double_out: bool,
+	pub is_one_click: bool,
+	pub address: String,
+	pub is_anti_mev: bool,
+	pub is_auto_slippage: bool,
+	pub gas_type: GasType,
+	pub slippage: u32,
+	pub wallet_index: u32,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateMarketOrderTxResponseData {
+	pub chain_id: u32,
+	pub order_id: u32,
+	pub tx_hash: Vec<String>,
+}
+
+// /v3/trade/send_order_tx
+
+#[derive(Deserialize, Serialize, Encode, Decode)]
+#[serde(rename_all = "camelCase")]
+pub struct SendOrderTxBody {
 	pub chain_id: u32,
 	pub order_id: u32,
 	pub tx_data: Vec<String>,
 }
 
-#[derive(Deserialize, Serialize, Encode, Decode, Clone)]
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct TxData {
+pub struct SendOrderTxResponseData {
 	pub tx_hash: Option<Vec<String>>,
 }
 
-#[derive(Deserialize, Encode, Decode)]
+// /v3/account/get_user_trade_info
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct UserTradeInfo {
+pub struct UserTradeInfoResponseData {
 	pub gas_type_base: GasType,
 	pub gas_type_bsc: GasType,
 	pub gas_type_eth: GasType,
@@ -175,9 +218,10 @@ pub struct UserTradeInfo {
 	pub slippage_display: String,
 }
 
+// /v3/trade/create_limit_order/
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct NewLimitOrder {
+pub struct CreateLimitOrderBody {
 	pub request_id: u32,
 	pub chain_id: u32,
 	pub token_ca: String,
@@ -195,25 +239,31 @@ pub struct NewLimitOrder {
 	pub wallet_index: u32,
 }
 
-#[derive(Deserialize, Serialize, Encode, Decode, Clone)]
+// Used in
+// /v3/trade/create_cross_order
+// /v3/trade/cross_fail
+// /v3/trade/create_limit_order/
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct OrderInfo {
+pub struct OrderInfoResponseData {
 	pub order_id: u32,
 }
 
+// /v3/account/verify_google_code
 #[derive(Serialize)]
 pub struct GoogleCode {
 	pub google_code: String,
 }
 
-#[derive(Deserialize, Encode, Decode)]
-pub struct DataResult {
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+pub struct VerifyGoogleCodeResponseData {
 	pub result: bool,
 }
 
+// /v3/trade/create_cross_order
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateCrossOrderData {
+pub struct CreateCrossOrderBody {
 	pub request_id: u32,
 	pub chain_id: u32,
 	pub token_ca: String,
@@ -233,9 +283,10 @@ pub struct CrossOrderInfo {
 	pub usd: String,
 }
 
+// /v3/trade/cross_fail
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CrossOrderFailData {
+pub struct CrossFailBody {
 	pub request_id: u32,
 	pub fail_reason: String,
 }

--- a/tee-worker/omni-executor/rpc-server/src/error_code.rs
+++ b/tee-worker/omni-executor/rpc-server/src/error_code.rs
@@ -23,6 +23,7 @@ const PUMPX_API_ADD_WALLET_FAILED_CODE: i32 = -32034;
 const PUMPX_API_CREATE_TRANSFER_UNSIGNED_TX_FAILED_CODE: i32 = -32035;
 const PUMPX_API_SEND_TRANSFER_TX_FAILED_CODE: i32 = -32036;
 const PUMPX_API_INVALID_INPUT_FAILED_CODE: i32 = -32037;
+const PUMPX_API_CREATE_TRANSFER_TX_FAILED_CODE: i32 = -32038;
 
 const PUMPX_SIGNER_REQUEST_SIGNATURE_FAILED_CODE: i32 = -32050;
 
@@ -49,6 +50,7 @@ pub fn get_native_task_error_code(error: &NativeTaskError) -> i32 {
 			},
 			PumpxApiError::SendTransferTxFailed => PUMPX_API_SEND_TRANSFER_TX_FAILED_CODE,
 			PumpxApiError::InvalidInput => PUMPX_API_INVALID_INPUT_FAILED_CODE,
+			PumpxApiError::CreateTransferTxFailed => PUMPX_API_CREATE_TRANSFER_TX_FAILED_CODE,
 		},
 		NativeTaskError::PumpxSignerError(signer_error) => match signer_error {
 			PumpxSignerError::RequestSignatureFailed => PUMPX_SIGNER_REQUEST_SIGNATURE_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
@@ -15,7 +15,7 @@ use heima_primitives::{
 use jsonrpsee::RpcModule;
 use native_task_handler::{NativeTaskOk, NativeTaskResponse};
 use pumpx::constants::*;
-use pumpx::types::{MarketOrderTxResponse, OrderInfoResponse, SwapType};
+use pumpx::types::{OrderInfoResponse, SendOrderTxResponse, SwapType};
 use serde::Serialize;
 
 #[derive(Debug, Deserialize)]
@@ -97,7 +97,7 @@ pub struct PumpxSubmitSwapOrderResponse {
 #[derive(Serialize, Clone)]
 struct BackendResponse {
 	pub limit_order_response: Option<OrderInfoResponse>,
-	pub market_order_response: Option<MarketOrderTxResponse>,
+	pub market_order_response: Option<SendOrderTxResponse>,
 }
 
 pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
@@ -243,7 +243,7 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 					match native_task_response {
 						Ok(NativeTaskOk::IntentSwapResponse(swap_response)) => {
 							if params.order_type == PumpxOrderType::Market {
-								let market_order_response: MarketOrderTxResponse =
+								let market_order_response: SendOrderTxResponse =
 									Decode::decode(&mut swap_response.as_slice())
 										.map_err(|_| ErrorCode::InternalError)?;
 								let response = PumpxSubmitSwapOrderResponse {

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
@@ -15,7 +15,7 @@ use heima_primitives::{
 use jsonrpsee::RpcModule;
 use native_task_handler::{NativeTaskOk, NativeTaskResponse};
 use pumpx::constants::*;
-use pumpx::types::{OrderInfoResponse, SendOrderTxResponse, SwapType};
+use pumpx::types::{CreateMarketOrderTxResponse, OrderInfoResponse, SwapType};
 use serde::Serialize;
 
 #[derive(Debug, Deserialize)]
@@ -97,7 +97,7 @@ pub struct PumpxSubmitSwapOrderResponse {
 #[derive(Serialize, Clone)]
 struct BackendResponse {
 	pub limit_order_response: Option<OrderInfoResponse>,
-	pub market_order_response: Option<SendOrderTxResponse>,
+	pub market_order_response: Option<CreateMarketOrderTxResponse>,
 }
 
 pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
@@ -243,7 +243,7 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 					match native_task_response {
 						Ok(NativeTaskOk::IntentSwapResponse(swap_response)) => {
 							if params.order_type == PumpxOrderType::Market {
-								let market_order_response: SendOrderTxResponse =
+								let market_order_response: CreateMarketOrderTxResponse =
 									Decode::decode(&mut swap_response.as_slice())
 										.map_err(|_| ErrorCode::InternalError)?;
 								let response = PumpxSubmitSwapOrderResponse {

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/transfer_widthdraw.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/transfer_widthdraw.rs
@@ -7,7 +7,7 @@ use executor_primitives::OmniAuth;
 use heima_primitives::{Identity, Web2IdentityType};
 use jsonrpsee::{types::ErrorObject, RpcModule};
 use native_task_handler::{NativeTaskError, NativeTaskOk, NativeTaskResponse};
-use pumpx::types::SendTransferTxResponse;
+use pumpx::types::CreateTransferTxResponse;
 use serde::Serialize;
 
 #[derive(Debug, Deserialize)]
@@ -26,7 +26,7 @@ pub struct TransferWithdrawParams {
 
 #[derive(Serialize, Clone)]
 pub struct TransferWithdrawResponse {
-	pub backend_response: SendTransferTxResponse,
+	pub backend_response: CreateTransferTxResponse,
 }
 
 impl From<TransferWithdrawParams> for NativeTaskWrapper<NativeTask> {
@@ -74,8 +74,8 @@ pub fn register_transfer_withdraw(module: &mut RpcModule<RpcContext>) {
 						Decode::decode(&mut response.as_slice())
 							.map_err(|_| internal_error.clone())?;
 					match native_task_response {
-						Ok(NativeTaskOk::PumpxTransferWithdraw(send_tx_response)) => {
-							Ok(TransferWithdrawResponse { backend_response: send_tx_response })
+						Ok(NativeTaskOk::PumpxTransferWithdraw(response)) => {
+							Ok(TransferWithdrawResponse { backend_response: response })
 						},
 						Err(NativeTaskError::InternalError) => {
 							log::error!("Internal error in native task");


### PR DESCRIPTION
### Context

As topic - a workaround until the worker can construct and send out tx on its own.

It also renames most of the structs to be 1:1 exact mapping to pumpx api name. It might be even better to give each pumpx method a separate file, but later