### PR TITLE
Including omni-executor's SGX enclave signature info in the release notes

### DIFF
--- a/parachain/scripts/generate-release-notes.sh
+++ b/parachain/scripts/generate-release-notes.sh
@@ -219,7 +219,7 @@ client version               : $WORKER_VERSION
 client name                  : $WORKER_BIN
 rustc                        : $WORKER_RUSTC_VERSION
 docker image                 : litentry/omni-executor:$OMNI_EXECUTOR_DOCKER_TAG
-sigstruct info
+SGX enclave info
 $SIGSTRUCT
 <CODEBLOCK>
 

--- a/parachain/scripts/generate-release-notes.sh
+++ b/parachain/scripts/generate-release-notes.sh
@@ -209,6 +209,8 @@ if is_omni_executor_release; then
   WORKER_VERSION=$(grep '^version' tee-worker/omni-executor/executor-worker/Cargo.toml | head -n1 | sed -E 's/^version *= *["'\''](.*)["'\'']/\1/')
   WORKER_BIN=$(grep '^name' tee-worker/omni-executor/executor-worker/Cargo.toml | head -n1 | sed -E 's/^name *= *["'\''](.*)["'\'']/\1/')
   WORKER_RUSTC_VERSION=$(cd tee-worker/omni-executor && rustc --version)
+  docker run --rm --entrypoint gramine-sgx-sigstruct-view -v /var/run/aesmd:/var/run/aesmd litentry/omni-executor:$OMNI_EXECUTOR_DOCKER_TAG omni-executor.sig > enclave-sigstruct.txt
+  SIGSTRUCT=$(<enclave-sigstruct.txt)
 cat << EOF >> "$1"
 ## Omni-Executor
 
@@ -217,6 +219,8 @@ client version               : $WORKER_VERSION
 client name                  : $WORKER_BIN
 rustc                        : $WORKER_RUSTC_VERSION
 docker image                 : litentry/omni-executor:$OMNI_EXECUTOR_DOCKER_TAG
+sigstruct info
+$SIGSTRUCT
 <CODEBLOCK>
 
 EOF


### PR DESCRIPTION
This pull request updates the `generate-release-notes.sh` script to include additional information about the Omni-Executor's enclave signature structure in the release notes. (MRENCLAVE, MRSIGNER, etc.)


