### PR TITLE
Fix EstimateUserOpGas response encoding

### DIFF
--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -874,9 +874,7 @@ async fn handle_native_task<
 			{
 				Ok(gas_estimates) => {
 					info!("Gas estimation successful: {:?}", gas_estimates);
-					if let Err(e) = response_sender.send(gas_estimates.encode()) {
-						error!("Failed to send gas estimation response: {:?}", e);
-					}
+					send_ok(response_sender, gas_estimates);
 				},
 				Err(e) => {
 					send_error(


### PR DESCRIPTION
## Summary

- Fixed response encoding for EstimateUserOpGas RPC method by using send_ok helper function
- Resolves "Failed to decode native task response" error by properly wrapping response in NativeTaskResponse::Ok()