### PR TITLE
Disable id-worker related dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/parachain"
+      - "/tee-worker/omni-executor"
     labels: ["automated-pr"]
     # Handle updates for crates from github.com/paritytech/substrate manually.
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,22 +29,10 @@ updates:
     schedule:
       interval: "weekly"
       
-  # npm dependencies for parachain
   - package-ecosystem: "npm"
-    directory: "/parachain"
-    labels: ["automated-pr"]
-    groups:
-      typescript-dependencies:
-        patterns:
-          - "*"
-    reviewers:
-      - "litentry/parachain"
-    schedule:
-      interval: "weekly"
-
-  # npm dependencies for omni-executor
-  - package-ecosystem: "npm"
-    directory: "/tee-worker/omni-executor"
+    directories:
+      - "/parachain"
+      - "/tee-worker/omni-executor"
     labels: ["automated-pr"]
     groups:
       typescript-dependencies:


### PR DESCRIPTION
### Context

As topic - it groups `parachain` and `tee-worker/omni-executor` to the same package manager


