### PR TITLE
Use snake_case `chain_type` in `omni_getSmartWalletRootSigner`

### DIFF
--- a/parachain/ts-tests/common/setup/wait-finalized-block.ts
+++ b/parachain/ts-tests/common/setup/wait-finalized-block.ts
@@ -25,17 +25,20 @@ const TIMEOUT_MIN = 5;
 
     console.log(`Connecting to parachain ${config.parachain_ws}`);
 
-    timeout = global.setTimeout(async () => {
-        if (typeof unsub === 'function') unsub();
+    timeout = global.setTimeout(
+        async () => {
+            if (typeof unsub === 'function') unsub();
 
-        if (api) api.disconnect();
-        provider.on('disconnected', () => {
-            console.log(
-                `\nno block production detected after ${TIMEOUT_MIN}min, you might want to check it manually. Quit now`
-            );
-            process.exit(1);
-        });
-    }, TIMEOUT_MIN * 60 * 1000);
+            if (api) api.disconnect();
+            provider.on('disconnected', () => {
+                console.log(
+                    `\nno block production detected after ${TIMEOUT_MIN}min, you might want to check it manually. Quit now`
+                );
+                process.exit(1);
+            });
+        },
+        TIMEOUT_MIN * 60 * 1000
+    );
 
     api = await ApiPromise.create({
         provider: provider,

--- a/parachain/ts-tests/common/utils/function.ts
+++ b/parachain/ts-tests/common/utils/function.ts
@@ -96,11 +96,16 @@ export const observeEvent = async (expectedSection: string, expectedMethod: stri
         let eventFound = false;
         let result: any;
         const query = (event: any) => true;
-        const timeout = setTimeout(() => {
-            if (!eventFound) {
-                reject(new Error(`Event -${expectedSection}.${expectedMethod} not found within the specified time`));
-            }
-        }, 5 * 60 * 1000); // 5 minutes
+        const timeout = setTimeout(
+            () => {
+                if (!eventFound) {
+                    reject(
+                        new Error(`Event -${expectedSection}.${expectedMethod} not found within the specified time`)
+                    );
+                }
+            },
+            5 * 60 * 1000
+        ); // 5 minutes
 
         const unsubscribe = api.rpc.chain.subscribeNewHeads(async (header) => {
             const events = await api.query.system.events.at(header.hash);

--- a/parachain/ts-tests/integration-tests/evm-contract.test.ts
+++ b/parachain/ts-tests/integration-tests/evm-contract.test.ts
@@ -92,9 +92,8 @@ describeLitentry('Test EVM Module Contract', ``, (context) => {
         const transferReceipt = await web3.eth.sendSignedTransaction(transferTransaction.rawTransaction!);
         console.log(`Tx successful with hash: ${transferReceipt.transactionHash}`);
 
-        const { nonce: eveCurrentNonce, data: eveCurrentBalance } = await context.api.query.system.account(
-            eveMappedSustrateAccount
-        );
+        const { nonce: eveCurrentNonce, data: eveCurrentBalance } =
+            await context.api.query.system.account(eveMappedSustrateAccount);
         const { nonce: evmAccountCurrentNonce, data: evmAccountCurrentBalance } =
             await context.api.query.system.account(evmAccountRaw.mappedAddress);
 

--- a/tee-worker/omni-executor/aa-contracts/aa-demo-app/src/lib/constants.ts
+++ b/tee-worker/omni-executor/aa-contracts/aa-demo-app/src/lib/constants.ts
@@ -77,7 +77,7 @@ export const DEFAULT_CLIENT_ID = "wildmeta";
 export const TEE_WORKER_CONFIG = {
 	rpcUrl: process.env.NEXT_PUBLIC_TEE_WORKER_RPC_URL || "http://localhost:3000",
 	clientId: "wildmeta",
-	chainType: "Evm" as const,
+	chainType: "evm" as const,
 	signerIndex: 0,
 	// Use proxy to avoid CORS issues when running in browser
 	useProxy: true,

--- a/tee-worker/omni-executor/aa-contracts/aa-demo-app/src/lib/tee-worker-client.ts
+++ b/tee-worker/omni-executor/aa-contracts/aa-demo-app/src/lib/tee-worker-client.ts
@@ -28,7 +28,7 @@ interface UserLoginResponse {
 
 interface GetSmartWalletRootSignerParams {
 	omni_account: string;
-	chain_type: "Evm" | "Solana" | "Tron";
+	chain_type: "evm" | "solana" | "tron";
 	wallet_index: number;
 }
 
@@ -149,7 +149,7 @@ export async function loginWithEvm(
 // Get the TEE worker's smart wallet root signer address
 export async function getSmartWalletRootSigner(
 	omniAccount: string,
-	chainType: "Evm" | "Solana" | "Tron" = TEE_WORKER_CONFIG.chainType,
+	chainType: "evm" | "solana" | "tron" = TEE_WORKER_CONFIG.chainType,
 	index: number = TEE_WORKER_CONFIG.signerIndex
 ): Promise<string> {
 	const params: GetSmartWalletRootSignerParams = {

--- a/tee-worker/omni-executor/omni-cli/src/main.rs
+++ b/tee-worker/omni-executor/omni-cli/src/main.rs
@@ -3,26 +3,15 @@ use clap::{Parser, Subcommand, ValueEnum};
 use executor_core::types::SerializablePackedUserOperation;
 use executor_primitives::ChainId;
 use serde::{Deserialize, Serialize};
-use signer_client::ChainType;
 use std::collections::HashMap;
 use tracing::{debug, info};
 
 #[derive(Debug, Clone, ValueEnum, Serialize)]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "snake_case")]
 enum CliChainType {
 	Evm,
 	Solana,
 	Tron,
-}
-
-impl From<CliChainType> for ChainType {
-	fn from(cli_type: CliChainType) -> Self {
-		match cli_type {
-			CliChainType::Evm => ChainType::Evm,
-			CliChainType::Solana => ChainType::Solana,
-			CliChainType::Tron => ChainType::Tron,
-		}
-	}
 }
 
 #[derive(Debug, Serialize)]
@@ -114,7 +103,7 @@ struct RequestEmailVerificationCodeParams {
 #[derive(Debug, Serialize)]
 struct GetSmartWalletRootSignerParams {
 	omni_account: String,
-	chain_type: ChainType,
+	chain_type: CliChainType,
 	wallet_index: u32,
 }
 
@@ -556,11 +545,7 @@ async fn handle_get_smart_wallet_root_signer(
 	chain_type: CliChainType,
 	wallet_index: u32,
 ) -> Result<()> {
-	let params = GetSmartWalletRootSignerParams {
-		omni_account,
-		chain_type: chain_type.into(),
-		wallet_index,
-	};
+	let params = GetSmartWalletRootSignerParams { omni_account, chain_type, wallet_index };
 
 	info!("Getting smart wallet root signer with params: {:?}", params);
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_smart_wallet_root_signer.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_smart_wallet_root_signer.rs
@@ -3,14 +3,33 @@ use executor_primitives::utils::hex::FromHexPrefixed;
 use heima_primitives::Address32;
 use jsonrpsee::RpcModule;
 use pumpx::pubkey_to_address;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use signer_client::ChainType;
 use tracing::{debug, error};
 
-#[derive(Debug, Deserialize, Serialize)]
+// used in rpc with backend only
+#[derive(Debug, Copy, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SerdeChainType {
+	Evm,
+	Solana,
+	Tron,
+}
+
+impl From<SerdeChainType> for ChainType {
+	fn from(c: SerdeChainType) -> Self {
+		match c {
+			SerdeChainType::Evm => Self::Evm,
+			SerdeChainType::Solana => Self::Solana,
+			SerdeChainType::Tron => Self::Tron,
+		}
+	}
+}
+
+#[derive(Debug, Deserialize)]
 pub struct GetSmartWalletRootSignerParams {
 	pub omni_account: String,
-	pub chain_type: ChainType,
+	pub chain_type: SerdeChainType,
 	pub wallet_index: u32,
 }
 
@@ -31,7 +50,11 @@ pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>)
 
 			let pubkey = ctx
 				.signer_client
-				.request_wallet(params.chain_type, params.wallet_index, address.as_ref().to_owned())
+				.request_wallet(
+					params.chain_type.into(),
+					params.wallet_index,
+					address.as_ref().to_owned(),
+				)
 				.await
 				.map_err(|_| {
 					error!("Failed to request wallet from signer client");
@@ -40,7 +63,7 @@ pub fn register_get_smart_wallet_root_signer(module: &mut RpcModule<RpcContext>)
 					))
 				})?;
 
-			let address = pubkey_to_address(params.chain_type, &pubkey).map_err(|_| {
+			let address = pubkey_to_address(params.chain_type.into(), &pubkey).map_err(|_| {
 				error!("Failed to convert pubkey to address");
 				PumpxRpcError::from_error_code(ErrorCode::ServerError(
 					PUMPX_SIGNER_PUBKEY_TO_ADDRESS_FAILED_CODE,


### PR DESCRIPTION
### Context

As topic.

Required by backend - to be consistent with other rpc param fields.

Signer is still referenced by worker and old pumpx/heima dex code - so we'll keep it unchanged for now. Then we'll need to do a simple mapping in worker.