### PR TITLE
Use correct OmniAccount in SignLimitOrder's NativeTask's

### DIFF
--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -814,7 +814,18 @@ async fn handle_native_task<
 			return;
 		},
 		NativeTask::PumpxSignLimitOrder(sender, chain_id, wallet_index, unsigned_tx) => {
-			let omni_account = sender.to_omni_account();
+			// This is a workaround, in this case the Substrate identity is the OmniAccount address itself
+			let omni_account: AccountId = match sender {
+				Identity::Substrate(ref account) => account.into(),
+				_ => {
+					send_error(
+						"Invalid sender type for PumpxSignLimitOrder".to_string(),
+						response_sender,
+						NativeTaskError::InternalError,
+					);
+					return;
+				},
+			};
 			let Some(chain) = ChainType::from_pumpx_chain_id(chain_id) else {
 				log::error!("Failed to map pumpx chain_id {}", chain_id);
 				let response = NativeTaskResponse::Err(NativeTaskError::InternalError);
@@ -942,11 +953,25 @@ async fn handle_native_task<
 				log::info!("Limit order result message for intent_id {}: {}", intent_id, msg);
 			}
 
+			// This is a workaround, in this case the Substrate identity is the OmniAccount address itself
+			let omni_account: AccountId = match sender {
+				Identity::Substrate(ref account) => account.into(),
+				_ => {
+					send_error(
+						"Invalid sender type for PumpxSignLimitOrder".to_string(),
+						response_sender,
+						NativeTaskError::InternalError,
+					);
+					return;
+				},
+			};
+
 			send_ok(response_sender, NativeTaskOk::PumpxNotifyLimitOrderResult);
+
 			notify_intent_completed(
 				&mut rpc_client,
 				ctx.transaction_signer.clone(),
-				sender.to_omni_account(),
+				omni_account,
 				intent_id,
 				execution_result,
 			)


### PR DESCRIPTION
This PR fixes an issue with the OmniAccount's extracted from these NativeTasks: `PumpxSignLimitOrder` and `PumpxNotifyLimitOrderResult`

We create the NativeTask using the OmniAccount itself as the sender: 
```rust
let omni_account = token.sub;
let Ok(address) = Address32::from_hex(&omni_account) else {
	error!("Not a valid address");
	return Err(internal_error);
};

let task_wrapper = NativeTaskWrapper {
	task: NativeTask::PumpxSignLimitOrder(
		Identity::Substrate(address),
		params.chain_id,
		params.wallet_index,
		params.unsigned_tx.iter().map(|tx| tx.to_vec()).collect(),
	),
	nonce: None,
	auth: Some(OmniAuth::AuthToken(params.auth_token)),
};
```
Using `to_omni_account` derives a different OmniAccount