### PR TITLE
Refactor PumpxConfig and swap providers for simpler string handling

### DIFF
--- a/common/primitives/core/Cargo.lock
+++ b/common/primitives/core/Cargo.lock
@@ -2581,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",

--- a/common/primitives/core/src/omni/intent.rs
+++ b/common/primitives/core/src/omni/intent.rs
@@ -28,7 +28,7 @@ pub enum Intent {
     Swap(
         SwapOrder,
         Option<CrossChainSwapProvider>,
-        SingleChainSwapProvider,
+        OnChainSingleChainSwapProvider,
     ),
 }
 
@@ -83,14 +83,72 @@ pub struct BinanceConfig {
     // placeholder
 }
 
-#[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
-pub enum SingleChainSwapProvider {
-    Pumpx(PumpxConfig),
+#[derive(Deserialize, Debug, Clone)]
+pub struct PumpxConfig {
+    pub order_type: PumpxOrderType,
+    pub swap_type: u32, // 1：buy 2：sell
+    pub from_chain_id: u32,
+    pub from_token_ca: String,
+    pub to_chain_id: u32,
+    pub to_token_ca: String,
+    pub from_amount: String,
+    pub double_out: bool,
+    pub is_one_click: bool,
+    pub is_anti_mev: bool,
+    pub is_auto_slippage: bool,
+    pub gas_type: u32, // 1: slow, 2: medium, 3: fast
+    pub slippage: u32,
+    pub wallet_index: u32,
+
+    // below is only relevant to limit order, thus `Option<>`
+    pub token_cap: Option<String>,
+    pub price_usd: Option<String>,
+    pub usd_worth: String,
+    pub trailing_percent: Option<u32>,
+}
+
+impl PumpxConfig {
+    pub fn is_cross_chain(&self) -> bool {
+        self.from_chain_id != self.to_chain_id
+    }
+}
+
+impl TryFrom<OnChainPumpxConfig> for PumpxConfig {
+    type Error = ();
+
+    fn try_from(config: OnChainPumpxConfig) -> Result<Self, Self::Error> {
+        Ok(PumpxConfig {
+            order_type: config.order_type,
+            swap_type: config.swap_type,
+            from_chain_id: config.from_chain_id,
+            from_token_ca: String::from_utf8(config.from_token_ca.to_vec()).map_err(|_| ())?,
+            to_chain_id: config.to_chain_id,
+            to_token_ca: String::from_utf8(config.to_token_ca.to_vec()).map_err(|_| ())?,
+            from_amount: String::from_utf8(config.from_amount.to_vec()).map_err(|_| ())?,
+            double_out: config.double_out,
+            is_one_click: config.is_one_click,
+            is_anti_mev: config.is_anti_mev,
+            is_auto_slippage: config.is_auto_slippage,
+            gas_type: config.gas_type,
+            slippage: config.slippage,
+            wallet_index: config.wallet_index,
+            token_cap: config
+                .token_cap
+                .map(|v| String::from_utf8(v.to_vec()).map_err(|_| ()))
+                .transpose()?,
+            price_usd: config
+                .price_usd
+                .map(|v| String::from_utf8(v.to_vec()).map_err(|_| ()))
+                .transpose()?,
+            usd_worth: String::from_utf8(config.usd_worth.to_vec()).map_err(|_| ())?,
+            trailing_percent: config.trailing_percent,
+        })
+    }
 }
 
 // basically copied from pumpx API
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
-pub struct PumpxConfig {
+pub struct OnChainPumpxConfig {
     pub order_type: PumpxOrderType,
     pub swap_type: u32, // 1：buy 2：sell
     pub from_chain_id: u32,
@@ -113,9 +171,40 @@ pub struct PumpxConfig {
     pub trailing_percent: Option<u32>,
 }
 
-impl PumpxConfig {
-    pub fn is_cross_chain(&self) -> bool {
-        self.from_chain_id != self.to_chain_id
+impl TryFrom<PumpxConfig> for OnChainPumpxConfig {
+    type Error = ();
+
+    fn try_from(config: PumpxConfig) -> Result<Self, Self::Error> {
+        Ok(OnChainPumpxConfig {
+            order_type: config.order_type,
+            swap_type: config.swap_type,
+            from_chain_id: config.from_chain_id,
+            from_token_ca: BoundedVec::try_from(config.from_token_ca.as_bytes().to_vec())
+                .map_err(|_| ())?,
+            to_chain_id: config.to_chain_id,
+            to_token_ca: BoundedVec::try_from(config.to_token_ca.as_bytes().to_vec())
+                .map_err(|_| ())?,
+            from_amount: BoundedVec::try_from(config.from_amount.as_bytes().to_vec())
+                .map_err(|_| ())?,
+            double_out: config.double_out,
+            is_one_click: config.is_one_click,
+            is_anti_mev: config.is_anti_mev,
+            is_auto_slippage: config.is_auto_slippage,
+            gas_type: config.gas_type,
+            slippage: config.slippage,
+            wallet_index: config.wallet_index,
+            token_cap: config
+                .token_cap
+                .map(|v| BoundedVec::try_from(v.as_bytes().to_vec()).map_err(|_| ()))
+                .transpose()?,
+            price_usd: config
+                .price_usd
+                .map(|v| BoundedVec::try_from(v.as_bytes().to_vec()).map_err(|_| ()))
+                .transpose()?,
+            usd_worth: BoundedVec::try_from(config.usd_worth.as_bytes().to_vec())
+                .map_err(|_| ())?,
+            trailing_percent: config.trailing_percent,
+        })
     }
 }
 
@@ -124,4 +213,40 @@ impl PumpxConfig {
 pub enum PumpxOrderType {
     Market,
     Limit,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub enum SingleChainSwapProvider {
+    Pumpx(PumpxConfig),
+}
+
+impl TryFrom<OnChainSingleChainSwapProvider> for SingleChainSwapProvider {
+    type Error = ();
+
+    fn try_from(scsp: OnChainSingleChainSwapProvider) -> Result<Self, Self::Error> {
+        match scsp {
+            OnChainSingleChainSwapProvider::Pumpx(pumpx_config) => {
+                let pumpx_config = PumpxConfig::try_from(pumpx_config)?;
+                Ok(SingleChainSwapProvider::Pumpx(pumpx_config))
+            }
+        }
+    }
+}
+
+#[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+pub enum OnChainSingleChainSwapProvider {
+    Pumpx(OnChainPumpxConfig),
+}
+
+impl TryFrom<SingleChainSwapProvider> for OnChainSingleChainSwapProvider {
+    type Error = ();
+
+    fn try_from(scsp: SingleChainSwapProvider) -> Result<Self, Self::Error> {
+        match scsp {
+            SingleChainSwapProvider::Pumpx(pumpx_config) => {
+                let on_chain_config = OnChainPumpxConfig::try_from(pumpx_config)?;
+                Ok(OnChainSingleChainSwapProvider::Pumpx(on_chain_config))
+            }
+        }
+    }
 }

--- a/common/primitives/core/src/omni/intent.rs
+++ b/common/primitives/core/src/omni/intent.rs
@@ -1,4 +1,5 @@
 use crate::{AccountId, Address20, Address32, Address33, Balance, BoundedVec, ChainAsset};
+use alloc::string::String;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::Deserialize;

--- a/parachain/runtime/heima/src/lib.rs
+++ b/parachain/runtime/heima/src/lib.rs
@@ -231,7 +231,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("heima"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9241,
+	spec_version: 9242,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -233,7 +233,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("heima"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9241,
+	spec_version: 9242,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/tee-worker/omni-executor/intent/executors/cross-chain/Cargo.toml
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/Cargo.toml
@@ -25,6 +25,7 @@ executor-core = { workspace = true }
 executor-primitives = { workspace = true }
 executor-storage = { workspace = true }
 heima-authentication = { workspace = true }
+heima-primitives = { workspace = true }
 intent-asset-lock = { workspace = true }
 intent-token-query = { workspace = true }
 parentchain-api-interface = { workspace = true }

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
@@ -1,7 +1,8 @@
 // TODO: put it into a mod for potential different providers (other than binance)
 
 use super::*;
-use executor_primitives::{PumpxConfig, SwapOrder};
+use executor_primitives::SwapOrder;
+use heima_primitives::PumpxConfig;
 use tracing::{debug, error, info};
 
 impl<
@@ -24,31 +25,6 @@ impl<
 			error!("Only market order supported");
 			return Err(());
 		}
-
-		// extract values from pumpx_config
-		let usd_worth = std::str::from_utf8(&pumpx_config.usd_worth)
-			.map_err(|_| {
-				error!("Failed to parse usd_worth");
-			})
-			.map(|v| v.to_string())?;
-
-		let from_token_ca = std::str::from_utf8(&pumpx_config.from_token_ca)
-			.map_err(|_| {
-				error!("Failed to parse from_token_ca");
-			})
-			.map(|v| v.to_string())?;
-
-		let to_token_ca = std::str::from_utf8(&pumpx_config.to_token_ca)
-			.map_err(|_| {
-				error!("Failed to parse to_token_ca");
-			})
-			.map(|v| v.to_string())?;
-
-		let from_amount = std::str::from_utf8(&pumpx_config.from_amount)
-			.map_err(|_| {
-				error!("Failed to parse from_amount");
-			})
-			.map(|v| v.to_string())?;
 
 		let Some(from_chain_type) = ChainType::from_pumpx_chain_id(pumpx_config.from_chain_id)
 		else {
@@ -79,10 +55,10 @@ impl<
 
 		self.pumpx_create_cross_order(
 			intent_id,
-			from_token_ca.clone(),
-			to_token_ca.clone(),
-			from_amount.clone(),
-			usd_worth,
+			pumpx_config.from_token_ca.clone(),
+			pumpx_config.to_token_ca.clone(),
+			pumpx_config.from_amount.clone(),
+			pumpx_config.usd_worth.clone(),
 			from_address.clone(),
 			access_token,
 			pumpx_config,
@@ -95,14 +71,14 @@ impl<
 				let payout_address = Address::from_str(&to_address).map_err(|_| {
 					error!("Failed to parse payout address");
 				})?;
-				debug!("cross chain swap details: intent_id: {}, from_token_ca: {}, to_token_ca: {}, from_amount: {}, from_address: {}, payout_address: {}", intent_id, from_token_ca, to_token_ca, from_amount, from_address, payout_address);
+				debug!("cross chain swap details: intent_id: {}, from_token_ca: {}, to_token_ca: {}, from_amount: {}, from_address: {}, payout_address: {}", intent_id, pumpx_config.from_token_ca, pumpx_config.to_token_ca, pumpx_config.from_amount, from_address, payout_address);
 
 				// TODO: this should be abstracted away
 				let (payout_amount, payout_amount_u256) = self
 					.do_binance_swap_sol_to_bsc(
 						omni_account,
 						swap_order.from_asset.clone(),
-						from_amount,
+						pumpx_config.from_amount.clone(),
 						from_address,
 						pumpx_config.wallet_index,
 						false,
@@ -119,14 +95,14 @@ impl<
 				let payout_address = Pubkey::from_str(&to_address).map_err(|_| {
 					error!("Failed to parse payout address");
 				})?;
-				debug!("cross chain swap details: intent_id: {}, from_token_ca: {}, to_token_ca: {}, from_amount: {}, from_address: {}, payout_address: {}", intent_id, from_token_ca, to_token_ca, from_amount, from_address, payout_address);
+				debug!("cross chain swap details: intent_id: {}, from_token_ca: {}, to_token_ca: {}, from_amount: {}, from_address: {}, payout_address: {}", intent_id, pumpx_config.from_token_ca, pumpx_config.to_token_ca, pumpx_config.from_amount, from_address, payout_address);
 
 				// TODO: this should be abstracted away
 				let (payout_amount, payout_amount_u256) = self
 					.do_binance_swap_bsc_to_sol(
 						omni_account,
 						swap_order.from_asset.clone(),
-						from_amount,
+						pumpx_config.from_amount.clone(),
 						from_address,
 						pumpx_config.wallet_index,
 						false,

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
@@ -322,7 +322,7 @@ async fn simple_cross_chain_swap_sol_to_bsc() {
 	let single_chain_swap_provider =
 		SingleChainSwapProvider::Pumpx(prepare_pumpx_config(from_chain_id, to_chain_id));
 
-	let intent = Intent::Swap(order, None, single_chain_swap_provider);
+	let intent = Intent::Swap(order, None, single_chain_swap_provider.try_into().unwrap());
 
 	let executor = CrossChainIntentExecutor::new(
 		rpc_endpoint_registry,
@@ -493,7 +493,7 @@ async fn simple_cross_chain_swap_bsc_to_sol() {
 			mockall::predicate::eq("test_token"),
 			mockall::predicate::eq(SendOrderTxBody {
 				chain_id: to_chain_id,
-				order_id: order_id,
+				order_id,
 				tx_data: vec!["0x01af865d0f942a8b8ed4309407c839ffedf902a0cd532ba94624100e31d0eec93c4fff60499f1e4784161b0464f104caafe660b3346a4101803582ca090d5e690e010001031faf636aea762c1a1fdc1e067cdae804c8990d13ab425fb7d6f49751ef0eacd50000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000102020001080000000000000000".to_string()]
 			}),
 		)
@@ -605,7 +605,7 @@ async fn simple_cross_chain_swap_bsc_to_sol() {
 	let single_chain_swap_provider =
 		SingleChainSwapProvider::Pumpx(prepare_pumpx_config(from_chain_id, to_chain_id));
 
-	let intent = Intent::Swap(order, None, single_chain_swap_provider);
+	let intent = Intent::Swap(order, None, single_chain_swap_provider.try_into().unwrap());
 
 	let executor = CrossChainIntentExecutor::new(
 		rpc_endpoint_registry,
@@ -681,10 +681,10 @@ fn prepare_pumpx_config(from_chain_id: u32, to_chain_id: u32) -> PumpxConfig {
 		order_type: PumpxOrderType::Market,
 		swap_type: 1,
 		from_chain_id,
-		from_token_ca: BoundedVec::truncate_from([0u8; 128].to_vec()),
+		from_token_ca: String::from_utf8([0u8; 128].to_vec()).unwrap(),
 		to_chain_id,
-		to_token_ca: BoundedVec::truncate_from([0u8; 128].to_vec()),
-		from_amount: BoundedVec::truncate_from("100".as_bytes().to_vec()),
+		to_token_ca: String::from_utf8([0u8; 128].to_vec()).unwrap(),
+		from_amount: "100".to_string(),
 		double_out: false,
 		is_one_click: false,
 		is_anti_mev: false,
@@ -694,7 +694,7 @@ fn prepare_pumpx_config(from_chain_id: u32, to_chain_id: u32) -> PumpxConfig {
 		wallet_index: 1,
 		token_cap: None,
 		price_usd: None,
-		usd_worth: BoundedVec::truncate_from([0u8; 128].to_vec()),
+		usd_worth: String::from_utf8([0u8; 128].to_vec()).unwrap(),
 		trailing_percent: None,
 	}
 }

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
@@ -943,7 +943,7 @@ async fn instant_payout_cross_chain_swap() {
 	let account_assets_lock: Arc<AccountAssetLocks<PreciseAssetsLock>> =
 		Arc::new(AccountAssetLocks::new(storage_db.clone()));
 
-	let intent = Intent::Swap(order, None, single_chain_swap_provider);
+	let intent = Intent::Swap(order, None, single_chain_swap_provider.try_into().unwrap());
 
 	let executor = CrossChainIntentExecutor::new(
 		account_assets_lock.clone(),

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -221,13 +221,9 @@ impl<
 				//
 
 				// TODO: update this when we have more providers
-				let SingleChainSwapProvider::Pumpx(pumpx_config) = scsp;
+				let SingleChainSwapProvider::Pumpx(pumpx_config) = scsp.to_owned().try_into()?;
 
-				let mut amount = std::str::from_utf8(&pumpx_config.from_amount)
-					.map_err(|_| {
-						error!("Failed to parse from_amount");
-					})
-					.map(|v| v.to_string())?;
+				let mut amount = pumpx_config.from_amount.clone();
 
 				let storage = PumpxJwtStorage::new(self.storage_db.clone());
 				let Ok(Some(access_token)) =
@@ -247,7 +243,7 @@ impl<
 							intent_id,
 							&access_token,
 							swap_order,
-							pumpx_config,
+							&pumpx_config,
 						)
 						.await
 					{
@@ -273,7 +269,7 @@ impl<
 						intent_id,
 						&access_token,
 						amount,
-						pumpx_config,
+						&pumpx_config,
 					)
 					.await?;
 

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain.rs
@@ -34,11 +34,7 @@ impl<
 		let to_address = pubkey_to_address(to_chain_type, &to_wallet)?;
 
 		// always use `to_token_ca` from RPC
-		let token_ca = std::str::from_utf8(&pumpx_config.to_token_ca)
-			.map_err(|_| {
-				error!("Failed to parse to_token_ca");
-			})
-			.map(|v| v.to_string())?;
+		let token_ca = pumpx_config.to_token_ca.clone();
 
 		debug!(
 			"single chain swap details: intent_id: {}, token_ca: {}, amount: {}, to_address: {}",
@@ -63,34 +59,11 @@ impl<
 			},
 			PumpxOrderType::Limit => {
 				debug!("Doing limit order");
-				let token_cap = match pumpx_config.token_cap {
-					Some(ref token_cap) => Some(
-						std::str::from_utf8(token_cap)
-							.map_err(|_| {
-								error!("Failed to parse token_cap");
-							})
-							.map(|v| v.to_string())?,
-					),
-					None => None,
-				};
-				let price_usd = match pumpx_config.price_usd {
-					Some(ref price_usd) => Some(
-						std::str::from_utf8(price_usd)
-							.map_err(|_| {
-								error!("Failed to parse price_usd");
-							})
-							.map(|v| v.to_string())?,
-					),
-					None => None,
-				};
-
 				self.do_limit_order(
 					intent_id,
 					amount,
 					token_ca,
 					to_address,
-					token_cap,
-					price_usd,
 					access_token,
 					pumpx_config,
 				)
@@ -378,8 +351,6 @@ impl<
 		amount: String,
 		token_ca: String,
 		recipient_address: String,
-		token_cap: Option<String>,
-		price_usd: Option<String>,
 		access_token: &str,
 		pumpx_config: &PumpxConfig,
 	) -> Result<Vec<u8>, ()> {
@@ -397,8 +368,8 @@ impl<
 				},
 			},
 			double_out: pumpx_config.double_out,
-			token_cap,
-			price_usd,
+			token_cap: pumpx_config.token_cap.clone(),
+			price_usd: pumpx_config.price_usd.clone(),
 			trailing_percent: pumpx_config.trailing_percent.map(|v| v.to_string()),
 			address: recipient_address,
 			is_anti_mev: pumpx_config.is_anti_mev,

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain_swap_tests.rs
@@ -64,10 +64,10 @@ async fn simple_single_chain_swap() {
 		order_type: PumpxOrderType::Limit,
 		swap_type: 1,
 		from_chain_id: 100000,
-		from_token_ca: BoundedVec::truncate_from([0u8; 128].to_vec()),
+		from_token_ca: String::from_utf8([0u8; 128].to_vec()).unwrap(),
 		to_chain_id: 100000,
-		to_token_ca: BoundedVec::truncate_from([0u8; 128].to_vec()),
-		from_amount: BoundedVec::truncate_from("100".as_bytes().to_vec()),
+		to_token_ca: String::from_utf8([0u8; 128].to_vec()).unwrap(),
+		from_amount: "100".to_string(),
 		double_out: false,
 		is_one_click: false,
 		is_anti_mev: false,
@@ -77,11 +77,11 @@ async fn simple_single_chain_swap() {
 		wallet_index: 1,
 		token_cap: None,
 		price_usd: None,
-		usd_worth: BoundedVec::truncate_from([0u8; 128].to_vec()),
+		usd_worth: String::from_utf8(vec![0u8; 128]).unwrap(),
 		trailing_percent: None,
 	});
 
-	let intent = Intent::Swap(order, None, single_chain_swap_provider);
+	let intent = Intent::Swap(order, None, single_chain_swap_provider.try_into().unwrap());
 
 	let mut pumpx_signer_client_mock = signer_client::mocks::MockSignerClient::new();
 	pumpx_signer_client_mock

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
@@ -192,55 +192,15 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 					return Err(PumpxRpcError::from_error_code(ErrorCode::InvalidParams));
 				},
 			};
-			let token_cap = params
-				.token_cap
-				.map(|token_ca| {
-					BoundedVec::try_from(token_ca.as_bytes().to_vec()).map_err(|_| {
-						error!("Failed to convert token_cap");
-						PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-					})
-				})
-				.transpose()?;
-			let price_usd = params
-				.price_usd
-				.map(|price_usd| {
-					BoundedVec::try_from(price_usd.as_bytes().to_vec()).map_err(|_| {
-						error!("Failed to convert price_usd");
-						PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-					})
-				})
-				.transpose()?;
-			let usd_worth =
-				BoundedVec::try_from(params.usd_worth.as_bytes().to_vec()).map_err(|_| {
-					error!("Failed to convert usd_worth");
-					PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-				})?;
 
 			let omni_config = PumpxConfig {
 				order_type: params.order_type.clone(),
 				swap_type: params.swap_type.to_number() as u32,
 				from_chain_id: params.from_chain_id,
-				from_token_ca: BoundedVec::try_from(
-					params.from_token_ca.unwrap_or("".to_string()).as_bytes().to_vec(),
-				)
-				.map_err(|_| {
-					error!("Failed to convert from_token_ca");
-					PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-				})?,
+				from_token_ca: params.from_token_ca.unwrap_or("".to_string()),
 				to_chain_id: params.to_chain_id,
-				to_token_ca: BoundedVec::try_from(
-					params.to_token_ca.unwrap_or("".to_string()).as_bytes().to_vec(),
-				)
-				.map_err(|_| {
-					error!("Failed to convert to_token_ca");
-					PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-				})?,
-				from_amount: BoundedVec::try_from(params.from_amount.as_bytes().to_vec()).map_err(
-					|_| {
-						error!("Failed to convert from_amount");
-						PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-					},
-				)?,
+				to_token_ca: params.to_token_ca.unwrap_or("".to_string()),
+				from_amount: params.from_amount,
 				double_out: params.double_out,
 				is_one_click: params.is_one_click,
 				is_anti_mev,
@@ -248,9 +208,9 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 				gas_type,
 				slippage,
 				wallet_index: params.wallet_index,
-				token_cap,
-				price_usd,
-				usd_worth,
+				token_cap: params.token_cap,
+				price_usd: params.price_usd,
+				usd_worth: params.usd_worth,
 				trailing_percent: params.trailing_percent,
 			};
 			let scs_provider = SingleChainSwapProvider::Pumpx(omni_config);
@@ -261,7 +221,10 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 				ccs_provider = Some(CrossChainSwapProvider::Binance(BinanceConfig {}));
 			}
 
-			let intent = Intent::Swap(swap_order, ccs_provider, scs_provider);
+			let intent = Intent::Swap(swap_order, ccs_provider, scs_provider.try_into().map_err(|_| {
+                error!("Failed to convert single chain swap provider");
+                PumpxRpcError::from_error_code(ErrorCode::InternalError)
+            })?);
 			let wrapper = NativeTaskWrapper::new(
 				NativeTask::RequestIntent(user_identity.clone(), params.intent_id, intent),
 				 None,

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
@@ -189,29 +189,6 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 					return Err(PumpxRpcError::from_error_code(ErrorCode::InvalidParams));
 				},
 			};
-			let token_cap = params
-				.token_cap
-				.map(|token_ca| {
-					BoundedVec::try_from(token_ca.as_bytes().to_vec()).map_err(|_| {
-						error!("Failed to convert token_cap");
-						PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-					})
-				})
-				.transpose()?;
-			let price_usd = params
-				.price_usd
-				.map(|price_usd| {
-					BoundedVec::try_from(price_usd.as_bytes().to_vec()).map_err(|_| {
-						error!("Failed to convert price_usd");
-						PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-					})
-				})
-				.transpose()?;
-			let usd_worth =
-				BoundedVec::try_from(params.usd_worth.as_bytes().to_vec()).map_err(|_| {
-					error!("Failed to convert usd_worth");
-					PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-				})?;
 
 			let is_anti_mev = check_and_get_option_response_data(user_trade_info.data.is_anti_mev, PUMPX_API_GET_USER_TRADE_INFO_FAILED_CODE, "Response data.is_anti_mev of call get_user_trade_info is none")?;
 			let is_auto_slippage = check_and_get_option_response_data(user_trade_info.data.is_auto_slippage, PUMPX_API_GET_USER_TRADE_INFO_FAILED_CODE, "Response data.is_auto_slippage of call get_user_trade_info is none")?;
@@ -221,27 +198,10 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 				order_type: params.order_type.clone(),
 				swap_type: params.swap_type.to_number() as u32,
 				from_chain_id: params.from_chain_id,
-				from_token_ca: BoundedVec::try_from(
-					params.from_token_ca.unwrap_or("".to_string()).as_bytes().to_vec(),
-				)
-				.map_err(|_| {
-					error!("Failed to convert from_token_ca");
-					PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-				})?,
+				from_token_ca: params.from_token_ca.unwrap_or("".to_string()),
 				to_chain_id: params.to_chain_id,
-				to_token_ca: BoundedVec::try_from(
-					params.to_token_ca.unwrap_or("".to_string()).as_bytes().to_vec(),
-				)
-				.map_err(|_| {
-					error!("Failed to convert to_token_ca");
-					PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-				})?,
-				from_amount: BoundedVec::try_from(params.from_amount.as_bytes().to_vec()).map_err(
-					|_| {
-						error!("Failed to convert from_amount");
-						PumpxRpcError::from_error_code(ErrorCode::InvalidParams)
-					},
-				)?,
+				to_token_ca: params.to_token_ca.unwrap_or("".to_string()),
+				from_amount: params.from_amount,
 				double_out: params.double_out,
 				is_one_click: params.is_one_click,
 				is_anti_mev,
@@ -249,9 +209,9 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 				gas_type,
 				slippage,
 				wallet_index: params.wallet_index,
-				token_cap,
-				price_usd,
-				usd_worth,
+				token_cap: params.token_cap,
+				price_usd: params.price_usd,
+				usd_worth: params.usd_worth,
 				trailing_percent: params.trailing_percent,
 			};
 			let scs_provider = SingleChainSwapProvider::Pumpx(pumpx_config);
@@ -262,7 +222,10 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 				ccs_provider = Some(CrossChainSwapProvider::Binance(BinanceConfig {}));
 			}
 
-			let intent = Intent::Swap(swap_order, ccs_provider, scs_provider);
+			let intent = Intent::Swap(swap_order, ccs_provider, scs_provider.try_into().map_err(|_| {
+                error!("Failed to convert SingleChainSwapProvider to OnChainSingleChainSwapProvider");
+                PumpxRpcError::from_error_code(ErrorCode::InternalError)
+            })?);
 			let wrapper = NativeTaskWrapper::new(
 				NativeTask::RequestIntent(user_identity.clone(), params.intent_id, intent),
 				 None,


### PR DESCRIPTION
This PR adds some refactoring to the `PumpxConfig`, `SingleChainSwapProvider`, and related components to improve type safety, simplify string handling, and reduce boilerplate code in cross-chain and single-chain swap functionality. The key changes include replacing `BoundedVec` with `String` for string fields in `PumpxConfig`, introducing conversion traits between `PumpxConfig` and `OnChainPumpxConfig`, and updating the `Intent` enum to use the new `OnChainSingleChainSwapProvider`. Additionally, test cases and dependencies have been updated to reflect these changes.
