### PR TITLE
Include Sender in OmniAuth 

### DIFF
--- a/tee-worker/omni-executor/executor-primitives/src/auth.rs
+++ b/tee-worker/omni-executor/executor-primitives/src/auth.rs
@@ -1,23 +1,27 @@
 use crate::{signature::HeimaMultiSignature, OmniAccountAuthType};
+use heima_primitives::Identity;
 use parity_scale_codec::{Decode, Encode};
 
 pub type VerificationCode = String;
+type Email = String;
+type OmniAccount = String;
+type JwtToken = String;
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 pub enum OmniAuth {
-	Web3(HeimaMultiSignature),
-	Email(String, VerificationCode),
-	AuthToken(String),
-	OAuth2(OAuth2Data),
+	Web3(Identity, HeimaMultiSignature), // (Signer, Signature)
+	Email(Email, VerificationCode),
+	AuthToken(OmniAccount, JwtToken),
+	OAuth2(Identity, OAuth2Data), // (Sender, OAuth2Data)
 }
 
 impl From<OmniAuth> for OmniAccountAuthType {
 	fn from(value: OmniAuth) -> Self {
 		match value {
-			OmniAuth::Web3(_) => Self::Web3,
+			OmniAuth::Web3(..) => Self::Web3,
 			OmniAuth::Email(..) => Self::Email,
-			OmniAuth::OAuth2(_) => Self::OAuth2,
-			OmniAuth::AuthToken(_) => Self::AuthToken,
+			OmniAuth::OAuth2(..) => Self::OAuth2,
+			OmniAuth::AuthToken(..) => Self::AuthToken,
 		}
 	}
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/add_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/add_wallet.rs
@@ -53,7 +53,7 @@ pub fn register_add_wallet(module: &mut RpcModule<RpcContext>) {
 						REQUIRE_AUTHENTICATION_CODE,
 					)));
 				};
-				verify_auth(ctx.clone(), auth, wrapper.task.sender()).await.map_err(|_| {
+				verify_auth(ctx.clone(), auth).await.map_err(|_| {
 					log::error!("Failed to verify auth: {:?}", wrapper.auth);
 					PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						AUTH_VERIFICATION_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/add_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/add_wallet.rs
@@ -3,7 +3,7 @@ use crate::{
 	Deserialize, ErrorCode,
 };
 use executor_core::native_task::*;
-use executor_primitives::OmniAuth;
+use executor_primitives::{utils::hex::ToHexPrefixed, OmniAuth};
 use heima_primitives::{Identity, Web2IdentityType};
 use jsonrpsee::RpcModule;
 use native_task_handler::NativeTaskOk;
@@ -25,13 +25,11 @@ pub struct RPCAddWalletResponse {
 
 impl From<AddWalletParams> for NativeTaskWrapper<NativeTask> {
 	fn from(p: AddWalletParams) -> Self {
+		let sender = Identity::from_web2_account(p.user_email.as_str(), Web2IdentityType::Email);
 		Self {
-			task: NativeTask::PumpxAddWallet(Identity::from_web2_account(
-				p.user_email.as_str(),
-				Web2IdentityType::Email,
-			)),
+			task: NativeTask::PumpxAddWallet(sender.clone()),
 			nonce: None,
-			auth: Some(OmniAuth::AuthToken(p.auth_token)),
+			auth: Some(OmniAuth::AuthToken(sender.to_omni_account().to_hex(), p.auth_token)),
 		}
 	}
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/export_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/export_wallet.rs
@@ -79,7 +79,7 @@ pub fn register_export_wallet(module: &mut RpcModule<RpcContext>) {
 						REQUIRE_AUTHENTICATION_CODE,
 					)));
 				};
-				verify_auth(ctx.clone(), auth, wrapper.task.sender()).await.map_err(|_| {
+				verify_auth(ctx.clone(), auth).await.map_err(|_| {
 					log::error!("Failed to verify auth: {:?}", wrapper.auth);
 					PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						AUTH_VERIFICATION_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/notify_limit_order_result.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/notify_limit_order_result.rs
@@ -75,7 +75,7 @@ pub fn register_notify_limit_order_result(module: &mut RpcModule<RpcContext>) {
 					params.message,
 				),
 				nonce: None,
-				auth: Some(OmniAuth::AuthToken(params.auth_token)),
+				auth: Some(OmniAuth::AuthToken(omni_account, params.auth_token)),
 			};
 
 			handle_omni_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_jwt.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_jwt.rs
@@ -63,7 +63,7 @@ pub fn register_request_jwt(module: &mut RpcModule<RpcContext>) {
 						REQUIRE_AUTHENTICATION_CODE,
 					)));
 				};
-				verify_auth(ctx.clone(), auth, wrapper.task.sender()).await.map_err(|_| {
+				verify_auth(ctx.clone(), auth).await.map_err(|_| {
 					log::error!("Failed to verify auth: {:?}", wrapper.auth);
 					PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						AUTH_VERIFICATION_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/sign_limit_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/sign_limit_order.rs
@@ -108,7 +108,7 @@ pub fn register_sign_limit_order_params(module: &mut RpcModule<RpcContext>) {
 					params.unsigned_tx.iter().map(|tx| tx.to_vec()).collect(),
 				),
 				nonce: None,
-				auth: Some(OmniAuth::AuthToken(params.auth_token)),
+				auth: Some(OmniAuth::AuthToken(omni_account, params.auth_token)),
 			};
 
 			handle_omni_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_native_task.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_native_task.rs
@@ -83,7 +83,7 @@ async fn parse(params: Params<'static>, ctx: Arc<RpcContext>) -> ParseResult {
 		let Some(ref auth) = wrapper.auth else {
 			return Err(ErrorCode::ServerError(REQUIRE_AUTHENTICATION_CODE).into());
 		};
-		verify_auth(ctx, auth, wrapper.task.sender()).await.map_err(|_| {
+		verify_auth(ctx, auth).await.map_err(|_| {
 			log::error!("Failed to verify auth: {:?}", wrapper.auth);
 			ErrorCode::ServerError(AUTH_VERIFICATION_FAILED_CODE)
 		})?;

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
@@ -4,7 +4,7 @@ use crate::{
 	Deserialize, ErrorCode,
 };
 use executor_core::native_task::*;
-use executor_primitives::OmniAuth;
+use executor_primitives::{utils::hex::ToHexPrefixed, OmniAuth};
 use executor_storage::{PumpxJwtStorage, Storage};
 use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
 use heima_hex_utils::decode_hex;
@@ -258,9 +258,9 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 
 			let intent = Intent::Swap(swap_order, ccs_provider, scs_provider);
 			let wrapper = NativeTaskWrapper {
-				task: NativeTask::RequestIntent(user_identity, params.intent_id, intent),
+				task: NativeTask::RequestIntent(user_identity.clone(), params.intent_id, intent),
 				nonce: None,
-				auth: Some(OmniAuth::AuthToken(params.auth_token)),
+				auth: Some(OmniAuth::AuthToken(user_identity.to_omni_account().to_hex(), params.auth_token)),
 			};
 
 			handle_omni_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
@@ -6,7 +6,7 @@ use crate::{
 use executor_core::native_task::*;
 use executor_primitives::{utils::hex::ToHexPrefixed, OmniAuth};
 use executor_storage::{PumpxJwtStorage, Storage};
-use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
+use heima_authentication::auth_token::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_ID_TYPE};
 use heima_hex_utils::decode_hex;
 use heima_primitives::{
 	Address20, Address32, BinanceConfig, BoundedVec, ChainAsset, CrossChainSwapProvider,
@@ -116,7 +116,7 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 
 			let user_identity =
 				Identity::from_web2_account(&params.user_email, Web2IdentityType::Email);
-			if verify_auth_token_authentication(ctx.clone(), &user_identity, &params.auth_token)
+			if verify_auth_token_authentication(ctx.clone(), user_identity.to_omni_account().to_hex(), &params.auth_token, AUTH_TOKEN_ID_TYPE, false)
 				.is_err()
 			{
 				log::error!("Failed to verify auth token");

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/transfer_widthdraw.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/transfer_widthdraw.rs
@@ -72,7 +72,7 @@ pub fn register_transfer_withdraw(module: &mut RpcModule<RpcContext>) {
 						REQUIRE_AUTHENTICATION_CODE,
 					)));
 				};
-				verify_auth(ctx.clone(), auth, wrapper.task.sender()).await.map_err(|_| {
+				verify_auth(ctx.clone(), auth).await.map_err(|_| {
 					log::error!("Failed to verify auth: {:?}", wrapper.auth);
 					PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						AUTH_VERIFICATION_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/add_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/add_wallet.rs
@@ -53,7 +53,7 @@ pub fn register_add_wallet(module: &mut RpcModule<RpcContext>) {
 						REQUIRE_AUTHENTICATION_CODE,
 					)));
 				};
-				verify_auth(ctx.clone(), auth, wrapper.task.sender()).await.map_err(|_| {
+				verify_auth(ctx.clone(), auth).await.map_err(|_| {
 					log::error!("Failed to verify auth: {:?}", wrapper.auth);
 					PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						AUTH_VERIFICATION_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/add_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/add_wallet.rs
@@ -3,7 +3,7 @@ use crate::{
 	Deserialize, ErrorCode,
 };
 use executor_core::native_task::*;
-use executor_primitives::OmniAuth;
+use executor_primitives::{utils::hex::ToHexPrefixed, OmniAuth};
 use heima_primitives::{Identity, Web2IdentityType};
 use jsonrpsee::RpcModule;
 use native_task_handler::NativeTaskOk;
@@ -25,13 +25,11 @@ pub struct RPCAddWalletResponse {
 
 impl From<AddWalletParams> for NativeTaskWrapper<NativeTask> {
 	fn from(p: AddWalletParams) -> Self {
+		let sender = Identity::from_web2_account(p.user_id.as_str(), Web2IdentityType::Pumpx);
 		Self {
-			task: NativeTask::PumpxAddWallet(Identity::from_web2_account(
-				p.user_id.as_str(),
-				Web2IdentityType::Pumpx,
-			)),
+			task: NativeTask::PumpxAddWallet(sender.clone()),
 			nonce: None,
-			auth: Some(OmniAuth::AuthToken(p.auth_token)),
+			auth: Some(OmniAuth::AuthToken(sender.to_omni_account().to_hex(), p.auth_token)),
 		}
 	}
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/export_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/export_wallet.rs
@@ -109,7 +109,7 @@ pub fn register_export_wallet(module: &mut RpcModule<RpcContext>) {
 						REQUIRE_AUTHENTICATION_CODE,
 					)));
 				};
-				verify_auth(ctx.clone(), auth, wrapper.task.sender()).await.map_err(|_| {
+				verify_auth(ctx.clone(), auth).await.map_err(|_| {
 					log::error!("Failed to verify auth: {:?}", wrapper.auth);
 					PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						AUTH_VERIFICATION_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/notify_limit_order_result.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/notify_limit_order_result.rs
@@ -75,7 +75,7 @@ pub fn register_notify_limit_order_result(module: &mut RpcModule<RpcContext>) {
 					params.message,
 				),
 				nonce: None,
-				auth: Some(OmniAuth::AuthToken(params.auth_token)),
+				auth: Some(OmniAuth::AuthToken(omni_account, params.auth_token)),
 			};
 
 			handle_pumpx_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/request_jwt.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/request_jwt.rs
@@ -63,7 +63,7 @@ pub fn register_request_jwt(module: &mut RpcModule<RpcContext>) {
 						REQUIRE_AUTHENTICATION_CODE,
 					)));
 				};
-				verify_auth(ctx.clone(), auth, wrapper.task.sender()).await.map_err(|_| {
+				verify_auth(ctx.clone(), auth).await.map_err(|_| {
 					log::error!("Failed to verify auth: {:?}", wrapper.auth);
 					PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						AUTH_VERIFICATION_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/sign_limit_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/sign_limit_order.rs
@@ -108,7 +108,7 @@ pub fn register_sign_limit_order_params(module: &mut RpcModule<RpcContext>) {
 					params.unsigned_tx.iter().map(|tx| tx.to_vec()).collect(),
 				),
 				nonce: None,
-				auth: Some(OmniAuth::AuthToken(params.auth_token)),
+				auth: Some(OmniAuth::AuthToken(omni_account, params.auth_token)),
 			};
 
 			handle_pumpx_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
@@ -257,9 +257,9 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 
 			let intent = Intent::Swap(swap_order, ccs_provider, scs_provider);
 			let wrapper = NativeTaskWrapper {
-				task: NativeTask::RequestIntent(user_identity, params.intent_id, intent),
+				task: NativeTask::RequestIntent(user_identity.clone(), params.intent_id, intent),
 				nonce: None,
-				auth: Some(OmniAuth::AuthToken(params.auth_token)),
+				auth: Some(OmniAuth::AuthToken(user_identity.to_omni_account().to_hex() ,params.auth_token)),
 			};
 
 			handle_pumpx_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/transfer_widthdraw.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/transfer_widthdraw.rs
@@ -101,7 +101,7 @@ pub fn register_transfer_withdraw(module: &mut RpcModule<RpcContext>) {
 						REQUIRE_AUTHENTICATION_CODE,
 					)));
 				};
-		        verify_auth(ctx.clone(), auth, wrapper.task.sender()).await.map_err(|_| {
+		        verify_auth(ctx.clone(), auth).await.map_err(|_| {
 		        	log::error!("Failed to verify auth: {:?}", wrapper.auth);
                     PumpxRpcError::from_error_code(ErrorCode::ServerError(
                         AUTH_VERIFICATION_FAILED_CODE,

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -1,8 +1,8 @@
 use crate::server::RpcContext;
 use executor_crypto::hashing::blake2_256;
 use executor_primitives::{
-	signature::HeimaMultiSignature, utils::hex::ToHexPrefixed, Hashable, Identity, OAuth2Data,
-	OAuth2Provider, OmniAuth, VerificationCode, Web2IdentityType,
+	signature::HeimaMultiSignature, Hashable, Identity, OAuth2Data, OAuth2Provider, OmniAuth,
+	VerificationCode, Web2IdentityType,
 };
 use executor_storage::{OAuth2StateVerifierStorage, Storage, StorageDB, VerificationCodeStorage};
 use heima_authentication::{
@@ -47,24 +47,20 @@ impl Display for AuthenticationError {
 	}
 }
 
-pub async fn verify_auth(
-	ctx: Arc<RpcContext>,
-	auth: &OmniAuth,
-	sender: &Identity,
-) -> Result<(), AuthenticationError> {
+pub async fn verify_auth(ctx: Arc<RpcContext>, auth: &OmniAuth) -> Result<(), AuthenticationError> {
 	match auth {
-		OmniAuth::Web3(ref signature) => {
-			verify_web3_authentication(ctx.storage_db.clone(), sender, signature)
+		OmniAuth::Web3(ref signer, ref signature) => {
+			verify_web3_authentication(ctx.storage_db.clone(), signer, signature)
 		},
 		OmniAuth::Email(ref email, ref verification_code) => {
 			verify_email_authentication(ctx, email, verification_code)
 		},
-		OmniAuth::OAuth2(ref oauth2_data) => {
+		OmniAuth::OAuth2(ref sender, ref oauth2_data) => {
 			verify_oauth2_authentication(ctx, sender, oauth2_data).await
 		},
-		OmniAuth::AuthToken(ref auth_token) => verify_auth_token_authentication(
+		OmniAuth::AuthToken(omni_account, ref auth_token) => verify_auth_token_authentication(
 			ctx,
-			sender.to_omni_account().to_hex(),
+			omni_account.to_string(),
 			auth_token,
 			AUTH_TOKEN_ID_TYPE,
 			false,


### PR DESCRIPTION
This pull request refactors the `OmniAuth` enum and updates its usage across the codebase to improve consistency in authentication handling, and separating Task execution from authentication. It also simplifies the `verify_auth` function by removing the `sender` parameter and adjusts related method calls accordingly.

