### PR TITLE
Refactor swap code logic and fix single-chain market order

### DIFF
--- a/common/primitives/core/src/omni/intent.rs
+++ b/common/primitives/core/src/omni/intent.rs
@@ -113,6 +113,12 @@ pub struct PumpxConfig {
     pub trailing_percent: Option<u32>,
 }
 
+impl PumpxConfig {
+    pub fn is_cross_chain(&self) -> bool {
+        self.from_chain_id != self.to_chain_id
+    }
+}
+
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PumpxOrderType {

--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -2462,6 +2462,7 @@ dependencies = [
  "serde_json",
  "solana",
  "solana-sdk",
+ "sp-core 35.0.0",
  "tempfile",
  "tokio",
 ]

--- a/tee-worker/omni-executor/intent/executors/cross-chain/Cargo.toml
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/Cargo.toml
@@ -11,6 +11,7 @@ log = { workspace = true }
 parity-scale-codec = { workspace = true }
 rust_decimal = { workspace = true }
 solana-sdk = { workspace = true }
+sp-core = { workspace = true }
 tokio = { workspace = true }
 
 # Local dependencies

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
@@ -1,0 +1,627 @@
+// TODO: put it into a mod for potential different providers (other than binance)
+
+use super::*;
+use executor_primitives::{PumpxConfig, SwapOrder};
+use log::{debug, error, info};
+
+impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
+	CrossChainIntentExecutor<BinanceClient, SolanaClient>
+{
+	pub async fn execute_cross_chain_swap(
+		&self,
+		omni_account: [u8; 32],
+		intent_id: IntentId,
+		access_token: &str,
+		swap_order: &SwapOrder,
+		pumpx_config: &PumpxConfig,
+	) -> Result<String, ()> {
+		debug!("executing cross chain swap");
+
+		if pumpx_config.to_chain_id != BSC_CHAIN_ID {
+			error!("Only bsc payout supported");
+			return Err(());
+		}
+
+		// extract values from pumpx_config
+		let usd_worth = std::str::from_utf8(&pumpx_config.usd_worth)
+			.map_err(|_| {
+				error!("Failed to parse usd_worth");
+			})
+			.map(|v| v.to_string())?;
+
+		let from_token_ca = std::str::from_utf8(&pumpx_config.from_token_ca)
+			.map_err(|_| {
+				error!("Failed to parse from_token_ca");
+			})
+			.map(|v| v.to_string())?;
+
+		let to_token_ca = std::str::from_utf8(&pumpx_config.to_token_ca)
+			.map_err(|_| {
+				error!("Failed to parse to_token_ca");
+			})
+			.map(|v| v.to_string())?;
+
+		let from_amount = std::str::from_utf8(&pumpx_config.from_amount)
+			.map_err(|_| {
+				error!("Failed to parse from_amount");
+			})
+			.map(|v| v.to_string())?;
+
+		let Some(from_chain_type) = ChainType::from_pumpx_chain_id(pumpx_config.from_chain_id)
+		else {
+			error!("Unsupported from_chain_id: {}", pumpx_config.from_chain_id);
+			return Err(());
+		};
+
+		let Some(to_chain_type) = ChainType::from_pumpx_chain_id(pumpx_config.to_chain_id) else {
+			error!("Unsupported to_chain_id: {}", pumpx_config.to_chain_id);
+			return Err(());
+		};
+
+		let from_wallet = self
+			.pumpx_signer_client
+			.request_wallet(from_chain_type, pumpx_config.wallet_index, omni_account.clone())
+			.await
+			.map_err(|e| error!("Could not get from_wallet from pumpx-signer: {:?}", e))?;
+
+		let from_address = pubkey_to_address(from_chain_type, &from_wallet)?;
+
+		let to_wallet = self
+			.pumpx_signer_client
+			.request_wallet(to_chain_type, pumpx_config.wallet_index, omni_account.clone())
+			.await
+			.map_err(|e| error!("Could not get to_wallet from pumpx-signer: {:?}", e))?;
+
+		let to_address = pubkey_to_address(to_chain_type, &to_wallet)?;
+
+		let payout_address = Address::from_str(&to_address).map_err(|_| {
+			error!("Failed to parse payout address");
+		})?;
+
+		self.pumpx_create_cross_order(
+			intent_id,
+			from_token_ca,
+			to_token_ca,
+			from_amount.clone(),
+			usd_worth,
+			from_address.clone(),
+			access_token,
+			pumpx_config,
+		)
+		.await?;
+
+		// TODO: this should be abstracted away
+		let (payout_amount, payout_amount_u256) = self
+			.do_binance_swap(
+				omni_account.clone(),
+				swap_order.from_asset.clone(),
+				from_amount,
+				from_address,
+				pumpx_config.wallet_index,
+				false,
+			)
+			.await?;
+
+		self.do_payout(&payout_address, &payout_amount_u256).await?;
+
+		self.apply_gas_fee(&payout_amount, access_token, pumpx_config).await
+	}
+
+	async fn pumpx_create_cross_order(
+		&self,
+		intent_id: IntentId,
+		from_token_ca: String,
+		to_token_ca: String,
+		from_amount: String,
+		usd_worth: String,
+		from_address: String,
+		access_token: &str,
+		pumpx_config: &PumpxConfig,
+	) -> Result<(), ()> {
+		let body = CreateCrossOrderBody {
+			request_id: intent_id,
+			chain_id: pumpx_config.to_chain_id,
+			token_ca: to_token_ca.clone(),
+			swap_type: match pumpx_config.swap_type {
+				1 => SwapType::Buy,
+				2 => SwapType::Sell,
+				_ => {
+					error!("Unsupported swap type: {}", pumpx_config.swap_type);
+					return Err(());
+				},
+			},
+			is_one_click: pumpx_config.is_one_click,
+			cross_info: vec![CrossOrderInfo {
+				chain_id: pumpx_config.from_chain_id,
+				wallet_index: pumpx_config.wallet_index,
+				address: from_address.clone(),
+				amount: from_amount.clone(),
+				usd: usd_worth,
+				token_ca: from_token_ca,
+			}],
+		};
+		debug!("Calling pumpx create_cross_order, body: {:?}", body);
+		let response =
+			self.pumpx_api.create_cross_order(&access_token, body).await.map_err(|_| {
+				error!("Failed to create cross order");
+			})?;
+		debug!("Response create_cross_order: {:?}", response);
+		Ok(())
+	}
+
+	// TODO: move `should_wait_for_deposit_confirm` to provider config
+	async fn do_binance_swap(
+		&self,
+		omni_account: [u8; 32],
+		from_asset: ChainAsset,
+		from_amount: String,
+		from_address: String,
+		wallet_index: u32,
+		should_wait_for_deposit_confirm: bool,
+	) -> Result<(String, U256), ()> {
+		let coins_info = WalletApi::new(self.binance_api.as_ref())
+			.get_all_coins_info()
+			.await
+			.map_err(|e| {
+				error!("Failed to get all coins info, {:?}", e);
+			})?;
+
+		// TODO: create an util function to convert ChainAsset to binance names
+		// and create constants for SOL, USDC, USDT, etc
+		let (from_network_name, binance_coin_name, token_address) = match from_asset {
+			ChainAsset::Solana(ref token) => {
+				let (asset, token_address) = match token {
+					SolanaToken::Native => ("SOL", ""),
+					SolanaToken::SPL(mint_address) => {
+						let mint_address_string = mint_address.as_ref().to_base58();
+						match mint_address_string.as_str() {
+							SOLANA_USDC_MINT_ADDRESS => ("USDC", SOLANA_USDC_MINT_ADDRESS),
+							SOLANA_USDT_MINT_ADDRESS => ("USDT", SOLANA_USDT_MINT_ADDRESS),
+							_ => {
+								error!("Unsupported SPL token: {:?}", mint_address);
+								return Err(());
+							},
+						}
+					},
+				};
+				("SOL".to_string(), asset.to_string(), token_address.to_string())
+			},
+			ChainAsset::Ethereum(..) => {
+				error!("Unsupported from_asset: {:?}", from_asset);
+				return Err(());
+			},
+		};
+
+		debug!(
+			"from_network_name: {}, binance_coin_name: {}, token_address: {}",
+			from_network_name, binance_coin_name, token_address
+		);
+
+		let Some(binance_coin_info) = coins_info.iter().find(|c| c.coin == binance_coin_name)
+		else {
+			error!("Failed to find binance network list for asset: {:?}", binance_coin_name);
+			return Err(());
+		};
+		let Some(binance_network_info) =
+			binance_coin_info.network_list.iter().find(|n| n.network == from_network_name)
+		else {
+			error!("Failed to find binance network list for asset: {:?}", binance_coin_name);
+			return Err(());
+		};
+
+		let deposit_address = WalletApi::new(self.binance_api.as_ref())
+			.get_deposit_address(&binance_coin_name, &binance_network_info.network)
+			.await
+			.map_err(|_| {
+				error!("Failed to get deposit address");
+			})?;
+
+		let from_amount_decimal = Decimal::from_str(&from_amount).map_err(|_| {
+			error!("Failed to parse from_amount_string");
+		})?;
+
+		debug!("Binance deposit address: {}, from_amount: {}", deposit_address, from_amount);
+
+		let asset_decimal_multiplier = match binance_coin_name.as_str() {
+			"USDC" => Decimal::from(1_000_000),    // 10^6
+			"USDT" => Decimal::from(1_000_000),    // 10^6
+			"SOL" => Decimal::from(1_000_000_000), // 10^9  TODO: double check this
+			_ => {
+				error!("Unsupported asset: {:?}", binance_coin_name);
+				return Err(());
+			},
+		};
+		let amount_to_transfer_decimal = from_amount_decimal * asset_decimal_multiplier;
+		let Some(amount_to_transfer) = amount_to_transfer_decimal.to_u64() else {
+			error!("Failed to convert amount to transfer to u64");
+			return Err(());
+		};
+
+		let (trade_symbol, order_side) = match binance_coin_name.as_str() {
+			"USDC" => ("BNBUSDC".to_string(), BinanceOrderSide::BUY),
+			"USDT" => ("BNBUSDT".to_string(), BinanceOrderSide::BUY),
+			"SOL" => ("SOLBNB".to_string(), BinanceOrderSide::SELL),
+			_ => {
+				error!("Unsupported asset: {:?}", binance_coin_name);
+				return Err(());
+			},
+		};
+
+		// init `payout_amount` with estimated-amount-to-receive
+		let mut payout_amount = estimate_bnb_amount(
+			&self.binance_api,
+			&trade_symbol,
+			&binance_coin_name,
+			from_amount_decimal,
+		)
+		.await?;
+
+		let mut payout_amount_u256 = str_to_u256(&payout_amount, 18)?;
+
+		// Fetch contract balance
+		let balance = self.accounting_contract_client.get_balance().await?;
+		if balance < payout_amount_u256 {
+			error!(
+				"There is not enough balance in the accounting contract, {} < {}",
+				balance, payout_amount_u256
+			);
+			return Err(());
+		}
+
+		let remote_signer: Box<dyn solana_sdk::signer::Signer + Send + Sync> =
+			Box::new(RemoteSigner::new(
+				self.pumpx_signer_client.clone(),
+				wallet_index,
+				omni_account,
+				Handle::current(),
+			));
+
+		let mut tx_id: Option<String> = None;
+		// TODO: change this when adding support for more tokens/chains
+		if binance_coin_name == "SOL" {
+			// Native transfer
+			debug!("Transfering {:?} SOL to {:?}", amount_to_transfer, deposit_address);
+			let signature = self
+				.solana_client
+				.transfer_sol(&deposit_address, amount_to_transfer, &remote_signer)
+				.await
+				.map_err(|_| {
+					error!("Failed to transfer SOL");
+				})?;
+			tx_id = Some(signature);
+		} else {
+			debug!(
+				"Transfering {:?} {:?} to {:?}",
+				amount_to_transfer, token_address, deposit_address
+			);
+			// SPL transfer
+			let signature = self
+				.solana_client
+				.transfer_spl(&deposit_address, amount_to_transfer, &token_address, &remote_signer)
+				.await
+				.map_err(|_| {
+					error!("Failed to transfer SPL");
+				})?;
+			tx_id = Some(signature);
+		}
+
+		if should_wait_for_deposit_confirm {
+			debug!("Waiting for deposit to be confirmed on Binance...");
+			debug!("Deposit tx_id: {:?}", tx_id);
+			debug!("Source address: {:?}", from_address);
+			let mut deposit_confirmed = false;
+			let start_time = std::time::Instant::now();
+			let timeout = Duration::from_secs(300); // 5 minute timeout
+
+			while !deposit_confirmed && start_time.elapsed() < timeout {
+				let Ok(deposit_history) = WalletApi::new(self.binance_api.as_ref())
+					.get_deposit_history(Some(binance_coin_name.clone()), tx_id.clone())
+					.await
+				else {
+					error!("Failed to get deposit history");
+					continue;
+				};
+
+				// Check if there's a recent successful deposit
+				for deposit in deposit_history {
+					debug!("Deposit: {:?}", deposit);
+					if deposit.status == 2 || deposit.status == 7 {
+						// 2 = rejected, 7 = Wrong Deposit
+						error!("Deposit failed with status: {}", deposit.status);
+						return Err(());
+					}
+					if deposit.status == 1 && // 1 = success
+							   deposit.coin == binance_coin_name &&
+							   deposit.network == binance_network_info.network &&
+                               deposit.source_address == Some(from_address.clone())
+					{
+						deposit_confirmed = true;
+						debug!(
+							"Deposit confirmed on Binance for {} {}",
+							deposit.amount, binance_coin_name
+						);
+						break;
+					}
+					debug!("Deposit not confirmed yet, status: {}", deposit.status);
+				}
+
+				if !deposit_confirmed {
+					debug!("Deposit not confirmed yet, waiting 5 seconds...");
+					sleep(Duration::from_secs(5)).await;
+				}
+			}
+
+			if !deposit_confirmed {
+				error!("Deposit not confirmed within timeout period");
+				return Err(());
+			}
+
+			// 3. Make the trade using binance spot trading api from_asset => BNB, If it fails, notify the backend via /v3/trade/cross_fail
+			let binance_order_params = BinanceCreateOrderParams {
+				symbol: trade_symbol.clone(),
+				side: order_side.clone(),
+				order_type: BinanceOrderType::MARKET,
+				quote_order_qty: match order_side {
+					BinanceOrderSide::BUY => Some(from_amount.clone()),
+					BinanceOrderSide::SELL => None,
+				},
+				quantity: match order_side {
+					BinanceOrderSide::BUY => None,
+					BinanceOrderSide::SELL => Some(from_amount.clone()),
+				},
+				..Default::default()
+			};
+			debug!("Creating binance order with params: {:?}", binance_order_params);
+			let Ok(binance_order) = SpotTradingApi::new(self.binance_api.as_ref())
+				.create_order(binance_order_params)
+				.await
+			else {
+				error!("Failed to create binance order");
+				WalletApi::new(self.binance_api.as_ref())
+					.withdraw(
+						&binance_coin_name,
+						&from_address,
+						from_amount,
+						Some(&binance_network_info.network),
+					)
+					.await
+					.map_err(|e| {
+						error!("Failed to withdraw asset back to omni account, error: {:?}", e);
+					})?;
+				debug!("Withdrawed asset back to omni account");
+				return Err(());
+			};
+
+			// Binance trade pair format:
+			// <base-asset><quote-asset>, e.g. BNBUSDT, SOLBNB...
+			//
+			// SELL: sell the "base-asset" to get "quote-asset"
+			// BUY:  buy the "base-asset" with "quote-asset"
+			//
+			// executedQty: quantity of "base-asset"
+			// cummulativeQuoteQty: quantity of "quote-asset"
+			//
+			// so, in SELL orders:
+			// - `executedQty` reflects the amount of the base-asset sold
+			// - `cummulativeQuoteQty` reflects the amount of the quote-asset received
+			//
+			// in BUY orders:
+			// - `executedQty` indicates the amount of the base-asset bought
+			// - `cummulativeQuoteQty`` shows the total amount of the quote-asset spent
+			let mut trade_success = false;
+			let mut bnb_acquired = "".to_string();
+			loop {
+				let trade_order = SpotTradingApi::new(self.binance_api.as_ref())
+					.get_order(&trade_symbol, Some(binance_order.order_id), None, None)
+					.await
+					.map_err(|_| {
+						error!("Failed to get binance order");
+					})?;
+
+				match trade_order.status {
+					BinanceOrderStatus::FILLED => {
+						info!("Binance order filled");
+						bnb_acquired = match trade_order.side {
+							BinanceOrderSide::BUY => trade_order.executed_qty,
+							BinanceOrderSide::SELL => trade_order.cummulative_quote_qty,
+						};
+						trade_success = true;
+						break;
+					},
+					BinanceOrderStatus::CANCELED => {
+						error!("Binance order canceled");
+					},
+					BinanceOrderStatus::REJECTED => {
+						error!("Binance order rejected");
+					},
+					BinanceOrderStatus::EXPIRED => {
+						error!("Binance order expired");
+					},
+					BinanceOrderStatus::EXPIRED_IN_MATCH => {
+						error!("Binance order expired in matching");
+					},
+					_ => {
+						debug!("Binance order status: {:?}", trade_order.status);
+					},
+				}
+				//todo: how long we wait ?
+				sleep(Duration::from_millis(500)).await;
+			}
+			if !trade_success {
+				error!("Binance order failed");
+				WalletApi::new(self.binance_api.as_ref())
+					.withdraw(
+						&binance_coin_name,
+						&from_address,
+						from_amount,
+						Some(&binance_network_info.network),
+					)
+					.await
+					.map_err(|e| {
+						error!("Failed to withdraw asset back to omni account, error: {:?}", e);
+					})?;
+				debug!("Withdrawed asset back to omni account");
+				return Err(());
+			}
+
+			debug!("Total acquired {} bnb", bnb_acquired);
+
+			// Update payout amount based on the order filled
+			// TODO: shall we apply 0.1% service fee here?
+			payout_amount = bnb_acquired;
+			payout_amount_u256 = str_to_u256(&payout_amount, 18)?;
+		}
+
+		Ok((payout_amount, payout_amount_u256))
+	}
+
+	async fn do_payout(&self, payout_address: &Address, payout_amount: &U256) -> Result<(), ()> {
+		debug!("Getting {:?} nonce for payout request", payout_address);
+		let user_nonce =
+			self.accounting_contract_client.get_nonce(*payout_address).await.map_err(|_| {
+				log::error!("Failed to get nonce");
+			})?;
+
+		debug!("Received {:?} nonce", user_nonce);
+		let user_nonce = user_nonce + U256::from(1u64);
+		debug!(
+			"Calling accounting contract payout with address {:?}, nonce {:?} and amount {:?}",
+			payout_address, user_nonce, payout_amount
+		);
+
+		self.accounting_contract_client
+			.execute_pay_out_request(*payout_address, user_nonce, *payout_amount)
+			.await
+			.map_err(|_| {
+				log::error!("Failed to execute pay out request");
+			})
+	}
+
+	async fn apply_gas_fee(
+		&self,
+		payout_amount: &str,
+		access_token: &str,
+		pumpx_config: &PumpxConfig,
+	) -> Result<String, ()> {
+		debug!("Calling pumpx get_gas_info, chain_id: {}", pumpx_config.to_chain_id);
+		let res = self
+			.pumpx_api
+			.get_gas_info(&access_token, pumpx_config.to_chain_id)
+			.await
+			.map_err(|_| {
+				log::error!("Failed to get gas info");
+			})?;
+		debug!("Response get_gas_info: {:?}", res);
+
+		let Some(gas_info_vec) = res.data.gas_info else {
+			log::error!("Response data.gas_info of call get gas info is none");
+			return Err(());
+		};
+		let Some(gas_info) =
+			gas_info_vec.iter().find(|g| g.chain_id == pumpx_config.to_chain_id.to_string())
+		else {
+			log::error!(
+				"Could not find matching gas_info with chain_id {}",
+				pumpx_config.to_chain_id
+			);
+			return Err(());
+		};
+
+		let gas_fee = match pumpx_config.gas_type {
+			1 => &gas_info.normal,
+			2 => &gas_info.fast,
+			3 => &gas_info.super_fast,
+			_ => {
+				log::error!("Unsupported gas type: {}", pumpx_config.gas_type);
+				return Err(());
+			},
+		};
+		debug!("Gas fee for chain_id {} is {}", pumpx_config.to_chain_id, gas_fee);
+
+		calculate_amount_in(payout_amount, gas_fee, 18)
+	}
+}
+
+async fn estimate_bnb_amount<BinanceClient: BinanceApi>(
+	binance_api: &Arc<BinanceClient>,
+	trade_symbol: &str,
+	binance_coin_name: &str,
+	from_amount_decimal: Decimal,
+) -> Result<String, ()> {
+	let price_str = SpotTradingApi::new(binance_api.as_ref())
+		.get_symbol_price(trade_symbol)
+		.await
+		.map_err(|_| {
+			log::error!("Failed to get symbol price for {}", trade_symbol);
+		})?;
+
+	let price = if binance_coin_name == "SOL" {
+		// For SOL, we sell SOL to get BNB, so get SOLBNB price
+		Decimal::from_str(&price_str).map_err(|_| {
+			log::error!("Failed to parse symbol price {}", price_str);
+		})?
+	} else {
+		// For USDC/USDT, we buy BNB with USDC/USDT, so get BNBUSDC/BNBUSDT price and invert
+		let price = Decimal::from_str(&price_str).map_err(|_| {
+			log::error!("Failed to parse symbol price {}", price_str);
+		})?;
+		if price.is_zero() {
+			log::error!("Symbol price is zero for {}", trade_symbol);
+			return Err(());
+		}
+		Decimal::ONE / price
+	};
+
+	let bnb_estimated = from_amount_decimal * price;
+
+	// Apply 0.1% service fee
+	let service_fee_rate = Decimal::from_str("0.001").expect("Failed to parse service fee rate");
+	let decimal_bnb_to_receive = bnb_estimated * (Decimal::ONE - service_fee_rate);
+
+	debug!("BNB estimated: {}, after 0.1% fee: {}", bnb_estimated, decimal_bnb_to_receive);
+
+	Ok(decimal_bnb_to_receive.to_string())
+}
+
+fn calculate_amount_in(amount: &str, gas: &str, decimals: u32) -> Result<String, ()> {
+	let amount = Decimal::from_str(amount).map_err(|_| ())?;
+	let gas = Decimal::from_str(gas).map_err(|_| ())?;
+	if amount <= gas {
+		Err(())
+	} else {
+		let amount = amount - gas;
+		Ok(amount.trunc_with_scale(decimals).to_string())
+	}
+}
+
+fn str_to_u256(amount: &str, decimals: u32) -> Result<U256, ()> {
+	let amount = Decimal::from_str(amount).map_err(|_| ())?;
+	let factor = Decimal::from(10u64.pow(decimals));
+	let scaled = amount * factor;
+	let int_str = scaled.trunc().to_string();
+	U256::from_str(&int_str).map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_calculate_amount_in() {
+		let bnb_to_receive = "0.0050773374896233926847036101";
+		let gas = "0.0004731804";
+		let decimals = 18;
+
+		let result = calculate_amount_in(bnb_to_receive, gas, decimals);
+		assert_eq!(result, Ok("0.004604157089623392".to_string()));
+	}
+
+	#[test]
+	fn test_str_to_u256() {
+		let amount = "0.0050773374896233926847036101";
+		let decimals = 18;
+
+		let result = str_to_u256(amount, decimals);
+		assert_eq!(result, Ok(U256::from_str("5077337489623392").unwrap()));
+	}
+}

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
@@ -15,10 +15,16 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 		swap_order: &SwapOrder,
 		pumpx_config: &PumpxConfig,
 	) -> Result<String, ()> {
+		// payout_amount
 		debug!("executing cross chain swap");
 
 		if pumpx_config.to_chain_id != BSC_CHAIN_ID {
 			error!("Only bsc payout supported");
+			return Err(());
+		}
+
+		if pumpx_config.order_type != PumpxOrderType::Market {
+			error!("Only market order supported");
 			return Err(());
 		}
 

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
@@ -60,7 +60,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 
 		let from_wallet = self
 			.pumpx_signer_client
-			.request_wallet(from_chain_type, pumpx_config.wallet_index, omni_account.clone())
+			.request_wallet(from_chain_type, pumpx_config.wallet_index, omni_account)
 			.await
 			.map_err(|e| error!("Could not get from_wallet from pumpx-signer: {:?}", e))?;
 
@@ -68,7 +68,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 
 		let to_wallet = self
 			.pumpx_signer_client
-			.request_wallet(to_chain_type, pumpx_config.wallet_index, omni_account.clone())
+			.request_wallet(to_chain_type, pumpx_config.wallet_index, omni_account)
 			.await
 			.map_err(|e| error!("Could not get to_wallet from pumpx-signer: {:?}", e))?;
 
@@ -93,7 +93,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 		// TODO: this should be abstracted away
 		let (payout_amount, payout_amount_u256) = self
 			.do_binance_swap(
-				omni_account.clone(),
+				omni_account,
 				swap_order.from_asset.clone(),
 				from_amount,
 				from_address,
@@ -142,7 +142,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 		};
 		debug!("Calling pumpx create_cross_order, body: {:?}", body);
 		let response =
-			self.pumpx_api.create_cross_order(&access_token, body).await.map_err(|_| {
+			self.pumpx_api.create_cross_order(access_token, body).await.map_err(|_| {
 				error!("Failed to create cross order");
 			})?;
 		debug!("Response create_cross_order: {:?}", response);
@@ -506,7 +506,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 		debug!("Calling pumpx get_gas_info, chain_id: {}", pumpx_config.to_chain_id);
 		let res = self
 			.pumpx_api
-			.get_gas_info(&access_token, pumpx_config.to_chain_id)
+			.get_gas_info(access_token, pumpx_config.to_chain_id)
 			.await
 			.map_err(|_| {
 				log::error!("Failed to get gas info");

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
@@ -102,7 +102,7 @@ async fn simple_cross_chain_swap() {
 			mockall::predicate::eq(pumpx_wallet_index),
 			mockall::predicate::eq(pumpx_wallet_omni_account),
 		)
-		.times(1)
+		.times(2)
 		.returning(|_, _, _| {
 			Ok([
 				3, 101, 219, 24, 34, 145, 151, 225, 255, 131, 94, 15, 170, 236, 154, 154, 153, 0,
@@ -183,7 +183,7 @@ async fn simple_cross_chain_swap() {
 				gas_type: GasType::Slow,
 				slippage: 0,
 				wallet_index: 1,
-				recipient_address: "".to_string()
+				recipient_address: expected_payout_address.to_string()
 			}
 		))
 		.times(1)
@@ -381,7 +381,7 @@ fn prepare_sol_coin_info(ticker: &str, name: &str) -> CoinInfo {
 
 fn prepare_pumpx_config(to_chain_id: u32) -> PumpxConfig {
 	PumpxConfig {
-		order_type: PumpxOrderType::Limit,
+		order_type: PumpxOrderType::Market,
 		swap_type: 1,
 		from_chain_id: 100000,
 		from_token_ca: BoundedVec::truncate_from([0u8; 128].to_vec()),

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
@@ -129,7 +129,7 @@ async fn simple_cross_chain_swap() {
 			mockall::predicate::eq(pumpx::signer_client::ChainType::Evm),
 			mockall::predicate::eq(pumpx_wallet_index),
 			mockall::predicate::eq(pumpx_wallet_omni_account),
-			mockall::predicate::eq(vec![create_order_encoded_tx.clone()]),
+			mockall::predicate::always(),
 		)
 		.times(1)
 		.returning(move |_, _, _, _| Ok(vec![create_order_tx_signature.to_vec()]));
@@ -207,7 +207,7 @@ async fn simple_cross_chain_swap() {
 			mockall::predicate::eq(SendOrderTxBody {
 				chain_id: to_chain_id,
 				order_id: order_id,
-				tx_data: vec!["f869808504e3b29200831e848094d8da6bf26964af9d7eed9e03e53415d37aa96045843b9aca008025a0f6c76effbee5ac9ff341a0efe85b5f9401ab673c5d1c2746041e446e3d19aea3a037470aac13f1cb4da20f086a475cceb36a5bb4fd9cf52b48300ad840ad1480ad".to_string()]
+				tx_data: vec!["0xf869808504e3b29200831e848094d8da6bf26964af9d7eed9e03e53415d37aa96045843b9aca008025a0f6c76effbee5ac9ff341a0efe85b5f9401ab673c5d1c2746041e446e3d19aea3a037470aac13f1cb4da20f086a475cceb36a5bb4fd9cf52b48300ad840ad1480ad".to_string()]
 			}) )
 		.times(1)
 		.returning(|_, _| Ok(SendOrderTxResponse {

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -70,7 +70,7 @@ use pumpx::methods::create_limit_order::CreateLimitOrderBody;
 use pumpx::methods::create_market_order_tx::CreateMarketOrderTxBody;
 use pumpx::methods::create_market_order_unsigned_tx::CreateMarketOrderUnsignedTxBody;
 use pumpx::methods::cross_fail::CrossFailBody;
-use pumpx::methods::send_order_tx::{SendOrderTxBody, SendOrderTxResponse};
+use pumpx::methods::send_order_tx::SendOrderTxBody;
 use pumpx::pubkey_to_address;
 use pumpx::signer_client::ChainType;
 use pumpx::signer_client::SignerClient;
@@ -290,76 +290,5 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait> IntentExecutor
 
 	async fn name(&self) -> &'static str {
 		"cross-chain"
-	}
-}
-
-impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
-	CrossChainIntentExecutor<BinanceClient, SolanaClient>
-{
-	pub async fn create_market_order_tx(
-		&self,
-		access_token: &str,
-		order: CreateMarketOrderUnsignedTxBody,
-		account_id: &AccountId,
-	) -> Result<SendOrderTxResponse, ()> {
-		let wallet_index = order.wallet_index;
-		let response = self
-			.pumpx_api
-			.create_market_order_unsigned_tx(access_token, order)
-			.await
-			.map_err(|_| log::error!("Failed to get unsigned market order tx"))?;
-
-		let unsigned_tx_string = response.data.tx_data.ok_or_else(|| {
-			log::error!("Failed to unwrap tx_data");
-		})?;
-		let order_id = response.data.order_id.ok_or_else(|| {
-			log::error!("Failed to unwrap order_id");
-		})?;
-		let chain_id = response.data.chain_id.ok_or_else(|| {
-			log::error!("Failed to unwrap chain_id");
-		})?;
-
-		let unsigned_tx_bytes = unsigned_tx_string
-			.iter()
-			.map(|s| {
-				let hex_str = s.trim_start_matches("0x");
-				hex::decode(hex_str).expect("Invalid hex string")
-			})
-			.collect();
-
-		let signatures = self
-			.pumpx_signer_client
-			.request_signatures(
-				ChainType::Evm,
-				wallet_index,
-				*account_id.as_ref(),
-				unsigned_tx_bytes,
-			)
-			.await?;
-
-		let mut tx_data: Vec<String> = vec![];
-		for (x, y) in unsigned_tx_string.into_iter().zip(signatures.into_iter()) {
-			let bytes = hex::decode(x.trim_start_matches("0x"))
-				.map_err(|_| log::error!("invalid hex string"))?;
-			// We should be able to decode it to Legacy Transaction
-			// As it is RLP Encoded Bytes which adheres to string encoding rules
-			let unsigned_tx = TxLegacy::decode(&mut &bytes[..])
-				.map_err(|_| log::error!("Failed to decode legacy tx"))?;
-			let signature = PrimitiveSignature::try_from(y.as_ref())
-				.map_err(|_| log::error!("Failed to create Typed signature"))?;
-
-			let signed_tx = unsigned_tx.into_signed(signature);
-			let mut encoded_signed_tx = vec![];
-			signed_tx.rlp_encode(&mut encoded_signed_tx);
-			tx_data.push(hex::encode(encoded_signed_tx));
-		}
-
-		let response = self
-			.pumpx_api
-			.send_order_tx(access_token, SendOrderTxBody { order_id, chain_id, tx_data })
-			.await
-			.map_err(|_| log::error!("Failed to send order tx"))?;
-
-		Ok(response)
 	}
 }

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -15,6 +15,7 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 #![allow(unused_assignments)]
+#![allow(clippy::too_many_arguments)]
 
 use alloy::consensus::{SignableTransaction, TxLegacy};
 use alloy::primitives::{Address, PrimitiveSignature, U256};

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(unused_assignments)]
+
 use alloy::consensus::{SignableTransaction, TxLegacy};
 use alloy::primitives::{Address, PrimitiveSignature, U256};
 use async_trait::async_trait;
@@ -45,12 +47,6 @@ use tokio::{
 // use intent_token_query::EthereumAddress;
 // use intent_token_query::SolanaPubkey;
 // use log::error;
-use parity_scale_codec::Encode;
-use pumpx::methods::common::{GasType, SwapType};
-use pumpx::methods::create_cross_order::CrossOrderInfo;
-use pumpx::signer_client::ChainType;
-use pumpx::signer_client::SignerClient;
-
 use accounting_contract_client::AccountingContractApi;
 use alloy::primitives::private::alloy_rlp::Decodable;
 use binance_api::spot_trading_api::SpotTradingApi;
@@ -64,18 +60,27 @@ use parentchain_rpc_client::CustomConfig;
 use parentchain_rpc_client::SubxtClient;
 use parentchain_rpc_client::SubxtClientFactory;
 use parentchain_signer::TxSigner;
+use parity_scale_codec::Encode;
+use pumpx::constants::*;
+use pumpx::methods::common::{GasType, SwapType};
 use pumpx::methods::create_cross_order::CreateCrossOrderBody;
+use pumpx::methods::create_cross_order::CrossOrderInfo;
 use pumpx::methods::create_limit_order::CreateLimitOrderBody;
 use pumpx::methods::create_market_order_tx::CreateMarketOrderTxBody;
 use pumpx::methods::create_market_order_unsigned_tx::CreateMarketOrderUnsignedTxBody;
 use pumpx::methods::cross_fail::CrossFailBody;
 use pumpx::methods::send_order_tx::{SendOrderTxBody, SendOrderTxResponse};
+use pumpx::pubkey_to_address;
+use pumpx::signer_client::ChainType;
+use pumpx::signer_client::SignerClient;
 use pumpx::PumpxApi;
-use pumpx::{pubkey_to_evm_address, pubkey_to_solana_address};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use log::debug;
+
+mod cross_chain;
+mod single_chain;
 
 #[cfg(test)]
 mod cross_chain_swap_tests;
@@ -149,7 +154,6 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait> IntentExecutor
 	for CrossChainIntentExecutor<BinanceClient, SolanaClient>
 {
-	#[allow(unused_assignments)]
 	async fn execute(
 		&self,
 		account_id: &AccountId,
@@ -209,25 +213,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait> IntentExecutor
 				// TODO: update this when we have more providers
 				let SingleChainSwapProvider::Pumpx(pumpx_config) = scsp;
 
-				let usd_worth = std::str::from_utf8(&pumpx_config.usd_worth)
-					.map_err(|_| {
-						log::error!("Failed to parse usd_worth");
-					})
-					.map(|v| v.to_string())?;
-
-				let from_token_ca = std::str::from_utf8(&pumpx_config.from_token_ca)
-					.map_err(|_| {
-						log::error!("Failed to parse from_token_ca");
-					})
-					.map(|v| v.to_string())?;
-
-				let to_token_ca = std::str::from_utf8(&pumpx_config.to_token_ca)
-					.map_err(|_| {
-						log::error!("Failed to parse to_token_ca");
-					})
-					.map(|v| v.to_string())?;
-
-				let from_amount = std::str::from_utf8(&pumpx_config.from_amount)
+				let mut amount = std::str::from_utf8(&pumpx_config.from_amount)
 					.map_err(|_| {
 						log::error!("Failed to parse from_amount");
 					})
@@ -241,822 +227,48 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait> IntentExecutor
 					return Err(());
 				};
 
-				let result: IntentExecutionResult;
+				let should_notify_parentchain = pumpx_config.order_type != PumpxOrderType::Limit;
 
-				if pumpx_config.from_chain_id == pumpx_config.to_chain_id {
-					debug!("from and to chain are equal, performing single chain swap");
-					let Some(chain_type) = ChainType::from_pumpx_chain_id(pumpx_config.to_chain_id)
-					else {
-						log::error!("Unsupported to_chain_id: {}", pumpx_config.to_chain_id);
-						return Err(());
-					};
-
-					let wallet_address = self
-						.pumpx_signer_client
-						.request_wallet(chain_type, pumpx_config.wallet_index, *account_id.as_ref())
+				// do cross-chain swap first, if required
+				if pumpx_config.is_cross_chain() {
+					amount = match self
+						.execute_cross_chain_swap(
+							*account_id.as_ref(),
+							intent_id,
+							&access_token,
+							swap_order,
+							pumpx_config,
+						)
 						.await
-						.map_err(|e| {
-							log::error!("Could not get wallet from pumpx-signer: {:?}", e)
-						})?;
-
-					let (order_response, should_notify_parentchain) = match pumpx_config.order_type
 					{
-						PumpxOrderType::Market => {
-							debug!("Doing market order");
-							let body = CreateMarketOrderTxBody {
-								request_id: intent_id,
-								chain_id: pumpx_config.to_chain_id,
-								token_ca: to_token_ca.clone(),
-								swap_type: match pumpx_config.swap_type {
-									1 => SwapType::Buy,
-									2 => SwapType::Sell,
-									_ => {
-										log::error!(
-											"Unsupported swap type: {}",
-											pumpx_config.swap_type
-										);
-										return Err(());
-									},
-								},
-								amount_in: from_amount.clone(),
-								double_out: pumpx_config.double_out,
-								is_one_click: pumpx_config.is_one_click,
-								address: match chain_type {
-									ChainType::Evm => pubkey_to_evm_address(&wallet_address)?,
-									ChainType::Solana => pubkey_to_solana_address(&wallet_address)?,
-									_ => {
-										log::error!("Unsupported {:?} wallet address", chain_type);
-										return Err(());
-									},
-								},
-								is_anti_mev: pumpx_config.is_anti_mev,
-								is_auto_slippage: pumpx_config.is_auto_slippage,
-								gas_type: match pumpx_config.gas_type {
-									1 => GasType::Slow,
-									2 => GasType::Medium,
-									3 => GasType::Fast,
-									_ => {
-										log::error!(
-											"Unsupported gas type: {}",
-											pumpx_config.gas_type
-										);
-										return Err(());
-									},
-								},
-								slippage: pumpx_config.slippage,
-								wallet_index: pumpx_config.wallet_index,
-							};
-							debug!("Calling pumpx create_market_order_tx, body: {:?}", body);
-							let response = self
-								.pumpx_api
-								.create_market_order_tx(&access_token, body)
-								.await
-								.map_err(|_| {
-									log::error!("Failed to create market order tx");
-								})?;
-
-							debug!("Response create_market_order_tx: {:?}", response);
-							(response.encode(), true)
-						},
-						PumpxOrderType::Limit => {
-							debug!("Doing limit order");
-							let token_cap = match pumpx_config.token_cap {
-								Some(ref token_cap) => Some(
-									std::str::from_utf8(token_cap)
-										.map_err(|_| {
-											log::error!("Failed to parse token_cap");
-										})
-										.map(|v| v.to_string())?,
-								),
-								None => None,
-							};
-							let price_usd = match pumpx_config.price_usd {
-								Some(ref price_usd) => Some(
-									std::str::from_utf8(price_usd)
-										.map_err(|_| {
-											log::error!("Failed to parse price_usd");
-										})
-										.map(|v| v.to_string())?,
-								),
-								None => None,
-							};
-
-							let new_limit_order = CreateLimitOrderBody {
-								request_id: intent_id,
-								chain_id: pumpx_config.to_chain_id,
-								token_ca: to_token_ca,
-								amount: from_amount,
-								swap_type: match pumpx_config.swap_type {
-									1 => SwapType::Buy,
-									2 => SwapType::Sell,
-									_ => {
-										log::error!(
-											"Unsupported swap type: {}",
-											pumpx_config.swap_type
-										);
-										return Err(());
-									},
-								},
-								double_out: pumpx_config.double_out,
-								token_cap,
-								price_usd,
-								trailing_percent: pumpx_config
-									.trailing_percent
-									.map(|v| v.to_string()),
-								address: match chain_type {
-									ChainType::Evm => pubkey_to_evm_address(&wallet_address)?,
-									ChainType::Solana => pubkey_to_solana_address(&wallet_address)?,
-									_ => {
-										log::error!("Unsupported {:?} wallet address", chain_type);
-										return Err(());
-									},
-								},
-								is_anti_mev: pumpx_config.is_anti_mev,
-								is_auto_slippage: pumpx_config.is_auto_slippage,
-								gas_type: match pumpx_config.gas_type {
-									1 => GasType::Slow,
-									2 => GasType::Medium,
-									3 => GasType::Fast,
-									_ => {
-										log::error!(
-											"Unsupported gas type: {}",
-											pumpx_config.gas_type
-										);
-										return Err(());
-									},
-								},
-								slippage: pumpx_config.slippage,
-								wallet_index: pumpx_config.wallet_index,
-							};
-							debug!(
-								"Calling pumpx create_limit_order, order: {:?}",
-								new_limit_order
+						Ok(amount) => amount,
+						Err(_) => {
+							log::error!(
+								"Error executing cross chain swap for intent_id: {}",
+								intent_id
 							);
-							let response = self
-								.pumpx_api
-								.create_limit_order(&access_token, new_limit_order)
-								.await
-								.map_err(|_| {
-									log::error!("Failed to create limit order");
-								})?;
-
-							debug!("Response create_limit_order: {:?}", response);
-
-							(response.encode(), false)
+							let body = CrossFailBody {
+								request_id: intent_id,
+								fail_reason: "".to_string(), // TODO: `execute_cross_chain_swap` should return concrete reasons
+							};
+							self.pumpx_api.cross_fail(&access_token, body).await.map_err(|_| {
+								log::error!("Failed to notify pumpx-signer");
+							})?;
+							return Err(());
 						},
-					};
-					result = (Some(order_response), should_notify_parentchain);
-				} else {
-					debug!("from and to chain are different, performing cross chain swap");
-					if !matches!(
-						swap_order.to_asset,
-						ChainAsset::Ethereum(pumpx::constants::BSC_CHAIN_ID, _)
-					) {
-						log::error!("Only BSC payout supported");
 					}
+				}
 
-					// notify backend about it
-					let Some(from_chain_type) =
-						ChainType::from_pumpx_chain_id(pumpx_config.from_chain_id)
-					else {
-						log::error!("Unsupported from_chain_id: {}", pumpx_config.from_chain_id);
-						return Err(());
-					};
-
-					let Some(to_chain_type) =
-						ChainType::from_pumpx_chain_id(pumpx_config.to_chain_id)
-					else {
-						log::error!("Unsupported to_chain_id: {}", pumpx_config.to_chain_id);
-						return Err(());
-					};
-
-					let from_wallet_address = self
-						.pumpx_signer_client
-						.request_wallet(
-							from_chain_type,
-							pumpx_config.wallet_index,
-							*account_id.as_ref(),
-						)
-						.await
-						.map_err(|e| {
-							log::error!("Could not get from_wallet from pumpx-signer: {:?}", e)
-						})?;
-
-					let from_address = match from_chain_type {
-						ChainType::Evm => pubkey_to_evm_address(&from_wallet_address)?,
-						ChainType::Solana => pubkey_to_solana_address(&from_wallet_address)?,
-						_ => {
-							log::error!("Unsupported {:?} wallet address", from_chain_type);
-							return Err(());
-						},
-					};
-
-					let to_wallet_address = self
-						.pumpx_signer_client
-						.request_wallet(
-							to_chain_type,
-							pumpx_config.wallet_index,
-							*account_id.as_ref(),
-						)
-						.await
-						.map_err(|e| {
-							log::error!("Could not get to_wallet from pumpx-signer: {:?}", e)
-						})?;
-
-					let to_address = match to_chain_type {
-						ChainType::Evm => pubkey_to_evm_address(&to_wallet_address)?,
-						ChainType::Solana => pubkey_to_solana_address(&to_wallet_address)?,
-						_ => {
-							log::error!("Unsupported {:?} wallet address", to_chain_type);
-							return Err(());
-						},
-					};
-
-					let body = CreateCrossOrderBody {
-						request_id: intent_id,
-						chain_id: pumpx_config.to_chain_id,
-						token_ca: to_token_ca.clone(),
-						swap_type: match pumpx_config.swap_type {
-							1 => SwapType::Buy,
-							2 => SwapType::Sell,
-							_ => {
-								log::error!("Unsupported swap type: {}", pumpx_config.swap_type);
-								return Err(());
-							},
-						},
-						is_one_click: pumpx_config.is_one_click,
-						cross_info: vec![CrossOrderInfo {
-							chain_id: pumpx_config.from_chain_id,
-							wallet_index: pumpx_config.wallet_index,
-							address: from_address.clone(),
-							amount: from_amount.clone(),
-							usd: usd_worth,
-							token_ca: from_token_ca,
-						}],
-					};
-					debug!("Calling pumpx create_cross_order, body: {:?}", body);
-					let response =
-						self.pumpx_api.create_cross_order(&access_token, body).await.map_err(
-							|_| {
-								log::error!("Failed to create cross order");
-							},
-						)?;
-					debug!("Response create_cross_order: {:?}", response);
-
-					// 2. transfer from_asset to binance deposit address
-					let should_wait_for_deposit_confirm = false; // Switch for strategy
-
-					let coins_info = WalletApi::new(self.binance_api.as_ref())
-						.get_all_coins_info()
-						.await
-						.map_err(|e| {
-							log::error!("Failed to get all coins info, {:?}", e);
-						})?;
-
-					// TODO: create an util function to convert ChainAsset to binance names
-					// and create constants for SOL, USDC, USDT, etc
-					let (from_network_name, binance_coin_name, token_address) =
-						match swap_order.from_asset {
-							ChainAsset::Solana(ref token) => {
-								let (asset, token_address) = match token {
-									SolanaToken::Native => ("SOL", ""),
-									SolanaToken::SPL(mint_address) => {
-										let mint_address_string = mint_address.as_ref().to_base58();
-										match mint_address_string.as_str() {
-											SOLANA_USDC_MINT_ADDRESS => {
-												("USDC", SOLANA_USDC_MINT_ADDRESS)
-											},
-											SOLANA_USDT_MINT_ADDRESS => {
-												("USDT", SOLANA_USDT_MINT_ADDRESS)
-											},
-											_ => {
-												log::error!(
-													"Unsupported SPL token: {:?}",
-													mint_address
-												);
-												return Err(());
-											},
-										}
-									},
-								};
-								("SOL".to_string(), asset.to_string(), token_address.to_string())
-							},
-							ChainAsset::Ethereum(..) => {
-								log::error!("Unsupported from_asset: {:?}", swap_order.from_asset);
-								return Err(());
-							},
-						};
-
-					log::debug!(
-						"from_network_name: {}, binance_coin_name: {}, token_address: {}",
-						from_network_name,
-						binance_coin_name,
-						token_address
-					);
-
-					let Some(binance_coin_info) =
-						coins_info.iter().find(|c| c.coin == binance_coin_name)
-					else {
-						log::error!(
-							"Failed to find binance network list for asset: {:?}",
-							binance_coin_name
-						);
-						return Err(());
-					};
-					let Some(binance_network_info) = binance_coin_info
-						.network_list
-						.iter()
-						.find(|n| n.network == from_network_name)
-					else {
-						log::error!(
-							"Failed to find binance network list for asset: {:?}",
-							binance_coin_name
-						);
-						return Err(());
-					};
-
-					let deposit_address = WalletApi::new(self.binance_api.as_ref())
-						.get_deposit_address(&binance_coin_name, &binance_network_info.network)
-						.await
-						.map_err(|_| {
-							log::error!("Failed to get deposit address");
-						})?;
-
-					let from_amount_decimal = Decimal::from_str(&from_amount).map_err(|_| {
-						log::error!("Failed to parse from_amount_string");
-					})?;
-
-					log::debug!(
-						"Binance deposit address: {}, from_amount: {}",
-						deposit_address,
-						from_amount
-					);
-
-					let asset_decimal_multiplier = match binance_coin_name.as_str() {
-						"USDC" => Decimal::from(1_000_000),    // 10^6
-						"USDT" => Decimal::from(1_000_000),    // 10^6
-						"SOL" => Decimal::from(1_000_000_000), // 10^9  TODO: double check this
-						_ => {
-							log::error!("Unsupported asset: {:?}", binance_coin_name);
-							return Err(());
-						},
-					};
-					let amount_to_transfer_decimal = from_amount_decimal * asset_decimal_multiplier;
-					let Some(amount_to_transfer) = amount_to_transfer_decimal.to_u64() else {
-						log::error!("Failed to convert amount to transfer to u64");
-						return Err(());
-					};
-
-					let (trade_symbol, order_side) = match binance_coin_name.as_str() {
-						"USDC" => ("BNBUSDC".to_string(), BinanceOrderSide::BUY),
-						"USDT" => ("BNBUSDT".to_string(), BinanceOrderSide::BUY),
-						"SOL" => ("SOLBNB".to_string(), BinanceOrderSide::SELL),
-						_ => {
-							log::error!("Unsupported asset: {:?}", binance_coin_name);
-							return Err(());
-						},
-					};
-
-					let estimated_bnb_receive = estimate_bnb_amount(
-						&self.binance_api,
-						&trade_symbol,
-						&binance_coin_name,
-						from_amount_decimal,
+				// then do a single (native) chain swap
+				let res = self
+					.execute_single_chain_swap(
+						*account_id.as_ref(),
+						intent_id,
+						&access_token,
+						amount,
+						pumpx_config,
 					)
 					.await?;
-					let mut payout_amount = match str_to_u256(&estimated_bnb_receive, 18) {
-						Some(a) => a,
-						None => {
-							log::error!(
-								"Fail to convert bnb amount {} to U256",
-								estimated_bnb_receive
-							);
-							let body = CrossFailBody {
-								request_id: intent_id,
-								fail_reason:
-									"Fail to construct payout request due to U256 conversion error"
-										.to_string(),
-							};
-							self.pumpx_api.cross_fail(&access_token, body).await.map_err(|_| {
-								log::error!("Failed to notify pumpx-signer");
-							})?;
-							return Err(());
-						},
-					};
-
-					// Fetch contract balance
-					let balance = self.accounting_contract_client.get_balance().await?;
-					if balance < payout_amount {
-						log::error!(
-							"There is not enough balance in the accounting contract, {} < {}",
-							balance,
-							payout_amount
-						);
-						return Err(());
-					}
-
-					let remote_signer: Box<dyn solana_sdk::signer::Signer + Send + Sync> =
-						Box::new(RemoteSigner::new(
-							self.pumpx_signer_client.clone(),
-							pumpx_config.wallet_index,
-							*account_id.as_ref(),
-							Handle::current(),
-						));
-
-					let mut tx_id: Option<String> = None;
-					// TODO: change this when adding support for more tokens/chains
-					if binance_coin_name == "SOL" {
-						// Native transfer
-						debug!("Transfering {:?} SOL to {:?}", amount_to_transfer, deposit_address);
-						let signature = self
-							.solana_client
-							.transfer_sol(&deposit_address, amount_to_transfer, &remote_signer)
-							.await
-							.map_err(|_| {
-								log::error!("Failed to transfer SOL");
-							})?;
-						tx_id = Some(signature);
-					} else {
-						debug!(
-							"Transfering {:?} {:?} to {:?}",
-							amount_to_transfer, token_address, deposit_address
-						);
-						// SPL transfer
-						let signature = self
-							.solana_client
-							.transfer_spl(
-								&deposit_address,
-								amount_to_transfer,
-								&token_address,
-								&remote_signer,
-							)
-							.await
-							.map_err(|_| {
-								log::error!("Failed to transfer SPL");
-							})?;
-						tx_id = Some(signature);
-					}
-
-					let mut bnb_to_receive = "".to_string();
-
-					if should_wait_for_deposit_confirm {
-						debug!("Waiting for deposit to be confirmed on Binance...");
-						debug!("Deposit tx_id: {:?}", tx_id);
-						debug!("Source address: {:?}", from_address);
-						let mut deposit_confirmed = false;
-						let start_time = std::time::Instant::now();
-						let timeout = Duration::from_secs(300); // 5 minute timeout
-
-						while !deposit_confirmed && start_time.elapsed() < timeout {
-							let Ok(deposit_history) = WalletApi::new(self.binance_api.as_ref())
-								.get_deposit_history(Some(binance_coin_name.clone()), tx_id.clone())
-								.await
-							else {
-								log::error!("Failed to get deposit history");
-								continue;
-							};
-
-							// Check if there's a recent successful deposit
-							for deposit in deposit_history {
-								debug!("Deposit: {:?}", deposit);
-								if deposit.status == 2 || deposit.status == 7 {
-									// 2 = rejected, 7 = Wrong Deposit
-									log::error!("Deposit failed with status: {}", deposit.status);
-									let body = CrossFailBody {
-										request_id: intent_id,
-										fail_reason: format!(
-											"Deposit failed with status: {}",
-											deposit.status
-										),
-									};
-									self.pumpx_api.cross_fail(&access_token, body).await.map_err(
-										|_| {
-											log::error!("Failed to notify pumpx-signer");
-										},
-									)?;
-									return Err(());
-								}
-								if deposit.status == 1 && // 1 = success
-							   deposit.coin == binance_coin_name &&
-							   deposit.network == binance_network_info.network &&
-                               deposit.source_address == Some(from_address.clone())
-								{
-									deposit_confirmed = true;
-									debug!(
-										"Deposit confirmed on Binance for {} {}",
-										deposit.amount, binance_coin_name
-									);
-									break;
-								}
-								debug!("Deposit not confirmed yet, status: {}", deposit.status);
-							}
-
-							if !deposit_confirmed {
-								debug!("Deposit not confirmed yet, waiting 5 seconds...");
-								sleep(Duration::from_secs(5)).await;
-							}
-						}
-
-						if !deposit_confirmed {
-							log::error!("Deposit not confirmed within timeout period");
-							let body = CrossFailBody {
-								request_id: intent_id,
-								fail_reason: "Deposit not confirmed on Binance".to_string(),
-							};
-							self.pumpx_api.cross_fail(&access_token, body).await.map_err(|_| {
-								log::error!("Failed to notify pumpx-signer");
-							})?;
-							return Err(());
-						}
-
-						// 3. Make the trade using binance spot trading api from_asset => BNB, If it fails, notify the backend via /v3/trade/cross_fail
-						let binance_order_params = BinanceCreateOrderParams {
-							symbol: trade_symbol.clone(),
-							side: order_side.clone(),
-							order_type: BinanceOrderType::MARKET,
-							quote_order_qty: match order_side {
-								BinanceOrderSide::BUY => Some(from_amount.clone()),
-								BinanceOrderSide::SELL => None,
-							},
-							quantity: match order_side {
-								BinanceOrderSide::BUY => None,
-								BinanceOrderSide::SELL => Some(from_amount.clone()),
-							},
-							..Default::default()
-						};
-						debug!("Creating binance order with params: {:?}", binance_order_params);
-						let Ok(binance_order) = SpotTradingApi::new(self.binance_api.as_ref())
-							.create_order(binance_order_params)
-							.await
-						else {
-							log::error!("Failed to create binance order");
-							WalletApi::new(self.binance_api.as_ref())
-								.withdraw(
-									&binance_coin_name,
-									&from_address,
-									from_amount,
-									Some(&binance_network_info.network),
-								)
-								.await
-								.map_err(|e| {
-									log::error!(
-									"Failed to withdraw asset back to omni account, error: {:?}",
-									e
-								);
-								})?;
-							log::debug!("Withdrawed asset back to omni account");
-
-							let body = CrossFailBody {
-								request_id: intent_id,
-								// TODO: is this a user facing error? what should we return?
-								fail_reason: "Failed to create binance order".to_string(),
-							};
-							self.pumpx_api.cross_fail(&access_token, body).await.map_err(|_| {
-								log::error!("Failed to notify pumpx-signer");
-							})?;
-
-							return Err(());
-						};
-
-						// Binance trade pair format:
-						// <base-asset><quote-asset>, e.g. BNBUSDT, SOLBNB...
-						//
-						// SELL: sell the "base-asset" to get "quote-asset"
-						// BUY:  buy the "base-asset" with "quote-asset"
-						//
-						// executedQty: quantity of "base-asset"
-						// cummulativeQuoteQty: quantity of "quote-asset"
-						//
-						// so, in SELL orders:
-						// - `executedQty` reflects the amount of the base-asset sold
-						// - `cummulativeQuoteQty` reflects the amount of the quote-asset received
-						//
-						// in BUY orders:
-						// - `executedQty` indicates the amount of the base-asset bought
-						// - `cummulativeQuoteQty`` shows the total amount of the quote-asset spent
-						let mut trade_success = false;
-						let mut bnb_acquired = "".to_string();
-						loop {
-							let trade_order = SpotTradingApi::new(self.binance_api.as_ref())
-								.get_order(&trade_symbol, Some(binance_order.order_id), None, None)
-								.await
-								.map_err(|_| {
-									log::error!("Failed to get binance order");
-								})?;
-
-							match trade_order.status {
-								BinanceOrderStatus::FILLED => {
-									log::info!("Binance order filled");
-									bnb_acquired = match trade_order.side {
-										BinanceOrderSide::BUY => trade_order.executed_qty,
-										BinanceOrderSide::SELL => trade_order.cummulative_quote_qty,
-									};
-									trade_success = true;
-									break;
-								},
-								BinanceOrderStatus::CANCELED => {
-									log::error!("Binance order canceled");
-								},
-								BinanceOrderStatus::REJECTED => {
-									log::error!("Binance order rejected");
-								},
-								BinanceOrderStatus::EXPIRED => {
-									log::error!("Binance order expired");
-								},
-								BinanceOrderStatus::EXPIRED_IN_MATCH => {
-									log::error!("Binance order expired in matching");
-								},
-								_ => {
-									log::debug!("Binance order status: {:?}", trade_order.status);
-								},
-							}
-							//todo: how long we wait ?
-							sleep(Duration::from_millis(500)).await;
-						}
-						if !trade_success {
-							log::error!("Binance order failed");
-							WalletApi::new(self.binance_api.as_ref())
-								.withdraw(
-									&binance_coin_name,
-									&from_address,
-									from_amount,
-									Some(&binance_network_info.network),
-								)
-								.await
-								.map_err(|e| {
-									log::error!(
-									"Failed to withdraw asset back to omni account, error: {:?}",
-									e
-								);
-								})?;
-							log::debug!("Withdrawed asset back to omni account");
-
-							let body = CrossFailBody {
-								request_id: intent_id,
-								// TODO: is this a user facing error? what should we return?
-								fail_reason: "Binance order failed".to_string(),
-							};
-							self.pumpx_api.cross_fail(&access_token, body).await.map_err(|_| {
-								log::error!("Failed to notify pumpx-signer");
-							})?;
-
-							return Err(());
-						}
-
-						debug!("Total acquired {} bnb", bnb_acquired);
-
-						// We need to recalculate payout amount based on the order filled
-						payout_amount = match str_to_u256(&bnb_acquired, 18) {
-							Some(a) => a,
-							None => {
-								log::error!(
-									"Fail to convert bnb amount {} to U256",
-									bnb_to_receive
-								);
-								let body = CrossFailBody {
-									request_id: intent_id,
-									fail_reason:
-									"Fail to construct payout request due to U256 conversion error"
-										.to_string(),
-								};
-								self.pumpx_api.cross_fail(&access_token, body).await.map_err(
-									|_| {
-										log::error!("Failed to notify pumpx-signer");
-									},
-								)?;
-								// TODO: what to do with user asset?
-								return Err(());
-							},
-						};
-
-						bnb_to_receive = bnb_acquired
-					} else {
-						// Estimate BNB payout (simulate spot trade, apply service fee)
-						bnb_to_receive = estimated_bnb_receive;
-					}
-
-					let payout_address = Address::from_str(&to_address).map_err(|_| {
-						log::error!("Failed to parse payout address");
-					})?;
-
-					debug!("Getting {:?} nonce for payout request", payout_address);
-					// 4. Call accounting contract on BSC
-					let user_nonce =
-						self.accounting_contract_client.get_nonce(payout_address).await.map_err(
-							|_| {
-								log::error!("Failed to get nonce");
-							},
-						)?;
-
-					debug!("Received {:?} nonce", user_nonce);
-					let user_nonce = user_nonce + U256::from(1u64);
-					debug!("Calling accounting contract payout with address {:?}, nonce {:?} and amount {:?}", payout_address, user_nonce, payout_amount);
-
-					self.accounting_contract_client
-						.execute_pay_out_request(payout_address, user_nonce, payout_amount)
-						.await
-						.map_err(|_| {
-							log::error!("Failed to execute pay out request");
-						})?;
-
-					debug!("Calling pumpx get_gas_info, chain_id: {}", pumpx_config.to_chain_id);
-					let res = self
-						.pumpx_api
-						.get_gas_info(&access_token, pumpx_config.to_chain_id)
-						.await
-						.map_err(|_| {
-							log::error!("Failed to get gas info");
-						})?;
-					debug!("Response get_gas_info: {:?}", res);
-
-					let Some(gas_info_vec) = res.data.gas_info else {
-						log::error!("Response data.gas_info of call get gas info is none");
-						return Err(());
-					};
-					let Some(gas_info) = gas_info_vec
-						.iter()
-						.find(|g| g.chain_id == pumpx_config.to_chain_id.to_string())
-					else {
-						log::error!(
-							"Could not find matching gas_info with chain_id {}",
-							pumpx_config.to_chain_id
-						);
-						return Err(());
-					};
-
-					let gas_fee = match pumpx_config.gas_type {
-						1 => &gas_info.normal,
-						2 => &gas_info.fast,
-						3 => &gas_info.super_fast,
-						_ => {
-							log::error!("Unsupported gas type: {}", pumpx_config.gas_type);
-							return Err(());
-						},
-					};
-					debug!("Gas fee for chain_id {} is {}", pumpx_config.to_chain_id, gas_fee);
-
-					let amount_in = match calculate_amount_in(&bnb_to_receive, gas_fee, 18) {
-						Some(a) => a,
-						None => {
-							log::error!(
-								"Fail to calculate amount_in from amount {}, gas {}",
-								bnb_to_receive,
-								gas_fee
-							);
-							let body = CrossFailBody {
-								request_id: intent_id,
-								fail_reason: "Fail to calculate amount_in".to_string(),
-							};
-							self.pumpx_api.cross_fail(&access_token, body).await.map_err(|_| {
-								log::error!("Failed to notify pumpx-signer");
-							})?;
-							// TODO: what to do with user asset?
-							return Err(());
-						},
-					};
-
-					debug!("Doing market order");
-					let body = CreateMarketOrderUnsignedTxBody {
-						request_id: intent_id,
-						chain_id: pumpx_config.to_chain_id,
-						token_ca: to_token_ca.clone(),
-						swap_type: match pumpx_config.swap_type {
-							1 => SwapType::Buy,
-							2 => SwapType::Sell,
-							_ => {
-								log::error!("Unsupported swap type: {}", pumpx_config.swap_type);
-								return Err(());
-							},
-						},
-						amount_in,
-						double_out: pumpx_config.double_out,
-						is_one_click: pumpx_config.is_one_click,
-						address: pubkey_to_evm_address(&to_wallet_address)?,
-						is_anti_mev: pumpx_config.is_anti_mev,
-						is_auto_slippage: pumpx_config.is_auto_slippage,
-						gas_type: match pumpx_config.gas_type {
-							1 => GasType::Slow,
-							2 => GasType::Medium,
-							3 => GasType::Fast,
-							_ => {
-								log::error!("Unsupported gas type: {}", pumpx_config.gas_type);
-								return Err(());
-							},
-						},
-						slippage: pumpx_config.slippage,
-						wallet_index: pumpx_config.wallet_index,
-						recipient_address: String::from(""),
-					};
-					debug!("Calling pumpx create_market_order_tx, body: {:?}", body);
-
-					let response = self
-						.create_market_order_tx(&access_token, body, account_id)
-						.await
-						.map_err(|_| log::error!("Failed to create and submit market order tx"))?;
-
-					debug!("Response create_market_order_tx: {:?}", response);
-					result = (Some(response.encode()), true);
-				}
 
 				// self.account_asset_lock.release(
 				// 	account_id.clone(),
@@ -1066,11 +278,11 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait> IntentExecutor
 				// 	})?,
 				// )?;
 
-				return Ok(result);
+				Ok((Some(res), should_notify_parentchain))
 			},
 			_ => {
 				log::error!("[CrossChainIntentExecutor]: Unsupported intent: {:?}", intent);
-				return Err(());
+				Err(())
 			},
 		}
 	}
@@ -1149,88 +361,4 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 
 		Ok(response)
 	}
-}
-
-fn str_to_u256(amount: &str, decimals: u32) -> Option<U256> {
-	let amount = Decimal::from_str(amount).ok()?;
-	let factor = Decimal::from(10u64.pow(decimals));
-	let scaled = amount * factor;
-	let int_str = scaled.trunc().to_string();
-	U256::from_str(&int_str).ok()
-}
-
-fn calculate_amount_in(amount: &str, gas: &str, decimals: u32) -> Option<String> {
-	let amount = Decimal::from_str(amount).ok()?;
-	let gas = Decimal::from_str(gas).ok()?;
-	if amount <= gas {
-		None
-	} else {
-		let amount = amount - gas;
-		Some(amount.trunc_with_scale(decimals).to_string())
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn test_str_to_u256() {
-		let amount = "0.0050773374896233926847036101";
-		let decimals = 18;
-
-		let result = str_to_u256(amount, decimals);
-		assert_eq!(result, Some(U256::from_str("5077337489623392").unwrap()));
-	}
-
-	#[test]
-	fn test_calculate_amount_in() {
-		let bnb_to_receive = "0.0050773374896233926847036101";
-		let gas = "0.0004731804";
-		let decimals = 18;
-
-		let result = calculate_amount_in(bnb_to_receive, gas, decimals);
-		assert_eq!(result, Some("0.004604157089623392".to_string()));
-	}
-}
-
-async fn estimate_bnb_amount<BinanceClient: BinanceApi>(
-	binance_api: &Arc<BinanceClient>,
-	trade_symbol: &str,
-	binance_coin_name: &str,
-	from_amount_decimal: Decimal,
-) -> Result<String, ()> {
-	let price_str = SpotTradingApi::new(binance_api.as_ref())
-		.get_symbol_price(trade_symbol)
-		.await
-		.map_err(|_| {
-			log::error!("Failed to get symbol price for {}", trade_symbol);
-		})?;
-
-	let price = if binance_coin_name == "SOL" {
-		// For SOL, we sell SOL to get BNB, so get SOLBNB price
-		Decimal::from_str(&price_str).map_err(|_| {
-			log::error!("Failed to parse symbol price {}", price_str);
-		})?
-	} else {
-		// For USDC/USDT, we buy BNB with USDC/USDT, so get BNBUSDC/BNBUSDT price and invert
-		let price = Decimal::from_str(&price_str).map_err(|_| {
-			log::error!("Failed to parse symbol price {}", price_str);
-		})?;
-		if price.is_zero() {
-			log::error!("Symbol price is zero for {}", trade_symbol);
-			return Err(());
-		}
-		Decimal::ONE / price
-	};
-
-	let bnb_estimated = from_amount_decimal * price;
-
-	// Apply 0.1% service fee
-	let service_fee_rate = Decimal::from_str("0.001").expect("Failed to parse service fee rate");
-	let decimal_bnb_to_receive = bnb_estimated * (Decimal::ONE - service_fee_rate);
-
-	debug!("BNB estimated: {}, after 0.1% fee: {}", bnb_estimated, decimal_bnb_to_receive);
-
-	Ok(decimal_bnb_to_receive.to_string())
 }

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain.rs
@@ -1,0 +1,330 @@
+use super::*;
+use executor_primitives::PumpxConfig;
+use log::{debug, error};
+use sp_core::keccak_256;
+
+impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
+	CrossChainIntentExecutor<BinanceClient, SolanaClient>
+{
+	pub async fn execute_single_chain_swap(
+		&self,
+		omni_account: [u8; 32],
+		intent_id: IntentId,
+		access_token: &str,
+		amount: String,
+		pumpx_config: &PumpxConfig,
+	) -> Result<Vec<u8>, ()> {
+		debug!("executing single chain swap");
+
+		let Some(to_chain_type) = ChainType::from_pumpx_chain_id(pumpx_config.to_chain_id) else {
+			error!("Unsupported to_chain_id: {}", pumpx_config.to_chain_id);
+			return Err(());
+		};
+
+		let to_wallet = self
+			.pumpx_signer_client
+			.request_wallet(to_chain_type, pumpx_config.wallet_index, omni_account.clone())
+			.await
+			.map_err(|e| error!("Could not get to_wallet from pumpx-signer: {:?}", e))?;
+
+		let to_address = pubkey_to_address(to_chain_type, &to_wallet)?;
+
+		// always use `to_token_ca` from RPC
+		let token_ca = std::str::from_utf8(&pumpx_config.to_token_ca)
+			.map_err(|_| {
+				error!("Failed to parse to_token_ca");
+			})
+			.map(|v| v.to_string())?;
+
+		match pumpx_config.order_type {
+			PumpxOrderType::Market => {
+				debug!("Doing market order");
+
+				// evm market order => worker constructs, signs and sends it
+				// solana market order => pumpx (backend) constructs, signs and sends it => TODO
+				match to_chain_type {
+					ChainType::Evm => {
+						self.worker_do_market_order(
+							omni_account,
+							intent_id,
+							to_address.clone(),
+							amount,
+							token_ca,
+							to_address,
+							access_token,
+							pumpx_config,
+						)
+						.await
+					},
+					ChainType::Solana => {
+						self.pumpx_do_market_order(
+							intent_id,
+							amount,
+							token_ca,
+							to_address,
+							access_token,
+							pumpx_config,
+						)
+						.await
+					},
+					_ => {
+						error!("Unsupported chain_type");
+						Err(())
+					},
+				}
+			},
+			PumpxOrderType::Limit => {
+				debug!("Doing limit order");
+				let token_cap = match pumpx_config.token_cap {
+					Some(ref token_cap) => Some(
+						std::str::from_utf8(token_cap)
+							.map_err(|_| {
+								log::error!("Failed to parse token_cap");
+							})
+							.map(|v| v.to_string())?,
+					),
+					None => None,
+				};
+				let price_usd = match pumpx_config.price_usd {
+					Some(ref price_usd) => Some(
+						std::str::from_utf8(price_usd)
+							.map_err(|_| {
+								log::error!("Failed to parse price_usd");
+							})
+							.map(|v| v.to_string())?,
+					),
+					None => None,
+				};
+
+				self.do_limit_order(
+					intent_id,
+					amount,
+					token_ca,
+					to_address,
+					token_cap,
+					price_usd,
+					access_token,
+					pumpx_config,
+				)
+				.await
+			},
+		}
+	}
+
+	// call backend API in one step - it requires backend has signing access to signer, which will be gradually deprecated
+	async fn pumpx_do_market_order(
+		&self,
+		intent_id: IntentId,
+		amount: String,
+		token_ca: String,
+		recipient_address: String,
+		access_token: &str,
+		pumpx_config: &PumpxConfig,
+	) -> Result<Vec<u8>, ()> {
+		debug!("executing pumpx_do_market_order");
+		let body = CreateMarketOrderTxBody {
+			request_id: intent_id,
+			chain_id: pumpx_config.to_chain_id,
+			token_ca,
+			swap_type: match pumpx_config.swap_type {
+				1 => SwapType::Buy,
+				2 => SwapType::Sell,
+				_ => {
+					log::error!("Unsupported swap type: {}", pumpx_config.swap_type);
+					return Err(());
+				},
+			},
+			amount_in: amount,
+			double_out: pumpx_config.double_out,
+			is_one_click: pumpx_config.is_one_click,
+			address: recipient_address,
+			is_anti_mev: pumpx_config.is_anti_mev,
+			is_auto_slippage: pumpx_config.is_auto_slippage,
+			gas_type: match pumpx_config.gas_type {
+				1 => GasType::Slow,
+				2 => GasType::Medium,
+				3 => GasType::Fast,
+				_ => {
+					log::error!("Unsupported gas type: {}", pumpx_config.gas_type);
+					return Err(());
+				},
+			},
+			slippage: pumpx_config.slippage,
+			wallet_index: pumpx_config.wallet_index,
+		};
+		debug!("Calling pumpx create_market_order_tx, body: {:?}", body);
+		let response =
+			self.pumpx_api.create_market_order_tx(&access_token, body).await.map_err(|_| {
+				log::error!("Failed to create market order tx");
+			})?;
+
+		debug!("Response create_market_order_tx: {:?}", response);
+		Ok(response.encode())
+	}
+
+	// call backend API in two steps, only worker has signing access to signer in this case
+	async fn worker_do_market_order(
+		&self,
+		omni_account: [u8; 32],
+		intent_id: IntentId,
+		initiator_address: String, // the address that initiates/places the market order
+		amount: String,
+		token_ca: String,
+		recipient_address: String,
+		access_token: &str,
+		pumpx_config: &PumpxConfig,
+	) -> Result<Vec<u8>, ()> {
+		debug!("executing worker_do_market_order");
+		let body = CreateMarketOrderUnsignedTxBody {
+			request_id: intent_id,
+			chain_id: pumpx_config.to_chain_id,
+			token_ca,
+			swap_type: match pumpx_config.swap_type {
+				1 => SwapType::Buy,
+				2 => SwapType::Sell,
+				_ => {
+					log::error!("Unsupported swap type: {}", pumpx_config.swap_type);
+					return Err(());
+				},
+			},
+			amount_in: amount,
+			double_out: pumpx_config.double_out,
+			is_one_click: pumpx_config.is_one_click,
+			address: initiator_address,
+			is_anti_mev: pumpx_config.is_anti_mev,
+			is_auto_slippage: pumpx_config.is_auto_slippage,
+			gas_type: match pumpx_config.gas_type {
+				1 => GasType::Slow,
+				2 => GasType::Medium,
+				3 => GasType::Fast,
+				_ => {
+					log::error!("Unsupported gas type: {}", pumpx_config.gas_type);
+					return Err(());
+				},
+			},
+			slippage: pumpx_config.slippage,
+			wallet_index: pumpx_config.wallet_index,
+			recipient_address,
+		};
+
+		let response = self
+			.pumpx_api
+			.create_market_order_unsigned_tx(access_token, body)
+			.await
+			.map_err(|_| log::error!("Failed to get unsigned market order tx"))?;
+
+		debug!("Response create_market_order_unsigned_tx: {:?}", response);
+
+		let unsigned_tx_string = response.data.tx_data.ok_or_else(|| {
+			log::error!("Failed to unwrap tx_data");
+		})?;
+		let order_id = response.data.order_id.ok_or_else(|| {
+			log::error!("Failed to unwrap order_id");
+		})?;
+		let chain_id = response.data.chain_id.ok_or_else(|| {
+			log::error!("Failed to unwrap chain_id");
+		})?;
+
+		let unsigned_tx_bytes = unsigned_tx_string
+			.iter()
+			.map(|s| {
+				let hex_str = s.trim_start_matches("0x");
+				let hex_decoded = hex::decode(hex_str).expect("Invalid hex string");
+				keccak_256(&hex_decoded).to_vec()
+			})
+			.collect();
+
+		let signatures = self
+			.pumpx_signer_client
+			.request_signatures(
+				ChainType::Evm,
+				pumpx_config.wallet_index,
+				omni_account,
+				unsigned_tx_bytes,
+			)
+			.await?;
+
+		let mut tx_data: Vec<String> = vec![];
+		for (x, y) in unsigned_tx_string.into_iter().zip(signatures.into_iter()) {
+			let bytes = hex::decode(x.trim_start_matches("0x"))
+				.map_err(|_| log::error!("invalid hex string"))?;
+			// We should be able to decode it to Legacy Transaction
+			// As it is RLP Encoded Bytes which adheres to string encoding rules
+			let unsigned_tx = TxLegacy::decode(&mut &bytes[..])
+				.map_err(|_| log::error!("Failed to decode legacy tx"))?;
+			let signature = PrimitiveSignature::try_from(y.as_ref())
+				.map_err(|_| log::error!("Failed to create Typed signature"))?;
+
+			let signed_tx = unsigned_tx.into_signed(signature);
+			let mut encoded_signed_tx = vec![];
+			signed_tx.rlp_encode(&mut encoded_signed_tx);
+			tx_data.push(hex::encode(encoded_signed_tx));
+		}
+
+		let response = self
+			.pumpx_api
+			.send_order_tx(access_token, SendOrderTxBody { order_id, chain_id, tx_data })
+			.await
+			.map_err(|_| log::error!("Failed to send order tx"))?;
+
+		debug!("Response send_order_tx: {:?}", response);
+
+		Ok(response.encode())
+	}
+
+	async fn do_limit_order(
+		&self,
+		intent_id: IntentId,
+		amount: String,
+		token_ca: String,
+		recipient_address: String,
+		token_cap: Option<String>,
+		price_usd: Option<String>,
+		access_token: &str,
+		pumpx_config: &PumpxConfig,
+	) -> Result<Vec<u8>, ()> {
+		let new_limit_order = CreateLimitOrderBody {
+			request_id: intent_id,
+			chain_id: pumpx_config.to_chain_id,
+			token_ca,
+			amount,
+			swap_type: match pumpx_config.swap_type {
+				1 => SwapType::Buy,
+				2 => SwapType::Sell,
+				_ => {
+					log::error!("Unsupported swap type: {}", pumpx_config.swap_type);
+					return Err(());
+				},
+			},
+			double_out: pumpx_config.double_out,
+			token_cap,
+			price_usd,
+			trailing_percent: pumpx_config.trailing_percent.map(|v| v.to_string()),
+			address: recipient_address,
+			is_anti_mev: pumpx_config.is_anti_mev,
+			is_auto_slippage: pumpx_config.is_auto_slippage,
+			gas_type: match pumpx_config.gas_type {
+				1 => GasType::Slow,
+				2 => GasType::Medium,
+				3 => GasType::Fast,
+				_ => {
+					log::error!("Unsupported gas type: {}", pumpx_config.gas_type);
+					return Err(());
+				},
+			},
+			slippage: pumpx_config.slippage,
+			wallet_index: pumpx_config.wallet_index,
+		};
+		debug!("Calling pumpx create_limit_order, order: {:?}", new_limit_order);
+		let response = self
+			.pumpx_api
+			.create_limit_order(&access_token, new_limit_order)
+			.await
+			.map_err(|_| {
+				log::error!("Failed to create limit order");
+			})?;
+
+		debug!("Response create_limit_order: {:?}", response);
+		Ok(response.encode())
+	}
+}

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain.rs
@@ -258,7 +258,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 			let signed_tx = unsigned_tx.into_signed(signature);
 			let mut encoded_signed_tx = vec![];
 			signed_tx.rlp_encode(&mut encoded_signed_tx);
-			tx_data.push(hex::encode(encoded_signed_tx));
+			tx_data.push(format!("0x{}", hex::encode(encoded_signed_tx)));
 		}
 
 		let response = self

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain.rs
@@ -23,7 +23,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 
 		let to_wallet = self
 			.pumpx_signer_client
-			.request_wallet(to_chain_type, pumpx_config.wallet_index, omni_account.clone())
+			.request_wallet(to_chain_type, pumpx_config.wallet_index, omni_account)
 			.await
 			.map_err(|e| error!("Could not get to_wallet from pumpx-signer: {:?}", e))?;
 
@@ -154,7 +154,7 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 		};
 		debug!("Calling pumpx create_market_order_tx, body: {:?}", body);
 		let response =
-			self.pumpx_api.create_market_order_tx(&access_token, body).await.map_err(|_| {
+			self.pumpx_api.create_market_order_tx(access_token, body).await.map_err(|_| {
 				log::error!("Failed to create market order tx");
 			})?;
 
@@ -316,13 +316,12 @@ impl<BinanceClient: BinanceApi, SolanaClient: SolanaClientTrait>
 			wallet_index: pumpx_config.wallet_index,
 		};
 		debug!("Calling pumpx create_limit_order, order: {:?}", new_limit_order);
-		let response = self
-			.pumpx_api
-			.create_limit_order(&access_token, new_limit_order)
-			.await
-			.map_err(|_| {
-				log::error!("Failed to create limit order");
-			})?;
+		let response =
+			self.pumpx_api.create_limit_order(access_token, new_limit_order).await.map_err(
+				|_| {
+					log::error!("Failed to create limit order");
+				},
+			)?;
 
 		debug!("Response create_limit_order: {:?}", response);
 		Ok(response.encode())

--- a/tee-worker/omni-executor/pumpx/src/lib.rs
+++ b/tee-worker/omni-executor/pumpx/src/lib.rs
@@ -30,6 +30,8 @@ use executor_primitives::ChainAsset;
 use log::error;
 use sp_core::keccak_256;
 
+use crate::signer_client::ChainType;
+
 pub fn chain_asset_to_pumpx_chain_id(asset: &ChainAsset) -> u32 {
 	match asset {
 		ChainAsset::Ethereum(id, _) => *id,
@@ -37,7 +39,7 @@ pub fn chain_asset_to_pumpx_chain_id(asset: &ChainAsset) -> u32 {
 	}
 }
 
-pub fn pubkey_to_evm_address_bytes(pubkey: &[u8]) -> Result<[u8; 20], ()> {
+fn pubkey_to_evm_address_bytes(pubkey: &[u8]) -> Result<[u8; 20], ()> {
 	let pubkey: [u8; 33] = pubkey.try_into().map_err(|_| {
 		error!("wrong pubkey length: expect 33 bytes");
 	})?;
@@ -52,10 +54,6 @@ pub fn pubkey_to_evm_address_bytes(pubkey: &[u8]) -> Result<[u8; 20], ()> {
 	Ok(keccak_256(&uncompressed_pubkey[1..])[12..].try_into().unwrap())
 }
 
-pub fn hex_encode_evm_address_bytes(bytes: &[u8]) -> String {
-	format!("0x{}", hex::encode(bytes))
-}
-
 pub fn pubkey_to_evm_address(pubkey: &[u8]) -> Result<String, ()> {
 	pubkey_to_evm_address_bytes(pubkey).map(|bytes| to_checksum(&bytes.into(), None))
 }
@@ -65,4 +63,15 @@ pub fn pubkey_to_solana_address(pubkey: &[u8]) -> Result<String, ()> {
 		error!("wrong pubkey length: expect 32 bytes");
 	})?;
 	Ok(pubkey.to_base58())
+}
+
+pub fn pubkey_to_address(chain_type: ChainType, pubkey: &[u8]) -> Result<String, ()> {
+	match chain_type {
+		ChainType::Evm => pubkey_to_evm_address(&pubkey),
+		ChainType::Solana => pubkey_to_solana_address(&pubkey),
+		_ => {
+			log::error!("Unsupported {:?} wallet address", chain_type);
+			Err(())
+		},
+	}
 }

--- a/tee-worker/omni-executor/pumpx/src/lib.rs
+++ b/tee-worker/omni-executor/pumpx/src/lib.rs
@@ -67,8 +67,8 @@ pub fn pubkey_to_solana_address(pubkey: &[u8]) -> Result<String, ()> {
 
 pub fn pubkey_to_address(chain_type: ChainType, pubkey: &[u8]) -> Result<String, ()> {
 	match chain_type {
-		ChainType::Evm => pubkey_to_evm_address(&pubkey),
-		ChainType::Solana => pubkey_to_solana_address(&pubkey),
+		ChainType::Evm => pubkey_to_evm_address(pubkey),
+		ChainType::Solana => pubkey_to_solana_address(pubkey),
 		_ => {
 			log::error!("Unsupported {:?} wallet address", chain_type);
 			Err(())


### PR DESCRIPTION
### Context

As topic

The PR tries to split the big `CrossChainIntentExecutor::execute` into smaller logic units/files, so that it's more readable and easy to maintain.

It populates the `recipient_address` in every case too.

There will be a few more readability improvements incoming, but much smaller than this one.