### PR TITLE
fix: add 0x prefix to hex string

### DIFF
--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
@@ -207,7 +207,7 @@ async fn simple_cross_chain_swap() {
 			mockall::predicate::eq(SendOrderTxBody {
 				chain_id: to_chain_id,
 				order_id: order_id,
-				tx_data: vec!["f869808504e3b29200831e848094d8da6bf26964af9d7eed9e03e53415d37aa96045843b9aca008025a0f6c76effbee5ac9ff341a0efe85b5f9401ab673c5d1c2746041e446e3d19aea3a037470aac13f1cb4da20f086a475cceb36a5bb4fd9cf52b48300ad840ad1480ad".to_string()]
+				tx_data: vec!["0xf869808504e3b29200831e848094d8da6bf26964af9d7eed9e03e53415d37aa96045843b9aca008025a0f6c76effbee5ac9ff341a0efe85b5f9401ab673c5d1c2746041e446e3d19aea3a037470aac13f1cb4da20f086a475cceb36a5bb4fd9cf52b48300ad840ad1480ad".to_string()]
 			}) )
 		.times(1)
 		.returning(|_, _| Ok(SendOrderTxResponse {

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -1140,7 +1140,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 			let signed_tx = unsigned_tx.into_signed(signature);
 			let mut encoded_signed_tx = vec![];
 			signed_tx.rlp_encode(&mut encoded_signed_tx);
-			tx_data.push(hex::encode(encoded_signed_tx));
+			tx_data.push(format!("0x{}", hex::encode(encoded_signed_tx)));
 		}
 
 		let response = self


### PR DESCRIPTION
As per title, in `Go` `hexUtil.decode` expects a `0x` prefixed hex string, but `hex::encode` doesn't provide `0x` prefixed string, so this PR adjusts it. 


