### PR TITLE
Fill in `gas_price` automatically

### DIFF
--- a/tee-worker/omni-executor/ethereum-rpc/src/lib.rs
+++ b/tee-worker/omni-executor/ethereum-rpc/src/lib.rs
@@ -140,10 +140,8 @@ impl RpcProvider for AlloyRpcProvider {
 
 		let signer_address = wallet.default_signer().address();
 		let mut tx = raw_tx.from(signer_address);
-		// Bump the gas by 10%
-		// TODO: Set gas fees via CLI
+		// Add a 10% buffer to gas to make it safer
 		tx.gas = Some(self.estimate_gas(tx.clone()).await? * 110 / 100);
-		tx.gas_price = Some(self.get_gas_price().await?);
 
 		let pending_tx = provider.send_transaction(tx).await.map_err(|e| {
 			error!("Could not send transaction: {:?}", e);

--- a/tee-worker/omni-executor/mock-server/src/evm.rs
+++ b/tee-worker/omni-executor/mock-server/src/evm.rs
@@ -48,6 +48,36 @@ pub(crate) fn handle() -> impl Filter<Extract = (impl warp::Reply,), Error = war
 					});
 					build_success_response(response)
 				},
+				"eth_maxPriorityFeePerGas" => {
+					// Mock max priority fee per pas
+					let response = json!({
+						"jsonrpc": "2.0",
+						"result": "0x77359400", // 2 Gwei
+						"id": id
+					});
+					build_success_response(response)
+				},
+				"eth_feeHistory" => {
+					// Mock fee history response
+					let response = json!({
+						"jsonrpc": "2.0",
+						"id": id,
+						"result": {
+							"oldestBlock": "0x5bad55", // arbitrary block number
+							"baseFeePerGas": [
+								"0x3b9aca00", // 1 Gwei
+								"0x3b9aca00"  // next block's base fee (must be n+1 elements)
+							],
+							"gasUsedRatio": [
+								0.5 // 50% gas used in the block
+							],
+							"reward": [
+								[ "0x77359400" ] // priority fee rewards (2 Gwei)
+							]
+						}
+					});
+					build_success_response(response)
+				},
 				"eth_getTransactionCount" => {
 					// Mock transaction count (nonce)
 					let response = json!({


### PR DESCRIPTION
### Context

IIUC when set manually, node will treat the tx as legacy tx. IMO it's better to let alloy provider to figure this out automatically (to use EIP1559 tx).

For gas we still add a 10% buffer.