### PR TITLE
Fix cross chain swap issues

### DIFF
--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "ethereum-rpc",
  "mockall",
  "sp-core 35.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tracing",
 ]
 

--- a/tee-worker/omni-executor/accounting-contract-client/Cargo.toml
+++ b/tee-worker/omni-executor/accounting-contract-client/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = { workspace = true }
 ethereum-rpc = { workspace = true }
 mockall = { workspace = true }
 sp-core = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 
 [lints]

--- a/tee-worker/omni-executor/accounting-contract-client/src/solana.rs
+++ b/tee-worker/omni-executor/accounting-contract-client/src/solana.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::sync::Arc;
 
 use alloy::primitives::U256;
 use anchor_client::{
@@ -12,6 +13,7 @@ use anchor_client::{
 	},
 	Client, Cluster,
 };
+use async_trait::async_trait;
 use sp_core::ed25519;
 use tracing::{error, info, warn};
 
@@ -42,17 +44,18 @@ impl AccountDeserialize for NonceAccount {
 	}
 }
 
+#[async_trait]
 pub trait AccountingContractApi: Send + Sync {
-	fn execute_pay_out_request(
+	async fn execute_pay_out_request(
 		&self,
 		beneficiary: Pubkey,
 		nonce: u64,
 		amount: U256,
 	) -> Result<(), ()>;
 
-	fn get_nonce(&self, user: Pubkey) -> Result<u64, ()>;
+	async fn get_nonce(&self, user: Pubkey) -> Result<u64, ()>;
 
-	fn get_balance(&self) -> Result<U256, ()>;
+	async fn get_balance(&self) -> Result<U256, ()>;
 }
 
 pub struct AccountingContractClient {
@@ -71,79 +74,121 @@ impl AccountingContractClient {
 		Self { payer, solana_url, program_id }
 	}
 
-	fn create_client(&self) -> Result<Client<&Keypair>, ()> {
+	fn create_client(&self) -> Result<Client<Arc<Keypair>>, ()> {
 		let cluster = Cluster::from_str(&self.solana_url).map_err(|err| {
 			error!("Failed to create solana cluster: {:?}", err);
 		})?;
-		Ok(Client::new_with_options(cluster, &self.payer, CommitmentConfig::confirmed()))
+		let payer = Arc::new(Keypair::from_bytes(&self.payer.to_bytes()).map_err(|err| {
+			error!("Failed to clone keypair: {:?}", err);
+		})?);
+		Ok(Client::new_with_options(cluster, payer, CommitmentConfig::confirmed()))
 	}
 }
 
+#[async_trait]
 impl AccountingContractApi for AccountingContractClient {
-	fn execute_pay_out_request(
+	async fn execute_pay_out_request(
 		&self,
 		beneficiary: Pubkey,
 		nonce: u64,
 		amount: U256,
 	) -> Result<(), ()> {
 		let client = self.create_client()?;
-		let program = client.program(self.program_id).expect("Failed to create program client");
+		let program = client.program(self.program_id).map_err(|e| {
+			error!("Failed to create program client: {:?}", e);
+		})?;
 
-		program
-			.request()
-			.accounts(accounting_contract::accounts::CreatePayRequest {
-				pay_out_request: Pubkey::find_program_address(
-					&[beneficiary.to_bytes().as_ref(), &nonce.to_le_bytes(), b"payout_request"],
-					&program.id(),
-				)
-				.0,
-				account_nonce: Pubkey::find_program_address(
-					&[beneficiary.to_bytes().as_ref(), b"nonce"],
-					&program.id(),
-				)
-				.0,
-				signer: self.payer.pubkey(),
-				worker: Pubkey::find_program_address(&[b"worker"], &program.id()).0,
-				treasury: Pubkey::find_program_address(&[b"treasury"], &program.id()).0,
-				beneficiary,
-				system_program: system_program::ID,
-			})
-			.args(accounting_contract::instruction::CreatePayRequest {
-				amount: amount.try_into().map_err(|_| {
-					error!("Failed to convert U256 to u64");
-				})?,
-				nonce,
-			})
-			.send()
-			.map_err(|e| {
+		let result = tokio::task::spawn_blocking(move || {
+			program
+				.request()
+				.accounts(accounting_contract::accounts::CreatePayRequest {
+					pay_out_request: Pubkey::find_program_address(
+						&[beneficiary.to_bytes().as_ref(), &nonce.to_le_bytes(), b"payout_request"],
+						&program.id(),
+					)
+					.0,
+					account_nonce: Pubkey::find_program_address(
+						&[beneficiary.to_bytes().as_ref(), b"nonce"],
+						&program.id(),
+					)
+					.0,
+					signer: program.payer(),
+					worker: Pubkey::find_program_address(&[b"worker"], &program.id()).0,
+					treasury: Pubkey::find_program_address(&[b"treasury"], &program.id()).0,
+					beneficiary,
+					system_program: system_program::ID,
+				})
+				.args(accounting_contract::instruction::CreatePayRequest {
+					amount: amount.try_into().map_err(|_| {
+						error!("Failed to convert U256 to u64");
+						anchor_client::ClientError::from(std::io::Error::new(
+							std::io::ErrorKind::InvalidData,
+							"Failed to convert U256 to u64",
+						))
+					})?,
+					nonce,
+				})
+				.send()
+		})
+		.await;
+
+		match result {
+			Ok(anchor_result) => match anchor_result {
+				Ok(_) => Ok(()),
+				Err(e) => {
+					error!("Anchor client error: {:?}", e);
+					Err(())
+				},
+			},
+			Err(e) => {
 				error!("Failed to execute pay out request: {:?}", e);
-			})?;
-		Ok(())
+				Err(())
+			},
+		}
 	}
 
-	fn get_nonce(&self, user: Pubkey) -> Result<u64, ()> {
+	async fn get_nonce(&self, user: Pubkey) -> Result<u64, ()> {
 		let client = self.create_client()?;
 
 		let (account_nonce, _bump) =
 			Pubkey::find_program_address(&[user.to_bytes().as_ref(), b"nonce"], &self.program_id);
 
-		let program = client.program(self.program_id).expect("Failed to create program client");
-
-		let nonce_account: NonceAccount = program.account(account_nonce).map_err(|e| {
-			if e.to_string().contains("AccountNotFound") {
-				info!("Nonce account {} not found, returning 0", account_nonce);
-			} else {
-				error!("Failed to get nonce account {}: {:?}", account_nonce, e);
-			}
+		let program = client.program(self.program_id).map_err(|e| {
+			error!("Failed to create program client: {:?}", e);
 		})?;
+
+		let nonce_account: NonceAccount =
+			tokio::task::spawn_blocking(move || program.account(account_nonce))
+				.await
+				.map_err(|e| {
+					error!("Failed to spawn blocking task: {:?}", e);
+				})?
+				.map_err(|e| {
+					if e.to_string().contains("AccountNotFound") {
+						info!("Nonce account {} not found, returning 0", account_nonce);
+					} else {
+						error!("Failed to get nonce account {}: {:?}", account_nonce, e);
+					}
+				})?;
 
 		Ok(nonce_account.nonce)
 	}
 
-	fn get_balance(&self) -> Result<U256, ()> {
+	async fn get_balance(&self) -> Result<U256, ()> {
 		let client = self.create_client()?;
-		let program = client.program(self.program_id).expect("Failed to create program client");
-		match program.rpc().get_balance(&self.payer.pubkey()) {
+		let program = client.program(self.program_id).map_err(|e| {
+			error!("Failed to create program client: {:?}", e);
+		})?;
+
+		let payer_pubkey = self.payer.pubkey();
+		let balance_result =
+			tokio::task::spawn_blocking(move || program.rpc().get_balance(&payer_pubkey))
+				.await
+				.map_err(|e| {
+					error!("Failed to spawn blocking task: {:?}", e);
+				})?;
+
+		match balance_result {
 			Ok(v) => {
 				let balance = U256::try_from(v).map_err(|err| {
 					warn!("Failed to convert balance to U256: {:?}", err);
@@ -163,24 +208,24 @@ pub mod mocks {
 	use crate::solana::AccountingContractApi;
 	use crate::U256;
 	use anchor_client::solana_sdk::pubkey::Pubkey;
+	use async_trait::async_trait;
 	use mockall::mock;
 
 	mock! {
-
 		pub AccountingContractClient {}
 
+		#[async_trait]
 		impl AccountingContractApi for AccountingContractClient {
-
-			fn execute_pay_out_request(
+			async fn execute_pay_out_request(
 				&self,
 				beneficiary: Pubkey,
 				nonce: u64,
 				amount: U256,
 			) -> Result<(), ()>;
 
-			fn get_nonce(&self, user: Pubkey) -> Result<u64, ()>;
+			async fn get_nonce(&self, user: Pubkey) -> Result<u64, ()>;
 
-			fn get_balance(&self) -> Result<U256, ()>;
+			async fn get_balance(&self) -> Result<U256, ()>;
 		}
 	}
 }

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
@@ -435,10 +435,9 @@ impl<
 		let binance_coin = binance_asset.coin;
 		let binance_address = binance_asset.address;
 
-		let amount_to_transfer = U256::from_str_radix(&amount_to_transfer_decimal.to_string(), 10)
-			.map_err(|err| {
-				error!("Failed to convert amount_to_transfer_decimal to U256: {:?}", err);
-			})?;
+		let amount_to_transfer = decimal_to_u256(amount_to_transfer_decimal).map_err(|err| {
+			error!("Failed to convert amount_to_transfer_decimal to U256: {:?}", err);
+		})?;
 
 		let (trade_symbol, order_side) = determine_trade_symbol_and_order_side(
 			binance_network.clone(),

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain.rs
@@ -210,7 +210,7 @@ impl<
 					)
 					.await?;
 
-				self.do_payout_bsc_to_sol(payout_address, payout_amount_u256)?;
+				self.do_payout_bsc_to_sol(payout_address, payout_amount_u256).await?;
 
 				Ok((
 					self.apply_gas_fee(
@@ -457,7 +457,7 @@ impl<
 		let mut payout_amount_u256 = str_to_u256(&payout_amount, BinanceCoin::Sol.decimals())?;
 
 		// Fetch contract balance
-		let balance = self.solana_accounting_contract_client.get_balance()?;
+		let balance = self.solana_accounting_contract_client.get_balance().await?;
 		if balance < payout_amount_u256 {
 			error!(
 				"There is not enough balance in the accounting contract, {} < {}",
@@ -529,12 +529,18 @@ impl<
 		Ok((payout_amount, payout_amount_u256))
 	}
 
-	fn do_payout_bsc_to_sol(&self, payout_address: Pubkey, payout_amount: U256) -> Result<(), ()> {
+	async fn do_payout_bsc_to_sol(
+		&self,
+		payout_address: Pubkey,
+		payout_amount: U256,
+	) -> Result<(), ()> {
 		debug!("Getting {:?} nonce for payout request", payout_address);
 		let user_nonce =
-			self.solana_accounting_contract_client.get_nonce(payout_address).map_err(|_| {
-				error!("Failed to get nonce");
-			})?;
+			self.solana_accounting_contract_client.get_nonce(payout_address).await.map_err(
+				|_| {
+					error!("Failed to get nonce");
+				},
+			)?;
 
 		debug!("Received {:?} nonce", user_nonce);
 		let user_nonce = user_nonce + 1u64;
@@ -545,6 +551,7 @@ impl<
 
 		self.solana_accounting_contract_client
 			.execute_pay_out_request(payout_address, user_nonce, payout_amount)
+			.await
 			.map_err(|_| {
 				error!("Failed to execute pay out request");
 			})

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -26,6 +26,7 @@ use accounting_contract_client::{
 use alloy::consensus::{SignableTransaction, TxLegacy};
 use alloy::network::TxSigner as AlloyTxSigner;
 use alloy::primitives::private::alloy_rlp::Decodable;
+use alloy::primitives::ruint::ParseError;
 use alloy::primitives::{Address, Signature, U256};
 use async_trait::async_trait;
 use binance_api::spot_trading_api::types::{
@@ -415,13 +416,10 @@ impl<
 				}
 			},
 			ChainAsset::Ethereum(_, _) => {
-				let amount_to_transfer = U256::from_str_radix(
-					&amount_to_transfer_decimal.to_string(),
-					10,
-				)
-				.map_err(|err| {
-					error!("Failed to convert amount_to_transfer_decimal to U256: {:?}", err);
-				})?;
+				let amount_to_transfer =
+					decimal_to_u256(amount_to_transfer_decimal).map_err(|err| {
+						error!("Failed to convert amount_to_transfer_decimal to U256: {:?}", err);
+					})?;
 
 				let remote_signer =
 					RemoteEvmSigner::new(pumpx_signer_client.clone(), wallet_index, omni_account)
@@ -477,5 +475,32 @@ impl<
 			},
 		};
 		Ok(from_amount * asset_decimal_multiplier)
+	}
+}
+
+fn decimal_to_u256(decimal: Decimal) -> Result<U256, ParseError> {
+	let decimal_str = decimal.normalize().to_string();
+	U256::from_str_radix(&decimal_str, 10).inspect_err(|err| {
+		error!("Failed to convert decimal {:?} to U256: {:?}", decimal_str, err);
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_decimal_to_u256() {
+		// with_decimal_point
+		let amount = Decimal::from_str("0.005").unwrap() * Decimal::from_str("100_000").unwrap();
+		assert_eq!(amount.to_string(), "500.000");
+		let value = decimal_to_u256(amount).unwrap();
+		assert_eq!(value, U256::from(500));
+
+		// without_decimal_point
+		let amount = Decimal::from_str("500").unwrap();
+		assert_eq!(amount.to_string(), "500");
+		let value = decimal_to_u256(amount).unwrap();
+		assert_eq!(value, U256::from(500));
 	}
 }


### PR DESCRIPTION
### Context
fix: add function decimal_to_u256 and resolve the 'InvalidDigit .' error
fix: resolve runtime drop in blocking error

error logs:
thread 'tokio-runtime-worker' panicked at /home/ubuntu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.44.2/src/runtime/blocking/shutdown.rs:51:21:
 Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
 stack backtrace:
    0:          0xbcb604a - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h5b6bd5631a6d1f6b
    1:          0xbcdd7c3 - core::fmt::write::h7550c97b06c86515
    2:          0xbcb27f3 - std::io::Write::write_fmt::h7b09c64fe0be9c84
    3:          0xbcb5e92 - std::sys::backtrace::BacktraceLock::print::h2395ccd2c84ba3aa
    4:          0xbcb6f7c - std::panicking::default_hook::{{closure}}::he19d4c7230e07961
    5:          0xbcb6dc2 - std::panicking::default_hook::hf614597d3c67bbdb
    6:          0xbcb7557 - std::panicking::rust_panic_with_hook::h8942133a8b252070
    7:          0xbcb73b6 - std::panicking::begin_panic_handler::{{closure}}::hb5f5963570096b29
    8:          0xbcb6529 - std::sys::backtrace::__rust_end_short_backtrace::h6208cedc1922feda
    9:          0xbcb707c - rust_begin_unwind
   10:          0xa6ab0a0 - core::panicking::panic_fmt::h0c3082644d1bf418
   11:          0xbc17e9b - tokio::runtime::blocking::shutdown::Receiver::wait::h5318698c87eb2933
   12:          0xbc06244 - tokio::runtime::blocking::pool::BlockingPool::shutdown::h55c3890cf7513b78
   13:          0xb3ca5ae - core::ptr::drop_in_place<tokio::runtime::blocking::pool::BlockingPool>::h348590e74d764fc1
   14:          0xb3ca87c - core::ptr::drop_in_place<anchor_client::Program<&solana_keypair::Keypair>>::hb1fa7a0d1209c980
   15:          0xb3cd33f - <accounting_contract_client::solana::AccountingContractClient as accounting_contract_client::solana::AccountingContractApi>::get_balance::h2b57e829afd50463
   16:          0xaa7bd6b - cross_chain_intent_executor::cross_chain::<impl cross_chain_intent_executor::CrossChainIntentExecutor<BinanceClient,EthereumClient,SolanaClient>>::execute_cross_chain_swap::{{closure}}::h38da1f2760db2c02
   17:          0xaa6d266 - <cross_chain_intent_executor::CrossChainIntentExecutor<BinanceClient,EthereumClient,SolanaClient> as executor_core::intent_executor::IntentExecutor>::execute::{{closure}}::h771611b0d53f56c6
   18:          0xa8d533a - native_task_handler::handle_native_task::{{closure}}::h4568130654a326fb
   19:          0xa90e795 - <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll::h287ff5b719351432
   20:          0xa982044 - native_task_handler::run_native_task_handler::{{closure}}::{{closure}}::{{closure}}::h4066b16272d643f6
   21:          0xa9b2936 - tokio::runtime::task::core::Core<T,S>::poll::h7663e2839c04cf24
   22:          0xa9d8f89 - tokio::runtime::task::harness::Harness<T,S>::poll::h99762592f58d471e
   23:          0xbbfd17b - tokio::runtime::scheduler::multi_thread::worker::Context::run_task::h99b196e1d0d0e045
   24:          0xbbfc131 - tokio::runtime::scheduler::multi_thread::worker::Context::run::h8b667bc47f7fb2ab
   25:          0xbc1a534 - tokio::runtime::context::runtime::enter_runtime::h32a65b3fc7bc7833
   26:          0xbbfbf9a - tokio::runtime::scheduler::multi_thread::worker::run::h2972861f284f060c
   27:          0xbc09437 - <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll::h3d56aa3f3f165a65
   28:          0xbc01583 - tokio::runtime::task::core::Core<T,S>::poll::h31e57f4c407603d6
   29:          0xbbf7b74 - tokio::runtime::task::harness::Harness<T,S>::poll::h69e03f423971a875
   30:          0xbc06c02 - tokio::runtime::blocking::pool::Inner::run::h9bb2047dbacb5259
   31:          0xbc11c8e - std::sys::backtrace::__rust_begin_short_backtrace::h15c3298375a6c985
   32:          0xbc12499 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h1f701d3724947397
   33:          0xbcb9c0b - std::sys::pal::unix::thread::thread::new::thread_start::hcc78f3943333fa94
   34:          0x9aab7eb - start_thread
   35:          0x9b237bd - __GI___clone
   36:                0x0 - <unknown>
 2025-05-30T07:57:02.077877Z ERROR rpc_server::methods::pumpx::common: Failed to receive response from native call handler: RecvError(())

<!-- Why are these changes needed? Please use auto-close keyword to link to an existing issue, if any -->

### Labels

Please apply following PR-related labels when appropriate:
- `C0-breaking`: if your change could break the existing client, e.g. API change, critical logic change 
- `C1-noteworthy`: if your change is non-breaking, but is still worth noticing for the client, e.g. reference code improvement

### How (Optional)

<!-- How were these changes implemented? -->

### Testing Evidences

Please attach any relevant evidences if applicable


