### PR TITLE
Update web3 sign-in message format

### DIFF
--- a/tee-worker/client-api/src/omni/interfaces/omniExecutor/definitions.ts
+++ b/tee-worker/client-api/src/omni/interfaces/omniExecutor/definitions.ts
@@ -42,7 +42,7 @@ export default {
     },
     OmniAuth: {
       _enum: {
-        Web3: "(Identity, HeimaMultiSignature)",
+        Web3: "(Text, Identity, HeimaMultiSignature)",
         Email: "(Text, Text)",
         AuthToken: "(Text)",
         OAuth2: "(Identity, OAuth2Data)",

--- a/tee-worker/omni-executor/executor-primitives/src/auth.rs
+++ b/tee-worker/omni-executor/executor-primitives/src/auth.rs
@@ -86,7 +86,7 @@ impl TryFrom<IdentitySerde> for Identity {
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 pub enum OmniAuth {
-	Web3(Identity, HeimaMultiSignature), // (Signer, Signature)
+	Web3(String, Identity, HeimaMultiSignature), // (client_id, Signer, Signature)
 	Email(Email, VerificationCode),
 	AuthToken(JwtToken),
 	OAuth2(Identity, OAuth2Data), // (Sender, OAuth2Data)

--- a/tee-worker/omni-executor/heima/authentication/src/web3.rs
+++ b/tee-worker/omni-executor/heima/authentication/src/web3.rs
@@ -2,5 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct HeimaMessagePayload {
+	pub client_id: String,
+	pub omni_account: String,
 	pub message_code: String,
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_message_code.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_message_code.rs
@@ -11,6 +11,7 @@ use tracing::error;
 
 #[derive(Deserialize)]
 pub struct GetMessageCodeParams {
+	pub client_id: String,
 	pub omni_account: String,
 }
 
@@ -36,7 +37,11 @@ pub fn register_get_message_code(module: &mut RpcModule<RpcContext>) {
 				Err(_) => return Err(ErrorCode::InternalError.into()),
 			};
 
-			Ok::<HeimaMessagePayload, ErrorObject>(HeimaMessagePayload { message_code })
+			Ok::<HeimaMessagePayload, ErrorObject>(HeimaMessagePayload {
+				message_code,
+				omni_account: omni_account.to_string(),
+				client_id: params.client_id,
+			})
 		})
 		.expect("Failed to register omni_getMessageCode method");
 }

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -47,8 +47,8 @@ impl Display for AuthenticationError {
 
 pub async fn verify_auth(ctx: Arc<RpcContext>, auth: &OmniAuth) -> Result<(), AuthenticationError> {
 	match auth {
-		OmniAuth::Web3(ref signer, ref signature) => {
-			verify_web3_authentication(ctx.storage_db.clone(), signer, signature)
+		OmniAuth::Web3(ref client_id, ref signer, ref signature) => {
+			verify_web3_authentication(ctx.storage_db.clone(), client_id, signer, signature)
 		},
 		OmniAuth::Email(ref email, ref verification_code) => {
 			verify_email_authentication(ctx, email, verification_code)
@@ -68,6 +68,7 @@ pub async fn verify_auth(ctx: Arc<RpcContext>, auth: &OmniAuth) -> Result<(), Au
 
 pub fn verify_web3_authentication(
 	storage_db: Arc<StorageDB>,
+	client_id: &str,
 	signer: &Identity,
 	signature: &HeimaMultiSignature,
 ) -> Result<(), AuthenticationError> {
@@ -79,7 +80,11 @@ pub fn verify_web3_authentication(
 	verification_code_storage
 		.remove(&storage_key)
 		.map_err(|_| AuthenticationError::VerificationCodeNotFound)?;
-	let message = HeimaMessagePayload { message_code };
+	let message = HeimaMessagePayload {
+		client_id: client_id.to_string(),
+		omni_account: signer.to_omni_account().to_string(),
+		message_code,
+	};
 	let payload = serde_json::to_string(&message).expect("Failed to serialize payload");
 	let hashed = blake2_256(payload.as_bytes());
 
@@ -185,14 +190,23 @@ mod tests {
 			.insert(&alice_omni_account.hash(), message_code.clone())
 			.expect("insert");
 
-		let message = HeimaMessagePayload { message_code };
+		let message = HeimaMessagePayload {
+			message_code,
+			omni_account: alice_omni_account.to_string(),
+			client_id: "test_client".to_string(),
+		};
 		let payload = serde_json::to_string(&message).expect("serialize");
 		let hashed = blake2_256(payload.as_bytes());
 
 		let signature = alice.sign(&hashed);
 		let multi_signature = HeimaMultiSignature::from(signature);
 
-		let result = verify_web3_authentication(storage_db, &alice_identity, &multi_signature);
+		let result = verify_web3_authentication(
+			storage_db,
+			"test_client",
+			&alice_identity,
+			&multi_signature,
+		);
 		assert!(result.is_ok());
 	}
 }

--- a/tee-worker/omni-executor/ts-tests/integration-tests/omni_account.test.ts
+++ b/tee-worker/omni-executor/ts-tests/integration-tests/omni_account.test.ts
@@ -36,7 +36,7 @@ describe('OmniAccount', function () {
             context.api,
             nativeTask,
             aliceWallet,
-            "00000",            
+            '00000',
             context.api.createType('Index', currentNonce),
             msgToSign
         );
@@ -88,7 +88,7 @@ describe('OmniAccount', function () {
             context.api,
             nativeTask,
             aliceWallet,
-            "00001",
+            '00001',
             context.api.createType('Index', currentNonce),
             msgToSign
         );
@@ -121,7 +121,7 @@ describe('OmniAccount', function () {
             context.api,
             nativeTask,
             aliceWallet,
-            "00002",
+            '00002',
             context.api.createType('Index', currentNonce),
             msgToSign
         );
@@ -173,7 +173,7 @@ describe('OmniAccount', function () {
             context.api,
             nativeTask,
             aliceWallet,
-            "00003",            
+            '00003',
             context.api.createType('Index', currentNonce),
             msgToSign
         );
@@ -213,7 +213,7 @@ describe('OmniAccount', function () {
             context.api,
             nativeTask,
             aliceWallet,
-            "000004",            
+            '000004',
             context.api.createType('Index', currentNonce),
             msgToSign
         );
@@ -251,7 +251,7 @@ describe('OmniAccount', function () {
             context.api,
             nativeTask,
             aliceWallet,
-            "00005",
+            '00005',
             context.api.createType('Index', currentNonce),
             msgToSign
         );

--- a/tee-worker/omni-executor/ts-tests/integration-tests/omni_account.test.ts
+++ b/tee-worker/omni-executor/ts-tests/integration-tests/omni_account.test.ts
@@ -5,7 +5,7 @@ import { createIntegrationTestContext, IntegrationTestContext } from './utils/co
 import { SubstrateSigner } from './utils/signer';
 import { getOmniAccount } from './utils/omni_account';
 import { createNativeTask, createNativeTaskWrapper, createOmniAccountPermission } from './utils/type_creators';
-import { getMessageCode, sendRawTaskPlain } from './utils/requests';
+import { getMessageToSign, sendRawTaskPlain } from './utils/requests';
 import { buildWeb3ValidationData } from './utils/identity';
 import { fundAccount, sleep } from './utils/helpers';
 import { encodeAddress } from '@polkadot/util-crypto';
@@ -29,8 +29,8 @@ describe('OmniAccount', function () {
         let accountStore = await context.api.query.omniAccount.accountStore(omniAccount);
         assert.isTrue(accountStore.isNone, 'accountStore already exists');
 
-        let msgCode = await getMessageCode(context, omniAccount);
-        console.log('msgCode:', msgCode);
+        let msgToSign = await getMessageToSign(context, 'heima', omniAccount);
+        console.log('msgCode:', msgToSign);
         const nativeTask = createNativeTask(context.api, ['CreateAccountStore', 'HeimaIdentity'], aliceIdentity);
         const nativeTaskWrapper = await createNativeTaskWrapper(
             context.api,
@@ -38,7 +38,7 @@ describe('OmniAccount', function () {
             aliceWallet,
             "00000",            
             context.api.createType('Index', currentNonce),
-            msgCode.message_code
+            msgToSign
         );
         console.log('nativeTaskWrapper:', nativeTaskWrapper.toHuman());
         await sendRawTaskPlain(context, nativeTaskWrapper);
@@ -83,14 +83,14 @@ describe('OmniAccount', function () {
                 [createOmniAccountPermission(context.api, 'All')],
             ]
         );
-        const msgCode = await getMessageCode(context, omniAccount);
+        const msgToSign = await getMessageToSign(context, 'heima', omniAccount);
         const nativeTaskWrapper = await createNativeTaskWrapper(
             context.api,
             nativeTask,
             aliceWallet,
             "00001",
             context.api.createType('Index', currentNonce),
-            msgCode.message_code
+            msgToSign
         );
         await sendRawTaskPlain(context, nativeTaskWrapper);
         currentNonce++;
@@ -116,14 +116,14 @@ describe('OmniAccount', function () {
             ['PublicizeAccount', '(HeimaIdentity, HeimaIdentity)'],
             [aliceIdentity, bobIdentity]
         );
-        const msgCode = await getMessageCode(context, omniAccount);
+        const msgToSign = await getMessageToSign(context, 'heima', omniAccount);
         const nativeTaskWrapper = await createNativeTaskWrapper(
             context.api,
             nativeTask,
             aliceWallet,
             "00002",
             context.api.createType('Index', currentNonce),
-            msgCode.message_code
+            msgToSign
         );
         await sendRawTaskPlain(context, nativeTaskWrapper);
         currentNonce++;
@@ -168,14 +168,14 @@ describe('OmniAccount', function () {
             ['SetPermissions', '(HeimaIdentity, HeimaIdentity, Vec<OmniAccountPermission>)'],
             [aliceIdentity, bobIdentity, newPermissions]
         );
-        const msgCode = await getMessageCode(context, omniAccount);
+        const msgToSign = await getMessageToSign(context, 'heima', omniAccount);
         const nativeTaskWrapper = await createNativeTaskWrapper(
             context.api,
             nativeTask,
             aliceWallet,
             "00003",            
             context.api.createType('Index', currentNonce),
-            msgCode.message_code
+            msgToSign
         );
         await sendRawTaskPlain(context, nativeTaskWrapper);
         currentNonce++;
@@ -208,14 +208,14 @@ describe('OmniAccount', function () {
             ['RemoveAccounts', '(HeimaIdentity, Vec<HeimaIdentity>)'],
             [aliceIdentity, [bobIdentity]]
         );
-        const msgCode = await getMessageCode(context, omniAccount);
+        const msgToSign = await getMessageToSign(context, 'heima', omniAccount);
         const nativeTaskWrapper = await createNativeTaskWrapper(
             context.api,
             nativeTask,
             aliceWallet,
             "000004",            
             context.api.createType('Index', currentNonce),
-            msgCode.message_code
+            msgToSign
         );
         await sendRawTaskPlain(context, nativeTaskWrapper);
         currentNonce++;
@@ -246,14 +246,14 @@ describe('OmniAccount', function () {
             ['RequestIntent', '(HeimaIdentity, u32, Intent)'],
             [aliceIdentity, intentId, intent]
         );
-        const msgCode = await getMessageCode(context, omniAccount);
+        const msgToSign = await getMessageToSign(context, 'heima', omniAccount);
         const nativeTaskWrapper = await createNativeTaskWrapper(
             context.api,
             nativeTask,
             aliceWallet,
             "00005",
             context.api.createType('Index', currentNonce),
-            msgCode.message_code
+            msgToSign
         );
         const response = await sendRawTaskPlain(context, nativeTaskWrapper);
         console.log('response:', response.toHuman());

--- a/tee-worker/omni-executor/ts-tests/integration-tests/utils/requests.ts
+++ b/tee-worker/omni-executor/ts-tests/integration-tests/utils/requests.ts
@@ -39,17 +39,27 @@ export async function sendRawTaskPlain(
     return sendRequest(context.teeWsClient, request, context.api, onMessageReceived);
 }
 
-type GetMessageCodeResponse = {
+export type SignMessagePayload = {
+    client_id: string;
+    omni_account: string;
     message_code: string;
 };
 
-export async function getMessageCode(
+/**
+ * Retrieves the message to sign for a given client ID and Omni account.
+ */
+export async function getMessageToSign(
     context: IntegrationTestContext,
+    clientId: string,
     omniAccount: string
-): Promise<GetMessageCodeResponse> {
-    const request = createJsonRpcRequest('omni_getMessageCode', { omni_account: omniAccount }, nextRequestId(context));
+): Promise<SignMessagePayload> {
+    const request = createJsonRpcRequest(
+        'omni_getMessageCode',
+        { client_id: clientId, omni_account: omniAccount },
+        nextRequestId(context)
+    );
 
-    const response = new Promise<GetMessageCodeResponse>((resolve, reject) =>
+    const response = new Promise<SignMessagePayload>((resolve, reject) =>
         context.teeWsClient.onMessage.addListener((data) => {
             const parsed = JSON.parse(data);
             if (parsed.id !== request.id) {

--- a/tee-worker/omni-executor/ts-tests/integration-tests/utils/type_creators.ts
+++ b/tee-worker/omni-executor/ts-tests/integration-tests/utils/type_creators.ts
@@ -13,7 +13,7 @@ import {
     NativeTaskWrapper,
 } from '@heima-network/api-argument/omni';
 import { Signer } from './signer';
-import { getMessageCode } from './requests';
+import { SignMessagePayload } from './requests';
 
 export async function createIdentityType(
     api: ApiPromise,
@@ -76,9 +76,9 @@ export async function createNativeTaskWrapper(
     signer: Signer,
     taskId: String,
     nonce: Codec,
-    msgCode: string
+    msgToSign: SignMessagePayload
 ): Promise<NativeTaskWrapper> {
-    const payload = JSON.stringify({ message_code: msgCode });
+    const payload = JSON.stringify(msgToSign);
     const hashedPayload = blake2AsHex(payload, 256);
     const signerIdentity = await signer.getIdentity(api);
 

--- a/tee-worker/omni-executor/ts-tests/integration-tests/utils/type_creators.ts
+++ b/tee-worker/omni-executor/ts-tests/integration-tests/utils/type_creators.ts
@@ -88,7 +88,7 @@ export async function createNativeTaskWrapper(
     });
 
     const auth: OmniAuth = api.createType('OmniAuth', {
-        Web3: api.createType('(Identity, HeimaMultiSignature)', [signerIdentity, signature]),
+        Web3: api.createType('(Text, Identity, HeimaMultiSignature)', ['heima', signerIdentity, signature]),
     });
     let n = api.createType('Option<Nonce>', nonce);
     let a = api.createType('Option<OmniAuth>', auth);


### PR DESCRIPTION
This PR updates the web3 sign-in message format to include `client_id` and `omni_account`. 