### PR TITLE
propagate parentchain rpc client error

### DIFF
--- a/tee-worker/omni-executor/parentchain/rpc-client/src/lib.rs
+++ b/tee-worker/omni-executor/parentchain/rpc-client/src/lib.rs
@@ -26,6 +26,7 @@ use async_trait::async_trait;
 use executor_primitives::{AccountId, BlockEvent, BlockNumber, EventId, Hash};
 use parity_scale_codec::{Decode, Encode};
 use scale_encode::EncodeAsType;
+use std::error::Error;
 use std::marker::PhantomData;
 use std::vec::Vec;
 use subxt::{
@@ -367,7 +368,7 @@ impl<ChainConfig: Config<AccountId = String, Header = RpcClientHeader>>
 
 #[async_trait]
 pub trait SubstrateRpcClientFactory<Header, RpcClient: SubstrateRpcClient<Header>> {
-	async fn new_client(&self) -> Result<RpcClient, ()>;
+	async fn new_client(&self) -> Result<RpcClient, Box<dyn Error>>;
 }
 
 #[derive(Clone)]
@@ -407,19 +408,13 @@ impl<ChainConfig: Config<AccountId = AccountId32, Header = RpcClientHeader>>
 	SubstrateRpcClientFactory<ChainConfig::Header, SubxtClient<ChainConfig>>
 	for SubxtClientFactory<ChainConfig>
 {
-	async fn new_client(&self) -> Result<SubxtClient<ChainConfig>, ()> {
+	async fn new_client(&self) -> Result<SubxtClient<ChainConfig>, Box<dyn Error>> {
 		let rpc_client = subxt::backend::rpc::reconnecting_rpc_client::RpcClient::builder()
 			.build(self.url.clone())
-			.await
-			.map_err(|e| {
-				error!("Could not create RpcClient: {:?}", e);
-			})?;
+			.await?;
 		let legacy = LegacyRpcMethods::new(rpc_client.into());
 
-		let online_client =
-			OnlineClient::from_insecure_url(self.url.clone()).await.map_err(|e| {
-				error!("Could not create OnlineClient: {:?}", e);
-			})?;
+		let online_client = OnlineClient::from_insecure_url(self.url.clone()).await?;
 
 		let events = online_client.events();
 		let tx = online_client.tx();


### PR DESCRIPTION
Propagate rpc client error so it can be logged by calling code 
before 
`2025-06-11T13:02:54.250490Z ERROR executor_storage: Could not create client: ()`
after
 `2025-06-11T13:01:53.084826Z ERROR executor_storage: Could not create client: Transport(RelativeUrlWithoutBase)`
