### PR TITLE
Enable jwt authentication on protected methods

### DIFF
--- a/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
@@ -7,7 +7,8 @@ use pumpx::*;
 mod omni;
 use omni::*;
 
-pub const PROTECTED_METHODS: [&str; 2] = ["omni_testProtectedMethod", "omni_addWallet"];
+pub const PROTECTED_METHODS: [&str; 3] =
+	["omni_testProtectedMethod", "omni_addWallet", "omni_notifyLimitOrderResult"];
 
 pub fn register_methods(module: &mut RpcModule<RpcContext>) {
 	register_omni(module);

--- a/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
@@ -7,8 +7,7 @@ use pumpx::*;
 mod omni;
 use omni::*;
 
-// TODO: list all protected methods here once the interface has been updated
-pub const PROTECTED_METHODS: [&str; 1] = ["omni_testProtectedMethod"];
+pub const PROTECTED_METHODS: [&str; 2] = ["omni_testProtectedMethod", "omni_addWallet"];
 
 pub fn register_methods(module: &mut RpcModule<RpcContext>) {
 	register_omni(module);

--- a/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
@@ -7,11 +7,12 @@ use pumpx::*;
 mod omni;
 use omni::*;
 
-pub const PROTECTED_METHODS: [&str; 4] = [
+pub const PROTECTED_METHODS: [&str; 5] = [
 	"omni_testProtectedMethod",
 	"omni_addWallet",
 	"omni_notifyLimitOrderResult",
 	"omni_signLimitOrder",
+	"omni_submitSwapOrder",
 ];
 
 pub fn register_methods(module: &mut RpcModule<RpcContext>) {

--- a/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
@@ -7,8 +7,12 @@ use pumpx::*;
 mod omni;
 use omni::*;
 
-pub const PROTECTED_METHODS: [&str; 3] =
-	["omni_testProtectedMethod", "omni_addWallet", "omni_notifyLimitOrderResult"];
+pub const PROTECTED_METHODS: [&str; 4] = [
+	"omni_testProtectedMethod",
+	"omni_addWallet",
+	"omni_notifyLimitOrderResult",
+	"omni_signLimitOrder",
+];
 
 pub fn register_methods(module: &mut RpcModule<RpcContext>) {
 	register_omni(module);

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/add_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/add_wallet.rs
@@ -1,9 +1,11 @@
+use super::common::{check_omni_api_response, handle_omni_native_task};
 use crate::{
-	error_code::*, methods::omni::PumpxRpcError, server::RpcContext, verify_auth::verify_auth,
+	error_code::*,
+	methods::omni::{common::check_auth, PumpxRpcError},
+	server::RpcContext,
 	Deserialize, ErrorCode,
 };
 use executor_core::native_task::*;
-use executor_primitives::OmniAuth;
 use heima_primitives::{Identity, Web2IdentityType};
 use jsonrpsee::RpcModule;
 use native_task_handler::NativeTaskOk;
@@ -11,12 +13,9 @@ use pumpx::methods::add_wallet::AddWalletResponse;
 use serde::Serialize;
 use tracing::{debug, error};
 
-use super::common::{check_omni_api_response, handle_omni_native_task};
-
 #[derive(Debug, Deserialize)]
 pub struct AddWalletParams {
 	pub user_email: String,
-	pub auth_token: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -27,17 +26,19 @@ pub struct RPCAddWalletResponse {
 impl From<AddWalletParams> for NativeTaskWrapper<NativeTask> {
 	fn from(p: AddWalletParams) -> Self {
 		let sender = Identity::from_web2_account(p.user_email.as_str(), Web2IdentityType::Email);
-		NativeTaskWrapper::new(
-			NativeTask::PumpxAddWallet(sender.clone()),
-			None,
-			Some(OmniAuth::AuthToken(p.auth_token)),
-		)
+		NativeTaskWrapper::new(NativeTask::PumpxAddWallet(sender.clone()), None, None)
 	}
 }
 
 pub fn register_add_wallet(module: &mut RpcModule<RpcContext>) {
 	module
-		.register_async_method("omni_addWallet", |params, ctx, _| async move {
+		.register_async_method("omni_addWallet", |params, ctx, ext| async move {
+			check_auth(&ext).map_err(|e| {
+				error!("Authentication check failed: {:?}", e);
+				PumpxRpcError::from_error_code(ErrorCode::ServerError(
+					AUTH_VERIFICATION_FAILED_CODE,
+				))
+			})?;
 			let params = params.parse::<AddWalletParams>().map_err(|e| {
 				error!("Failed to parse params: {:?}", e);
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
@@ -46,21 +47,6 @@ pub fn register_add_wallet(module: &mut RpcModule<RpcContext>) {
 			debug!("Received omni_addWallet, user_email: {}", params.user_email);
 
 			let wrapper: NativeTaskWrapper<NativeTask> = params.into();
-
-			if wrapper.task.require_auth() {
-				let Some(ref auth) = wrapper.auth else {
-					error!("Missing auth token");
-					return Err(PumpxRpcError::from_error_code(ErrorCode::ServerError(
-						REQUIRE_AUTHENTICATION_CODE,
-					)));
-				};
-				verify_auth(ctx.clone(), auth).await.map_err(|_| {
-					error!("Failed to verify auth: {:?}", wrapper.auth);
-					PumpxRpcError::from_error_code(ErrorCode::ServerError(
-						AUTH_VERIFICATION_FAILED_CODE,
-					))
-				})?;
-			}
 
 			handle_omni_native_task(&ctx, wrapper, |task_ok| match task_ok {
 				NativeTaskOk::PumpxAddWallet(response) => {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/common.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/common.rs
@@ -1,9 +1,10 @@
+use http::Extensions;
 use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
 use parity_scale_codec::Codec;
 use pumpx::methods::common::ApiResponse;
 use serde::Serialize;
 
-use crate::{error_code::*, oneshot, server::RpcContext, Decode};
+use crate::{error_code::*, middlewares::RpcExtensions, oneshot, server::RpcContext, Decode};
 use executor_core::native_task::*;
 use native_task_handler::{NativeTaskError, NativeTaskOk, NativeTaskResponse};
 use tracing::error;
@@ -119,4 +120,19 @@ where
 		return Err(PumpxRpcError::from_api_response(response));
 	}
 	Ok(())
+}
+
+pub struct User {
+	pub omni_account: String,
+}
+
+/// This is used to verify that the request is authenticated.
+/// If the RpcExtensions is not found, it indicates that the request is not authenticated.
+/// If the RpcExtensions is found, it contains the sender's omni account extracted from the JWT.
+/// Check rpc_middleware.rs
+pub fn check_auth(ext: &Extensions) -> Result<User, ()> {
+	if let Some(rpc_extensions) = ext.get::<RpcExtensions>() {
+		return Ok(User { omni_account: rpc_extensions.sender.clone() });
+	}
+	Err(())
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/notify_limit_order_result.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/notify_limit_order_result.rs
@@ -1,27 +1,30 @@
-use crate::methods::omni::PumpxRpcError;
-use crate::verify_auth::verify_auth_token_authentication;
+use super::common::handle_omni_native_task;
+use crate::methods::omni::{common::check_auth, PumpxRpcError};
 use crate::{error_code::*, server::RpcContext, Deserialize, ErrorCode};
 use executor_core::native_task::*;
-use executor_primitives::{utils::hex::FromHexPrefixed, OmniAuth};
-use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
+use executor_primitives::utils::hex::FromHexPrefixed;
 use heima_primitives::{Address32, Identity};
 use jsonrpsee::RpcModule;
 use native_task_handler::NativeTaskOk;
 use tracing::{debug, error};
-
-use super::common::handle_omni_native_task;
 
 #[derive(Debug, Deserialize)]
 pub struct NotifyLimitOrderResultParams {
 	pub intent_id: u32,
 	pub result: String,
 	pub message: Option<String>,
-	pub auth_token: String,
 }
 
 pub fn register_notify_limit_order_result(module: &mut RpcModule<RpcContext>) {
 	module
-		.register_async_method("omni_notifyLimitOrderResult", |params, ctx, _| async move {
+		.register_async_method("omni_notifyLimitOrderResult", |params, ctx, ext| async move {
+			let user = check_auth(&ext).map_err(|e| {
+				error!("Authentication check failed: {:?}", e);
+				PumpxRpcError::from_error_code(ErrorCode::ServerError(
+					AUTH_VERIFICATION_FAILED_CODE,
+				))
+			})?;
+
 			let params = params.parse::<NotifyLimitOrderResultParams>().map_err(|e| {
 				error!("Failed to parse params: {:?}", e);
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
@@ -32,22 +35,7 @@ pub fn register_notify_limit_order_result(module: &mut RpcModule<RpcContext>) {
 				params.intent_id, params.result, params.message
 			);
 
-			let omni_account = match verify_auth_token_authentication(
-				&ctx.jwt_rsa_private_key,
-				&params.auth_token,
-				AUTH_TOKEN_ACCESS_TYPE,
-				true,
-			) {
-				Ok(claims) => claims.sub,
-				Err(_) => {
-					error!("Failed to verify auth token");
-					return Err(PumpxRpcError::from_error_code(ErrorCode::ServerError(
-						AUTH_VERIFICATION_FAILED_CODE,
-					)));
-				},
-			};
-
-			let Ok(address) = Address32::from_hex(&omni_account) else {
+			let Ok(address) = Address32::from_hex(&user.omni_account) else {
 				error!("Failed to parse from omni account token");
 				return Err(PumpxRpcError::from_error_code(ErrorCode::InternalError));
 			};
@@ -60,7 +48,7 @@ pub fn register_notify_limit_order_result(module: &mut RpcModule<RpcContext>) {
 					params.message,
 				),
 				None,
-				Some(OmniAuth::AuthToken(params.auth_token)),
+				None,
 			);
 
 			handle_omni_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/sign_limit_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/sign_limit_order.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
+use super::common::handle_omni_native_task;
 use crate::error_code::AUTH_VERIFICATION_FAILED_CODE;
 use crate::methods::omni::common::check_auth;
 use crate::methods::omni::PumpxRpcError;
@@ -33,8 +34,6 @@ use native_task_handler::NativeTaskOk;
 use serde::Deserialize;
 use serde::Serialize;
 use tracing::{debug, error};
-
-use super::common::handle_omni_native_task;
 
 #[derive(Debug, Deserialize)]
 pub struct SignLimitOrderParams {
@@ -56,7 +55,7 @@ pub struct SignLimitOrderResponse {
 pub fn register_sign_limit_order_params(module: &mut RpcModule<RpcContext>) {
 	module
 		.register_async_method("omni_signLimitOrder", |params, ctx, ext| async move {
-           	let user = check_auth(&ext).map_err(|e| {
+			let user = check_auth(&ext).map_err(|e| {
 				error!("Authentication check failed: {:?}", e);
 				PumpxRpcError::from_error_code(ErrorCode::ServerError(
 					AUTH_VERIFICATION_FAILED_CODE,
@@ -68,7 +67,7 @@ pub fn register_sign_limit_order_params(module: &mut RpcModule<RpcContext>) {
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
 			})?;
 
-			debug!("Received omni_signLimitOrder, intent_id: {}, order_id: {}, chain_id: {}, wallet_index: {}", params.intent_id, params.order_id, params.chain_id, params.wallet_index);
+			debug!("Received omni_signLimitOrder, params: {:?}", params);
 
 			let Ok(address) = Address32::from_hex(&user.omni_account) else {
 				error!("Failed to parse from omni account token");
@@ -82,7 +81,7 @@ pub fn register_sign_limit_order_params(module: &mut RpcModule<RpcContext>) {
 					params.wallet_index,
 					params.unsigned_tx.iter().map(|tx| tx.to_vec()).collect(),
 				),
-		     	None,
+				None,
 				None,
 			);
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/sign_limit_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/sign_limit_order.rs
@@ -15,9 +15,9 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::error_code::AUTH_VERIFICATION_FAILED_CODE;
+use crate::methods::omni::common::check_auth;
 use crate::methods::omni::PumpxRpcError;
 use crate::server::RpcContext;
-use crate::verify_auth::verify_auth_token_authentication;
 use crate::ErrorCode;
 use ethers::types::Bytes;
 use executor_core::native_task::NativeTask;
@@ -25,8 +25,6 @@ use executor_core::native_task::NativeTaskWrapper;
 use executor_core::native_task::PumpxChainId;
 use executor_core::native_task::PumxWalletIndex;
 use executor_primitives::utils::hex::FromHexPrefixed;
-use executor_primitives::OmniAuth;
-use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use heima_primitives::Address32;
 use heima_primitives::Identity;
 use heima_primitives::IntentId;
@@ -45,7 +43,6 @@ pub struct SignLimitOrderParams {
 	pub chain_id: PumpxChainId,
 	pub wallet_index: PumxWalletIndex,
 	pub unsigned_tx: Vec<Bytes>,
-	pub auth_token: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -58,7 +55,14 @@ pub struct SignLimitOrderResponse {
 
 pub fn register_sign_limit_order_params(module: &mut RpcModule<RpcContext>) {
 	module
-		.register_async_method("omni_signLimitOrder", |params, ctx, _| async move {
+		.register_async_method("omni_signLimitOrder", |params, ctx, ext| async move {
+           	let user = check_auth(&ext).map_err(|e| {
+				error!("Authentication check failed: {:?}", e);
+				PumpxRpcError::from_error_code(ErrorCode::ServerError(
+					AUTH_VERIFICATION_FAILED_CODE,
+				))
+			})?;
+
 			let params = params.parse::<SignLimitOrderParams>().map_err(|e| {
 				error!("Failed to parse params: {:?}", e);
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
@@ -66,22 +70,7 @@ pub fn register_sign_limit_order_params(module: &mut RpcModule<RpcContext>) {
 
 			debug!("Received omni_signLimitOrder, intent_id: {}, order_id: {}, chain_id: {}, wallet_index: {}", params.intent_id, params.order_id, params.chain_id, params.wallet_index);
 
-           	let omni_account = match verify_auth_token_authentication(
-				&ctx.jwt_rsa_private_key,
-				&params.auth_token,
-				AUTH_TOKEN_ACCESS_TYPE,
-				true,
-			) {
-				Ok(claims) => claims.sub,
-				Err(_) => {
-					error!("Failed to verify auth token");
-					return Err(PumpxRpcError::from_error_code(ErrorCode::ServerError(
-						AUTH_VERIFICATION_FAILED_CODE,
-					)));
-				},
-			};
-
-			let Ok(address) = Address32::from_hex(&omni_account) else {
+			let Ok(address) = Address32::from_hex(&user.omni_account) else {
 				error!("Failed to parse from omni account token");
 				return Err(PumpxRpcError::from_error_code(ErrorCode::InternalError));
 			};
@@ -94,7 +83,7 @@ pub fn register_sign_limit_order_params(module: &mut RpcModule<RpcContext>) {
 					params.unsigned_tx.iter().map(|tx| tx.to_vec()).collect(),
 				),
 		     	None,
-				Some(OmniAuth::AuthToken(params.auth_token)),
+				None,
 			);
 
 			handle_omni_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
@@ -119,8 +119,7 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
 			})?;
 
-			debug!("Received omni_submitSwapOrder, user_email: {}, intent_id: {}, order_type: {:?}, swap_type: {:?}, from_chain_id: {}, from_token_ca: {:?}, from_amount: {}, to_chain_id: {}, to_token_ca: {:?}, wallet_index: {}",
-			params.user_email, params.intent_id, params.order_type, params.swap_type, params.from_chain_id, params.from_token_ca, params.from_amount, params.to_chain_id, params.to_token_ca, params.wallet_index);
+			debug!("Received omni_submitSwapOrder, params: {:?}", params);
 
 			let Ok(omni_account) = AccountId::from_str(&user.omni_account) else {
 				error!("Failed to parse from omni account token");

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/submit_swap_order.rs
@@ -1,12 +1,13 @@
-use crate::methods::omni::PumpxRpcError;
+use super::common::{check_omni_api_response, handle_omni_native_task};
 use crate::{
-	error_code::*, server::RpcContext, verify_auth::verify_auth_token_authentication, Decode,
-	Deserialize, ErrorCode,
+	error_code::*,
+	methods::omni::{common::check_auth, PumpxRpcError},
+	server::RpcContext,
+	Decode, Deserialize, ErrorCode,
 };
 use executor_core::native_task::*;
-use executor_primitives::OmniAuth;
 use executor_storage::{HeimaJwtStorage, Storage};
-use heima_authentication::constants::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_ID_TYPE};
+use heima_authentication::constants::AUTH_TOKEN_ACCESS_TYPE;
 use heima_primitives::{
 	AccountId, Address20, Address32, BinanceConfig, BoundedVec, ChainAsset, CrossChainSwapProvider,
 	EthereumToken, Identity, Intent, PumpxConfig, PumpxOrderType, SingleChainSwapProvider,
@@ -21,8 +22,6 @@ use pumpx::methods::send_order_tx::SendOrderTxResponse;
 use serde::Serialize;
 use std::str::FromStr;
 use tracing::{debug, error};
-
-use super::common::{check_omni_api_response, handle_omni_native_task};
 
 #[derive(Debug, Deserialize)]
 pub struct SubmitSwapOrderParams {
@@ -42,7 +41,6 @@ pub struct SubmitSwapOrderParams {
 	pub usd_worth: String,
 	pub trailing_percent: Option<u32>,
 	pub wallet_index: u32,
-	pub auth_token: String,
 }
 
 impl SubmitSwapOrderParams {
@@ -108,7 +106,14 @@ struct BackendResponse {
 
 pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 	module
-		.register_async_method("omni_submitSwapOrder", |params, ctx, _| async move {
+		.register_async_method("omni_submitSwapOrder", |params, ctx, ext| async move {
+			let user = check_auth(&ext).map_err(|e| {
+				error!("Authentication check failed: {:?}", e);
+				PumpxRpcError::from_error_code(ErrorCode::ServerError(
+					AUTH_VERIFICATION_FAILED_CODE,
+				))
+			})?;
+
 			let params = params.parse::<SubmitSwapOrderParams>().map_err(|e| {
 				error!("Failed to parse params: {:?}", e);
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
@@ -117,20 +122,10 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 			debug!("Received omni_submitSwapOrder, user_email: {}, intent_id: {}, order_type: {:?}, swap_type: {:?}, from_chain_id: {}, from_token_ca: {:?}, from_amount: {}, to_chain_id: {}, to_token_ca: {:?}, wallet_index: {}",
 			params.user_email, params.intent_id, params.order_type, params.swap_type, params.from_chain_id, params.from_token_ca, params.from_amount, params.to_chain_id, params.to_token_ca, params.wallet_index);
 
-            let omni_account = match verify_auth_token_authentication(&ctx.jwt_rsa_private_key, &params.auth_token, AUTH_TOKEN_ID_TYPE, false) {
-                Ok(claims) => {
-                    AccountId::from_str(&claims.sub).map_err(|_| {
-                        error!("Failed to parse account id from auth token");
-                        PumpxRpcError::from_error_code(ErrorCode::InternalError)
-                    })?
-                },
-                Err(_) => {
-                    error!("Failed to verify auth token");
-                    return Err(PumpxRpcError::from_error_code(ErrorCode::ServerError(
-                        AUTH_VERIFICATION_FAILED_CODE,
-                    )));
-                }
-            };
+			let Ok(omni_account) = AccountId::from_str(&user.omni_account) else {
+				error!("Failed to parse from omni account token");
+				return Err(PumpxRpcError::from_error_code(ErrorCode::InternalError));
+			};
 
 			let from_chain_asset = params.try_get_from_chain_asset().map_err(|_| {
 				error!("Failed to get from chain asset");
@@ -155,8 +150,7 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 				})?;
 
 			let storage = HeimaJwtStorage::new(ctx.storage_db.clone());
-			let Ok(Some(access_token)) =
-				storage.get(&(omni_account, AUTH_TOKEN_ACCESS_TYPE))
+			let Ok(Some(access_token)) = storage.get(&(omni_account, AUTH_TOKEN_ACCESS_TYPE))
 			else {
 				error!("Failed to get access token from storage");
 				return Err(PumpxRpcError::from_error_code(ErrorCode::InternalError));
@@ -178,14 +172,35 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 
 			debug!("Response pumpx get_user_trade_info: {:?}", user_trade_info);
 
-			let gas_type_base = check_and_get_option_user_trade_info_field(user_trade_info.data.gas_type_base, "gas_type_base")?;
-			let gas_type_bsc = check_and_get_option_user_trade_info_field(user_trade_info.data.gas_type_bsc, "gas_type_bsc")?;
-			let gas_type_eth = check_and_get_option_user_trade_info_field(user_trade_info.data.gas_type_eth, "gas_type_eth")?;
-			let gas_type_sol = check_and_get_option_user_trade_info_field(user_trade_info.data.gas_type_sol, "gas_type_sol")?;
+			let gas_type_base = check_and_get_option_user_trade_info_field(
+				user_trade_info.data.gas_type_base,
+				"gas_type_base",
+			)?;
+			let gas_type_bsc = check_and_get_option_user_trade_info_field(
+				user_trade_info.data.gas_type_bsc,
+				"gas_type_bsc",
+			)?;
+			let gas_type_eth = check_and_get_option_user_trade_info_field(
+				user_trade_info.data.gas_type_eth,
+				"gas_type_eth",
+			)?;
+			let gas_type_sol = check_and_get_option_user_trade_info_field(
+				user_trade_info.data.gas_type_sol,
+				"gas_type_sol",
+			)?;
 
-			let is_anti_mev = check_and_get_option_user_trade_info_field(user_trade_info.data.is_anti_mev, "is_anti_mev")?;
-			let is_auto_slippage = check_and_get_option_user_trade_info_field(user_trade_info.data.is_auto_slippage, "is_auto_slippage")?;
-			let slippage = check_and_get_option_user_trade_info_field(user_trade_info.data.slippage, "slippage")?;
+			let is_anti_mev = check_and_get_option_user_trade_info_field(
+				user_trade_info.data.is_anti_mev,
+				"is_anti_mev",
+			)?;
+			let is_auto_slippage = check_and_get_option_user_trade_info_field(
+				user_trade_info.data.is_auto_slippage,
+				"is_auto_slippage",
+			)?;
+			let slippage = check_and_get_option_user_trade_info_field(
+				user_trade_info.data.slippage,
+				"slippage",
+			)?;
 
 			let gas_type = match params.to_chain_id {
 				BASE_CHAIN_ID => gas_type_base.to_number() as u32,
@@ -226,16 +241,20 @@ pub fn register_submit_swap_order(module: &mut RpcModule<RpcContext>) {
 				ccs_provider = Some(CrossChainSwapProvider::Binance(BinanceConfig {}));
 			}
 
-			let intent = Intent::Swap(swap_order, ccs_provider, scs_provider.try_into().map_err(|_| {
-                error!("Failed to convert single chain swap provider");
-                PumpxRpcError::from_error_code(ErrorCode::InternalError)
-            })?);
-           	let user_identity =
+			let intent = Intent::Swap(
+				swap_order,
+				ccs_provider,
+				scs_provider.try_into().map_err(|_| {
+					error!("Failed to convert single chain swap provider");
+					PumpxRpcError::from_error_code(ErrorCode::InternalError)
+				})?,
+			);
+			let user_identity =
 				Identity::from_web2_account(&params.user_email, Web2IdentityType::Pumpx);
 			let wrapper = NativeTaskWrapper::new(
 				NativeTask::RequestIntent(user_identity, params.intent_id, intent),
-				 None,
-				 Some(OmniAuth::AuthToken(params.auth_token)),
+				None,
+				None,
 			);
 
 			handle_omni_native_task(&ctx, wrapper, |task_ok| match task_ok {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/test_protected_method.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/test_protected_method.rs
@@ -1,12 +1,13 @@
-use crate::{middlewares::RpcExtensions, server::RpcContext};
+use crate::methods::omni::common::check_auth;
+use crate::server::RpcContext;
 use jsonrpsee::{types::ErrorObject, RpcModule};
 
 #[cfg(test)]
 pub fn register_test_protected_method(module: &mut RpcModule<RpcContext>) {
 	module
 		.register_method("omni_testProtectedMethod", |_, _, ext| {
-			if let Some(rpc_extensions) = ext.get::<RpcExtensions>() {
-				return Ok::<String, ErrorObject>(rpc_extensions.sender.clone());
+			if let Ok(user) = check_auth(ext) {
+				return Ok::<String, ErrorObject>(user.omni_account);
 			}
 			panic!("RpcExtensions not found in request extensions");
 		})

--- a/tee-worker/omni-executor/rpc-server/src/middlewares/rpc_middleware.rs
+++ b/tee-worker/omni-executor/rpc-server/src/middlewares/rpc_middleware.rs
@@ -2,7 +2,7 @@ use crate::{
 	error_code::AUTH_VERIFICATION_FAILED_CODE, methods::PROTECTED_METHODS,
 	middlewares::HttpExtensions, verify_auth::verify_auth_token_authentication,
 };
-use heima_authentication::constants::AUTH_TOKEN_ID_TYPE;
+use heima_authentication::constants::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_ID_TYPE};
 use jsonrpsee::{
 	server::{
 		middleware::rpc::{ResponseFuture, RpcServiceT},
@@ -60,7 +60,7 @@ where
 				match verify_auth_token_authentication(
 					&self.rsa_private_key,
 					token,
-					AUTH_TOKEN_ID_TYPE, // TODO: conditionally set token type based on the method
+					auth_token_type_for_method(req.method_name()),
 					false,
 				) {
 					Ok(claims) => {
@@ -88,5 +88,16 @@ where
 		}
 
 		ResponseFuture::future(self.service.call(req))
+	}
+}
+
+// Defines the methods that require "access" auth token type
+const ACCESS_TOKEN_PROTECTED_METHODS: [&str; 1] = ["omni_notifyLimitOrderResult"];
+
+fn auth_token_type_for_method(method: &str) -> &'static str {
+	if ACCESS_TOKEN_PROTECTED_METHODS.contains(&method) {
+		AUTH_TOKEN_ACCESS_TYPE
+	} else {
+		AUTH_TOKEN_ID_TYPE
 	}
 }

--- a/tee-worker/omni-executor/rpc-server/src/middlewares/rpc_middleware.rs
+++ b/tee-worker/omni-executor/rpc-server/src/middlewares/rpc_middleware.rs
@@ -92,7 +92,8 @@ where
 }
 
 // Defines the methods that require "access" auth token type
-const ACCESS_TOKEN_PROTECTED_METHODS: [&str; 1] = ["omni_notifyLimitOrderResult"];
+const ACCESS_TOKEN_PROTECTED_METHODS: [&str; 2] =
+	["omni_notifyLimitOrderResult", "omni_signLimitOrder"];
 
 fn auth_token_type_for_method(method: &str) -> &'static str {
 	if ACCESS_TOKEN_PROTECTED_METHODS.contains(&method) {

--- a/tee-worker/omni-executor/rpc-server/src/middlewares/rpc_middleware.rs
+++ b/tee-worker/omni-executor/rpc-server/src/middlewares/rpc_middleware.rs
@@ -13,7 +13,6 @@ use jsonrpsee::{
 use tower::layer::util::{Identity, Stack};
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // TODO: remove this once the extensions are used in the methods
 pub struct RpcExtensions {
 	pub sender: String,
 }


### PR DESCRIPTION
In this PR we are enabling and enforcing jwt authentication (through the authorization header) the the required methods instead of receiving the tokens in the methods params
