### PR TITLE
Set `Content-Length` explicitly for http request to pumpx API

### DIFF
--- a/tee-worker/omni-executor/pumpx/src/pumpx_api/mod.rs
+++ b/tee-worker/omni-executor/pumpx/src/pumpx_api/mod.rs
@@ -113,6 +113,7 @@ impl PumpxApi {
 			.post(endpoint)
 			.header("X-Language", language.unwrap_or("en".to_string()))
 			.bearer_auth(access_token)
+			.json(&serde_json::json!({}))
 			.send()
 			.await
 			.map_err(|e| {

--- a/tee-worker/omni-executor/pumpx/src/pumpx_api/mod.rs
+++ b/tee-worker/omni-executor/pumpx/src/pumpx_api/mod.rs
@@ -111,9 +111,9 @@ impl PumpxApi {
 		let response = self
 			.http_client
 			.post(endpoint)
+			.header("Content-Length", 0)
 			.header("X-Language", language.unwrap_or("en".to_string()))
 			.bearer_auth(access_token)
-			.json(&serde_json::json!({}))
 			.send()
 			.await
 			.map_err(|e| {


### PR DESCRIPTION
as title. a tiny PR. 
Looks like the database has set up strict rules about it.
Any idea about it? @Kailai-Wang @silva-fj 


