### PR TITLE
feat: disable omni_submitUserOpTest in production worker

### DIFF
--- a/tee-worker/omni-executor/Makefile
+++ b/tee-worker/omni-executor/Makefile
@@ -3,6 +3,7 @@
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 SGX ?= 1
+TEST_BUILD ?= 0
 
 BIN_NAME = omni-executor
 COMPILATION_FEATURES =
@@ -17,14 +18,13 @@ COMPILATION_FEATURES := $(COMPILATION_FEATURES),gramine-quote
 all: $(BIN_NAME).manifest.sgx $(BIN_NAME).sig
 endif
 
+ifeq ($(TEST_BUILD), 1)
+COMPILATION_FEATURES := $(COMPILATION_FEATURES),test-endpoints
+endif
+
 .PHONY: $(BIN_NAME)
 $(BIN_NAME):
 	cargo build --release --locked --features=$(COMPILATION_FEATURES)
-	cp target/release/executor-worker $(BIN_NAME)
-
-.PHONY: $(BIN_NAME)-test
-$(BIN_NAME)-test:
-	cargo build --release --locked --features=$(COMPILATION_FEATURES),test-endpoints
 	cp target/release/executor-worker $(BIN_NAME)
 
 

--- a/tee-worker/omni-executor/Makefile
+++ b/tee-worker/omni-executor/Makefile
@@ -22,6 +22,11 @@ $(BIN_NAME):
 	cargo build --release --locked --features=$(COMPILATION_FEATURES)
 	cp target/release/executor-worker $(BIN_NAME)
 
+.PHONY: $(BIN_NAME)-test
+$(BIN_NAME)-test:
+	cargo build --release --locked --features=$(COMPILATION_FEATURES),test-endpoints
+	cp target/release/executor-worker $(BIN_NAME)
+
 
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
@@ -89,7 +94,7 @@ stop-local:
 
 .PHONY: build-docker-test
 build-docker-test:
-	docker build --build-arg CARGO_FEATURES="mock-server" --target executor-worker -t litentry/$(BIN_NAME):latest -f $(OMNI_DIR)/Dockerfile $(ROOTDIR)
+	docker build --build-arg CARGO_FEATURES="mock-server,test-endpoints" --target executor-worker -t litentry/$(BIN_NAME):latest -f $(OMNI_DIR)/Dockerfile $(ROOTDIR)
 
 .PHONY: start-test
 start-test:

--- a/tee-worker/omni-executor/README.md
+++ b/tee-worker/omni-executor/README.md
@@ -22,11 +22,14 @@ Gramine is required for running inside TEE, please refer to [installation option
 2. Build omni-executor docker image:
 
    ```bash
-   # for local
+   # for local (production build - excludes test endpoints)
    make build-docker
-   # for integration test
+   # for integration test (includes test endpoints)
    make build-docker-test
    ```
+
+   **Note:** The `test-endpoints` feature flag controls test-only RPC methods like `omni_submitUserOpTest`. 
+   Production builds exclude these by default. Use `cargo build --release --features test-endpoints` to include them.
 
 3. Start omni-executor:
    ```bash

--- a/tee-worker/omni-executor/executor-worker/Cargo.toml
+++ b/tee-worker/omni-executor/executor-worker/Cargo.toml
@@ -47,6 +47,7 @@ wildmeta-api = { workspace = true }
 [features]
 default = []
 mock-server = []
+test-endpoints = ["rpc-server/test-endpoints"]
 
 [lints]
 workspace = true

--- a/tee-worker/omni-executor/rpc-server/Cargo.toml
+++ b/tee-worker/omni-executor/rpc-server/Cargo.toml
@@ -62,3 +62,4 @@ workspace = true
 
 [features]
 gramine-quote = []
+test-endpoints = []

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
@@ -73,7 +73,9 @@ use parentchain_rpc_client::{SubstrateRpcClient, SubstrateRpcClientFactory};
 #[cfg(test)]
 mod test_protected_method;
 
+#[cfg(feature = "test-endpoints")]
 mod submit_user_op_test;
+#[cfg(feature = "test-endpoints")]
 use submit_user_op_test::*;
 
 pub fn register_omni<
@@ -121,5 +123,6 @@ pub fn register_omni<
 	#[cfg(test)]
 	test_protected_method::register_test_protected_method(module);
 
+	#[cfg(feature = "test-endpoints")]
 	register_submit_user_op_test(module);
 }


### PR DESCRIPTION
## Summary

Added `test-endpoints` feature flag to control test-only RPC methods in omni-executor. The `omni_submitUserOpTest` endpoint is now excluded from production builds by default and only included when explicitly enabled with the feature flag.