### PR TITLE
Toggle parentchain listener through CLI

### DIFF
--- a/tee-worker/omni-executor/docker/docker-compose.yml
+++ b/tee-worker/omni-executor/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       heima-node:
         condition: service_healthy
         restart: true
-    command: ["executor-worker", "run", "ws://heima-node:9944", "http://ethereum-node:8545", "https://api.devnet.solana.com", "pumpx-signer-url", "ws://omni-executor:2100", "bsc-url", "bsc-testnet-url",]
+    command: ["executor-worker", "run", "ws://heima-node:9944", "http://ethereum-node:8545", "https://api.devnet.solana.com", "pumpx-signer-url", "ws://omni-executor:2100", "bsc-url", "bsc-testnet-url", "--parentchain-sync"]
     privileged: true
     restart: unless-stopped
     networks:

--- a/tee-worker/omni-executor/executor-worker/src/cli.rs
+++ b/tee-worker/omni-executor/executor-worker/src/cli.rs
@@ -41,6 +41,8 @@ pub struct RunArgs {
 		value_name = "accounting contract address"
 	)]
 	pub accounting_contract_address: String,
+	#[arg(long, value_name = "should sync with parentchain")]
+	pub parentchain_sync: bool,
 }
 
 #[derive(Args)]

--- a/tee-worker/omni-executor/executor-worker/src/main.rs
+++ b/tee-worker/omni-executor/executor-worker/src/main.rs
@@ -282,7 +282,9 @@ async fn main() -> Result<(), ()> {
 				error!("Could not start server: {:?}", e);
 			})?;
 
-			listen_to_parentchain(*args, storage_db).await.unwrap();
+			if args.parentchain_sync {
+				listen_to_parentchain(*args, storage_db).await.unwrap();
+			}
 
 			match signal::ctrl_c().await {
 				Ok(()) => {},


### PR DESCRIPTION
By default it's set to false (if flag is not present). It will not run parentchain listener so if there is any logic based on onchain events it won't be triggered.


