### PR TITLE
monitor wallet balances

### DIFF
--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -3326,6 +3326,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "async-trait",
+ "executor-core",
  "log",
  "mockall",
 ]
@@ -9276,6 +9277,7 @@ name = "solana"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "executor-core",
  "log",
  "mockall",
  "pumpx",

--- a/tee-worker/omni-executor/ethereum-rpc/Cargo.toml
+++ b/tee-worker/omni-executor/ethereum-rpc/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [dependencies]
 alloy = { workspace = true, features = ["contract", "signer-local", "rpc", "rpc-types", "eips"] }
 async-trait = { workspace = true }
+executor-core = { workspace = true }
 log = { workspace = true }
 mockall = { workspace = true }
 

--- a/tee-worker/omni-executor/ethereum-rpc/src/lib.rs
+++ b/tee-worker/omni-executor/ethereum-rpc/src/lib.rs
@@ -159,9 +159,10 @@ impl WalletBalanceFetcher for AlloyRpcProvider {
 	async fn fetch(&self, address: &str) -> Result<f64, ()> {
 		let provider = ProviderBuilder::new()
 			.on_http(self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?);
-
+		let address =
+			Address::from_str(address).map_err(|e| error!("Could not parse address: {:?}", e))?;
 		provider
-			.get_balance(Address::from_str(address).unwrap())
+			.get_balance(address)
 			.await
 			.map_err(|e| error!("Could not fetch wallet balance: {:?}", e))
 			.map(|b| b.to::<u64>() as f64)

--- a/tee-worker/omni-executor/ethereum-rpc/src/lib.rs
+++ b/tee-worker/omni-executor/ethereum-rpc/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::str::FromStr;
+
 use alloy::network::EthereumWallet;
 use alloy::primitives::Address;
 use alloy::primitives::U256;
@@ -21,6 +23,7 @@ use alloy::providers::Provider;
 use alloy::providers::ProviderBuilder;
 use alloy::rpc::types::TransactionRequest;
 use async_trait::async_trait;
+use executor_core::wallet_metrics::WalletBalanceFetcher;
 use log::error;
 
 pub trait RpcProviderFactory {
@@ -148,6 +151,20 @@ impl RpcProvider for AlloyRpcProvider {
 		let result = provider.call(tx).await.map_err(|e| error!("Could not call: {:?}", e))?;
 
 		Ok(result.to_vec())
+	}
+}
+
+#[async_trait]
+impl WalletBalanceFetcher for AlloyRpcProvider {
+	async fn fetch(&self, address: &str) -> Result<f64, ()> {
+		let provider = ProviderBuilder::new()
+			.on_http(self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?);
+
+		provider
+			.get_balance(Address::from_str(address).unwrap())
+			.await
+			.map_err(|e| error!("Could not fetch wallet balance: {:?}", e))
+			.map(|b| b.to::<u64>() as f64)
 	}
 }
 

--- a/tee-worker/omni-executor/executor-core/src/lib.rs
+++ b/tee-worker/omni-executor/executor-core/src/lib.rs
@@ -23,3 +23,4 @@ pub mod listener;
 pub mod native_task;
 pub mod shielding_key_store;
 pub mod sync_checkpoint_repository;
+pub mod wallet_metrics;

--- a/tee-worker/omni-executor/executor-core/src/wallet_metrics.rs
+++ b/tee-worker/omni-executor/executor-core/src/wallet_metrics.rs
@@ -1,0 +1,107 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+use metrics::{describe_gauge, gauge};
+use std::{collections::HashMap, sync::Arc, thread, time::Duration};
+use tokio::{runtime::Handle, task::JoinHandle};
+
+pub type WalletName = String;
+pub type WalletAddress = String;
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub struct WalletId {
+	pub address: WalletAddress,
+	pub network_type: WalletNetworkType,
+}
+
+pub struct Wallet {
+	pub id: WalletId,
+	pub name: WalletName,
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum WalletNetworkType {
+	Ethereum(u32),
+	Solana,
+}
+
+#[async_trait::async_trait]
+pub trait WalletBalanceFetcher: Send + Sync {
+	async fn fetch(&self, address: &str) -> Result<f64, ()>;
+}
+
+struct WalletMetric {
+	name: WalletName,
+	wallet_id: WalletId,
+}
+
+impl WalletMetric {
+	pub fn new(name: WalletName, wallet_id: WalletId) -> Self {
+		describe_gauge!(wallet_metrics_name(&name), "Wallet balance");
+		Self { name, wallet_id }
+	}
+
+	pub fn update(&self, balance: f64) {
+		gauge!(wallet_metrics_name(&self.name)).set(balance);
+	}
+}
+
+pub struct WalletMetrics {
+	metrics: Vec<WalletMetric>,
+	balance_fetchers: HashMap<WalletNetworkType, Arc<Box<dyn WalletBalanceFetcher>>>,
+}
+
+impl WalletMetrics {
+	pub fn new(
+		balance_fetchers: HashMap<WalletNetworkType, Arc<Box<dyn WalletBalanceFetcher>>>,
+	) -> Self {
+		Self { metrics: Vec::new(), balance_fetchers }
+	}
+
+	pub fn register(&mut self, wallet: Wallet) {
+		let metric = WalletMetric::new(wallet.name, wallet.id);
+		self.metrics.push(metric);
+	}
+
+	async fn update(&mut self) {
+		for metric in self.metrics.iter() {
+			if let Some(fetcher) = self.balance_fetchers.get(&metric.wallet_id.network_type) {
+				match fetcher.fetch(&metric.wallet_id.address).await {
+					Ok(balance) => metric.update(balance),
+					Err(e) => log::error!(
+						"Error while fetching balance for: {:?}, reason: {:?}",
+						metric.wallet_id,
+						e
+					),
+				};
+			} else {
+				log::error!("There is not fetcher for {:?}", metric.wallet_id);
+			}
+		}
+	}
+}
+
+pub fn start_wallet_metrics(handle: Handle, mut metrics: WalletMetrics) -> JoinHandle<()> {
+	handle.clone().spawn_blocking(move || loop {
+		handle.block_on(metrics.update());
+		// update once per hour
+		thread::sleep(Duration::from_secs(60 * 60));
+	})
+}
+
+fn wallet_metrics_name(wallet_name: &str) -> String {
+	format!("{}_balance", wallet_name)
+}

--- a/tee-worker/omni-executor/executor-worker/src/main.rs
+++ b/tee-worker/omni-executor/executor-worker/src/main.rs
@@ -26,6 +26,10 @@ use ethereum_intent_executor::EthereumIntentExecutor;
 use executor_core::ecdsa_key_store::EcdsaKeyStore;
 use executor_core::key_store::KeyStore;
 use executor_core::shielding_key_store::ShieldingKeyStore;
+use executor_core::wallet_metrics::Wallet;
+use executor_core::wallet_metrics::{
+	start_wallet_metrics, WalletBalanceFetcher, WalletId, WalletMetrics, WalletNetworkType,
+};
 use executor_crypto::rsa::{traits::PublicKeyParts, Rsa3072PubKey};
 use executor_crypto::{ecdsa, PairTrait};
 use executor_primitives::AccountId;
@@ -48,6 +52,7 @@ use pumpx::{PumpxApi, PumpxApiClient};
 use rpc_server::{start_server as start_rpc_server, AuthTokenKeyStore};
 use solana::SolanaRpcClient;
 use solana_intent_executor::SolanaIntentExecutor;
+use std::collections::HashMap;
 use std::env;
 use std::io::Write;
 use std::net::SocketAddr;
@@ -221,6 +226,33 @@ async fn main() -> Result<(), ()> {
 				args.accounting_contract_address.parse().unwrap(),
 			);
 
+			// wallet monitoring setup start
+			let bsc_wallet_balance_fetcher: Arc<Box<dyn WalletBalanceFetcher>> =
+				Arc::new(Box::new(ethereum_rpc::AlloyRpcProvider::new(&args.bsc_url)));
+
+			let solana_wallet_balance_fetcher: Arc<Box<dyn WalletBalanceFetcher>> =
+				Arc::new(Box::new(SolanaRpcClient::new(&args.solana_url)));
+
+			let mut balance_fetchers: HashMap<
+				WalletNetworkType,
+				Arc<Box<dyn WalletBalanceFetcher>>,
+			> = HashMap::new();
+			balance_fetchers.insert(WalletNetworkType::Solana, solana_wallet_balance_fetcher);
+			balance_fetchers.insert(WalletNetworkType::Ethereum(56), bsc_wallet_balance_fetcher);
+
+			let mut wallet_metrics = WalletMetrics::new(balance_fetchers);
+
+			wallet_metrics.register(Wallet {
+				id: WalletId {
+					address: args.accounting_contract_address.to_string(),
+					network_type: WalletNetworkType::Ethereum(56),
+				},
+				name: "bsc_accounting_contract".to_string(),
+			});
+
+			let join = start_wallet_metrics(Handle::current(), wallet_metrics);
+			// wallet monitoring setup end
+
 			let cross_chain_intent_executor = CrossChainIntentExecutor::new(
 				rpc_endpoint_registry,
 				pumpx_signer_client.clone(),
@@ -295,6 +327,10 @@ async fn main() -> Result<(), ()> {
 			if args.parentchain_sync {
 				listen_to_parentchain(*args, storage_db).await.unwrap();
 			}
+
+			if let Err(e) = join.await {
+				error!("There was an error in associated task: {:?}", e);
+			};
 
 			match signal::ctrl_c().await {
 				Ok(()) => {},

--- a/tee-worker/omni-executor/solana/Cargo.toml
+++ b/tee-worker/omni-executor/solana/Cargo.toml
@@ -15,6 +15,7 @@ spl-token = { workspace = true }
 tokio = { workspace = true }
 
 # Local dependencies
+executor-core = { workspace = true }
 pumpx = { workspace = true }
 
 [lints]

--- a/tee-worker/omni-executor/solana/src/lib.rs
+++ b/tee-worker/omni-executor/solana/src/lib.rs
@@ -175,8 +175,10 @@ impl SolanaClient for SolanaRpcClient {
 #[async_trait]
 impl WalletBalanceFetcher for SolanaRpcClient {
 	async fn fetch(&self, address: &str) -> Result<f64, ()> {
+		let pubkey = Pubkey::from_str(address)
+			.map_err(|e| log::error!("Could not parse pubkey: {:?}", e))?;
 		self.rpc_client
-			.get_balance(&Pubkey::from_str(address).unwrap())
+			.get_balance(&pubkey)
 			.await
 			.map_err(|e| log::error!("Could not fetch wallet balance: {:?}", e))
 			.map(|b| b as f64)

--- a/tee-worker/omni-executor/solana/src/lib.rs
+++ b/tee-worker/omni-executor/solana/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod signer;
 
 use async_trait::async_trait;
+use executor_core::wallet_metrics::WalletBalanceFetcher;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
 	commitment_config::CommitmentConfig, pubkey::Pubkey, signer::Signer as SignerTrait,
@@ -168,6 +169,17 @@ impl SolanaClient for SolanaRpcClient {
 		log::debug!("Transaction signature: {:?}", tx_signature);
 
 		Ok(tx_signature.to_string())
+	}
+}
+
+#[async_trait]
+impl WalletBalanceFetcher for SolanaRpcClient {
+	async fn fetch(&self, address: &str) -> Result<f64, ()> {
+		self.rpc_client
+			.get_balance(&Pubkey::from_str(address).unwrap())
+			.await
+			.map_err(|e| log::error!("Could not fetch wallet balance: {:?}", e))
+			.map(|b| b as f64)
 	}
 }
 


### PR DESCRIPTION
Adds logic for periodically fetching important wallet balances and exposing them as prometheus metrics.

Currently only BSC accounting contract is registered to be monitored. 