### PR TITLE
Fix Wildmeta email template text styling

### DIFF
--- a/tee-worker/omni-executor/heima/identity-verification/src/web2/email/mailer/template.rs
+++ b/tee-worker/omni-executor/heima/identity-verification/src/web2/email/mailer/template.rs
@@ -154,7 +154,7 @@ pub const WILDMETA_EMAIL_VERIFICATION_TEMPLATE: &str = r##"
                 <tr>
                   <td align="center" style="padding-bottom: 20px">
                     <div style="font-size: 36px; font-weight: 300">
-                      <span class="sm-block" style="background: linear-gradient(91.37deg, #DFEAEA 32.76%, #E3FFFE 94.73%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; text-fill-color: transparent; display: inline">Trade
+                      <span class="sm-block" style="color: #E3FFFE; display: inline">Trade
                       better on</span>
                       <span class="sm-block sm-ml-3" style="display: inline">
                       <img src="https://dex-cdn.wildmeta.io/index/email_hyperliquid.png" alt="Hyperliquid" style="max-width: 100%; display: inline-block; height: 40px; width: auto; vertical-align: middle">


### PR DESCRIPTION
Remove gradient style from Wildmeta email template text and use solid color instead for better compatibility.

<img width="1011" height="268" alt="Screenshot 2025-09-09 at 6 15 47 PM" src="https://github.com/user-attachments/assets/ed55fc71-e488-40fb-b8e3-9351707b7861" />
