### PR TITLE
add missing `subxt` feature

### DIFF
--- a/tee-worker/omni-executor/parentchain/rpc-client/Cargo.toml
+++ b/tee-worker/omni-executor/parentchain/rpc-client/Cargo.toml
@@ -10,7 +10,7 @@ log = { workspace = true }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-encode = { workspace = true }
 serde_json = { workspace = true }
-subxt = { workspace = true }
+subxt = { workspace = true, features = ["reconnecting-rpc-client"] }
 subxt-core = { workspace = true }
 tokio = { workspace = true }
 


### PR DESCRIPTION
It fails when testing package alone:

`cargo test -p parentchain-rpc-client`
```
error[E0433]: failed to resolve: could not find `reconnecting_rpc_client` in `rpc`
   --> parentchain/rpc-client/src/lib.rs:402:41
    |
402 |         let rpc_client = subxt::backend::rpc::reconnecting_rpc_client::RpcClient::builder()
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ could not find `reconnecting_rpc_client` in `rpc`
```