### PR TITLE
add `omni-executor` metrics

### DIFF
--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -1304,6 +1304,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,12 +1452,15 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.100",
+ "which",
 ]
 
 [[package]]
@@ -2096,6 +2122,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "coins-bip32"
@@ -3644,6 +3679,7 @@ dependencies = [
  "executor-primitives",
  "heima-authentication",
  "log",
+ "metrics",
  "parity-scale-codec",
  "rand 0.8.5",
  "regex",
@@ -3720,6 +3756,7 @@ dependencies = [
  "executor-storage",
  "hex",
  "log",
+ "metrics-exporter-prometheus",
  "native-task-handler",
  "parentchain-attestation",
  "parentchain-listener",
@@ -4228,6 +4265,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -4917,6 +4960,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.23.25",
+ "rustls-native-certs",
  "rustls-pki-types 1.11.0",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -6110,6 +6154,53 @@ dependencies = [
  "keccak",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "metrics"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+dependencies = [
+ "ahash 0.8.11",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "indexmap 2.9.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.2",
+ "metrics",
+ "quanta",
+ "rand 0.9.0",
+ "rand_xoshiro",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -7646,6 +7737,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8188,6 +8288,7 @@ version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.14",
@@ -8295,6 +8396,7 @@ version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.14",
  "rustls-pki-types 1.11.0",
  "untrusted 0.9.0",
@@ -9052,6 +9154,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
@@ -13379,6 +13487,18 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
 
 [[package]]
 name = "wide"

--- a/tee-worker/omni-executor/Cargo.toml
+++ b/tee-worker/omni-executor/Cargo.toml
@@ -52,6 +52,8 @@ jsonrpsee = { version = "0.24", features = ["server"] }
 jsonwebtoken = "9.3.0"
 libsecp256k1 = "0.7.1"
 log = "0.4.22"
+metrics = "0.24.1"
+metrics-exporter-prometheus = "0.16.2"
 mockall = "0.13.1"
 parity-scale-codec = "3.6.12"
 rand = "0.8.5"

--- a/tee-worker/omni-executor/README.md
+++ b/tee-worker/omni-executor/README.md
@@ -22,7 +22,7 @@ Gramine is required for running inside TEE, please refer to [installation option
 2. Build omni-executor docker image:
 
    ```bash
-   make docker-build
+   make build-docker
    ```
 
 3. Start local omni-executor:

--- a/tee-worker/omni-executor/docker/docker-compose.yml
+++ b/tee-worker/omni-executor/docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - litentry-test-network
     ports:
       - "2100:2100"
+      - "9090:9090"
     healthcheck:
       test: [ "CMD-SHELL", "curl -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"omni_getHealth\",\"id\":1}' http://localhost:2100 || exit 1"]
       interval: 30s

--- a/tee-worker/omni-executor/executor-core/Cargo.toml
+++ b/tee-worker/omni-executor/executor-core/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 log = { workspace = true }
+metrics = { workspace = true }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/tee-worker/omni-executor/executor-core/src/intent_executor.rs
+++ b/tee-worker/omni-executor/executor-core/src/intent_executor.rs
@@ -20,6 +20,7 @@ use tokio::sync::mpsc;
 use executor_primitives::AccountId;
 use executor_primitives::Intent;
 use executor_primitives::IntentId;
+use metrics::describe_gauge;
 
 pub type IntentExecutionResult = (Option<Vec<u8>>, bool);
 
@@ -32,6 +33,13 @@ pub trait IntentExecutor: Send {
 		intent_id: IntentId,
 		intent: Intent,
 	) -> Result<IntentExecutionResult, ()>;
+
+	async fn name(&self) -> &'static str;
+
+	async fn on_execution_error(&self) {
+		let name = self.name().await;
+		describe_gauge!(executor_gauge_name(name), executor_gauge_desc(name));
+	}
 }
 
 pub struct MockedIntentExecutor {
@@ -55,4 +63,16 @@ impl IntentExecutor for MockedIntentExecutor {
 	) -> Result<IntentExecutionResult, ()> {
 		self.sender.send(()).map(|_| (None, false)).map_err(|_| ())
 	}
+
+	async fn name(&self) -> &'static str {
+		"mocked"
+	}
+}
+
+fn executor_gauge_name(name: &str) -> String {
+	format!("{}_intent_execution_failures", name)
+}
+
+fn executor_gauge_desc(name: &str) -> String {
+	format!("Number of {} intent executor failures", name)
 }

--- a/tee-worker/omni-executor/executor-core/src/listener.rs
+++ b/tee-worker/omni-executor/executor-core/src/listener.rs
@@ -23,6 +23,7 @@ use crate::event_handler::{Error, EventHandler};
 use crate::fetcher::{EventsFetcher, LastFinalizedBlockNumFetcher};
 use crate::sync_checkpoint_repository::{Checkpoint, CheckpointRepository};
 use executor_primitives::GetEventId;
+use metrics::{describe_gauge, gauge};
 
 /// Component, used to listen to chain and execute requested intents
 /// Requires specific implementations of:
@@ -65,6 +66,7 @@ impl<
 		stop_signal: Receiver<()>,
 		last_processed_log_repository: CheckpointRepositoryT,
 	) -> Result<Self, ()> {
+		describe_gauge!(synced_block_gauge_name(id), "Last synced block");
 		Ok(Self {
 			id: id.to_string(),
 			handle,
@@ -185,6 +187,7 @@ impl<
 						self.checkpoint_repository
 							.save(CheckpointT::from(block_number_to_sync))
 							.expect("Could not save checkpoint");
+						gauge!(synced_block_gauge_name(&self.id)).set(block_number_to_sync as f64);
 						log::debug!("Finished syncing block: {}", block_number_to_sync);
 						block_number_to_sync += 1;
 					},
@@ -204,4 +207,8 @@ impl<
 			}
 		}
 	}
+}
+
+fn synced_block_gauge_name(listener_id: &str) -> String {
+	format!("{}_synced_block", listener_id)
 }

--- a/tee-worker/omni-executor/executor-worker/Cargo.toml
+++ b/tee-worker/omni-executor/executor-worker/Cargo.toml
@@ -10,6 +10,7 @@ clap = { workspace = true, features = ["derive"] }
 env_logger = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 scale-encode = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }

--- a/tee-worker/omni-executor/executor-worker/src/cli.rs
+++ b/tee-worker/omni-executor/executor-worker/src/cli.rs
@@ -43,6 +43,8 @@ pub struct RunArgs {
 	pub accounting_contract_address: String,
 	#[arg(long, value_name = "should sync with parentchain")]
 	pub parentchain_sync: bool,
+	#[arg(short, long, default_value = "9090", value_name = "metrics port")]
+	pub metrics_port: String,
 }
 
 #[derive(Args)]

--- a/tee-worker/omni-executor/executor-worker/src/main.rs
+++ b/tee-worker/omni-executor/executor-worker/src/main.rs
@@ -31,6 +31,7 @@ use executor_crypto::{ecdsa, PairTrait};
 use executor_primitives::AccountId;
 use executor_storage::{init_storage, StorageDB};
 use log::{error, info};
+use metrics_exporter_prometheus::PrometheusBuilder;
 use native_task_handler::{
 	run_native_task_handler, Aes256KeyStore, TaskHandlerContext, MAX_CONCURRENT_TASKS,
 };
@@ -49,7 +50,9 @@ use solana::SolanaClient;
 use solana_intent_executor::SolanaIntentExecutor;
 use std::env;
 use std::io::Write;
+use std::net::SocketAddr;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
@@ -80,6 +83,14 @@ async fn main() -> Result<(), ()> {
 
 	match cli.cmd {
 		Commands::Run(args) => {
+			let builder = PrometheusBuilder::new();
+
+			let address = SocketAddr::from_str(&format!("0.0.0.0:{}", args.metrics_port)).unwrap();
+			builder
+				.with_http_listener(address)
+				.install()
+				.expect("failed to install Prometheus recorder");
+
 			let auth_token_key_store = AuthTokenKeyStore::new(
 				Path::new(&args.local_directory_path)
 					.join("keystore/auth_token_key.bin")

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -1078,6 +1078,10 @@ impl<Provider: EthereumRpcProvider<Transaction = TransactionRequest> + Send + Sy
 			},
 		}
 	}
+
+	async fn name(&self) -> &'static str {
+		"cross-chain"
+	}
 }
 
 fn str_to_u256(amount: &str, decimals: u32) -> Option<U256> {

--- a/tee-worker/omni-executor/intent/executors/ethereum/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/ethereum/src/lib.rs
@@ -91,6 +91,10 @@ impl IntentExecutor for EthereumIntentExecutor {
 		}
 		Ok((None, false))
 	}
+
+	async fn name(&self) -> &'static str {
+		"ethereum"
+	}
 }
 
 #[cfg(test)]

--- a/tee-worker/omni-executor/intent/executors/solana/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/solana/src/lib.rs
@@ -85,4 +85,8 @@ impl IntentExecutor for SolanaIntentExecutor {
 
 		Ok((None, false))
 	}
+
+	async fn name(&self) -> &'static str {
+		"solana"
+	}
 }

--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -411,6 +411,7 @@ async fn handle_native_task<
 						},
 						Err(e) => {
 							log::error!("Error executing intent: {:?}", e);
+							ctx.cross_chain_intent_executor.on_execution_error().await;
 							(IntentCompletedDetail::Failure, true, None)
 						},
 					};


### PR DESCRIPTION
Adds basic metrics with prometheus endpoint to monitor:

* last synced parentchain block
* intent execution failures