### PR TITLE
Deterministic binary build for Gramine

### DIFF
--- a/tee-worker/omni-executor/Dockerfile
+++ b/tee-worker/omni-executor/Dockerfile
@@ -69,7 +69,7 @@ ENV BUILD_DIR=$HOME/tee-worker/omni-executor
 COPY . $HOME
 WORKDIR $BUILD_DIR
 
-RUN make SGX=1 SGX_DEBUG=0
+RUN make SGX=1 SGX_DEBUG=0 SOURCE_DATE_EPOCH=1700000000 CARGO_PROFILE_RELEASE_DEBUG=false
 
 
 ### Release image (with SGX Hardware)

--- a/tee-worker/omni-executor/Makefile
+++ b/tee-worker/omni-executor/Makefile
@@ -19,7 +19,7 @@ endif
 
 .PHONY: $(BIN_NAME)
 $(BIN_NAME):
-	cargo build --release --features=$(COMPILATION_FEATURES)
+	cargo build --release --locked --features=$(COMPILATION_FEATURES)
 	cp target/release/executor-worker $(BIN_NAME)
 
 


### PR DESCRIPTION
Slightly adjusts `omni-executor` binary build process in order to achieve bitwise identical output of two different runs.
This will ensure that two builds results in same `MRENCLAVE` value.