### PR TITLE
fix: hash the msg before requesting signer

### DIFF
--- a/tee-worker/omni-executor/intent/executors/cross-chain/Cargo.toml
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/Cargo.toml
@@ -11,8 +11,8 @@ log = { workspace = true }
 parity-scale-codec = { workspace = true }
 rust_decimal = { workspace = true }
 solana-sdk = { workspace = true }
-tokio = { workspace = true }
 sp-core = { workspace = true }
+tokio = { workspace = true }
 
 # Local dependencies
 accounting-contract-client = { workspace = true }

--- a/tee-worker/omni-executor/intent/executors/cross-chain/Cargo.toml
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/Cargo.toml
@@ -12,6 +12,7 @@ parity-scale-codec = { workspace = true }
 rust_decimal = { workspace = true }
 solana-sdk = { workspace = true }
 tokio = { workspace = true }
+sp-core = { workspace = true }
 
 # Local dependencies
 accounting-contract-client = { workspace = true }

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
@@ -129,7 +129,7 @@ async fn simple_cross_chain_swap() {
 			mockall::predicate::eq(pumpx::signer_client::ChainType::Evm),
 			mockall::predicate::eq(pumpx_wallet_index),
 			mockall::predicate::eq(pumpx_wallet_omni_account),
-			mockall::predicate::eq(vec![create_order_encoded_tx.clone()]),
+			mockall::predicate::always(),
 		)
 		.times(1)
 		.returning(move |_, _, _, _| Ok(vec![create_order_tx_signature.to_vec()]));

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -34,6 +34,7 @@ use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
 use rust_decimal::prelude::*;
 use rust_decimal::Decimal;
 use solana::{signer::RemoteSigner, SolanaClient as SolanaClientTrait};
+use sp_core::keccak_256;
 use std::str::FromStr;
 use tokio::{
 	runtime::Handle,
@@ -1110,7 +1111,8 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 			.iter()
 			.map(|s| {
 				let hex_str = s.trim_start_matches("0x");
-				hex::decode(hex_str).expect("Invalid hex string")
+				let hex_decoded = hex::decode(hex_str).expect("Invalid hex string");
+				keccak_256(&hex_decoded).to_vec()
 			})
 			.collect();
 


### PR DESCRIPTION
So as per the title, 
I think i missed this part that the signer expects hashed messages, this should fix the signer errors we received. 


