### PR TITLE
Update param name in `omni_getSmartWalletRootSigner`

### DIFF
--- a/tee-worker/omni-executor/aa-contracts/aa-demo-app/src/lib/tee-worker-client.ts
+++ b/tee-worker/omni-executor/aa-contracts/aa-demo-app/src/lib/tee-worker-client.ts
@@ -28,7 +28,7 @@ interface UserLoginResponse {
 
 interface GetSmartWalletRootSignerParams {
 	chain_type: "Evm" | "Solana" | "Tron";
-	index: number;
+	wallet_index: number;
 }
 
 // JSON-RPC request helper
@@ -49,7 +49,7 @@ async function makeRpcRequest<T>(
 	// If params is already an array (for methods like omni_getWeb3SignInMessage), it's the actual params
 	// If params is an object or null/undefined, use it directly
 	const rpcParams = params ?? null;
-	
+
 	const requestBody = {
 		jsonrpc: "2.0",
 		method,
@@ -82,8 +82,8 @@ async function makeRpcRequest<T>(
 	if (data.error) {
 		console.error(`[TEE Worker RPC] Error from ${method}:`, data.error);
 		// Include error code in the error message for better debugging
-		const errorMessage = data.error.data 
-			? `${data.error.message} (${data.error.data})` 
+		const errorMessage = data.error.data
+			? `${data.error.message} (${data.error.data})`
 			: data.error.message || "RPC error";
 		throw new Error(errorMessage);
 	}
@@ -99,10 +99,10 @@ export async function getWeb3SignInMessage(
 	// The omniAccount should already be a properly formatted 32-byte hex string (64 chars) with 0x prefix
 	// from calculateOmniAccount function
 	console.log('[TEE Worker] Using omni account:', omniAccount);
-	
+
 	// Pass parameters as an array for positional arguments
 	return makeRpcRequest<Web3SignInMessageResponse>(
-		"omni_getWeb3SignInMessage", 
+		"omni_getWeb3SignInMessage",
 		[clientId, omniAccount]
 	);
 }
@@ -118,7 +118,7 @@ export async function loginWithEvm(
 	// The server expects the message to be a JSON string of the payload
 	const message = JSON.stringify(messagePayload);
 	console.log("[TEE Worker] Message to sign:", message);
-	
+
 	const signature = await walletClient.signMessage({
 		account: evmAddress as `0x${string}`,
 		message,
@@ -140,7 +140,7 @@ export async function loginWithEvm(
 	};
 
 	console.log("[TEE Worker] UserLogin params:", JSON.stringify(params, null, 2));
-	
+
 	// Pass the params object directly
 	return makeRpcRequest<UserLoginResponse>("omni_userLogin", params);
 }
@@ -153,7 +153,7 @@ export async function getSmartWalletRootSigner(
 ): Promise<string> {
 	const params: GetSmartWalletRootSignerParams = {
 		chain_type: chainType,
-		index,
+		wallet_index: index,
 	};
 
 	return makeRpcRequest<string>("omni_getSmartWalletRootSigner", params, idToken);
@@ -205,16 +205,16 @@ export async function authorizeTEEWorker(
 			};
 		} catch (error) {
 			console.error(`[TEE Worker] Authorization attempt ${retryCount + 1} failed:`, error);
-			
+
 			// If this was our last retry, throw the error
 			if (retryCount >= maxRetries) {
 				throw error;
 			}
-			
+
 			// Wait a bit before retrying to ensure any server-side state is cleared
 			console.log("[TEE Worker] Waiting 1 second before retry...");
 			await new Promise(resolve => setTimeout(resolve, 1000));
-			
+
 			retryCount++;
 		}
 	}

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_smart_wallet_root_signer.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_smart_wallet_root_signer.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error};
 pub struct GetSmartWalletRootSignerParams {
 	pub omni_account: String,
 	pub chain_type: ChainType,
-	pub index: u32,
+	pub wallet_index: u32,
 }
 
 pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>) {
@@ -22,7 +22,7 @@ pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>)
 				PumpxRpcError::from_error_code(ErrorCode::ParseError)
 			})?;
 
-			debug!("Received omni_getSmartWalletRootSigner");
+			debug!("Received omni_getSmartWalletRootSigner, params: {:?}", params);
 
 			let Ok(address) = Address32::from_hex(&params.omni_account) else {
 				error!("Failed to parse from omni account token");
@@ -31,7 +31,7 @@ pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>)
 
 			let pubkey = ctx
 				.signer_client
-				.request_wallet(params.chain_type, params.index, address.as_ref().to_owned())
+				.request_wallet(params.chain_type, params.wallet_index, address.as_ref().to_owned())
 				.await
 				.map_err(|_| {
 					error!("Failed to request wallet from signer client");


### PR DESCRIPTION
### Context

As topic, to make the name consistent in different methods, so the rpc param would be like:

```
{
  "omni_account": "0x1234....",
  "chain_type": "Evm",
  "wallet_index": 0
}
```
