### PR TITLE
Include client_id as aud claim in jwt

### DIFF
--- a/tee-worker/omni-executor/executor-crypto/src/jwt.rs
+++ b/tee-worker/omni-executor/executor-crypto/src/jwt.rs
@@ -17,6 +17,7 @@ pub fn create<T: Serialize>(claims: &T, private_key: &[u8]) -> Result<String, St
 pub fn decode<T: DeserializeOwned>(
 	token: &str,
 	public_key: &[u8],
+	audiences: Option<&[&str]>,
 	skip_exp_check: bool,
 ) -> Result<T, Error> {
 	let mut validation = Validation::new(Algorithm::RS256);
@@ -24,6 +25,9 @@ pub fn decode<T: DeserializeOwned>(
 		validation.validate_exp = false;
 	}
 	validation.set_required_spec_claims(&["sub", "typ", "aud"]);
+	if let Some(audiences) = audiences {
+		validation.set_audience(audiences);
+	}
 	let decoding_key = DecodingKey::from_rsa_der(public_key);
 	decode_jwt::<T>(token, &decoding_key, &validation).map(|data| data.claims)
 }
@@ -41,6 +45,7 @@ mod tests {
 	struct JwtClaims {
 		pub sub: String,
 		pub exp: i64,
+		pub aud: String,
 	}
 
 	#[test]
@@ -55,10 +60,11 @@ mod tests {
 			.checked_add_days(Days::new(1))
 			.expect("Failed to calculate expiration")
 			.timestamp();
-		let claims = JwtClaims { sub: "test".to_string(), exp };
+		let claims = JwtClaims { sub: "test".to_string(), exp, aud: "test_aud".to_string() };
 
 		let token = create(&claims, private_key.as_bytes()).unwrap();
-		let decoded = decode::<JwtClaims>(&token, public_key.as_bytes(), false).unwrap();
+		let decoded =
+			decode::<JwtClaims>(&token, public_key.as_bytes(), Some(&["test_aud"]), false).unwrap();
 
 		assert_eq!(claims, decoded);
 	}
@@ -75,10 +81,11 @@ mod tests {
 			.checked_sub_days(Days::new(5)) // some time before now
 			.expect("Failed to calculate expiration")
 			.timestamp();
-		let claims = JwtClaims { sub: "test".to_string(), exp };
+		let claims = JwtClaims { sub: "test".to_string(), exp, aud: "test_aud".to_string() };
 
 		let token = create(&claims, private_key.as_bytes()).unwrap();
-		let decoded = decode::<JwtClaims>(&token, public_key.as_bytes(), true).unwrap();
+		let decoded =
+			decode::<JwtClaims>(&token, public_key.as_bytes(), Some(&["test_aud"]), true).unwrap();
 
 		assert_eq!(claims, decoded);
 	}

--- a/tee-worker/omni-executor/executor-crypto/src/jwt.rs
+++ b/tee-worker/omni-executor/executor-crypto/src/jwt.rs
@@ -23,7 +23,7 @@ pub fn decode<T: DeserializeOwned>(
 	if skip_exp_check {
 		validation.validate_exp = false;
 	}
-	validation.set_required_spec_claims(&["sub", "typ"]);
+	validation.set_required_spec_claims(&["sub", "typ", "aud"]);
 	let decoding_key = DecodingKey::from_rsa_der(public_key);
 	decode_jwt::<T>(token, &decoding_key, &validation).map(|data| data.claims)
 }

--- a/tee-worker/omni-executor/heima/authentication/src/auth_token.rs
+++ b/tee-worker/omni-executor/heima/authentication/src/auth_token.rs
@@ -24,11 +24,12 @@ pub struct AuthTokenClaims {
 	pub sub: String,
 	pub typ: String,
 	pub exp: i64,
+	pub aud: String,
 }
 
 impl AuthTokenClaims {
-	pub fn new(sub: String, typ: String, options: AuthOptions) -> Self {
-		Self { sub, typ, exp: options.expires_at }
+	pub fn new(sub: String, typ: String, aud: String, options: AuthOptions) -> Self {
+		Self { sub, typ, exp: options.expires_at, aud }
 	}
 }
 
@@ -134,6 +135,7 @@ mod tests {
 		let claims = AuthTokenClaims::new(
 			omni_account.to_hex(),
 			AUTH_TOKEN_ID_TYPE.to_string(),
+			CLIENT_ID_HEIMA.to_string(),
 			AuthOptions { expires_at },
 		);
 		let token = jwt::create(&claims, private_key.as_bytes()).unwrap();
@@ -157,6 +159,7 @@ mod tests {
 		let claims = AuthTokenClaims::new(
 			omni_account.to_hex(),
 			AUTH_TOKEN_ID_TYPE.to_string(),
+			CLIENT_ID_HEIMA.to_string(),
 			AuthOptions { expires_at: 100 },
 		);
 		let token = jwt::create(&claims, private_key.as_bytes()).unwrap();
@@ -232,6 +235,7 @@ mod tests {
 		let claims = AuthTokenClaims::new(
 			omni_account.to_hex(),
 			AUTH_TOKEN_ACCESS_TYPE.to_string(),
+			CLIENT_ID_HEIMA.to_string(),
 			AuthOptions { expires_at },
 		);
 		let token = jwt::create(&claims, private_key.as_bytes()).unwrap();

--- a/tee-worker/omni-executor/heima/authentication/src/auth_token.rs
+++ b/tee-worker/omni-executor/heima/authentication/src/auth_token.rs
@@ -14,10 +14,6 @@ pub enum Error {
 	JwtError(jwt::ErrorKind),
 }
 
-pub const AUTH_TOKEN_EXPIRATION_DAYS: u64 = 7; // 1 week
-pub const AUTH_TOKEN_ACCESS_TYPE: &str = "access";
-pub const AUTH_TOKEN_ID_TYPE: &str = "id";
-
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 pub struct AuthOptions {
 	pub expires_at: i64,
@@ -101,6 +97,8 @@ impl AuthTokenValidator<AuthTokenClaims> for &str {
 
 #[cfg(test)]
 mod tests {
+	use crate::constants::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_ID_TYPE, CLIENT_ID_HEIMA};
+
 	use super::*;
 	use chrono::{Days, Utc};
 	use executor_primitives::{utils::hex::ToHexPrefixed, Identity, Web2IdentityType};

--- a/tee-worker/omni-executor/heima/authentication/src/auth_token.rs
+++ b/tee-worker/omni-executor/heima/authentication/src/auth_token.rs
@@ -1,3 +1,4 @@
+use crate::constants::{CLIENT_ID_HEIMA, CLIENT_ID_PUMPX};
 use executor_crypto::jwt;
 use parity_scale_codec::{Decode, Encode};
 use rsa::{
@@ -68,9 +69,13 @@ impl AuthTokenValidator<AuthTokenClaims> for String {
 			.to_public_key()
 			.to_pkcs1_der()
 			.map_err(|_| Error::InternalError)?;
-		let claims =
-			jwt::decode::<AuthTokenClaims>(self, public_key.as_bytes(), validation.skip_exp_check)
-				.map_err(|e| Error::JwtError(e.kind().clone()))?;
+		let claims = jwt::decode::<AuthTokenClaims>(
+			self,
+			public_key.as_bytes(),
+			Some(&[CLIENT_ID_HEIMA, CLIENT_ID_PUMPX]),
+			validation.skip_exp_check,
+		)
+		.map_err(|e| Error::JwtError(e.kind().clone()))?;
 		validation.validate(&claims)?;
 		Ok(claims)
 	}
@@ -88,9 +93,13 @@ impl AuthTokenValidator<AuthTokenClaims> for &str {
 			.to_public_key()
 			.to_pkcs1_der()
 			.map_err(|_| Error::InternalError)?;
-		let claims =
-			jwt::decode::<AuthTokenClaims>(self, public_key.as_bytes(), validation.skip_exp_check)
-				.map_err(|e| Error::JwtError(e.kind().clone()))?;
+		let claims = jwt::decode::<AuthTokenClaims>(
+			self,
+			public_key.as_bytes(),
+			Some(&[CLIENT_ID_HEIMA, CLIENT_ID_PUMPX]),
+			validation.skip_exp_check,
+		)
+		.map_err(|e| Error::JwtError(e.kind().clone()))?;
 		validation.validate(&claims)?;
 		Ok(claims)
 	}

--- a/tee-worker/omni-executor/heima/authentication/src/constants.rs
+++ b/tee-worker/omni-executor/heima/authentication/src/constants.rs
@@ -1,0 +1,8 @@
+// Authentication related constants
+pub const AUTH_TOKEN_EXPIRATION_DAYS: u64 = 7; // 1 week
+pub const AUTH_TOKEN_ACCESS_TYPE: &str = "access";
+pub const AUTH_TOKEN_ID_TYPE: &str = "id";
+
+// Client ID constants for JWT audience
+pub const CLIENT_ID_HEIMA: &str = "heima";
+pub const CLIENT_ID_PUMPX: &str = "pumpx";

--- a/tee-worker/omni-executor/heima/authentication/src/lib.rs
+++ b/tee-worker/omni-executor/heima/authentication/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod auth_token;
+pub mod constants;
 pub mod web3;

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/cross_chain_swap_tests.rs
@@ -36,7 +36,7 @@ use executor_primitives::{EthereumToken, PumpxConfig, SwapOrder};
 use executor_storage::Storage;
 use executor_storage::StorageDB;
 use executor_storage::{PumpxJwtStorage, PumpxProfileStorage};
-use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
+use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use heima_primitives::BoundedVec;
 use heima_primitives::IdentityString;
 use intent_asset_lock::precise::PreciseAssetsLock;

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/lib.rs
@@ -47,7 +47,7 @@ use executor_primitives::PumpxOrderType;
 use executor_primitives::SingleChainSwapProvider;
 use executor_storage::StorageDB;
 use executor_storage::{PumpxJwtStorage, Storage};
-use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
+use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use intent_asset_lock::precise::PreciseAssetsLock;
 use intent_asset_lock::AccountAssetLocks;
 use intent_asset_lock::AmountType;

--- a/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain_swap_tests.rs
+++ b/tee-worker/omni-executor/intent/executors/cross-chain/src/single_chain_swap_tests.rs
@@ -31,7 +31,7 @@ use executor_primitives::{EthereumToken, PumpxConfig, SwapOrder};
 use executor_storage::PumpxJwtStorage;
 use executor_storage::Storage;
 use executor_storage::StorageDB;
-use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
+use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use heima_primitives::BoundedVec;
 use heima_primitives::IdentityString;
 use intent_asset_lock::precise::PreciseAssetsLock;

--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -18,7 +18,13 @@ use executor_storage::{
 	IntentIdStorage, MemberOmniAccountStorage, PumpxJwtStorage, PumpxProfileStorage, Storage,
 	StorageDB,
 };
-use heima_authentication::auth_token::*;
+use heima_authentication::{
+	auth_token::*,
+	constants::{
+		AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_EXPIRATION_DAYS, AUTH_TOKEN_ID_TYPE, CLIENT_ID_HEIMA,
+		CLIENT_ID_PUMPX,
+	},
+};
 use heima_identity_verification::{get_verification_message, web2, web3};
 use parentchain_api_interface::runtime_types::{
 	frame_system::pallet::Call as SystemCall,
@@ -230,12 +236,14 @@ async fn handle_native_task<
 					AuthTokenClaims::new(
 						email.to_string(),
 						AUTH_TOKEN_ID_TYPE.to_string(),
+						CLIENT_ID_HEIMA.to_string(),
 						auth_options,
 					)
 				},
 				_ => AuthTokenClaims::new(
 					sender.hash().to_string(),
 					AUTH_TOKEN_ID_TYPE.to_string(),
+					CLIENT_ID_HEIMA.to_string(),
 					auth_options,
 				),
 			};
@@ -618,6 +626,7 @@ async fn handle_native_task<
 			let access_token_claims = AuthTokenClaims::new(
 				omni_account.to_hex(),
 				AUTH_TOKEN_ACCESS_TYPE.to_string(),
+				CLIENT_ID_PUMPX.to_string(),
 				auth_options.clone(),
 			);
 			let Ok(access_token) = jwt::create(&access_token_claims, &ctx.jwt_rsa_private_key)
@@ -665,6 +674,7 @@ async fn handle_native_task<
 			let id_token_claims = AuthTokenClaims::new(
 				omni_account.to_hex(),
 				AUTH_TOKEN_ID_TYPE.to_string(),
+				CLIENT_ID_PUMPX.to_string(),
 				auth_options,
 			);
 			let Ok(id_token) = jwt::create(&id_token_claims, &ctx.jwt_rsa_private_key) else {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/notify_limit_order_result.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/notify_limit_order_result.rs
@@ -3,7 +3,7 @@ use crate::verify_auth::verify_auth_token_authentication;
 use crate::{error_code::*, server::RpcContext, Deserialize, ErrorCode};
 use executor_core::native_task::*;
 use executor_primitives::{utils::hex::FromHexPrefixed, OmniAuth};
-use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
+use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use heima_primitives::{Address32, Identity};
 use jsonrpsee::RpcModule;
 use native_task_handler::NativeTaskOk;

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/sign_limit_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/sign_limit_order.rs
@@ -26,7 +26,7 @@ use executor_core::native_task::PumpxChainId;
 use executor_core::native_task::PumxWalletIndex;
 use executor_primitives::utils::hex::FromHexPrefixed;
 use executor_primitives::OmniAuth;
-use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
+use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use heima_primitives::Address32;
 use heima_primitives::Identity;
 use heima_primitives::IntentId;

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
@@ -6,7 +6,7 @@ use crate::{
 use executor_core::native_task::*;
 use executor_primitives::OmniAuth;
 use executor_storage::{PumpxJwtStorage, Storage};
-use heima_authentication::auth_token::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_ID_TYPE};
+use heima_authentication::constants::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_ID_TYPE};
 use heima_primitives::{
 	AccountId, Address20, Address32, BinanceConfig, BoundedVec, ChainAsset, CrossChainSwapProvider,
 	EthereumToken, Identity, Intent, PumpxConfig, PumpxOrderType, SingleChainSwapProvider,

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/test_protected_method.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/test_protected_method.rs
@@ -20,8 +20,9 @@ mod test {
 	use executor_crypto::jwt;
 	use executor_primitives::utils::hex::ToHexPrefixed;
 	use executor_storage::StorageDB;
-	use heima_authentication::auth_token::{
-		AuthOptions, AuthTokenClaims, AUTH_TOKEN_EXPIRATION_DAYS, AUTH_TOKEN_ID_TYPE,
+	use heima_authentication::{
+		auth_token::{AuthOptions, AuthTokenClaims},
+		constants::{AUTH_TOKEN_EXPIRATION_DAYS, AUTH_TOKEN_ID_TYPE, CLIENT_ID_HEIMA},
 	};
 	use heima_primitives::{Identity, Web2IdentityType};
 	use jsonrpsee::core::client::ClientT;
@@ -73,9 +74,10 @@ mod test {
 		let access_token_claims = AuthTokenClaims::new(
 			omni_account.to_hex(),
 			AUTH_TOKEN_ID_TYPE.to_string(),
+			CLIENT_ID_HEIMA.to_string(),
 			auth_options.clone(),
 		);
-		let token = jwt::create(&access_token_claims, &jwt_private_key.as_bytes().to_vec())
+		let token = jwt::create(&access_token_claims, jwt_private_key.as_bytes())
 			.expect("Failed to create access token");
 
 		headers.insert("Authorization", format!("Bearer {}", token).parse().unwrap());

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/notify_limit_order_result.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/notify_limit_order_result.rs
@@ -3,7 +3,7 @@ use crate::verify_auth::verify_auth_token_authentication;
 use crate::{error_code::*, server::RpcContext, Deserialize, ErrorCode};
 use executor_core::native_task::*;
 use executor_primitives::{utils::hex::FromHexPrefixed, OmniAuth};
-use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
+use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use heima_primitives::{Address32, Identity};
 use jsonrpsee::RpcModule;
 use native_task_handler::NativeTaskOk;

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/sign_limit_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/sign_limit_order.rs
@@ -26,7 +26,7 @@ use executor_core::native_task::PumpxChainId;
 use executor_core::native_task::PumxWalletIndex;
 use executor_primitives::utils::hex::FromHexPrefixed;
 use executor_primitives::OmniAuth;
-use heima_authentication::auth_token::AUTH_TOKEN_ACCESS_TYPE;
+use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use heima_primitives::Address32;
 use heima_primitives::Identity;
 use heima_primitives::IntentId;

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/submit_swap_order.rs
@@ -6,7 +6,7 @@ use crate::{
 use executor_core::native_task::*;
 use executor_primitives::OmniAuth;
 use executor_storage::{PumpxJwtStorage, Storage};
-use heima_authentication::auth_token::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_ID_TYPE};
+use heima_authentication::constants::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_ID_TYPE};
 use heima_primitives::{
 	AccountId, Address20, Address32, BinanceConfig, BoundedVec, ChainAsset, CrossChainSwapProvider,
 	EthereumToken, Identity, Intent, PumpxConfig, PumpxOrderType, SingleChainSwapProvider,

--- a/tee-worker/omni-executor/rpc-server/src/middlewares/rpc_middleware.rs
+++ b/tee-worker/omni-executor/rpc-server/src/middlewares/rpc_middleware.rs
@@ -2,7 +2,7 @@ use crate::{
 	error_code::AUTH_VERIFICATION_FAILED_CODE, methods::PROTECTED_METHODS,
 	middlewares::HttpExtensions, verify_auth::verify_auth_token_authentication,
 };
-use heima_authentication::auth_token::AUTH_TOKEN_ID_TYPE;
+use heima_authentication::constants::AUTH_TOKEN_ID_TYPE;
 use jsonrpsee::{
 	server::{
 		middleware::rpc::{ResponseFuture, RpcServiceT},

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -6,10 +6,8 @@ use executor_primitives::{
 };
 use executor_storage::{OAuth2StateVerifierStorage, Storage, StorageDB, VerificationCodeStorage};
 use heima_authentication::{
-	auth_token::{
-		AuthTokenClaims, AuthTokenValidator, Error as AuthTokenError, Validation,
-		AUTH_TOKEN_ID_TYPE,
-	},
+	auth_token::{AuthTokenClaims, AuthTokenValidator, Error as AuthTokenError, Validation},
+	constants::AUTH_TOKEN_ID_TYPE,
 	web3::HeimaMessagePayload,
 };
 use heima_identity_verification::web2::google::decode_id_token;


### PR DESCRIPTION
This pull request introduces changes to improve JWT handling and refactor constants usage across the codebase. The most significant updates include adding an audience (`aud`) claim to JWTs, centralizing authentication-related constants, and updating references to these constants in multiple modules.

