### PR TITLE
Do not require auth for rootSigner getter

### DIFF
--- a/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/mod.rs
@@ -7,7 +7,7 @@ use pumpx::*;
 mod omni;
 use omni::*;
 
-pub const PROTECTED_METHODS: [&str; 8] = [
+pub const PROTECTED_METHODS: [&str; 7] = [
 	"omni_testProtectedMethod",
 	"omni_addWallet",
 	"omni_notifyLimitOrderResult",
@@ -15,7 +15,6 @@ pub const PROTECTED_METHODS: [&str; 8] = [
 	"omni_submitSwapOrder",
 	"omni_transferWithdraw",
 	"omni_exportWallet",
-	"omni_getSmartWalletRootSigner",
 ];
 
 pub fn register_methods(module: &mut RpcModule<RpcContext>) {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_smart_wallet_root_signer.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_smart_wallet_root_signer.rs
@@ -14,20 +14,14 @@ use tracing::{debug, error};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetSmartWalletRootSignerParams {
+	pub omni_account: String,
 	pub chain_type: ChainType,
 	pub index: u32,
 }
 
 pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>) {
 	module
-		.register_async_method("omni_getSmartWalletRootSigner", |params, ctx, ext| async move {
-			let user = check_auth(&ext).map_err(|e| {
-				error!("Authentication check failed: {:?}", e);
-				PumpxRpcError::from_error_code(ErrorCode::ServerError(
-					AUTH_VERIFICATION_FAILED_CODE,
-				))
-			})?;
-
+		.register_async_method("omni_getSmartWalletRootSigner", |params, _, ext| async move {
 			let params = params.parse::<GetSmartWalletRootSignerParams>().map_err(|e| {
 				error!("Failed to parse params: {:?}", e);
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
@@ -35,7 +29,7 @@ pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>)
 
 			debug!("Received omni_getSmartWalletRootSigner");
 
-			let Ok(address) = Address32::from_hex(&user.omni_account) else {
+			let Ok(address) = Address32::from_hex(&omni_account) else {
 				error!("Failed to parse from omni account token");
 				return Err(PumpxRpcError::from_error_code(ErrorCode::InternalError));
 			};

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_smart_wallet_root_signer.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_smart_wallet_root_signer.rs
@@ -1,9 +1,4 @@
-use crate::{
-	error_code::*,
-	methods::omni::{common::check_auth, PumpxRpcError},
-	server::RpcContext,
-	ErrorCode,
-};
+use crate::{error_code::*, methods::omni::PumpxRpcError, server::RpcContext, ErrorCode};
 use executor_primitives::utils::hex::FromHexPrefixed;
 use heima_primitives::Address32;
 use jsonrpsee::RpcModule;
@@ -21,7 +16,7 @@ pub struct GetSmartWalletRootSignerParams {
 
 pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>) {
 	module
-		.register_async_method("omni_getSmartWalletRootSigner", |params, _, ext| async move {
+		.register_async_method("omni_getSmartWalletRootSigner", |params, ctx, _| async move {
 			let params = params.parse::<GetSmartWalletRootSignerParams>().map_err(|e| {
 				error!("Failed to parse params: {:?}", e);
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
@@ -29,7 +24,7 @@ pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>)
 
 			debug!("Received omni_getSmartWalletRootSigner");
 
-			let Ok(address) = Address32::from_hex(&omni_account) else {
+			let Ok(address) = Address32::from_hex(&params.omni_account) else {
 				error!("Failed to parse from omni account token");
 				return Err(PumpxRpcError::from_error_code(ErrorCode::InternalError));
 			};


### PR DESCRIPTION
### Context

As a follow-up of stateless UserOp submission we remove the auth required to query the authorisedKey from worker.

Lmk if you see any problems