### PR TITLE
Update omni-executor release setting

### DIFF
--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -253,7 +253,7 @@ jobs:
       - name: Write enclave signing key
         run: |
           cat << EOF > tee-worker/omni-executor/enclave_key.pem
-          ${{ secrets.IDENTITY_ENCLAVE_PROD_SIGNING_KEY }}
+          ${{ secrets.OMNI_EXECUTOR_ENCLAVE_PROD_SIGNING_KEY }}
           EOF
 
       - name: Build omni-executor image

--- a/tee-worker/omni-executor/omni-executor.manifest.template
+++ b/tee-worker/omni-executor/omni-executor.manifest.template
@@ -18,11 +18,10 @@ loader.env.RUST_BACKTRACE = "full"
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
-  { path = "/data", uri = "file:data", type="encrypted", key_name="{{'_sgx_mrsigner' if env.get('SGX', '0') == '1' else 'fake_sgx_mrsigner'}}" },
   { path = "/etc", uri = "file:/etc" },
   { path = "/usr", uri = "file:/usr" },
   { path = "/storage_db", uri = "file:storage_db", type="encrypted", key_name="{{'_sgx_mrsigner' if env.get('SGX', '0') == '1' else 'fake_sgx_mrsigner'}}" },
-  { path = "/local/keystore", uri = "file:local/keystore", type="encrypted", key_name="{{'_sgx_mrsigner' if env.get('SGX', '0') == '1' else 'fake_sgx_mrsigner'}}" },
+  { path = "/local", uri = "file:local", type="encrypted", key_name="{{'_sgx_mrsigner' if env.get('SGX', '0') == '1' else 'fake_sgx_mrsigner'}}" },
 ]
 
 sgx.debug = {{ 'true' if env.get('SGX_DEBUG', '0') == '1' else 'false' }}

--- a/tee-worker/omni-executor/parentchain/attestation/src/lib.rs
+++ b/tee-worker/omni-executor/parentchain/attestation/src/lib.rs
@@ -51,7 +51,7 @@ pub async fn perform_attestation(
 			DcapQuote::decode(&mut quote.as_slice()).expect("Failed to decode quote");
 
 		mrenclave = dcap_quote.body.mr_enclave;
-		info!("MRENCLAVE {:?}", mrenclave);
+		info!("MRENCLAVE in hex {:?}", hex::encode(mrenclave));
 	}
 	#[cfg(not(feature = "gramine-quote"))]
 	{


### PR DESCRIPTION
### Context

As topic.

- update env key in CI
- I don't think `data/` folder is used anywhere?
- `local/log` is used for checkpoints

I don't know how it's mounted in the devops - I assume we need to have a folder `local` containing both `log` and `keystore` as sub-dir and mount it?

