### PR TITLE
Use OmniAccount hash as storage key for email verification code

### DIFF
--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/account-store.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/account-store.request.test.ts
@@ -459,7 +459,7 @@ describe('account-store', () => {
     console.log('Step 1: create account store');
     await (async () => {
       // Request email verification code for next account store creation
-      await requestEmailVerificationCode({ email });
+      await requestEmailVerificationCode({ email, clientId: 'account-store-test-client' });
       // Get the email verification code from the email inbox
       const verificationCode = 'emailVerificationCodeYouReceivedInEmail';
 
@@ -487,7 +487,7 @@ describe('account-store', () => {
     // Step 2: request auth token
     console.log('Step 2: request auth token');
     // Request email verification code again for next auth token request
-    await requestEmailVerificationCode({ email });
+    await requestEmailVerificationCode({ email, clientId: 'account-store-test-client' });
     // Get the email verification code from the email inbox
     const verificationCode = 'emailVerificationCodeYouReceivedInEmail';
 

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/pumpx-request-jwt.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/pumpx-request-jwt.request.test.ts
@@ -40,7 +40,7 @@ describe('pumpx-request-jwt', () => {
 
         // Step 1
         it('request email verification code', async () => {
-            await requestEmailVerificationCode({ email });
+            await requestEmailVerificationCode({ email, clientId: 'pumpx-test-client' });
         });
 
         // Step 2

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/request-email-verification-code.request.test.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/__test__/request-email-verification-code.request.test.ts
@@ -4,6 +4,7 @@ describe.skip('request-email-verification-code', () => {
   it('should works', async () => {
     await requestEmailVerificationCode({
       email: 'test@google.com',
+      clientId: 'test-client-id',
     });
   });
 });

--- a/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/request-email-verification-code.request.ts
+++ b/tee-worker/omni-executor/client-sdk/packages/client-sdk/src/lib/requests/request-email-verification-code.request.ts
@@ -9,13 +9,15 @@ import { enclave, Enclave } from '@lib/enclave';
  *
  * @param {Object} args - The args object containing the following properties:
  * @param {string} args.email - The email address to send the verification code to.
+ * @param {string} args.clientId - The client ID to associate with the verification request.
  * @param {Enclave} [enclaveInstance] - The enclave instance to use for the request.
- * @throws {Error} Throws an error if the email is empty.
+ * @throws {Error} Throws an error if the email or clientId is empty.
  * @returns {Promise<void>} A promise that resolves when the request is sent.
  */
-export async function requestEmailVerificationCode(args: { email: string }, enclaveInstance: Enclave = enclave): Promise<void> {
-  const { email } = args;
+export async function requestEmailVerificationCode(args: { email: string; clientId: string }, enclaveInstance: Enclave = enclave): Promise<void> {
+  const { email, clientId } = args;
   assert(email.length > 0, 'Email is required');
+  assert(clientId.length > 0, 'Client ID is required');
 
   // send the request to the Enclave
   const rpcRequest: JsonRpcRequest = {
@@ -23,6 +25,7 @@ export async function requestEmailVerificationCode(args: { email: string }, encl
     method: 'omni_requestEmailVerificationCode',
     params: {
       user_email: email,
+      client_id: clientId,
     },
   };
 

--- a/tee-worker/omni-executor/executor-primitives/src/auth.rs
+++ b/tee-worker/omni-executor/executor-primitives/src/auth.rs
@@ -92,7 +92,7 @@ impl TryFrom<UserId> for Identity {
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 pub enum OmniAuth {
 	Web3(String, Identity, HeimaMultiSignature), // (client_id, Signer, Signature)
-	Email(Email, VerificationCode),
+	Email(String, Email, VerificationCode),      // (client_id, Email, VerificationCode)
 	AuthToken(JwtToken),
 	OAuth2(Identity, OAuth2Data), // (Sender, OAuth2Data)
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/export_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/export_wallet.rs
@@ -18,6 +18,7 @@ use super::common::handle_omni_native_task;
 #[derive(Debug, Deserialize)]
 pub struct ExportWalletParams {
 	pub user_email: String,
+	pub client_id: String,
 	pub key: Bytes, // RSA-encrypted AES key to encrypt the wallet private key, in 0x-hex-string
 	pub google_code: String,
 	pub chain_id: PumpxChainId,
@@ -37,7 +38,7 @@ impl From<ExportWalletParams> for NativeTaskWrapper<NativeTask> {
 				p.wallet_address,
 			),
 			None,
-			Some(OmniAuth::Email(p.user_email, p.email_code)),
+			Some(OmniAuth::Email(p.client_id.clone(), p.user_email, p.email_code)),
 		)
 	}
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_email_verification_code.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_email_verification_code.rs
@@ -1,5 +1,5 @@
 use crate::{server::RpcContext, Deserialize};
-use executor_primitives::{Identity, Web2IdentityType};
+use executor_primitives::{Hashable, Identity, Web2IdentityType};
 use executor_storage::{Storage, VerificationCodeStorage};
 use heima_identity_verification::web2::email::{
 	generate_verification_code, send_verification_email,
@@ -12,6 +12,7 @@ use tracing::{debug, error};
 
 #[derive(Debug, Deserialize)]
 pub struct RequestEmailVerificationCodeParams {
+	pub client_id: String,
 	pub user_email: String,
 }
 
@@ -20,16 +21,20 @@ pub fn register_request_email_verification_code(module: &mut RpcModule<RpcContex
 		.register_async_method("omni_requestEmailVerificationCode", |params, ctx, _| async move {
 			let params = params.parse::<RequestEmailVerificationCodeParams>()?;
 
-			debug!("Received omni_requestEmailVerificationCode, user_email: {}", params.user_email);
+			debug!(
+				"Received omni_requestEmailVerificationCode, client_id: {}, user_email: {}",
+				params.client_id, params.user_email
+			);
 
-			// please note here we still use `email_identity` as key
+			// Create omni account from email identity and client_id
 			let email_identity =
 				Identity::from_web2_account(&params.user_email, Web2IdentityType::Email);
+			let omni_account = email_identity.to_omni_account_with_client_id(&params.client_id);
 			let verification_code_storage = VerificationCodeStorage::new(ctx.storage_db.clone());
 			let verification_code = generate_verification_code();
 
 			verification_code_storage
-				.insert(&email_identity.hash(), verification_code.clone())
+				.insert(&omni_account.hash(), verification_code.clone())
 				.map_err(|_| ErrorCode::InternalError)?;
 
 			send_verification_email(&ctx.mailer, params.user_email, verification_code)

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_email_verification_code.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_email_verification_code.rs
@@ -26,7 +26,6 @@ pub fn register_request_email_verification_code(module: &mut RpcModule<RpcContex
 				params.client_id, params.user_email
 			);
 
-			// Create omni account from email identity and client_id
 			let email_identity =
 				Identity::from_web2_account(&params.user_email, Web2IdentityType::Email);
 			let omni_account = email_identity.to_omni_account_with_client_id(&params.client_id);

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_jwt.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_jwt.rs
@@ -16,6 +16,7 @@ use super::common::{check_omni_api_response, handle_omni_native_task};
 #[derive(Debug, Deserialize)]
 pub struct RequestJwtParams {
 	pub user_email: String,
+	pub client_id: String,
 	pub invite_code: Option<String>,
 	pub google_code: String,
 	pub language: Option<String>,
@@ -40,7 +41,7 @@ impl From<RequestJwtParams> for NativeTaskWrapper<NativeTask> {
 				p.language,
 			),
 			None,
-			Some(OmniAuth::Email(p.user_email, p.email_code)),
+			Some(OmniAuth::Email(p.client_id.clone(), p.user_email, p.email_code)),
 		)
 	}
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/transfer_widthdraw.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/transfer_widthdraw.rs
@@ -16,6 +16,7 @@ use super::common::{check_omni_api_response, handle_omni_native_task};
 #[derive(Debug, Deserialize)]
 pub struct TransferWithdrawParams {
 	pub user_email: String,
+	pub client_id: String,
 	pub request_id: Option<u32>,
 	pub chain_id: u32,
 	pub wallet_index: PumxWalletIndex,
@@ -47,7 +48,7 @@ impl From<TransferWithdrawParams> for NativeTaskWrapper<NativeTask> {
 				p.lang,
 			),
 			None,
-			Some(OmniAuth::Email(p.user_email, p.email_code)),
+			Some(OmniAuth::Email(p.client_id.clone(), p.user_email, p.email_code)),
 		)
 	}
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/user_login.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/user_login.rs
@@ -43,7 +43,7 @@ impl TryFrom<UserLoginParams> for OmniAuth {
 					error!("User ID must be an email for Email authentication");
 					return Err(ErrorCode::ParseError);
 				};
-				OmniAuth::Email(email, code)
+				OmniAuth::Email(p.client_id.clone(), email, code)
 			},
 			UserAuth::Substrate(signature) => {
 				let identity = Identity::try_from(p.user_id).map_err(|_| {

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/export_wallet.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/export_wallet.rs
@@ -22,6 +22,7 @@ use super::common::handle_pumpx_native_task;
 pub struct ExportWalletParams {
 	pub user_id: String,
 	pub user_email: String,
+	pub client_id: String,
 	pub key: Bytes, // RSA-encrypted AES key to encrypt the wallet private key, in 0x-hex-string
 	pub google_code: String,
 	pub chain_id: PumpxChainId,
@@ -41,7 +42,7 @@ impl From<ExportWalletParams> for NativeTaskWrapper<NativeTask> {
 				p.wallet_address,
 			),
 			None,
-			Some(OmniAuth::Email(p.user_email, p.email_code)),
+			Some(OmniAuth::Email(p.client_id.clone(), p.user_email, p.email_code)),
 		)
 	}
 }
@@ -103,7 +104,7 @@ pub fn register_export_wallet(module: &mut RpcModule<RpcContext>) {
 
            	if wrapper.task.require_auth() {
 				let Some(ref auth) = wrapper.auth else {
-					error!("Missing auth token");
+					error!("Missing auth");
 					return Err(PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						REQUIRE_AUTHENTICATION_CODE,
 					)));

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/request_jwt.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/request_jwt.rs
@@ -16,6 +16,7 @@ use super::common::{check_pumpx_api_response, handle_pumpx_native_task};
 #[derive(Debug, Deserialize)]
 pub struct RequestJwtParams {
 	pub user_email: String,
+	pub client_id: String,
 	pub invite_code: Option<String>,
 	pub google_code: String,
 	pub language: Option<String>,
@@ -40,7 +41,7 @@ impl From<RequestJwtParams> for NativeTaskWrapper<NativeTask> {
 				p.language,
 			),
 			None,
-			Some(OmniAuth::Email(p.user_email, p.email_code)),
+			Some(OmniAuth::Email(p.client_id.clone(), p.user_email, p.email_code)),
 		)
 	}
 }
@@ -59,7 +60,7 @@ pub fn register_request_jwt(module: &mut RpcModule<RpcContext>) {
 
 			if wrapper.task.require_auth() {
 				let Some(ref auth) = wrapper.auth else {
-					error!("Missing auth token");
+					error!("Missing auth");
 					return Err(PumpxRpcError::from_error_code(ErrorCode::ServerError(
 						REQUIRE_AUTHENTICATION_CODE,
 					)));

--- a/tee-worker/omni-executor/rpc-server/src/methods/pumpx/transfer_widthdraw.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/pumpx/transfer_widthdraw.rs
@@ -20,6 +20,7 @@ use super::common::{check_pumpx_api_response, handle_pumpx_native_task};
 pub struct TransferWithdrawParams {
 	pub user_id: String,
 	pub user_email: String,
+	pub client_id: String,
 	pub request_id: Option<u32>,
 	pub chain_id: u32,
 	pub wallet_index: PumxWalletIndex,
@@ -51,7 +52,7 @@ impl From<TransferWithdrawParams> for NativeTaskWrapper<NativeTask> {
 				p.lang,
 			),
 			None,
-			Some(OmniAuth::Email(p.user_email, p.email_code)),
+			Some(OmniAuth::Email(p.client_id.clone(), p.user_email, p.email_code)),
 		)
 	}
 }

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -49,8 +49,8 @@ pub async fn verify_auth(ctx: Arc<RpcContext>, auth: &OmniAuth) -> Result<(), Au
 		OmniAuth::Web3(ref client_id, ref signer, ref signature) => {
 			verify_web3_authentication(ctx.storage_db.clone(), client_id, signer, signature)
 		},
-		OmniAuth::Email(ref email, ref verification_code) => {
-			verify_email_authentication(ctx, email, verification_code)
+		OmniAuth::Email(ref client_id, ref email, ref verification_code) => {
+			verify_email_authentication(ctx, client_id, email, verification_code)
 		},
 		OmniAuth::OAuth2(ref sender, ref oauth2_data) => {
 			verify_oauth2_authentication(ctx, sender, oauth2_data).await
@@ -96,10 +96,13 @@ pub fn verify_web3_authentication(
 
 pub fn verify_email_authentication(
 	ctx: Arc<RpcContext>,
+	client_id: &str,
 	email: &str,
 	verification_code: &VerificationCode,
 ) -> Result<(), AuthenticationError> {
-	let storage_key = Identity::from_web2_account(email, Web2IdentityType::Email).hash();
+	let email_identity = Identity::from_web2_account(email, Web2IdentityType::Email);
+	let omni_account = email_identity.to_omni_account_with_client_id(client_id);
+	let storage_key = omni_account.hash();
 	let verification_code_storage = VerificationCodeStorage::new(ctx.storage_db.clone());
 	let Ok(Some(code)) = verification_code_storage.get(&storage_key) else {
 		return Err(AuthenticationError::VerificationCodeNotFound);


### PR DESCRIPTION
Refactors the email verification code flow to use the omni account hash (derived from email and client_id) as the storage key in VerificationCodeStorage, instead of the email identity hash and updates all relevant RPC methods.



