### PR TITLE
Improve Ethereum RPC client error handling

### DIFF
--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -22,8 +22,10 @@ dependencies = [
  "heima-primitives",
  "mockall",
  "rand 0.8.5",
+ "regex",
  "sha2 0.10.9",
  "test-log",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -3663,8 +3665,10 @@ dependencies = [
  "serde_json",
  "signer-client",
  "sp-core 35.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/tee-worker/omni-executor/Cargo.toml
+++ b/tee-worker/omni-executor/Cargo.toml
@@ -86,6 +86,7 @@ serde_json = "1"
 serde_repr = "0.1.20"
 serde_with = { version = "3.11", features = ["hex"] }
 sha2 = "0.10.8"
+thiserror = "2"
 solana-client = "2.2.1"
 solana-sdk = "2.2.1"
 sp-core = "35.0.0"

--- a/tee-worker/omni-executor/aa-contracts-client/Cargo.toml
+++ b/tee-worker/omni-executor/aa-contracts-client/Cargo.toml
@@ -10,6 +10,8 @@ heima-primitives = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 rand = { workspace = true }
+thiserror = { workspace = true }
+regex = { workspace = true }
 
 ethereum-rpc = { workspace = true }
 

--- a/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
@@ -392,7 +392,9 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 		loop {
 			// Calculate gas fees with increasing buffer on retries
 			let (base_max_fee, base_priority_fee) =
-				self.calculate_gas_fees_with_buffer(gas_buffer_adjustment).await?;
+				self.calculate_gas_fees_with_buffer(gas_buffer_adjustment).await.map_err(|_| {
+					error!("Failed to calculate gas fees");
+				})?;
 
 			// Build transaction with adjusted gas
 			let ops = user_ops.to_vec();

--- a/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
+use crate::error::{AaContractError, ContractError, RpcError};
 use crate::types::{
 	createAccountCall, depositToCall, getSenderAddressCall, getUserOpHashCall, handleOpsCall,
 	simulateHandleOpsCall, simulateValidationCall, ExecutionResult, OwnerType, SenderAddressResult,
@@ -209,7 +210,7 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 	}
 
 	pub async fn get_wallet_address(&self) -> Result<Address, ()> {
-		self.rpc_client.get_wallet_address().await
+		self.rpc_client.get_wallet_address().await.map_err(|_| ())
 	}
 
 	/// Calculate dynamic gas fees based on current network conditions
@@ -288,14 +289,23 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 					error!("Could not decode ValidationResult from response");
 				})
 			},
-			Err(Some(revert_data)) => {
-				// In some cases, the simulation might revert with ValidationResult data
-				ValidationResult::abi_decode(&revert_data).map_err(|_| {
-					error!("Could not decode ValidationResult from revert data");
-				})
-			},
-			Err(None) => {
-				error!("Simulation failed with no data");
+			Err(err) => {
+				// Check if this is an execution reverted error with data
+				if let ethereum_rpc::RpcProviderError::ExecutionReverted { reason } = &err {
+					// Try to extract revert data from the reason string
+					if reason.contains("0x") {
+						// Extract hex data after "0x"
+						if let Some(start) = reason.find("0x") {
+							let hex_data = &reason[start..];
+							if let Ok(revert_data) = hex::decode(&hex_data[2..]) {
+								return ValidationResult::abi_decode(&revert_data).map_err(|_| {
+									error!("Could not decode ValidationResult from revert data");
+								});
+							}
+						}
+					}
+				}
+				error!("Simulation failed: {:?}", err);
 				Err(())
 			},
 		}
@@ -330,14 +340,27 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 					error!("Could not decode ExecutionResult[] from response");
 				})
 			},
-			Err(Some(revert_data)) => {
-				// In some cases, the simulation might revert with ExecutionResult[] data
-				Vec::<ExecutionResult>::abi_decode(&revert_data).map_err(|_| {
-					error!("Could not decode ExecutionResult[] from revert data");
-				})
-			},
-			Err(None) => {
-				error!("Simulation failed with no data");
+			Err(err) => {
+				// Check if this is an execution reverted error with data
+				if let ethereum_rpc::RpcProviderError::ExecutionReverted { reason } = &err {
+					// Try to extract revert data from the reason string
+					if reason.contains("0x") {
+						// Extract hex data after "0x"
+						if let Some(start) = reason.find("0x") {
+							let hex_data = &reason[start..];
+							if let Ok(revert_data) = hex::decode(&hex_data[2..]) {
+								return Vec::<ExecutionResult>::abi_decode(&revert_data).map_err(
+									|_| {
+										error!(
+											"Could not decode ExecutionResult[] from revert data"
+										);
+									},
+								);
+							}
+						}
+					}
+				}
+				error!("Simulation failed: {:?}", err);
 				Err(())
 			},
 		}
@@ -391,9 +414,14 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 					}
 					return Ok(tx_hash);
 				},
-				Err(_) => {
-					// Since RPC provider returns unit error, we treat all errors as potentially gas-related
-					// TODO: improve error handling, classify retryable vs non-retryable errors
+				Err(rpc_error) => {
+					let error = self.classify_rpc_error(rpc_error);
+
+					// Check if the error is retryable
+					if !error.is_retryable() {
+						error!("Non-retryable error encountered: {:?}", error);
+						return Err(());
+					}
 
 					attempt += 1;
 					if attempt >= self.retry_config.max_attempts {
@@ -421,59 +449,6 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 		}
 	}
 
-	/// Calculate gas fees with additional buffer percentage
-	async fn calculate_gas_fees_with_buffer(
-		&self,
-		additional_buffer_percent: u64,
-	) -> Result<(U256, U256), ()> {
-		// Try EIP-1559 estimation first
-		match self.rpc_client.estimate_eip1559_fees().await {
-			Ok(eip1559_estimate) => {
-				// Use EIP-1559 fees with buffer
-				let total_buffer =
-					self.gas_config.gas_price_buffer_percent + additional_buffer_percent;
-				let buffer_multiplier = 100 + total_buffer;
-
-				let max_fee_per_gas = U256::from(eip1559_estimate.max_fee_per_gas)
-					.saturating_mul(U256::from(buffer_multiplier))
-					.checked_div(U256::from(100))
-					.unwrap_or(U256::from(eip1559_estimate.max_fee_per_gas));
-
-				// Use the EIP-1559 priority fee with bounds
-				let priority_fee = U256::from(eip1559_estimate.max_priority_fee_per_gas)
-					.max(U256::from(self.gas_config.min_priority_fee))
-					.min(U256::from(self.gas_config.max_priority_fee));
-
-				Ok((max_fee_per_gas, priority_fee))
-			},
-			Err(_) => {
-				// Fallback to legacy gas price calculation
-				let current_gas_price = self
-					.rpc_client
-					.get_gas_price()
-					.await
-					.map_err(|_| error!("Failed to fetch gas price"))?;
-
-				// Apply base buffer plus additional retry buffer
-				let total_buffer =
-					self.gas_config.gas_price_buffer_percent + additional_buffer_percent;
-				let buffer_multiplier = 100 + total_buffer;
-
-				let max_fee_per_gas = U256::from(current_gas_price)
-					.saturating_mul(U256::from(buffer_multiplier))
-					.checked_div(U256::from(100))
-					.unwrap_or(U256::from(current_gas_price));
-
-				// Calculate priority fee (tip) with bounds
-				let priority_fee = U256::from(current_gas_price / 10)
-					.max(U256::from(self.gas_config.min_priority_fee))
-					.min(U256::from(self.gas_config.max_priority_fee));
-
-				Ok((max_fee_per_gas, priority_fee))
-			},
-		}
-	}
-
 	/// Calculate exponential backoff delay with jitter
 	fn calculate_backoff_delay(&self, attempt: u8) -> u64 {
 		let base_delay = self.retry_config.initial_delay_ms;
@@ -491,14 +466,24 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 		let call_data = getSenderAddressCall { initCode: init_code }.abi_encode();
 		let tx = build_call_transaction(self.entry_point_address, call_data);
 		match self.rpc_client.call(tx).await {
-			Err(e) => {
-				if let Some(bytes) = e {
-					let result = SenderAddressResult::abi_decode(&bytes)
-						.map_err(|_| error!("Could not decode SenderAddressResult"))?;
-					Ok(result.sender)
-				} else {
-					Err(())
+			Err(err) => {
+				// Check if this is an execution reverted error with data
+				if let ethereum_rpc::RpcProviderError::ExecutionReverted { reason } = &err {
+					// Try to extract revert data from the reason string
+					if reason.contains("0x") {
+						// Extract hex data after "0x"
+						if let Some(start) = reason.find("0x") {
+							let hex_data = &reason[start..];
+							if let Ok(revert_data) = hex::decode(&hex_data[2..]) {
+								let result = SenderAddressResult::abi_decode(&revert_data)
+									.map_err(|_| error!("Could not decode SenderAddressResult"))?;
+								return Ok(result.sender);
+							}
+						}
+					}
 				}
+				error!("Failed to get sender address: {:?}", err);
+				Err(())
 			},
 			Ok(_) => Err(()),
 		}
@@ -683,6 +668,167 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 			signature: Bytes::new(),
 		})
 	}
+
+	/// Calculate gas fees with additional buffer percentage
+	async fn calculate_gas_fees_with_buffer(
+		&self,
+		additional_buffer_percent: u64,
+	) -> Result<(U256, U256), AaContractError> {
+		// Try EIP-1559 estimation first
+		match self.rpc_client.estimate_eip1559_fees().await {
+			Ok(eip1559_estimate) => {
+				// Use EIP-1559 fees with buffer
+				let total_buffer =
+					self.gas_config.gas_price_buffer_percent + additional_buffer_percent;
+				let buffer_multiplier = 100 + total_buffer;
+
+				let max_fee_per_gas = U256::from(eip1559_estimate.max_fee_per_gas)
+					.saturating_mul(U256::from(buffer_multiplier))
+					.checked_div(U256::from(100))
+					.unwrap_or(U256::from(eip1559_estimate.max_fee_per_gas));
+
+				// Use the EIP-1559 priority fee with bounds
+				let priority_fee = U256::from(eip1559_estimate.max_priority_fee_per_gas)
+					.max(U256::from(self.gas_config.min_priority_fee))
+					.min(U256::from(self.gas_config.max_priority_fee));
+
+				Ok((max_fee_per_gas, priority_fee))
+			},
+			Err(_) => {
+				// Fallback to legacy gas price calculation
+				let current_gas_price = self.rpc_client.get_gas_price().await.map_err(|e| {
+					error!("Failed to fetch gas price: {:?}", e);
+					AaContractError::from(e)
+				})?;
+
+				// Apply base buffer plus additional retry buffer
+				let total_buffer =
+					self.gas_config.gas_price_buffer_percent + additional_buffer_percent;
+				let buffer_multiplier = 100 + total_buffer;
+
+				let max_fee_per_gas = U256::from(current_gas_price)
+					.saturating_mul(U256::from(buffer_multiplier))
+					.checked_div(U256::from(100))
+					.unwrap_or(U256::from(current_gas_price));
+
+				// Calculate priority fee (tip) with bounds
+				let priority_fee = U256::from(current_gas_price / 10)
+					.max(U256::from(self.gas_config.min_priority_fee))
+					.min(U256::from(self.gas_config.max_priority_fee));
+
+				Ok((max_fee_per_gas, priority_fee))
+			},
+		}
+	}
+
+	/// Classify RPC errors into our error taxonomy
+	fn classify_rpc_error(&self, rpc_error: ethereum_rpc::RpcProviderError) -> AaContractError {
+		match rpc_error {
+			ethereum_rpc::RpcProviderError::InvalidUrl(url) => {
+				AaContractError::Validation(format!("Invalid RPC URL: {}", url))
+			},
+			ethereum_rpc::RpcProviderError::Network(msg) => {
+				AaContractError::Rpc(RpcError::ConnectionFailed { endpoint: msg })
+			},
+			ethereum_rpc::RpcProviderError::NoWallet => {
+				AaContractError::Validation("No wallet configured for signing".to_string())
+			},
+			ethereum_rpc::RpcProviderError::ExecutionReverted { reason } => {
+				AaContractError::Contract(ContractError::ExecutionReverted { reason })
+			},
+			ethereum_rpc::RpcProviderError::JsonRpc { code, message, data } => {
+				// Parse JSON-RPC error codes for specific error types
+				match code {
+					-32099..=-32000 => {
+						// Server errors - parse message for specific conditions
+						let message_lower = message.to_lowercase();
+						if message_lower.contains("nonce too low")
+							|| message_lower.contains("nonce already used")
+						{
+							AaContractError::Rpc(RpcError::NonceTooLow)
+						} else if message_lower.contains("replacement transaction underpriced")
+							|| message_lower.contains("transaction underpriced")
+							|| message_lower.contains("max fee per gas less than block base fee")
+							|| message_lower.contains("gasfeecap less than block base fee")
+						{
+							AaContractError::Rpc(RpcError::TransactionUnderpriced)
+						} else if message_lower.contains("insufficient funds")
+							|| message_lower.contains("insufficient balance")
+						{
+							AaContractError::Contract(ContractError::InsufficientFunds)
+						} else if message_lower.contains("gas required exceeds")
+							|| message_lower.contains("out of gas")
+							|| message_lower.contains("gas too low")
+							|| message_lower.contains("intrinsic gas too low")
+						{
+							AaContractError::Contract(ContractError::GasEstimationFailed {
+								reason: message.clone(),
+							})
+						} else if message_lower.contains("invalid signature")
+							|| message_lower.contains("ecrecover")
+						{
+							AaContractError::Contract(ContractError::InvalidSignature)
+						} else {
+							AaContractError::Rpc(RpcError::Generic { code, message })
+						}
+					},
+					429 => {
+						// HTTP 429 Too Many Requests
+						AaContractError::Rpc(RpcError::RateLimited)
+					},
+					-32603 => {
+						// Internal error - usually retryable
+						AaContractError::Rpc(RpcError::Generic { code, message })
+					},
+					_ => {
+						// Other error codes
+						if let Some(ref data_str) = data {
+							// Check if this is contract revert data
+							if data_str.starts_with("0x08c379a0") {
+								AaContractError::Contract(ContractError::ExecutionReverted {
+									reason: message,
+								})
+							} else {
+								AaContractError::Rpc(RpcError::Generic { code, message })
+							}
+						} else {
+							AaContractError::Rpc(RpcError::Generic { code, message })
+						}
+					},
+				}
+			},
+			ethereum_rpc::RpcProviderError::Transaction(msg) => {
+				let msg_lower = msg.to_lowercase();
+				if msg_lower.contains("nonce too low") || msg_lower.contains("nonce already used") {
+					AaContractError::Rpc(RpcError::NonceTooLow)
+				} else if msg_lower.contains("replacement transaction underpriced")
+					|| msg_lower.contains("transaction underpriced")
+					|| msg_lower.contains("max fee per gas less than block base fee")
+					|| msg_lower.contains("gasfeecap less than block base fee")
+					|| msg_lower.contains("gas price too low")
+				{
+					AaContractError::Rpc(RpcError::TransactionUnderpriced)
+				} else if msg_lower.contains("insufficient funds")
+					|| msg_lower.contains("insufficient balance")
+				{
+					AaContractError::Contract(ContractError::InsufficientFunds)
+				} else if msg_lower.contains("gas required exceeds")
+					|| msg_lower.contains("out of gas")
+					|| msg_lower.contains("gas too low")
+					|| msg_lower.contains("intrinsic gas too low")
+				{
+					AaContractError::Contract(ContractError::GasEstimationFailed {
+						reason: msg.clone(),
+					})
+				} else if msg_lower.contains("execution reverted") || msg_lower.contains("revert") {
+					AaContractError::Contract(ContractError::ExecutionReverted { reason: msg })
+				} else {
+					AaContractError::Transaction(msg)
+				}
+			},
+			ethereum_rpc::RpcProviderError::Generic(msg) => AaContractError::Generic(msg),
+		}
+	}
 }
 
 #[allow(dead_code)]
@@ -771,12 +917,18 @@ pub mod test {
 		let root_address = address!("0x0000000000000000000000000000000000000001");
 		let mut rpc_client = MockRpcProvider::new();
 
-		rpc_client.expect_call()
-            .with(mockall::predicate::always())
-            .times(1)
-            .returning(|_| {
-                Err(Some(hex::decode("0x6ca7b8060000000000000000000000005dfec187c82986cf670f4e2ed6de1cd001cee5be").unwrap()))
-            });
+		rpc_client
+			.expect_call()
+			.with(mockall::predicate::always())
+			.times(1)
+			.returning(|_| {
+				let revert_data = hex::decode(
+					"0x6ca7b8060000000000000000000000005dfec187c82986cf670f4e2ed6de1cd001cee5be",
+				)
+				.unwrap();
+				let reason = format!("execution reverted: 0x{}", hex::encode(&revert_data));
+				Err(ethereum_rpc::RpcProviderError::ExecutionReverted { reason })
+			});
 
 		let entrypoint_client = EntryPointClient::new(entrypoint_address, Arc::new(rpc_client));
 
@@ -1089,7 +1241,9 @@ pub mod test {
 		let mut rpc_client = MockRpcProvider::new();
 
 		// Mock EIP-1559 to fail, forcing legacy fallback
-		rpc_client.expect_estimate_eip1559_fees().times(1).returning(|| Err(()));
+		rpc_client.expect_estimate_eip1559_fees().times(1).returning(|| {
+			Err(ethereum_rpc::RpcProviderError::Generic("EIP-1559 not supported".to_string()))
+		});
 		// Mock gas price at 30 gwei
 		let mock_gas_price = 30_000_000_000u128;
 		rpc_client.expect_get_gas_price().times(1).returning(move || Ok(mock_gas_price));
@@ -1105,7 +1259,9 @@ pub mod test {
 
 		// Test with mainnet config
 		let mut mainnet_rpc_client = MockRpcProvider::new();
-		mainnet_rpc_client.expect_estimate_eip1559_fees().times(1).returning(|| Err(()));
+		mainnet_rpc_client.expect_estimate_eip1559_fees().times(1).returning(|| {
+			Err(ethereum_rpc::RpcProviderError::Generic("EIP-1559 not supported".to_string()))
+		});
 		mainnet_rpc_client
 			.expect_get_gas_price()
 			.times(1)
@@ -1128,7 +1284,9 @@ pub mod test {
 		// Test with L2 config and lower gas price
 		let mut l2_rpc_client = MockRpcProvider::new();
 		let l2_gas_price = 1_000_000_000u128; // 1 gwei
-		l2_rpc_client.expect_estimate_eip1559_fees().times(1).returning(|| Err(()));
+		l2_rpc_client.expect_estimate_eip1559_fees().times(1).returning(|| {
+			Err(ethereum_rpc::RpcProviderError::Generic("EIP-1559 not supported".to_string()))
+		});
 		l2_rpc_client
 			.expect_get_gas_price()
 			.times(1)
@@ -1217,7 +1375,9 @@ pub mod test {
 		let counter_clone = counter.clone();
 
 		// Set up EIP-1559 to fail, forcing legacy fallback
-		mock_client.expect_estimate_eip1559_fees().times(3).returning(|| Err(()));
+		mock_client.expect_estimate_eip1559_fees().times(3).returning(|| {
+			Err(ethereum_rpc::RpcProviderError::Generic("EIP-1559 not supported".to_string()))
+		});
 		// Set up gas price expectation
 		mock_client.expect_get_gas_price().times(3).returning(|| Ok(30_000_000_000u128)); // 30 gwei
 
@@ -1225,7 +1385,8 @@ pub mod test {
 		mock_client.expect_send_transaction().times(3).returning(move |_| {
 			let count = counter_clone.fetch_add(1, Ordering::SeqCst);
 			if count < 2 {
-				Err(()) // Fail first two attempts
+				Err(ethereum_rpc::RpcProviderError::Network("Temporary network error".to_string()))
+			// Fail first two attempts
 			} else {
 				Ok("0x1234567890abcdef".to_string()) // Succeed on third
 			}
@@ -1256,12 +1417,16 @@ pub mod test {
 		let mut mock_client = MockRpcProvider::new();
 
 		// Set up EIP-1559 to fail, forcing legacy fallback
-		mock_client.expect_estimate_eip1559_fees().times(3).returning(|| Err(()));
+		mock_client.expect_estimate_eip1559_fees().times(3).returning(|| {
+			Err(ethereum_rpc::RpcProviderError::Generic("EIP-1559 not supported".to_string()))
+		});
 		// Set up gas price expectation
 		mock_client.expect_get_gas_price().times(3).returning(|| Ok(30_000_000_000u128)); // 30 gwei
 
 		// Set up send_transaction to always fail
-		mock_client.expect_send_transaction().times(3).returning(|_| Err(()));
+		mock_client.expect_send_transaction().times(3).returning(|_| {
+			Err(ethereum_rpc::RpcProviderError::Network("Connection failed".to_string()))
+		});
 
 		let client = EntryPointClient::new_with_config(
 			address!("0x0000000000000000000000000000000000000000"),
@@ -1286,7 +1451,9 @@ pub mod test {
 		let mut mock_client = MockRpcProvider::new();
 
 		// Set up EIP-1559 to fail, forcing legacy fallback
-		mock_client.expect_estimate_eip1559_fees().times(1).returning(|| Err(()));
+		mock_client.expect_estimate_eip1559_fees().times(1).returning(|| {
+			Err(ethereum_rpc::RpcProviderError::Generic("EIP-1559 not supported".to_string()))
+		});
 
 		// Set up gas price expectation
 		mock_client.expect_get_gas_price().times(1).returning(|| Ok(20_000_000_000u128)); // 20 gwei
@@ -1347,7 +1514,9 @@ pub mod test {
 		let mut mock_client = MockRpcProvider::new();
 
 		// Set up EIP-1559 to fail, fallback to legacy
-		mock_client.expect_estimate_eip1559_fees().times(1).returning(|| Err(()));
+		mock_client.expect_estimate_eip1559_fees().times(1).returning(|| {
+			Err(ethereum_rpc::RpcProviderError::Generic("EIP-1559 not supported".to_string()))
+		});
 
 		mock_client.expect_get_gas_price().times(1).returning(|| Ok(30_000_000_000u128)); // 30 gwei
 
@@ -1369,5 +1538,160 @@ pub mod test {
 		assert_eq!(max_fee, U256::from(45_000_000_000u128));
 		// Priority fee: 30 gwei / 10 = 3 gwei (within bounds)
 		assert_eq!(priority_fee, U256::from(3_000_000_000u128));
+	}
+
+	#[test]
+	fn test_error_classification() {
+		use crate::error::{AaContractError, ContractError, RpcError};
+		use ethereum_rpc::RpcProviderError;
+
+		let client = EntryPointClient::new(
+			address!("0x0000000000000000000000000000000000000000"),
+			Arc::new(MockRpcProvider::new()),
+		);
+
+		// Test network error classification
+		let network_error = RpcProviderError::Network("Connection refused".to_string());
+		let classified = client.classify_rpc_error(network_error);
+		match classified {
+			AaContractError::Rpc(RpcError::ConnectionFailed { endpoint }) => {
+				assert_eq!(endpoint, "Connection refused");
+			},
+			_ => panic!("Expected ConnectionFailed error"),
+		}
+
+		// Test nonce too low error
+		let nonce_error = RpcProviderError::Transaction(
+			"nonce too low: address 0x123 current nonce 5".to_string(),
+		);
+		let classified = client.classify_rpc_error(nonce_error);
+		match classified {
+			AaContractError::Rpc(RpcError::NonceTooLow) => {},
+			_ => panic!("Expected NonceTooLow error"),
+		}
+
+		// Test transaction underpriced error
+		let gas_error =
+			RpcProviderError::Transaction("replacement transaction underpriced".to_string());
+		let classified = client.classify_rpc_error(gas_error);
+		match classified {
+			AaContractError::Rpc(RpcError::TransactionUnderpriced) => {},
+			_ => panic!("Expected TransactionUnderpriced error"),
+		}
+
+		// Test insufficient funds error
+		let funds_error =
+			RpcProviderError::Transaction("insufficient funds for gas * price + value".to_string());
+		let classified = client.classify_rpc_error(funds_error);
+		match classified {
+			AaContractError::Contract(ContractError::InsufficientFunds) => {},
+			_ => panic!("Expected InsufficientFunds error"),
+		}
+
+		// Test execution reverted error
+		let revert_error = RpcProviderError::Transaction(
+			"execution reverted: ERC20: transfer amount exceeds balance".to_string(),
+		);
+		let classified = client.classify_rpc_error(revert_error);
+		match classified {
+			AaContractError::Contract(ContractError::ExecutionReverted { reason }) => {
+				assert!(reason.contains("execution reverted"));
+			},
+			_ => panic!("Expected ExecutionReverted error"),
+		}
+
+		// Test rate limiting error
+		let rate_limit_error = RpcProviderError::JsonRpc {
+			code: 429,
+			message: "too many requests, please retry later".to_string(),
+			data: None,
+		};
+		let classified = client.classify_rpc_error(rate_limit_error);
+		match classified {
+			AaContractError::Rpc(RpcError::RateLimited) => {},
+			_ => panic!("Expected RateLimited error"),
+		}
+
+		// Test new error patterns
+		// Test "max fee per gas less than block base fee"
+		let max_fee_error =
+			RpcProviderError::Transaction("max fee per gas less than block base fee".to_string());
+		let classified = client.classify_rpc_error(max_fee_error);
+		match classified {
+			AaContractError::Rpc(RpcError::TransactionUnderpriced) => {},
+			_ => panic!("Expected TransactionUnderpriced for max fee per gas error"),
+		}
+
+		// Test "gas too low"
+		let gas_low_error = RpcProviderError::Transaction("gas too low".to_string());
+		let classified = client.classify_rpc_error(gas_low_error);
+		match classified {
+			AaContractError::Contract(ContractError::GasEstimationFailed { reason }) => {
+				assert!(reason.contains("gas too low"));
+			},
+			_ => panic!("Expected GasEstimationFailed for gas too low error"),
+		}
+
+		// Test "intrinsic gas too low"
+		let intrinsic_gas_error = RpcProviderError::JsonRpc {
+			code: -32000,
+			message: "intrinsic gas too low".to_string(),
+			data: None,
+		};
+		let classified = client.classify_rpc_error(intrinsic_gas_error);
+		match classified {
+			AaContractError::Contract(ContractError::GasEstimationFailed { reason }) => {
+				assert!(reason.contains("intrinsic gas too low"));
+			},
+			_ => panic!("Expected GasEstimationFailed for intrinsic gas error"),
+		}
+
+		// Test "gas price too low"
+		let gas_price_error = RpcProviderError::Transaction("gas price too low".to_string());
+		let classified = client.classify_rpc_error(gas_price_error);
+		match classified {
+			AaContractError::Rpc(RpcError::TransactionUnderpriced) => {},
+			_ => panic!("Expected TransactionUnderpriced for gas price too low error"),
+		}
+	}
+
+	#[test(tokio::test)]
+	async fn test_handle_ops_with_retry_non_retryable() {
+		// Create a mock that implements RpcProvider
+		let mut mock_client = MockRpcProvider::new();
+
+		// Mock estimate_eip1559_fees_ext to fail, forcing legacy fallback
+		mock_client.expect_estimate_eip1559_fees().times(1).returning(|| {
+			Err(ethereum_rpc::RpcProviderError::Generic("EIP-1559 not supported".to_string()))
+		});
+		mock_client.expect_get_gas_price().times(1).returning(|| Ok(30_000_000_000u128));
+
+		// Mock send_transaction to return a non-retryable error
+		mock_client.expect_send_transaction().times(1).returning(|_| {
+			Err(ethereum_rpc::RpcProviderError::ExecutionReverted {
+				reason: "Contract error".to_string(),
+			})
+		});
+
+		let client = EntryPointClient::new_with_config(
+			address!("0x0000000000000000000000000000000000000000"),
+			Arc::new(mock_client),
+			GasPriceConfig::default(),
+			crate::RetryConfig {
+				max_attempts: 3,
+				initial_delay_ms: 100,
+				max_delay_ms: 1000,
+				gas_increase_percent: 10,
+			},
+		);
+
+		// Test that non-retryable errors fail immediately
+		let result = client
+			.handle_ops_with_retry(&[], address!("0x0000000000000000000000000000000000000000"))
+			.await;
+
+		// With current implementation using unit errors, this will still retry
+		// In real implementation with typed errors, non-retryable errors would fail immediately
+		assert!(result.is_err());
 	}
 }

--- a/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
@@ -341,11 +341,8 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 				})
 			},
 			Err(err) => {
-				// Check if this is an execution reverted error with data
 				if let ethereum_rpc::RpcProviderError::ExecutionReverted { reason } = &err {
-					// Try to extract revert data from the reason string
 					if reason.contains("0x") {
-						// Extract hex data after "0x"
 						if let Some(start) = reason.find("0x") {
 							let hex_data = &reason[start..];
 							if let Ok(revert_data) = hex::decode(&hex_data[2..]) {
@@ -419,7 +416,6 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 				Err(rpc_error) => {
 					let error = self.classify_rpc_error(rpc_error);
 
-					// Check if the error is retryable
 					if !error.is_retryable() {
 						error!("Non-retryable error encountered: {:?}", error);
 						return Err(());
@@ -431,10 +427,8 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 						return Err(());
 					}
 
-					// Calculate backoff delay
 					let delay = self.calculate_backoff_delay(attempt);
 
-					// Increase gas buffer for next attempt
 					gas_buffer_adjustment += self.retry_config.gas_increase_percent as u64;
 
 					warn!(
@@ -469,11 +463,8 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 		let tx = build_call_transaction(self.entry_point_address, call_data);
 		match self.rpc_client.call(tx).await {
 			Err(err) => {
-				// Check if this is an execution reverted error with data
 				if let ethereum_rpc::RpcProviderError::ExecutionReverted { reason } = &err {
-					// Try to extract revert data from the reason string
 					if reason.contains("0x") {
-						// Extract hex data after "0x"
 						if let Some(start) = reason.find("0x") {
 							let hex_data = &reason[start..];
 							if let Ok(revert_data) = hex::decode(&hex_data[2..]) {

--- a/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
@@ -714,7 +714,6 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 		}
 	}
 
-	/// Classify RPC errors into our error taxonomy
 	fn classify_rpc_error(&self, rpc_error: ethereum_rpc::RpcProviderError) -> AaContractError {
 		match rpc_error {
 			ethereum_rpc::RpcProviderError::InvalidUrl(url) => {
@@ -1683,8 +1682,6 @@ pub mod test {
 			.handle_ops_with_retry(&[], address!("0x0000000000000000000000000000000000000000"))
 			.await;
 
-		// With current implementation using unit errors, this will still retry
-		// In real implementation with typed errors, non-retryable errors would fail immediately
 		assert!(result.is_err());
 	}
 }

--- a/tee-worker/omni-executor/aa-contracts-client/src/error.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/error.rs
@@ -132,18 +132,6 @@ impl AaContractError {
 	}
 }
 
-// Conversion from unit type for backward compatibility
-impl From<()> for AaContractError {
-	fn from(_: ()) -> Self {
-		AaContractError::Generic("Operation failed".to_string())
-	}
-}
-
-// Allow converting back to unit type for gradual migration
-impl From<AaContractError> for () {
-	fn from(_: AaContractError) -> Self {}
-}
-
 // Conversion from RpcProviderError
 impl From<ethereum_rpc::RpcProviderError> for AaContractError {
 	fn from(err: ethereum_rpc::RpcProviderError) -> Self {

--- a/tee-worker/omni-executor/aa-contracts-client/src/error.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/error.rs
@@ -1,0 +1,201 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+use thiserror::Error;
+
+/// Main error type for AA contract client operations
+#[derive(Error, Debug, Clone)]
+pub enum AaContractError {
+	/// RPC-related errors
+	#[error("RPC error: {0}")]
+	Rpc(#[from] RpcError),
+
+	/// Contract-specific errors
+	#[error("Contract error: {0}")]
+	Contract(#[from] ContractError),
+
+	/// Validation errors
+	#[error("Validation error: {0}")]
+	Validation(String),
+
+	/// Transaction errors
+	#[error("Transaction error: {0}")]
+	Transaction(String),
+
+	/// Generic errors for backward compatibility
+	#[error("Operation failed: {0}")]
+	Generic(String),
+}
+
+/// RPC-specific errors that can occur during network communication
+#[derive(Error, Debug, Clone)]
+pub enum RpcError {
+	/// Connection refused or node unavailable
+	#[error("Failed to connect to RPC endpoint: {endpoint}")]
+	ConnectionFailed { endpoint: String },
+
+	/// Rate limiting error
+	#[error("Rate limited by RPC provider")]
+	RateLimited,
+
+	/// Transaction underpriced (gas price too low)
+	#[error("Transaction underpriced")]
+	TransactionUnderpriced,
+
+	/// Nonce too low
+	#[error("Nonce too low")]
+	NonceTooLow,
+
+	/// Generic RPC error with code
+	#[error("RPC error (code {code}): {message}")]
+	Generic { code: i32, message: String },
+}
+
+/// Contract-specific errors that occur during smart contract interaction
+#[derive(Error, Debug, Clone)]
+pub enum ContractError {
+	/// Insufficient funds for transaction
+	#[error("Insufficient funds")]
+	InsufficientFunds,
+
+	/// Contract execution reverted
+	#[error("Execution reverted: {reason}")]
+	ExecutionReverted { reason: String },
+
+	/// Invalid signature
+	#[error("Invalid signature")]
+	InvalidSignature,
+
+	/// Gas estimation failed
+	#[error("Gas estimation failed: {reason}")]
+	GasEstimationFailed { reason: String },
+}
+
+impl RpcError {
+	/// Check if this error is retryable
+	pub fn is_retryable(&self) -> bool {
+		match self {
+			RpcError::ConnectionFailed { .. } => true,
+			RpcError::RateLimited => true,
+			RpcError::TransactionUnderpriced => true,
+			RpcError::NonceTooLow => true,
+			RpcError::Generic { code, .. } => {
+				// Common retryable error codes
+				matches!(
+					*code,
+					-32603 | // Internal JSON-RPC error
+					-32000 | // Server error
+					-32005 // Limit exceeded
+				)
+			},
+		}
+	}
+}
+
+impl ContractError {
+	/// Check if this error is retryable
+	pub fn is_retryable(&self) -> bool {
+		match self {
+			// These errors won't be fixed by retrying
+			ContractError::InsufficientFunds => false,
+			ContractError::ExecutionReverted { .. } => false,
+			ContractError::InvalidSignature => false,
+
+			// Gas estimation might succeed on retry if network conditions change
+			ContractError::GasEstimationFailed { .. } => true,
+		}
+	}
+}
+
+impl AaContractError {
+	/// Check if this error is retryable
+	pub fn is_retryable(&self) -> bool {
+		match self {
+			AaContractError::Rpc(e) => e.is_retryable(),
+			AaContractError::Contract(e) => e.is_retryable(),
+			// Other error types are generally not retryable
+			_ => false,
+		}
+	}
+}
+
+// Conversion from unit type for backward compatibility
+impl From<()> for AaContractError {
+	fn from(_: ()) -> Self {
+		AaContractError::Generic("Operation failed".to_string())
+	}
+}
+
+// Allow converting back to unit type for gradual migration
+impl From<AaContractError> for () {
+	fn from(_: AaContractError) -> Self {}
+}
+
+// Conversion from RpcProviderError
+impl From<ethereum_rpc::RpcProviderError> for AaContractError {
+	fn from(err: ethereum_rpc::RpcProviderError) -> Self {
+		match err {
+			ethereum_rpc::RpcProviderError::Network(msg) => {
+				AaContractError::Rpc(RpcError::ConnectionFailed { endpoint: msg })
+			},
+			ethereum_rpc::RpcProviderError::Transaction(msg) => {
+				AaContractError::Generic(format!("Transaction error: {}", msg))
+			},
+			ethereum_rpc::RpcProviderError::JsonRpc { code, message, .. } => {
+				AaContractError::Rpc(RpcError::Generic { code, message })
+			},
+			ethereum_rpc::RpcProviderError::ExecutionReverted { reason } => {
+				AaContractError::Contract(ContractError::ExecutionReverted { reason })
+			},
+			ethereum_rpc::RpcProviderError::Generic(msg) => AaContractError::Generic(msg),
+			_ => AaContractError::Generic("RPC provider error".to_string()),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_rpc_error_retryability() {
+		// Retryable errors
+		assert!(RpcError::ConnectionFailed { endpoint: "http://localhost:8545".to_string() }
+			.is_retryable());
+		assert!(RpcError::RateLimited.is_retryable());
+		assert!(RpcError::TransactionUnderpriced.is_retryable());
+		assert!(RpcError::NonceTooLow.is_retryable());
+		assert!(RpcError::Generic { code: -32603, message: "Internal error".to_string() }
+			.is_retryable());
+
+		// Non-retryable errors
+		assert!(!RpcError::Generic { code: -32601, message: "Method not found".to_string() }
+			.is_retryable());
+	}
+
+	#[test]
+	fn test_contract_error_retryability() {
+		// Non-retryable errors
+		assert!(!ContractError::InsufficientFunds.is_retryable());
+		assert!(!ContractError::ExecutionReverted { reason: "Transfer failed".to_string() }
+			.is_retryable());
+		assert!(!ContractError::InvalidSignature.is_retryable());
+
+		// Retryable errors
+		assert!(ContractError::GasEstimationFailed { reason: "Network congestion".to_string() }
+			.is_retryable());
+	}
+}

--- a/tee-worker/omni-executor/aa-contracts-client/src/lib.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/lib.rs
@@ -15,6 +15,7 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 mod entry_point_client;
+mod error;
 mod omni_account_client;
 mod types;
 mod utils;
@@ -22,6 +23,7 @@ mod utils;
 pub use entry_point_client::{
 	prepare_factory_init_code, EntryPointClient, GasPriceConfig, RetryConfig,
 };
+pub use error::{AaContractError, ContractError, RpcError};
 pub use omni_account_client::OmniAccountClient;
 pub use types::{OwnerType, PackedUserOperation};
 pub use utils::{calculate_omni_account_address, calculate_user_operation_hash};

--- a/tee-worker/omni-executor/aa-contracts-client/src/omni_account_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/omni_account_client.rs
@@ -388,7 +388,9 @@ pub mod test {
 			.expect_send_transaction()
 			.with(mockall::predicate::always())
 			.times(1)
-			.returning(|_| Err(ethereum_rpc::RpcProviderError::Transaction("Transaction failed".to_string())));
+			.returning(|_| {
+				Err(ethereum_rpc::RpcProviderError::Transaction("Transaction failed".to_string()))
+			});
 
 		let client = OmniAccountClient::new(account_address, Arc::new(rpc_client));
 		let result = client.add_root_signer(root_signer).await;
@@ -407,7 +409,9 @@ pub mod test {
 			.expect_send_transaction()
 			.with(mockall::predicate::always())
 			.times(1)
-			.returning(|_| Err(ethereum_rpc::RpcProviderError::Transaction("Transaction failed".to_string())));
+			.returning(|_| {
+				Err(ethereum_rpc::RpcProviderError::Transaction("Transaction failed".to_string()))
+			});
 
 		let client = OmniAccountClient::new(account_address, Arc::new(rpc_client));
 		let result = client.remove_root_signer(root_signer).await;

--- a/tee-worker/omni-executor/aa-contracts-client/src/omni_account_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/omni_account_client.rs
@@ -388,7 +388,7 @@ pub mod test {
 			.expect_send_transaction()
 			.with(mockall::predicate::always())
 			.times(1)
-			.returning(|_| Err(()));
+			.returning(|_| Err(ethereum_rpc::RpcProviderError::Transaction("Transaction failed".to_string())));
 
 		let client = OmniAccountClient::new(account_address, Arc::new(rpc_client));
 		let result = client.add_root_signer(root_signer).await;
@@ -407,7 +407,7 @@ pub mod test {
 			.expect_send_transaction()
 			.with(mockall::predicate::always())
 			.times(1)
-			.returning(|_| Err(()));
+			.returning(|_| Err(ethereum_rpc::RpcProviderError::Transaction("Transaction failed".to_string())));
 
 		let client = OmniAccountClient::new(account_address, Arc::new(rpc_client));
 		let result = client.remove_root_signer(root_signer).await;
@@ -443,7 +443,7 @@ pub mod test {
 			.expect_call()
 			.with(mockall::predicate::always())
 			.times(1)
-			.returning(|_| Err(None));
+			.returning(|_| Err(ethereum_rpc::RpcProviderError::Generic("Call failed".to_string())));
 
 		let client = OmniAccountClient::new(account_address, Arc::new(rpc_client));
 		let result = client.get_nonce().await;

--- a/tee-worker/omni-executor/accounting-contract-client/src/lib.rs
+++ b/tee-worker/omni-executor/accounting-contract-client/src/lib.rs
@@ -97,7 +97,9 @@ impl<P: RpcProvider<Transaction = TransactionRequest> + Send + Sync>
 			..Default::default()
 		};
 
-		self.provider.send_transaction(tx).await.map(|_| ())
+		let _ = self.provider.send_transaction(tx).await.map(|_| ())?;
+
+		Ok(())
 	}
 
 	async fn get_nonce(&self, user: Address) -> Result<U256, ()> {
@@ -108,8 +110,8 @@ impl<P: RpcProvider<Transaction = TransactionRequest> + Send + Sync>
 			input: TransactionInput { data: Some(call.into()), ..Default::default() },
 			..Default::default()
 		};
-		self.provider.call(tx).await.map_or(Err(()), |nonce| {
-			let nonce = U256::abi_decode(&nonce).unwrap();
+		self.provider.call(tx).await.map_err(|_| ()).and_then(|nonce| {
+			let nonce = U256::abi_decode(&nonce).map_err(|_| ())?;
 			Ok(nonce)
 		})
 	}
@@ -122,8 +124,8 @@ impl<P: RpcProvider<Transaction = TransactionRequest> + Send + Sync>
 			input: TransactionInput { data: Some(call.into()), ..Default::default() },
 			..Default::default()
 		};
-		self.provider.call(tx).await.map_or(Err(()), |balance| {
-			let balance = U256::abi_decode(&balance).unwrap();
+		self.provider.call(tx).await.map_err(|_| ()).and_then(|balance| {
+			let balance = U256::abi_decode(&balance).map_err(|_| ())?;
 			Ok(balance)
 		})
 	}

--- a/tee-worker/omni-executor/accounting-contract-client/src/lib.rs
+++ b/tee-worker/omni-executor/accounting-contract-client/src/lib.rs
@@ -97,7 +97,7 @@ impl<P: RpcProvider<Transaction = TransactionRequest> + Send + Sync>
 			..Default::default()
 		};
 
-		let _ = self.provider.send_transaction(tx).await.map(|_| ())?;
+		self.provider.send_transaction(tx).await.map_err(|_| ())?;
 
 		Ok(())
 	}

--- a/tee-worker/omni-executor/ethereum-rpc/Cargo.toml
+++ b/tee-worker/omni-executor/ethereum-rpc/Cargo.toml
@@ -12,8 +12,10 @@ hex-literal = { workspace = true }
 libsecp256k1 = { workspace = true }
 mockall = { workspace = true }
 sp-core = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 # Local dependencies
 mock-server = { workspace = true }

--- a/tee-worker/omni-executor/ethereum-rpc/src/error.rs
+++ b/tee-worker/omni-executor/ethereum-rpc/src/error.rs
@@ -1,0 +1,220 @@
+// Copyright 2020-2024 Trust Computing GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
+
+use alloy::transports::RpcError as AlloyRpcError;
+use serde_json::Value;
+use thiserror::Error;
+
+/// Error type for RPC operations
+#[derive(Error, Debug, Clone)]
+pub enum RpcProviderError {
+	/// URL parsing errors
+	#[error("Invalid URL: {0}")]
+	InvalidUrl(String),
+
+	/// Network/transport errors
+	#[error("Network error: {0}")]
+	Network(String),
+
+	/// Transaction-related errors
+	#[error("Transaction error: {0}")]
+	Transaction(String),
+
+	/// JSON-RPC error response
+	#[error("RPC error (code {code}): {message}")]
+	JsonRpc {
+		/// Error code from JSON-RPC
+		code: i32,
+		/// Error message
+		message: String,
+		/// Optional error data
+		data: Option<String>,
+	},
+
+	/// Contract revert with reason
+	#[error("Execution reverted: {reason}")]
+	ExecutionReverted {
+		/// Revert reason or data
+		reason: String,
+	},
+
+	/// No wallet configured for signing
+	#[error("No wallet configured")]
+	NoWallet,
+
+	/// Generic error for other cases
+	#[error("{0}")]
+	Generic(String),
+}
+
+impl RpcProviderError {
+	/// Convert from alloy RpcError
+	pub fn from_alloy_error<E>(err: AlloyRpcError<E>) -> Self
+	where
+		E: std::error::Error + Send + Sync + 'static,
+	{
+		match err {
+			AlloyRpcError::ErrorResp(resp) => {
+				// Extract data if available
+				let data = resp.data.map(|v| match serde_json::from_str::<Value>(v.get()) {
+					Ok(Value::String(s)) => s,
+					Ok(v) => v.to_string(),
+					Err(_) => v.get().to_string(),
+				});
+
+				// Check for common execution revert patterns
+				if let Some(ref data_str) = data {
+					if data_str.starts_with("0x08c379a0") || // Standard revert
+					   data_str.contains("execution reverted") ||
+					   resp.message.contains("execution reverted")
+					{
+						return Self::ExecutionReverted { reason: resp.message.to_string() };
+					}
+				}
+
+				Self::JsonRpc { code: resp.code as i32, message: resp.message.to_string(), data }
+			},
+			AlloyRpcError::Transport(err) => Self::Network(err.to_string()),
+			AlloyRpcError::LocalUsageError(err) => {
+				Self::Generic(format!("Local usage error: {}", err))
+			},
+			AlloyRpcError::UnsupportedFeature(msg) => {
+				Self::Generic(format!("Unsupported feature: {}", msg))
+			},
+			AlloyRpcError::NullResp => Self::Generic("Null response from RPC".to_string()),
+			AlloyRpcError::SerError(err) => Self::Generic(format!("Serialization error: {}", err)),
+			AlloyRpcError::DeserError { err, text } => {
+				Self::Generic(format!("Deserialization error: {} (text: {})", err, text))
+			},
+		}
+	}
+
+	/// Check if this is a retryable error
+	pub fn is_retryable(&self) -> bool {
+		match self {
+			// Network errors are usually retryable
+			Self::Network(_) => true,
+			Self::InvalidUrl(_) => false,
+			Self::NoWallet => false,
+			Self::ExecutionReverted { .. } => false,
+
+			// Check JSON-RPC error codes
+			Self::JsonRpc { code, message, .. } => {
+				match *code {
+					// Standard JSON-RPC errors that might be retryable
+					-32603 => true, // Internal error
+					-32099..=-32000 => {
+						// Server errors - check message for specifics
+						// First check if it's intrinsic gas too low (NOT retryable)
+						if message.contains("intrinsic gas too low") {
+							false
+						} else {
+							// Check for retryable errors
+							message.contains("nonce too low")
+								|| message.contains("replacement transaction underpriced")
+								|| message.contains("transaction underpriced")
+								|| message.contains("already known")
+								|| message.contains("timeout")
+								|| message.contains("max fee per gas less than block base fee")
+								|| message.contains("gas too low")
+								|| message.contains("gas price too low")
+						}
+					},
+					// Rate limiting
+					429 => true,
+					_ => false,
+				}
+			},
+
+			Self::Transaction(msg) => {
+				// Parse transaction errors for retryable conditions
+				// First check if it's intrinsic gas too low (NOT retryable)
+				if msg.contains("intrinsic gas too low") {
+					false
+				} else {
+					// Check for retryable errors
+					msg.contains("nonce too low")
+						|| msg.contains("replacement transaction underpriced")
+						|| msg.contains("transaction underpriced")
+						|| msg.contains("gas price too low")
+						|| msg.contains("max fee per gas less than block base fee")
+						|| msg.contains("gas too low")
+				}
+			},
+
+			Self::Generic(_) => false,
+		}
+	}
+}
+
+// Conversion from unit type for backward compatibility
+impl From<()> for RpcProviderError {
+	fn from(_: ()) -> Self {
+		RpcProviderError::Generic("Unknown error".to_string())
+	}
+}
+
+// Allow converting to unit type for gradual migration
+impl From<RpcProviderError> for () {
+	fn from(_: RpcProviderError) -> Self {}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_new_error_patterns_retryability() {
+		// Test "max fee per gas less than block base fee" - should be retryable
+		let error1 = RpcProviderError::Transaction("max fee per gas less than block base fee".to_string());
+		assert!(error1.is_retryable());
+
+		let error2 = RpcProviderError::JsonRpc { 
+			code: -32000, 
+			message: "max fee per gas less than block base fee".to_string(),
+			data: None
+		};
+		assert!(error2.is_retryable());
+
+		// Test "gas too low" - should be retryable
+		let error3 = RpcProviderError::Transaction("gas too low".to_string());
+		assert!(error3.is_retryable());
+
+		// Test "intrinsic gas too low" - should NOT be retryable
+		let error4 = RpcProviderError::Transaction("intrinsic gas too low".to_string());
+		assert!(!error4.is_retryable());
+
+		let error5 = RpcProviderError::JsonRpc {
+			code: -32000,
+			message: "intrinsic gas too low".to_string(),
+			data: None
+		};
+		assert!(!error5.is_retryable());
+
+		// Test "transaction underpriced" - should be retryable
+		let error6 = RpcProviderError::Transaction("transaction underpriced".to_string());
+		assert!(error6.is_retryable());
+
+		// Test "gas price too low" - should be retryable
+		let error7 = RpcProviderError::JsonRpc {
+			code: -32000,
+			message: "gas price too low for the network".to_string(),
+			data: None
+		};
+		assert!(error7.is_retryable());
+	}
+}
+

--- a/tee-worker/omni-executor/ethereum-rpc/src/error.rs
+++ b/tee-worker/omni-executor/ethereum-rpc/src/error.rs
@@ -160,14 +160,12 @@ impl RpcProviderError {
 	}
 }
 
-// Conversion from unit type for backward compatibility
 impl From<()> for RpcProviderError {
 	fn from(_: ()) -> Self {
 		RpcProviderError::Generic("Unknown error".to_string())
 	}
 }
 
-// Allow converting to unit type for gradual migration
 impl From<RpcProviderError> for () {
 	fn from(_: RpcProviderError) -> Self {}
 }

--- a/tee-worker/omni-executor/ethereum-rpc/src/error.rs
+++ b/tee-worker/omni-executor/ethereum-rpc/src/error.rs
@@ -179,13 +179,14 @@ mod tests {
 	#[test]
 	fn test_new_error_patterns_retryability() {
 		// Test "max fee per gas less than block base fee" - should be retryable
-		let error1 = RpcProviderError::Transaction("max fee per gas less than block base fee".to_string());
+		let error1 =
+			RpcProviderError::Transaction("max fee per gas less than block base fee".to_string());
 		assert!(error1.is_retryable());
 
-		let error2 = RpcProviderError::JsonRpc { 
-			code: -32000, 
+		let error2 = RpcProviderError::JsonRpc {
+			code: -32000,
 			message: "max fee per gas less than block base fee".to_string(),
-			data: None
+			data: None,
 		};
 		assert!(error2.is_retryable());
 
@@ -200,7 +201,7 @@ mod tests {
 		let error5 = RpcProviderError::JsonRpc {
 			code: -32000,
 			message: "intrinsic gas too low".to_string(),
-			data: None
+			data: None,
 		};
 		assert!(!error5.is_retryable());
 
@@ -212,9 +213,8 @@ mod tests {
 		let error7 = RpcProviderError::JsonRpc {
 			code: -32000,
 			message: "gas price too low for the network".to_string(),
-			data: None
+			data: None,
 		};
 		assert!(error7.is_retryable());
 	}
 }
-

--- a/tee-worker/omni-executor/ethereum-rpc/src/lib.rs
+++ b/tee-worker/omni-executor/ethereum-rpc/src/lib.rs
@@ -15,6 +15,7 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 pub mod client;
+pub mod error;
 pub mod signer;
 
 use alloy::hex;
@@ -32,6 +33,8 @@ use executor_core::wallet_metrics::WalletBalanceFetcher;
 use std::collections::HashMap;
 use std::str::FromStr;
 use tracing::log::error;
+
+pub use error::RpcProviderError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Eip1559FeeEstimate {
@@ -74,27 +77,27 @@ pub trait RpcProvider: Send + Sync {
 	type Addr;
 	type Transaction;
 
-	async fn get_balance(&self, address: Self::Addr) -> Result<U256, ()>;
-	async fn get_transaction_count(&self, address: Self::Addr) -> Result<u64, ()>;
-	async fn send_transaction(&self, tx: Self::Transaction) -> Result<String, ()>;
+	async fn get_balance(&self, address: Self::Addr) -> Result<U256, RpcProviderError>;
+	async fn get_transaction_count(&self, address: Self::Addr) -> Result<u64, RpcProviderError>;
+	async fn send_transaction(&self, tx: Self::Transaction) -> Result<String, RpcProviderError>;
 	async fn send_transaction_with_wallet(
 		&self,
 		wallet: &EthereumWallet,
 		tx: Self::Transaction,
-	) -> Result<String, ()>;
-	async fn estimate_gas(&self, tx: Self::Transaction) -> Result<u64, ()>;
-	async fn get_gas_price(&self) -> Result<u128, ()>;
-	async fn estimate_eip1559_fees(&self) -> Result<Eip1559FeeEstimate, ()>;
+	) -> Result<String, RpcProviderError>;
+	async fn estimate_gas(&self, tx: Self::Transaction) -> Result<u64, RpcProviderError>;
+	async fn get_gas_price(&self) -> Result<u128, RpcProviderError>;
+	async fn estimate_eip1559_fees(&self) -> Result<Eip1559FeeEstimate, RpcProviderError>;
 
-	async fn get_code_at(&self, address: Self::Addr) -> Result<Vec<u8>, ()>;
+	async fn get_code_at(&self, address: Self::Addr) -> Result<Vec<u8>, RpcProviderError>;
 
-	async fn call(&self, tx: Self::Transaction) -> Result<Vec<u8>, Option<Vec<u8>>>;
+	async fn call(&self, tx: Self::Transaction) -> Result<Vec<u8>, RpcProviderError>;
 	async fn call_with_state_override(
 		&self,
 		tx: Self::Transaction,
 		state_override: HashMap<Address, AccountOverride>,
-	) -> Result<Vec<u8>, Option<Vec<u8>>>;
-	async fn get_wallet_address(&self) -> Result<Address, ()>;
+	) -> Result<Vec<u8>, RpcProviderError>;
+	async fn get_wallet_address(&self) -> Result<Address, RpcProviderError>;
 }
 
 pub struct AlloyRpcProvider {
@@ -117,30 +120,33 @@ impl RpcProvider for AlloyRpcProvider {
 	type Addr = Address;
 	type Transaction = TransactionRequest;
 
-	async fn get_balance(&self, address: Self::Addr) -> Result<U256, ()> {
+	async fn get_balance(&self, address: Self::Addr) -> Result<U256, RpcProviderError> {
 		let provider = ProviderBuilder::new().connect_http(
-			self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?,
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
 		);
-		provider
-			.get_balance(address)
-			.await
-			.map_err(|e| error!("Could not get balance: {:?}", e))
+		provider.get_balance(address).await.map_err(RpcProviderError::from_alloy_error)
 	}
 
-	async fn get_transaction_count(&self, address: Self::Addr) -> Result<u64, ()> {
+	async fn get_transaction_count(&self, address: Self::Addr) -> Result<u64, RpcProviderError> {
 		let provider = ProviderBuilder::new().connect_http(
-			self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?,
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
 		);
 		provider
 			.get_transaction_count(address)
 			.await
-			.map_err(|e| error!("Could not get transaction count: {:?}", e))
+			.map_err(RpcProviderError::from_alloy_error)
 	}
 
-	async fn send_transaction(&self, raw_tx: Self::Transaction) -> Result<String, ()> {
+	async fn send_transaction(
+		&self,
+		raw_tx: Self::Transaction,
+	) -> Result<String, RpcProviderError> {
 		let Some(ref wallet) = self.wallet else {
-			error!("Provider without a wallet cannot send transactions");
-			return Err(());
+			return Err(RpcProviderError::NoWallet);
 		};
 
 		self.send_transaction_with_wallet(wallet, raw_tx).await
@@ -150,9 +156,11 @@ impl RpcProvider for AlloyRpcProvider {
 		&self,
 		wallet: &EthereumWallet,
 		raw_tx: Self::Transaction,
-	) -> Result<String, ()> {
+	) -> Result<String, RpcProviderError> {
 		let provider = ProviderBuilder::new().wallet(wallet.clone()).connect_http(
-			self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?,
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
 		);
 
 		let signer_address = wallet.default_signer().address();
@@ -160,52 +168,56 @@ impl RpcProvider for AlloyRpcProvider {
 		// Add a 10% buffer to gas to make it safer
 		tx.gas = Some(self.estimate_gas(tx.clone()).await? * 110 / 100);
 
-		let pending_tx = provider.send_transaction(tx).await.map_err(|e| {
-			error!("Could not send transaction: {:?}", e);
-		})?;
+		let pending_tx = provider
+			.send_transaction(tx)
+			.await
+			.map_err(RpcProviderError::from_alloy_error)?;
 
 		// Get transaction hash before waiting for receipt
 		let tx_hash = pending_tx.tx_hash().to_string();
 
 		// wait for transaction to be included
 		let _ = pending_tx.get_receipt().await.map_err(|e| {
-			error!("Could not get transaction receipt: {:?}", e);
+			RpcProviderError::Transaction(format!("Failed to get transaction receipt: {}", e))
 		})?;
 
 		Ok(tx_hash)
 	}
 
-	async fn estimate_gas(&self, tx: Self::Transaction) -> Result<u64, ()> {
+	async fn estimate_gas(&self, tx: Self::Transaction) -> Result<u64, RpcProviderError> {
 		let provider = ProviderBuilder::new().connect_http(
-			self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?,
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
 		);
 
 		provider
 			.estimate_gas(tx.clone())
 			.await
-			.map_err(|e| error!("Could not estimate gas: {:?}", e))
+			.map_err(RpcProviderError::from_alloy_error)
 	}
 
-	async fn get_gas_price(&self) -> Result<u128, ()> {
+	async fn get_gas_price(&self) -> Result<u128, RpcProviderError> {
 		let provider = ProviderBuilder::new().connect_http(
-			self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?,
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
 		);
 
-		provider
-			.get_gas_price()
-			.await
-			.map_err(|e| error!("Could not get gas price: {:?}", e))
+		provider.get_gas_price().await.map_err(RpcProviderError::from_alloy_error)
 	}
 
-	async fn estimate_eip1559_fees(&self) -> Result<Eip1559FeeEstimate, ()> {
+	async fn estimate_eip1559_fees(&self) -> Result<Eip1559FeeEstimate, RpcProviderError> {
 		let provider = ProviderBuilder::new().connect_http(
-			self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?,
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
 		);
 
 		let estimation = provider
 			.estimate_eip1559_fees()
 			.await
-			.map_err(|e| error!("Could not estimate EIP-1559 fees: {:?}", e))?;
+			.map_err(RpcProviderError::from_alloy_error)?;
 
 		Ok(Eip1559FeeEstimate {
 			max_fee_per_gas: estimation.max_fee_per_gas,
@@ -213,46 +225,43 @@ impl RpcProvider for AlloyRpcProvider {
 		})
 	}
 
-	async fn get_code_at(&self, address: Self::Addr) -> Result<Vec<u8>, ()> {
+	async fn get_code_at(&self, address: Self::Addr) -> Result<Vec<u8>, RpcProviderError> {
 		let provider = ProviderBuilder::new().connect_http(
-			self.url.parse().map_err(|e| error!("Could not parse rpc url: {:?}", e))?,
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
 		);
 
 		provider
 			.get_code_at(address)
 			.await
-			.map_err(|e| error!("Could not get gas price: {:?}", e))
+			.map_err(RpcProviderError::from_alloy_error)
 			.map(|b| b.to_vec())
 	}
 
-	async fn call(&self, tx: Self::Transaction) -> Result<Vec<u8>, Option<Vec<u8>>> {
-		let provider = ProviderBuilder::new().connect_http(self.url.parse().map_err(|e| {
-			error!("Could not parse rpc url: {:?}", e);
-			None
-		})?);
-		let result = match provider.call(tx).await {
-			Ok(r) => r,
-			Err(e) => {
-				error!("Error from call: {:?}", e);
-				match e {
-					RpcError::ErrorResp(resp) => match resp.data {
-						Some(value) => {
-							let value: String = serde_json::from_str(value.get()).map_err(|e| {
-								error!("Could not deserialize rpc response: {:?}", e);
-								None
-							})?;
-							let decoded = hex::decode(value).map_err(|e| {
-								error!("Could not decode rpc response: {:?}", e);
-								None
-							})?;
-							return Err(Some(decoded));
-						},
-						None => return Err(None),
-					},
-					_ => return Err(None),
+	async fn call(&self, tx: Self::Transaction) -> Result<Vec<u8>, RpcProviderError> {
+		let provider = ProviderBuilder::new().connect_http(
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
+		);
+		let result = provider.call(tx).await.map_err(|e| {
+			// Special handling for contract reverts
+			if let RpcError::ErrorResp(resp) = &e {
+				if let Some(data) = &resp.data {
+					// Try to extract revert data
+					if let Ok(value) = serde_json::from_str::<String>(data.get()) {
+						if value.starts_with("0x") {
+							// This is likely revert data, return as execution reverted
+							return RpcProviderError::ExecutionReverted {
+								reason: resp.message.to_string(),
+							};
+						}
+					}
 				}
-			},
-		};
+			}
+			RpcProviderError::from_alloy_error(e)
+		})?;
 		Ok(result.to_vec())
 	}
 
@@ -260,52 +269,50 @@ impl RpcProvider for AlloyRpcProvider {
 		&self,
 		tx: Self::Transaction,
 		state_override: HashMap<Address, AccountOverride>,
-	) -> Result<Vec<u8>, Option<Vec<u8>>> {
-		let provider = ProviderBuilder::new().connect_http(self.url.parse().map_err(|e| {
-			error!("Could not parse rpc url: {:?}", e);
-			None
-		})?);
+	) -> Result<Vec<u8>, RpcProviderError> {
+		let provider = ProviderBuilder::new().connect_http(
+			self.url
+				.parse()
+				.map_err(|e: url::ParseError| RpcProviderError::InvalidUrl(e.to_string()))?,
+		);
 
 		// Use the raw_request method to make eth_call with state override
 		let params = serde_json::json!([tx, "latest", state_override]);
 
-		let result = match provider.raw_request::<_, String>("eth_call".into(), params).await {
-			Ok(r) => r,
-			Err(e) => {
-				error!("Error from call with state override: {:?}", e);
-				match e {
-					RpcError::ErrorResp(resp) => match resp.data {
-						Some(value) => {
-							let value: String = serde_json::from_str(value.get()).map_err(|e| {
-								error!("Could not deserialize rpc response: {:?}", e);
-								None
-							})?;
-							let decoded = hex::decode(value).map_err(|e| {
-								error!("Could not decode rpc response: {:?}", e);
-								None
-							})?;
-							return Err(Some(decoded));
-						},
-						None => return Err(None),
-					},
-					_ => return Err(None),
-				}
-			},
-		};
+		let result =
+			provider
+				.raw_request::<_, String>("eth_call".into(), params)
+				.await
+				.map_err(|e| {
+					// Special handling for contract reverts with state override
+					if let RpcError::ErrorResp(resp) = &e {
+						if let Some(data) = &resp.data {
+							// Try to extract revert data
+							if let Ok(value) = serde_json::from_str::<String>(data.get()) {
+								if value.starts_with("0x") {
+									// This is likely revert data, return as execution reverted
+									return RpcProviderError::ExecutionReverted {
+										reason: resp.message.to_string(),
+									};
+								}
+							}
+						}
+					}
+					RpcProviderError::from_alloy_error(e)
+				})?;
 
 		let decoded = hex::decode(&result[2..]).map_err(|e| {
-			error!("Could not decode hex response: {:?}", e);
-			None
+			RpcProviderError::Generic(format!("Failed to decode hex response: {}", e))
 		})?;
 
 		Ok(decoded)
 	}
 
-	async fn get_wallet_address(&self) -> Result<Address, ()> {
+	async fn get_wallet_address(&self) -> Result<Address, RpcProviderError> {
 		if let Some(ref wallet) = self.wallet {
 			Ok(<EthereumWallet as NetworkWallet<Ethereum>>::default_signer_address(wallet))
 		} else {
-			Err(())
+			Err(RpcProviderError::NoWallet)
 		}
 	}
 }
@@ -330,6 +337,7 @@ impl WalletBalanceFetcher for AlloyRpcProvider {
 pub mod mocks {
 	use crate::Eip1559FeeEstimate;
 	use crate::RpcProvider as RpcProviderTrait;
+	use crate::RpcProviderError;
 	use crate::RpcProviderFactory;
 	use alloy::network::EthereumWallet;
 	use alloy::primitives::Address;
@@ -349,17 +357,17 @@ pub mod mocks {
 			type Addr = Address;
 			type Transaction = TransactionRequest;
 
-			async fn get_balance(&self, address: Address) -> Result<U256, ()>;
-			async fn get_transaction_count(&self, address: Address) -> Result<u64, ()>;
-			async fn send_transaction(&self, tx: TransactionRequest) -> Result<String, ()>;
-			async fn send_transaction_with_wallet(&self, wallet: &EthereumWallet, tx: TransactionRequest) -> Result<String, ()>;
-			async fn estimate_gas(&self, tx: TransactionRequest) -> Result<u64, ()>;
-			async fn get_gas_price(&self) -> Result<u128, ()>;
-			async fn estimate_eip1559_fees(&self) -> Result<Eip1559FeeEstimate, ()>;
-			async fn get_code_at(&self, address: Address) -> Result<Vec<u8>, ()>;
-			async fn call(&self, tx: TransactionRequest) -> Result<Vec<u8>, Option<Vec<u8>>>;
-			async fn call_with_state_override(&self, tx: TransactionRequest, state_override: HashMap<Address, AccountOverride>) -> Result<Vec<u8>, Option<Vec<u8>>>;
-			async fn get_wallet_address(&self) -> Result<Address, ()>;
+			async fn get_balance(&self, address: Address) -> Result<U256, RpcProviderError>;
+			async fn get_transaction_count(&self, address: Address) -> Result<u64, RpcProviderError>;
+			async fn send_transaction(&self, tx: TransactionRequest) -> Result<String, RpcProviderError>;
+			async fn send_transaction_with_wallet(&self, wallet: &EthereumWallet, tx: TransactionRequest) -> Result<String, RpcProviderError>;
+			async fn estimate_gas(&self, tx: TransactionRequest) -> Result<u64, RpcProviderError>;
+			async fn get_gas_price(&self) -> Result<u128, RpcProviderError>;
+			async fn estimate_eip1559_fees(&self) -> Result<Eip1559FeeEstimate, RpcProviderError>;
+			async fn get_code_at(&self, address: Address) -> Result<Vec<u8>, RpcProviderError>;
+			async fn call(&self, tx: TransactionRequest) -> Result<Vec<u8>, RpcProviderError>;
+			async fn call_with_state_override(&self, tx: TransactionRequest, state_override: HashMap<Address, AccountOverride>) -> Result<Vec<u8>, RpcProviderError>;
+			async fn get_wallet_address(&self) -> Result<Address, RpcProviderError>;
 		}
 
 	}

--- a/tee-worker/omni-executor/intent/token-query/src/lib.rs
+++ b/tee-worker/omni-executor/intent/token-query/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn query_ethereum<
 	token: &EthereumToken,
 ) -> Result<U256, ()> {
 	match token {
-		EthereumToken::Native => provider.get_balance(account).await,
+		EthereumToken::Native => provider.get_balance(account).await.map_err(|_| ()),
 		EthereumToken::ERC20(address) => {
 			let address = address.as_ref().into();
 			let call = IERC20::balanceOfCall { account };

--- a/tee-worker/omni-executor/intent/token-query/src/lib.rs
+++ b/tee-worker/omni-executor/intent/token-query/src/lib.rs
@@ -380,7 +380,9 @@ pub mod tests {
 				.expect_get_balance()
 				.with(mockall::predicate::eq(address))
 				.times(1)
-				.returning(|_| Err(ethereum_rpc::error::RpcProviderError::Network("Test error".to_string())));
+				.returning(|_| {
+					Err(ethereum_rpc::error::RpcProviderError::Network("Test error".to_string()))
+				});
 
 			let result = query_ethereum(&mock_provider, address, &EthereumToken::Native).await;
 
@@ -414,7 +416,9 @@ pub mod tests {
 			let token_address = hex!("5FC8d32690cc91D4c39d9d3abcBD16989F875707");
 			let token = EthereumToken::ERC20(token_address.try_into().unwrap());
 
-			mock_provider.expect_call().times(1).returning(|_| Err(ethereum_rpc::error::RpcProviderError::Transaction("Test error".to_string())));
+			mock_provider.expect_call().times(1).returning(|_| {
+				Err(ethereum_rpc::error::RpcProviderError::Transaction("Test error".to_string()))
+			});
 
 			let result = query_ethereum(&mock_provider, account, &token).await;
 

--- a/tee-worker/omni-executor/intent/token-query/src/lib.rs
+++ b/tee-worker/omni-executor/intent/token-query/src/lib.rs
@@ -380,7 +380,7 @@ pub mod tests {
 				.expect_get_balance()
 				.with(mockall::predicate::eq(address))
 				.times(1)
-				.returning(|_| Err(()));
+				.returning(|_| Err(ethereum_rpc::error::RpcProviderError::Network("Test error".to_string())));
 
 			let result = query_ethereum(&mock_provider, address, &EthereumToken::Native).await;
 
@@ -414,7 +414,7 @@ pub mod tests {
 			let token_address = hex!("5FC8d32690cc91D4c39d9d3abcBD16989F875707");
 			let token = EthereumToken::ERC20(token_address.try_into().unwrap());
 
-			mock_provider.expect_call().times(1).returning(|_| Err(None));
+			mock_provider.expect_call().times(1).returning(|_| Err(ethereum_rpc::error::RpcProviderError::Transaction("Test error".to_string())));
 
 			let result = query_ethereum(&mock_provider, account, &token).await;
 


### PR DESCRIPTION
## Summary

- Replace unit type errors with typed error enums throughout ethereum-rpc and aa-contracts-client
- Add error classification with retryability checks for better retry logic
- Improve error propagation and handling of contract reverts
- Update all dependent modules to handle new error types