### PR TITLE
Append new deployment artefacts

### DIFF
--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -162,9 +162,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6b7b6a501cba311fdb8f7d7798a6d9ca8a5bec16609f1629efeafbac68476e"
+checksum = "2e2a5d689ccd182f1d138a61f081841b905034e0089f5278f6c200f2bcdab00a"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec84ecc0f92bb13b2955d04d3d6bd638415f17069f7ed802de819642fa3a73c"
+checksum = "d213580c17d239ae83c0d897ac3315db7cda83d2d4936a9823cc3517552f2e24"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -215,7 +215,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
- "secp256k1 0.31.1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.16",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e953646f3d5bde9ddf26a0387a35e435044f8728602dc1cb5b9f5cadb642bd"
+checksum = "81443e3b8dccfeac7cd511aced15928c97ff253f4177acbb97de97178e543f6c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a411d7b472b11ceb953741faf26bad31dcac8236e2df84078951a6951561c4"
+checksum = "de217ab604f1bcfa2e3b0aff86d50812d5931d47522f9f0a949cc263ec2d108e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9ebd288f87aa496179b83471f5b00bcd01def4048714234d3ddbf97a6b9dd2"
+checksum = "2a15b4b0f6bab47aae017d52bb5a739bda381553c09fb9918b7172721ef5f5de"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7517225168655178328679a37691b97fb67236d798e96f9e5ccfe2c769a88b9b"
+checksum = "33ba1cbc25a07e0142e8875fcbe80e1fdb02be8160ae186b90f4b9a69a72ed2b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9bedc5c977a179ef037ccadb2e711718118446b0a0cead3427fd5b6712b3"
+checksum = "f8882ec8e4542cfd02aadc6dccbe90caa73038f60016d936734eb6ced53d2167"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c6bffd937626c66734750f022d1808ccf6d5432969044dfde973cae99930d8"
+checksum = "51d6d87d588bda509881a7a66ae77c86514bd1193ac30fbff0e0f24db95eb5a5"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf37162ea3d9809750c6279e09e1012124fc797b02ffb0651974a505f7f88ff"
+checksum = "5b14fa9ba5774e0b30ae6a04176d998211d516c8af69c9c530af7c6c42a8c508"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66feb57febd81b85a66480eeeb15579342aae1384445d8271bc965c50601554f"
+checksum = "9d82efad69266f38e1ef3c6fbfe2f86fa7aec3cf4726368a64914ff5f7a37a0d"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -471,7 +471,7 @@ dependencies = [
  "derive_more 2.0.1",
  "foldhash",
  "hashbrown 0.15.5",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -479,7 +479,7 @@ dependencies = [
  "proptest",
  "rand 0.9.2",
  "ruint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf52603a852c8040686e45649f1211987fa6c96885174a5c4a31a1e07c1ddef7"
+checksum = "475a5141313c3665b75d818be97d5fa3eb5e0abb7e832e9767edd94746db28e3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -513,7 +513,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.16.0",
+ "lru 0.13.0",
  "parking_lot",
  "pin-project",
  "reqwest 0.12.23",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87118d5dc24e682978fb51e3dc1cccb3ef3021e4b98825a357c3efb9256187d5"
+checksum = "25289674cd8c58fcca2568b5350423cb0dd7bca8c596c5e2869bfe4c5c57ed14"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835576f756f0e99b6341eb44d2de4bf162586995819da81f808b32265953167e"
+checksum = "39676beaa50db545cf15447fc94ec5513b64e85a48357a0625b9a04aef08a910"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563ea9dff1d90a3be9454a86456e52b89b473a352003307e21c2f03a17019e30"
+checksum = "a9c8cad42fa936000be72ab80fcd97386a6a226c35c2989212756da9e76c1521"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953599f7a753a6d17296c21b40e15248b69b5845e8764b2fef696e2e012a3f84"
+checksum = "01bac57c987c93773787619e20f89167db74d460a2d1d40f591d94fb7c22c379"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177e49c5d9dffbd8a427cbe757e202e5ef71718d5a8ae7d6858b6e3f448131b"
+checksum = "1cd1e1b4dcdf13eaa96343e5c0dafc2d2e8ce5d20b90347169d46a1df0dec210"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743e0fe099fe90a07215ae08413b271b8fac12fca6880c85326ce61341566e6f"
+checksum = "f1b3b1078b8775077525bc9fe9f6577e815ceaecd6c412a4f3b4d8aa2836e8f6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236cfc2c09ca2af29a2b0e622247c38e47657da97fc9636d5fbe64b6020026c6"
+checksum = "10ab1b8d4649bf7d0db8ab04e31658a6cc20364d920795484d886c35bed3bab4"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626cdb6bb897a09e74d7e502e1834eac83dc0fd94bbb4c9e2cf342dba7f037a9"
+checksum = "7bdeec36c8d9823102b571b3eab8b323e053dc19c12da14a9687bd474129bf2a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -693,7 +693,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a568f574d8d11fc054e3a32f19f476fdcc4db9216246b1db0b2ecad157a6f963"
+checksum = "dce5129146a76ca6139a19832c75ad408857a56bcd18cd2c684183b8eacd78d8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4c00f7c7c6af5660423e6747d22f04ca7e019371eae2dc6535c17b1d636469"
+checksum = "e2379d998f46d422ec8ef2b61603bc28cda931e5e267aea1ebe71f62da61d101"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40696658bb1ac21f742107185fc2b0f60695598e4f16695e5bd24f4cfc0ddc29"
+checksum = "3b5becb9c269a7d05a2f28d549f86df5a5dbc923e2667eff84fdecac8cda534c"
 dependencies = [
  "alloy-primitives",
  "darling 0.21.3",
@@ -1007,12 +1007,6 @@ dependencies = [
  "syn 1.0.109",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -1460,7 +1454,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.8",
+ "rustix",
  "slab",
  "windows-sys 0.60.2",
 ]
@@ -1502,7 +1496,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite",
- "rustix 1.0.8",
+ "rustix",
 ]
 
 [[package]]
@@ -1517,7 +1511,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.8",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.60.2",
@@ -1615,9 +1609,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1625,11 +1619,11 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -1764,29 +1758,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.4",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.106",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1795,10 +1766,12 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.106",
 ]
@@ -2301,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2371,17 +2344,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2435,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2445,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2457,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3550,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3607,12 +3579,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4311,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "finito"
@@ -4933,7 +4905,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -5048,7 +5020,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -5067,7 +5039,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -5820,9 +5792,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -6022,9 +5994,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -6103,7 +6075,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -6314,12 +6286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6357,7 +6323,7 @@ version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "libc",
@@ -6484,15 +6450,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -6512,9 +6472,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
@@ -6527,9 +6487,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.5",
 ]
@@ -6704,7 +6664,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -7159,9 +7119,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nybbles"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63cb50036b1ad148038105af40aaa70ff24d8a14fbc44ae5c914e1348533d12e"
+checksum = "f0418987d1aaed324d95b4beffc93635e19be965ed5d63ec07a35980fe3b71a4"
 dependencies = [
  "alloy-rlp",
  "cfg-if",
@@ -7620,7 +7580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
 ]
 
 [[package]]
@@ -7829,7 +7789,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 1.0.8",
+ "rustix",
  "windows-sys 0.60.2",
 ]
 
@@ -8160,7 +8120,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.31",
  "socket2 0.6.0",
  "thiserror 2.0.16",
@@ -8181,7 +8141,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring 0.17.14",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.31",
  "rustls-pki-types",
  "rustls-platform-verifier 0.6.1",
@@ -8350,9 +8310,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.5.0"
+version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.9.4",
 ]
@@ -8824,12 +8784,6 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -8869,28 +8823,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
-dependencies = [
- "bitflags 2.9.4",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8916,7 +8857,7 @@ dependencies = [
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.5",
  "subtle",
  "zeroize",
 ]
@@ -8930,7 +8871,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.3.0",
+ "security-framework 3.4.0",
 ]
 
 [[package]]
@@ -8966,8 +8907,8 @@ dependencies = [
  "rustls 0.23.31",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.4",
- "security-framework 3.3.0",
+ "rustls-webpki 0.103.5",
+ "security-framework 3.4.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -8987,8 +8928,8 @@ dependencies = [
  "rustls 0.23.31",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.4",
- "security-framework 3.3.0",
+ "rustls-webpki 0.103.5",
+ "security-framework 3.4.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.2",
  "windows-sys 0.59.0",
@@ -9012,9 +8953,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.14",
@@ -9216,11 +9157,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -9373,17 +9314,6 @@ dependencies = [
  "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes 0.14.0",
- "rand 0.9.2",
- "secp256k1-sys 0.11.0",
  "serde",
 ]
 
@@ -9401,15 +9331,6 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -9447,9 +9368,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.10.1",
@@ -9460,9 +9381,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -9613,7 +9534,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -9762,9 +9683,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
 dependencies = [
  "approx",
  "num-complex 0.4.6",
@@ -9895,7 +9816,7 @@ dependencies = [
  "slab",
  "smallvec",
  "soketto",
- "twox-hash 2.1.1",
+ "twox-hash 2.1.2",
  "wasmi",
  "x25519-dalek",
  "zeroize",
@@ -10173,7 +10094,7 @@ dependencies = [
  "dashmap 5.5.3",
  "futures",
  "futures-util",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "indicatif",
  "log",
  "quinn",
@@ -10320,7 +10241,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures-util",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -10350,9 +10271,9 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.3.7"
+version = "2.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b162f50499b391b785d57b2f2c73e3b9754d88fd4894bef444960b00bda8dcca"
+checksum = "8ae1f4d4aeca2150abd9c731d23ff6c157af0d6828c1c17a3fc22b1a7804c8ee"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -11751,7 +11672,7 @@ dependencies = [
  "futures-util",
  "governor",
  "histogram",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.12.1",
  "libc",
  "log",
@@ -11930,7 +11851,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "indicatif",
  "log",
  "rayon",
@@ -13977,15 +13898,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -14096,9 +14017,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
  "num-conv",
@@ -14110,15 +14031,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -14342,7 +14263,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -14600,9 +14521,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -14654,9 +14575,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-normalization"
@@ -14894,30 +14815,40 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -14929,9 +14860,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -14942,9 +14873,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -14952,9 +14883,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14965,9 +14896,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
@@ -15038,9 +14969,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -15090,18 +15021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15144,11 +15063,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -15165,7 +15084,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -15199,12 +15118,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -15215,7 +15140,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -15224,7 +15149,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -15270,6 +15195,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -15324,7 +15258,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -15536,9 +15470,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"
@@ -15665,18 +15599,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15816,9 +15750,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/tee-worker/omni-executor/aa-contracts/.gitignore
+++ b/tee-worker/omni-executor/aa-contracts/.gitignore
@@ -18,3 +18,6 @@ broadcast/
 
 # Deployment artifacts
 deployments/local/
+
+# Test deployment directories (created during testing)
+test_deployments/

--- a/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/arbitrum-sepolia.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/arbitrum-sepolia.json
@@ -1,12 +1,11 @@
 {
   "network": "Arbitrum Sepolia",
   "chainId": 421614,
-  "timestamp": 1754300402,
-  "blockNumber": 180527788,
   "deployer": "0x4Af24bE88b6F683E4e415b7649A3B1bBf6DE430c",
   "contracts": {
     "EntryPointV1": {
       "address": "0x332058832970B17D9fF657ad03bab074c49443aa",
+      "blockNumber": 180527788,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xe374D687f02008aB497D4A5f106445388a2831b7",
+      "blockNumber": 180527788,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0xD4dCB31763CBA7295bA4023E9411CB6db607DE07",
+      "blockNumber": 180527788,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/arbitrum.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/arbitrum.json
@@ -1,12 +1,11 @@
 {
   "network": "Arbitrum Mainnet",
   "chainId": 42161,
-  "timestamp": 1754300820,
-  "blockNumber": 364836376,
   "deployer": "0x4Af24bE88b6F683E4e415b7649A3B1bBf6DE430c",
   "contracts": {
     "EntryPointV1": {
       "address": "0x332058832970B17D9fF657ad03bab074c49443aa",
+      "blockNumber": 364836376,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xe374D687f02008aB497D4A5f106445388a2831b7",
+      "blockNumber": 364836376,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0xD4dCB31763CBA7295bA4023E9411CB6db607DE07",
+      "blockNumber": 364836376,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/base.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/base.json
@@ -1,12 +1,11 @@
 {
   "network": "Base",
   "chainId": 8453,
-  "timestamp": 1757491511,
-  "blockNumber": 35351082,
   "deployer": "0x4Af24bE88b6F683E4e415b7649A3B1bBf6DE430c",
   "contracts": {
     "EntryPointV1": {
       "address": "0x332058832970B17D9fF657ad03bab074c49443aa",
+      "blockNumber": 35351082,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xe374D687f02008aB497D4A5f106445388a2831b7",
+      "blockNumber": 35351082,
       "abi": [
         {
           "type": "constructor",
@@ -1204,6 +1204,7 @@
     },
     "SimplePaymaster": {
       "address": "0xD4dCB31763CBA7295bA4023E9411CB6db607DE07",
+      "blockNumber": 35351082,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/bsc.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/bsc.json
@@ -1,12 +1,11 @@
 {
   "network": "BSC Mainnet",
   "chainId": 56,
-  "timestamp": 1757491788,
-  "blockNumber": 60657629,
   "deployer": "0x4Af24bE88b6F683E4e415b7649A3B1bBf6DE430c",
   "contracts": {
     "EntryPointV1": {
       "address": "0x332058832970B17D9fF657ad03bab074c49443aa",
+      "blockNumber": 60657629,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xe374D687f02008aB497D4A5f106445388a2831b7",
+      "blockNumber": 60657629,
       "abi": [
         {
           "type": "constructor",
@@ -1204,6 +1204,7 @@
     },
     "SimplePaymaster": {
       "address": "0xD4dCB31763CBA7295bA4023E9411CB6db607DE07",
+      "blockNumber": 60657629,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/ethereum-sepolia.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/ethereum-sepolia.json
@@ -1,12 +1,11 @@
 {
   "network": "Ethereum Sepolia",
   "chainId": 11155111,
-  "timestamp": 1754554380,
-  "blockNumber": 8931153,
   "deployer": "0x4Af24bE88b6F683E4e415b7649A3B1bBf6DE430c",
   "contracts": {
     "EntryPointV1": {
       "address": "0x332058832970B17D9fF657ad03bab074c49443aa",
+      "blockNumber": 8931153,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xe374D687f02008aB497D4A5f106445388a2831b7",
+      "blockNumber": 8931153,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0xD4dCB31763CBA7295bA4023E9411CB6db607DE07",
+      "blockNumber": 8931153,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/ethereum.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/ethereum.json
@@ -1,12 +1,11 @@
 {
   "network": "Ethereum Mainnet",
   "chainId": 1,
-  "timestamp": 1754554895,
-  "blockNumber": 23087956,
   "deployer": "0x4Af24bE88b6F683E4e415b7649A3B1bBf6DE430c",
   "contracts": {
     "EntryPointV1": {
       "address": "0x332058832970B17D9fF657ad03bab074c49443aa",
+      "blockNumber": 23087956,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xe374D687f02008aB497D4A5f106445388a2831b7",
+      "blockNumber": 23087956,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0xD4dCB31763CBA7295bA4023E9411CB6db607DE07",
+      "blockNumber": 23087956,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/hyperevm-testnet.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/hyperevm-testnet.json
@@ -1,12 +1,11 @@
 {
   "network": "HyperEVM Testnet",
   "chainId": 998,
-  "timestamp": 1754301253,
-  "blockNumber": 28736991,
   "deployer": "0x4Af24bE88b6F683E4e415b7649A3B1bBf6DE430c",
   "contracts": {
     "EntryPointV1": {
       "address": "0x332058832970B17D9fF657ad03bab074c49443aa",
+      "blockNumber": 28736991,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xe374D687f02008aB497D4A5f106445388a2831b7",
+      "blockNumber": 28736991,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0xD4dCB31763CBA7295bA4023E9411CB6db607DE07",
+      "blockNumber": 28736991,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/hyperevm.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/prod-v1/hyperevm.json
@@ -1,12 +1,11 @@
 {
   "network": "HyperEVM Mainnet",
   "chainId": 999,
-  "timestamp": 1754301449,
-  "blockNumber": 10217406,
   "deployer": "0x4Af24bE88b6F683E4e415b7649A3B1bBf6DE430c",
   "contracts": {
     "EntryPointV1": {
       "address": "0x332058832970B17D9fF657ad03bab074c49443aa",
+      "blockNumber": 10217406,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xe374D687f02008aB497D4A5f106445388a2831b7",
+      "blockNumber": 10217406,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0xD4dCB31763CBA7295bA4023E9411CB6db607DE07",
+      "blockNumber": 10217406,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v0/arbitrum-sepolia.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v0/arbitrum-sepolia.json
@@ -1,11 +1,11 @@
 {
   "network": "Arbitrum Sepolia",
   "chainId": 421614,
-  "timestamp": 1752529355,
   "deployer": "0x6eCd109368A8dF927A3dDE6FD4c1648C346Caec7",
   "contracts": {
     "EntryPoint": {
       "address": "0xf1646af389deE47DC7d45E6616A1bCdc9F2b0140",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",
@@ -1075,6 +1075,7 @@
     },
     "OmniAccountFactory": {
       "address": "0xca470c1990B1E3DBF24676D8ACDF4B5867CD410e",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",
@@ -1198,6 +1199,7 @@
     },
     "SimplePaymaster": {
       "address": "0xB529AcA1D832be817Bd8B30c2f2a51490792fcff",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v0/arbitrum.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v0/arbitrum.json
@@ -1,11 +1,11 @@
 {
   "network": "Arbitrum Mainnet",
   "chainId": 42161,
-  "timestamp": 1752570039,
   "deployer": "0x6eCd109368A8dF927A3dDE6FD4c1648C346Caec7",
   "contracts": {
     "EntryPoint": {
       "address": "0xf1646af389deE47DC7d45E6616A1bCdc9F2b0140",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",
@@ -1075,6 +1075,7 @@
     },
     "OmniAccountFactory": {
       "address": "0xca470c1990B1E3DBF24676D8ACDF4B5867CD410e",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",
@@ -1198,6 +1199,7 @@
     },
     "SimplePaymaster": {
       "address": "0xB529AcA1D832be817Bd8B30c2f2a51490792fcff",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v0/hyperevm-testnet.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v0/hyperevm-testnet.json
@@ -1,11 +1,11 @@
 {
   "network": "HyperEVM Testnet",
   "chainId": 998,
-  "timestamp": 1753100887,
   "deployer": "0x6eCd109368A8dF927A3dDE6FD4c1648C346Caec7",
   "contracts": {
     "EntryPoint": {
       "address": "0xf1646af389deE47DC7d45E6616A1bCdc9F2b0140",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",
@@ -1075,6 +1075,7 @@
     },
     "OmniAccountFactory": {
       "address": "0xca470c1990B1E3DBF24676D8ACDF4B5867CD410e",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",
@@ -1198,6 +1199,7 @@
     },
     "SimplePaymaster": {
       "address": "0xB529AcA1D832be817Bd8B30c2f2a51490792fcff",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v0/hyperevm.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v0/hyperevm.json
@@ -1,11 +1,11 @@
 {
   "network": "HyperEVM Mainnet",
   "chainId": 999,
-  "timestamp": 1753101018,
   "deployer": "0x6eCd109368A8dF927A3dDE6FD4c1648C346Caec7",
   "contracts": {
     "EntryPoint": {
       "address": "0xf1646af389deE47DC7d45E6616A1bCdc9F2b0140",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",
@@ -1075,6 +1075,7 @@
     },
     "OmniAccountFactory": {
       "address": "0xca470c1990B1E3DBF24676D8ACDF4B5867CD410e",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",
@@ -1198,6 +1199,7 @@
     },
     "SimplePaymaster": {
       "address": "0xB529AcA1D832be817Bd8B30c2f2a51490792fcff",
+      "blockNumber": 1,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/arbitrum-sepolia.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/arbitrum-sepolia.json
@@ -1672,6 +1672,780 @@
       "metadata": {
         "initialBundler": "0x5CE2DFd32381d33BdA69B2CF0ECf4B6A97cb7eF6"
       }
+    },
+    "ERC20PaymasterV1": {
+      "address": "0xA8535e013236E04FAD5dc03eCc4c05A464c01f38",
+      "blockNumber": 9174509,
+      "abi": [
+        {
+          "type": "constructor",
+          "inputs": [
+            {
+              "name": "_entryPoint",
+              "type": "address",
+              "internalType": "contract IEntryPoint"
+            },
+            {
+              "name": "_initialBundler",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "receive",
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "_isApprovalOperation_exposed",
+          "inputs": [
+            {
+              "name": "userOp",
+              "type": "tuple",
+              "internalType": "struct PackedUserOperation",
+              "components": [
+                {
+                  "name": "sender",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "initCode",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "accountGasLimits",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "preVerificationGas",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "gasFees",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "paymasterAndData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "signature",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            },
+            {
+              "name": "tokenAddress",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "acceptOwnership",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "addStake",
+          "inputs": [
+            {
+              "name": "unstakeDelaySec",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "authorizedBundlers",
+          "inputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "beneficiary",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "calculateExchangeRate",
+          "inputs": [
+            {
+              "name": "tokenDecimals",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "tokensPerEth",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "exchangeRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "deposit",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "entryPoint",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "contract IEntryPoint"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getDeposit",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getTokenDecimals",
+          "inputs": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "decimals",
+              "type": "uint8",
+              "internalType": "uint8"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pause",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "paused",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pendingOwner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "postOp",
+          "inputs": [
+            {
+              "name": "mode",
+              "type": "uint8",
+              "internalType": "enum IPaymaster.PostOpMode"
+            },
+            {
+              "name": "context",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "actualGasCost",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "actualUserOpFeePerGas",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "renounceOwnership",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "setAuthorizedBundler",
+          "inputs": [
+            {
+              "name": "bundler",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "authorized",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "setBeneficiary",
+          "inputs": [
+            {
+              "name": "_beneficiary",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "unlockStake",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "unpause",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "validatePaymasterUserOp",
+          "inputs": [
+            {
+              "name": "userOp",
+              "type": "tuple",
+              "internalType": "struct PackedUserOperation",
+              "components": [
+                {
+                  "name": "sender",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "initCode",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "callData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "accountGasLimits",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "preVerificationGas",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "gasFees",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "paymasterAndData",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                },
+                {
+                  "name": "signature",
+                  "type": "bytes",
+                  "internalType": "bytes"
+                }
+              ]
+            },
+            {
+              "name": "userOpHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "maxCost",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "context",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "validationData",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "version",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "withdrawStake",
+          "inputs": [
+            {
+              "name": "withdrawAddress",
+              "type": "address",
+              "internalType": "address payable"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "withdrawTo",
+          "inputs": [
+            {
+              "name": "withdrawAddress",
+              "type": "address",
+              "internalType": "address payable"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "withdrawTokens",
+          "inputs": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "to",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "event",
+          "name": "AuthorizedBundlerUpdated",
+          "inputs": [
+            {
+              "name": "bundler",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "authorized",
+              "type": "bool",
+              "indexed": false,
+              "internalType": "bool"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "BeneficiaryUpdated",
+          "inputs": [
+            {
+              "name": "oldBeneficiary",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newBeneficiary",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferStarted",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "OwnershipTransferred",
+          "inputs": [
+            {
+              "name": "previousOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "newOwner",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Paused",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "TokensWithdrawn",
+          "inputs": [
+            {
+              "name": "token",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "to",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "Unpaused",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "indexed": false,
+              "internalType": "address"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "event",
+          "name": "UserOpSponsored",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "indexed": true,
+              "internalType": "address"
+            },
+            {
+              "name": "actualGasCost",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            },
+            {
+              "name": "tokenAmount",
+              "type": "uint256",
+              "indexed": false,
+              "internalType": "uint256"
+            }
+          ],
+          "anonymous": false
+        },
+        {
+          "type": "error",
+          "name": "EnforcedPause",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "ExpectedPause",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InsufficientDeposit",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InsufficientTokenAllowance",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InsufficientTokenBalance",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidExchangeRate",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidPaymasterData",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "InvalidToken",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "OwnableInvalidOwner",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "OwnableUnauthorizedAccount",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "PostOpGasLimitTooLow",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "ReentrancyGuardReentrantCall",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "RefundFailed",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "SafeERC20FailedOperation",
+          "inputs": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "type": "error",
+          "name": "TimestampValidationFailed",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "TokenTransferFailed",
+          "inputs": []
+        },
+        {
+          "type": "error",
+          "name": "UnauthorizedBundler",
+          "inputs": []
+        }
+      ],
+      "bytecode": "0x60806040526004361015610022575b3615610018575f80fd5b610020611687565b005b..."
     }
   }
 }

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/arbitrum-sepolia.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/arbitrum-sepolia.json
@@ -1,12 +1,11 @@
 {
   "network": "Arbitrum Sepolia",
   "chainId": 421614,
-  "timestamp": 1754055145,
-  "blockNumber": 8889724,
   "deployer": "0xD4E40A734b52f6c44e27A40e8d62E7d745A8C3F3",
   "contracts": {
     "EntryPointV1": {
       "address": "0xe6042188857a822DDfcFE5fd9E17118049Ab539a",
+      "blockNumber": 8889724,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xC099F3Cc3cA145546B502A8d8B2866283Aaf054e",
+      "blockNumber": 8889724,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912",
+      "blockNumber": 8889724,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/arbitrum.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/arbitrum.json
@@ -1,12 +1,11 @@
 {
   "network": "Arbitrum Mainnet",
   "chainId": 42161,
-  "timestamp": 1754057562,
-  "blockNumber": 23046748,
   "deployer": "0xD4E40A734b52f6c44e27A40e8d62E7d745A8C3F3",
   "contracts": {
     "EntryPointV1": {
       "address": "0xe6042188857a822DDfcFE5fd9E17118049Ab539a",
+      "blockNumber": 23046748,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xC099F3Cc3cA145546B502A8d8B2866283Aaf054e",
+      "blockNumber": 23046748,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912",
+      "blockNumber": 23046748,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/base.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/base.json
@@ -1,12 +1,11 @@
 {
   "network": "Base",
   "chainId": 8453,
-  "timestamp": 1757406025,
-  "blockNumber": 35308339,
   "deployer": "0xD4E40A734b52f6c44e27A40e8d62E7d745A8C3F3",
   "contracts": {
     "EntryPointV1": {
       "address": "0xe6042188857a822DDfcFE5fd9E17118049Ab539a",
+      "blockNumber": 35308339,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xC099F3Cc3cA145546B502A8d8B2866283Aaf054e",
+      "blockNumber": 35308339,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912",
+      "blockNumber": 35308339,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/bsc.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/bsc.json
@@ -1,12 +1,11 @@
 {
   "network": "BSC Mainnet",
   "chainId": 56,
-  "timestamp": 1757404938,
-  "blockNumber": 60541852,
   "deployer": "0xD4E40A734b52f6c44e27A40e8d62E7d745A8C3F3",
   "contracts": {
     "EntryPointV1": {
       "address": "0xe6042188857a822DDfcFE5fd9E17118049Ab539a",
+      "blockNumber": 60541852,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xC099F3Cc3cA145546B502A8d8B2866283Aaf054e",
+      "blockNumber": 60541852,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912",
+      "blockNumber": 60541852,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/ethereum-sepolia.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/ethereum-sepolia.json
@@ -1,12 +1,11 @@
 {
   "network": "Ethereum Sepolia",
   "chainId": 11155111,
-  "timestamp": 1754553072,
-  "blockNumber": 8931047,
   "deployer": "0xD4E40A734b52f6c44e27A40e8d62E7d745A8C3F3",
   "contracts": {
     "EntryPointV1": {
       "address": "0xe6042188857a822DDfcFE5fd9E17118049Ab539a",
+      "blockNumber": 8931047,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xC099F3Cc3cA145546B502A8d8B2866283Aaf054e",
+      "blockNumber": 8931047,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912",
+      "blockNumber": 8931047,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/ethereum.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/ethereum.json
@@ -1,12 +1,11 @@
 {
   "network": "Ethereum Mainnet",
   "chainId": 1,
-  "timestamp": 1754553923,
-  "blockNumber": 23087875,
   "deployer": "0xD4E40A734b52f6c44e27A40e8d62E7d745A8C3F3",
   "contracts": {
     "EntryPointV1": {
       "address": "0xe6042188857a822DDfcFE5fd9E17118049Ab539a",
+      "blockNumber": 23087875,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xC099F3Cc3cA145546B502A8d8B2866283Aaf054e",
+      "blockNumber": 23087875,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912",
+      "blockNumber": 23087875,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/hyperevm-testnet.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/hyperevm-testnet.json
@@ -1,12 +1,11 @@
 {
   "network": "HyperEVM Testnet",
   "chainId": 998,
-  "timestamp": 1754061803,
-  "blockNumber": 28494471,
   "deployer": "0xD4E40A734b52f6c44e27A40e8d62E7d745A8C3F3",
   "contracts": {
     "EntryPointV1": {
       "address": "0xe6042188857a822DDfcFE5fd9E17118049Ab539a",
+      "blockNumber": 28494471,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xC099F3Cc3cA145546B502A8d8B2866283Aaf054e",
+      "blockNumber": 28494471,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912",
+      "blockNumber": 28494471,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/hyperevm.json
+++ b/tee-worker/omni-executor/aa-contracts/deployments/staging-v1/hyperevm.json
@@ -1,12 +1,11 @@
 {
   "network": "HyperEVM Mainnet",
   "chainId": 999,
-  "timestamp": 1754062190,
-  "blockNumber": 9974438,
   "deployer": "0xD4E40A734b52f6c44e27A40e8d62E7d745A8C3F3",
   "contracts": {
     "EntryPointV1": {
       "address": "0xe6042188857a822DDfcFE5fd9E17118049Ab539a",
+      "blockNumber": 9974438,
       "abi": [
         {
           "type": "constructor",
@@ -1077,6 +1076,7 @@
     },
     "OmniAccountFactoryV1": {
       "address": "0xC099F3Cc3cA145546B502A8d8B2866283Aaf054e",
+      "blockNumber": 9974438,
       "abi": [
         {
           "type": "constructor",
@@ -1201,6 +1201,7 @@
     },
     "SimplePaymaster": {
       "address": "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912",
+      "blockNumber": 9974438,
       "abi": [
         {
           "type": "constructor",

--- a/tee-worker/omni-executor/aa-contracts/foundry.toml
+++ b/tee-worker/omni-executor/aa-contracts/foundry.toml
@@ -6,6 +6,9 @@ solc_version = "0.8.28"
 optimizer = true
 optimizer_runs = 1000000
 via_ir = true
-fs_permissions = [{ access = "read-write", path = "./deployments" }]
+fs_permissions = [
+    { access = "read-write", path = "./deployments" },
+    { access = "read-write", path = "./test_deployments" }
+]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/tee-worker/omni-executor/aa-contracts/foundry.toml
+++ b/tee-worker/omni-executor/aa-contracts/foundry.toml
@@ -8,7 +8,8 @@ optimizer_runs = 1000000
 via_ir = true
 fs_permissions = [
     { access = "read-write", path = "./deployments" },
-    { access = "read-write", path = "./test_deployments" }
+    { access = "read-write", path = "./test_deployments" },
+    { access = "read-write", path = "./broadcast" }
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/tee-worker/omni-executor/aa-contracts/script/DeploymentHelper.sol
+++ b/tee-worker/omni-executor/aa-contracts/script/DeploymentHelper.sol
@@ -17,13 +17,12 @@ library DeploymentHelper {
         string abi;
         string bytecode;
         string metadata;
+        uint256 blockNumber;
     }
 
     struct DeploymentArtifact {
         string network;
         uint256 chainId;
-        uint256 timestamp;
-        uint256 blockNumber;
         address deployer;
         ContractDeployment[] contracts;
     }
@@ -128,6 +127,9 @@ library DeploymentHelper {
                     '      "address": "',
                     vm.toString(deployments[i].addr),
                     '",\n',
+                    '      "blockNumber": ',
+                    vm.toString(deployments[i].blockNumber),
+                    ",\n",
                     '      "abi": ',
                     deployments[i].abi,
                     ",\n",
@@ -154,12 +156,6 @@ library DeploymentHelper {
                 '",\n',
                 '  "chainId": ',
                 vm.toString(chainId),
-                ",\n",
-                '  "timestamp": ',
-                vm.toString(block.timestamp),
-                ",\n",
-                '  "blockNumber": ',
-                vm.toString(block.number),
                 ",\n",
                 '  "deployer": "',
                 vm.toString(msg.sender),
@@ -210,8 +206,17 @@ library DeploymentHelper {
                     // This contract exists! Extract all its properties
                     string memory existingContractObjKey = string(abi.encodePacked("existing_", contractName));
 
-                    // Get the contract properties
+                    // Get the contract properties - in the desired order
                     vm.serializeAddress(existingContractObjKey, "address", contractAddr);
+
+                    // Get blockNumber (second field)
+                    try vm.parseJsonUint(existingJson, string(abi.encodePacked(contractPath, ".blockNumber"))) returns (
+                        uint256 blockNum
+                    ) {
+                        vm.serializeUint(existingContractObjKey, "blockNumber", blockNum);
+                    } catch {
+                        vm.serializeUint(existingContractObjKey, "blockNumber", block.number);
+                    }
 
                     // Get ABI - handle both array format and string format
                     try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".abi"))) returns (
@@ -266,16 +271,17 @@ library DeploymentHelper {
             for (uint256 i = 0; i < newDeployments.length; i++) {
                 string memory contractObjKey = string(abi.encodePacked("newContract_", vm.toString(i)));
 
-                // Build the new contract JSON using Foundry's serialization
+                // Build the new contract JSON using Foundry's serialization - in the desired order
                 vm.serializeAddress(contractObjKey, "address", newDeployments[i].addr);
+                vm.serializeUint(contractObjKey, "blockNumber", newDeployments[i].blockNumber);
                 vm.serializeString(contractObjKey, "abi", newDeployments[i].abi);
+                vm.serializeString(contractObjKey, "bytecode", newDeployments[i].bytecode);
 
                 string memory newContractJson;
                 if (bytes(newDeployments[i].metadata).length > 0) {
-                    vm.serializeString(contractObjKey, "bytecode", newDeployments[i].bytecode);
                     newContractJson = vm.serializeString(contractObjKey, "metadata", newDeployments[i].metadata);
                 } else {
-                    newContractJson = vm.serializeString(contractObjKey, "bytecode", newDeployments[i].bytecode);
+                    newContractJson = vm.serializeUint(contractObjKey, "blockNumber", newDeployments[i].blockNumber);
                 }
 
                 // Add this new contract to the merged contracts object
@@ -286,8 +292,6 @@ library DeploymentHelper {
             string memory deploymentObjKey = "finalDeployment";
             vm.serializeString(deploymentObjKey, "network", networkName);
             vm.serializeUint(deploymentObjKey, "chainId", chainId);
-            vm.serializeUint(deploymentObjKey, "timestamp", block.timestamp);
-            vm.serializeUint(deploymentObjKey, "blockNumber", block.number);
             vm.serializeAddress(deploymentObjKey, "deployer", msg.sender);
 
             return vm.serializeString(deploymentObjKey, "contracts", mergedContractsJson);
@@ -465,7 +469,8 @@ library DeploymentHelper {
             addr: addr,
             abi: getContractAbi(vm, name),
             bytecode: getDeployedBytecode(addr),
-            metadata: metadata
+            metadata: metadata,
+            blockNumber: block.number
         });
     }
 }

--- a/tee-worker/omni-executor/aa-contracts/script/DeploymentHelper.sol
+++ b/tee-worker/omni-executor/aa-contracts/script/DeploymentHelper.sol
@@ -77,9 +77,9 @@ library DeploymentHelper {
         // Check if file already exists and merge if needed
         string memory json;
         try vm.readFile(filename) returns (string memory existingContent) {
-            // File exists, merge the new contracts with existing ones
+            // File exists, try to merge the new contracts with existing ones
             json = mergeDeploymentJson(vm, existingContent, networkName, chainId, deployments);
-            console.log("Merging new contracts with existing deployment file:", filename);
+            console.log("Appending new contracts to existing deployment file:", filename);
         } catch {
             // File doesn't exist, create new JSON
             json = buildDeploymentJson(vm, networkName, chainId, deployments);
@@ -170,7 +170,7 @@ library DeploymentHelper {
 
     /**
      * @notice Merges new deployment contracts with existing deployment JSON
-     * Uses Foundry's JSON capabilities for parsing and a cleaner approach
+     * Uses VM methods for JSON parsing but preserves existing contract order and appends new contracts
      * @param vm The Foundry VM instance
      * @param existingJson The existing JSON content from the file
      * @param networkName The name of the network
@@ -184,117 +184,90 @@ library DeploymentHelper {
         string memory networkName,
         uint256 chainId,
         ContractDeployment[] memory newDeployments
-    ) internal returns (string memory) {
+    ) internal view returns (string memory) {
         try vm.parseJson(existingJson, ".contracts") returns (bytes memory) {
-            // Successfully parsed existing contracts section - now rebuild with proper JSON
+            // Successfully parsed - extract existing contracts and append new ones
 
-            // Create a new merged contracts object
-            string memory mergedContractsObjKey = "mergedContracts";
-            string memory mergedContractsJson = "";
+            // Extract existing contract names - try all known contract names and see which exist
+            ContractDeployment[] memory existingDeployments = new ContractDeployment[](0);
 
-            // Parse existing contract names that might exist and add them to merged object
-            string[] memory commonContractNames = getCommonContractNames();
-
-            // Try to extract each existing contract and add to merged object if it exists
-            for (uint256 i = 0; i < commonContractNames.length; i++) {
-                string memory contractName = commonContractNames[i];
+            string[] memory allKnownNames = getCommonContractNames();
+            for (uint256 i = 0; i < allKnownNames.length; i++) {
+                string memory contractName = allKnownNames[i];
                 string memory contractPath = string(abi.encodePacked(".contracts.", contractName));
 
                 try vm.parseJsonAddress(existingJson, string(abi.encodePacked(contractPath, ".address"))) returns (
                     address contractAddr
                 ) {
-                    // This contract exists! Extract all its properties
-                    string memory existingContractObjKey = string(abi.encodePacked("existing_", contractName));
-
-                    // Get the contract properties - in the desired order
-                    vm.serializeAddress(existingContractObjKey, "address", contractAddr);
-
-                    // Get blockNumber (second field)
+                    // This contract exists! Extract its properties
+                    uint256 blockNum;
                     try vm.parseJsonUint(existingJson, string(abi.encodePacked(contractPath, ".blockNumber"))) returns (
-                        uint256 blockNum
+                        uint256 bn
                     ) {
-                        vm.serializeUint(existingContractObjKey, "blockNumber", blockNum);
+                        blockNum = bn;
                     } catch {
-                        vm.serializeUint(existingContractObjKey, "blockNumber", block.number);
+                        blockNum = block.number; // fallback
                     }
 
-                    // Get ABI - handle both array format and string format
+                    string memory abiString;
                     try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".abi"))) returns (
                         string memory abiStr
                     ) {
-                        vm.serializeString(existingContractObjKey, "abi", abiStr);
+                        abiString = abiStr;
                     } catch {
-                        vm.serializeString(existingContractObjKey, "abi", "[]");
+                        abiString = "[]"; // fallback
                     }
 
-                    // Get bytecode
-                    try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".bytecode"))) returns (
-                        string memory bytecode
-                    ) {
-                        vm.serializeString(existingContractObjKey, "bytecode", bytecode);
-                    } catch {
-                        vm.serializeString(existingContractObjKey, "bytecode", "0x");
-                    }
-
-                    // Complete the contract JSON (metadata is optional and often not present)
-                    string memory existingContractJson;
-
-                    // Try to get bytecode first for the final serialization
-                    string memory finalBytecode;
+                    string memory bytecode;
                     try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".bytecode"))) returns (
                         string memory bc
                     ) {
-                        finalBytecode = bc;
+                        bytecode = bc;
                     } catch {
-                        finalBytecode = "0x";
+                        bytecode = "0x"; // fallback
                     }
 
-                    // Try to add metadata if it exists, otherwise just finalize with bytecode
+                    string memory metadata;
                     try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".metadata"))) returns (
-                        string memory metadata
+                        string memory md
                     ) {
-                        existingContractJson = vm.serializeString(existingContractObjKey, "metadata", metadata);
+                        metadata = md;
                     } catch {
-                        // No metadata field exists, just finalize with bytecode
-                        existingContractJson = vm.serializeString(existingContractObjKey, "bytecode", finalBytecode);
+                        metadata = ""; // no metadata
                     }
 
-                    // Add this existing contract to the merged contracts object
-                    mergedContractsJson = vm.serializeString(mergedContractsObjKey, contractName, existingContractJson);
+                    // Add to existing deployments array
+                    ContractDeployment[] memory newExisting = new ContractDeployment[](existingDeployments.length + 1);
+                    for (uint256 j = 0; j < existingDeployments.length; j++) {
+                        newExisting[j] = existingDeployments[j];
+                    }
+                    newExisting[existingDeployments.length] = ContractDeployment({
+                        name: contractName,
+                        addr: contractAddr,
+                        abi: abiString,
+                        bytecode: bytecode,
+                        metadata: metadata,
+                        blockNumber: blockNum
+                    });
+                    existingDeployments = newExisting;
                 } catch {
                     // Contract doesn't exist, skip it
                     continue;
                 }
             }
 
-            // Add new contracts to the merged object
+            // Now combine existing deployments with new deployments
+            ContractDeployment[] memory allDeployments =
+                new ContractDeployment[](existingDeployments.length + newDeployments.length);
+            for (uint256 i = 0; i < existingDeployments.length; i++) {
+                allDeployments[i] = existingDeployments[i];
+            }
             for (uint256 i = 0; i < newDeployments.length; i++) {
-                string memory contractObjKey = string(abi.encodePacked("newContract_", vm.toString(i)));
-
-                // Build the new contract JSON using Foundry's serialization - in the desired order
-                vm.serializeAddress(contractObjKey, "address", newDeployments[i].addr);
-                vm.serializeUint(contractObjKey, "blockNumber", newDeployments[i].blockNumber);
-                vm.serializeString(contractObjKey, "abi", newDeployments[i].abi);
-                vm.serializeString(contractObjKey, "bytecode", newDeployments[i].bytecode);
-
-                string memory newContractJson;
-                if (bytes(newDeployments[i].metadata).length > 0) {
-                    newContractJson = vm.serializeString(contractObjKey, "metadata", newDeployments[i].metadata);
-                } else {
-                    newContractJson = vm.serializeUint(contractObjKey, "blockNumber", newDeployments[i].blockNumber);
-                }
-
-                // Add this new contract to the merged contracts object
-                mergedContractsJson = vm.serializeString(mergedContractsObjKey, newDeployments[i].name, newContractJson);
+                allDeployments[existingDeployments.length + i] = newDeployments[i];
             }
 
-            // Build the complete deployment JSON with updated metadata
-            string memory deploymentObjKey = "finalDeployment";
-            vm.serializeString(deploymentObjKey, "network", networkName);
-            vm.serializeUint(deploymentObjKey, "chainId", chainId);
-            vm.serializeAddress(deploymentObjKey, "deployer", msg.sender);
-
-            return vm.serializeString(deploymentObjKey, "contracts", mergedContractsJson);
+            // Build final JSON with all contracts (existing first, new last)
+            return buildDeploymentJson(vm, networkName, chainId, allDeployments);
         } catch {
             console.log("JSON parsing failed, creating new deployment file");
             return buildDeploymentJson(vm, networkName, chainId, newDeployments);
@@ -334,7 +307,7 @@ library DeploymentHelper {
      * @notice Logs contract addresses to console as fallback
      * @param deployments Array of contract deployments
      */
-    function logContractAddresses(ContractDeployment[] memory deployments) internal view {
+    function logContractAddresses(ContractDeployment[] memory deployments) internal pure {
         console.log("Contract addresses (save manually if needed):");
         for (uint256 i = 0; i < deployments.length; i++) {
             console.log(string(abi.encodePacked(deployments[i].name, ": ")), deployments[i].addr);
@@ -410,11 +383,9 @@ library DeploymentHelper {
 
     /**
      * @notice Reads the ABI from Foundry artifacts
-     * @param vm The Foundry VM instance
-     * @param contractName The name of the contract
      * @return The ABI as a JSON string
      */
-    function getContractAbi(Vm vm, string memory contractName) internal view returns (string memory) {
+    function getContractAbi(Vm, /* vm */ string memory /* contractName */ ) internal pure returns (string memory) {
         // Due to Solidity limitations with JSON parsing, especially for arrays,
         // we'll return a placeholder. In production, use a post-deployment script
         // to enrich the deployment artifacts with ABIs from the Foundry artifacts.
@@ -452,25 +423,203 @@ library DeploymentHelper {
     }
 
     /**
-     * @notice Creates a ContractDeployment struct with all artifact data
+     * @notice Creates a ContractDeployment struct with accurate deployment block from broadcast file
+     * @dev This function attempts to read the actual deployment block from Foundry broadcast files.
+     *      If broadcast files are not available (e.g., local testing), it gracefully falls back to block.number.
      * @param vm The Foundry VM instance
      * @param name The contract name
      * @param addr The deployed contract address
      * @param metadata Optional metadata JSON string
-     * @return The ContractDeployment struct
+     * @return The ContractDeployment struct with accurate block number
      */
     function createContractDeployment(Vm vm, string memory name, address addr, string memory metadata)
         internal
         view
         returns (ContractDeployment memory)
     {
+        // Try to get actual deployment block from broadcast file
+        uint256 actualBlockNumber = getActualDeploymentBlockSafe(vm, addr);
+
         return ContractDeployment({
             name: name,
             addr: addr,
             abi: getContractAbi(vm, name),
             bytecode: getDeployedBytecode(addr),
             metadata: metadata,
-            blockNumber: block.number
+            blockNumber: actualBlockNumber
         });
+    }
+
+    /**
+     * @notice Gets the actual deployment block number automatically detecting script and chain
+     * @dev This function tries common script names and uses current chain ID
+     * @param vm The Foundry VM instance
+     * @param contractAddress The deployed contract address
+     * @return The actual block number where the contract was deployed
+     */
+    function getActualDeploymentBlockSafe(Vm vm, address contractAddress) internal view returns (uint256) {
+        // Try common script names in order of likelihood
+        string[5] memory commonScripts =
+            ["Deploy.s.sol", "DeployLocal.s.sol", "DeployLocalWithPaymaster.s.sol", "script.s.sol", "Script.s.sol"];
+
+        uint256 currentChainId = block.chainid;
+
+        for (uint256 i = 0; i < commonScripts.length; i++) {
+            uint256 blockNum = getActualDeploymentBlock(vm, contractAddress, commonScripts[i], currentChainId);
+            if (blockNum != block.number) {
+                // Found actual deployment block (not fallback)
+                return blockNum;
+            }
+        }
+
+        // All attempts failed, use fallback
+        return block.number;
+    }
+
+    /**
+     * @notice Gets the actual deployment block number from broadcast file
+     * @param vm The Foundry VM instance
+     * @param contractAddress The deployed contract address
+     * @param scriptName The script name (e.g., "Deploy.s.sol")
+     * @param chainId The chain ID
+     * @return The actual block number where the contract was deployed
+     */
+    function getActualDeploymentBlock(Vm vm, address contractAddress, string memory scriptName, uint256 chainId)
+        public
+        view
+        returns (uint256)
+    {
+        try vm.projectRoot() returns (string memory root) {
+            string memory broadcastPath =
+                string(abi.encodePacked(root, "/broadcast/", scriptName, "/", vm.toString(chainId), "/run-latest.json"));
+
+            try vm.readFile(broadcastPath) returns (string memory json) {
+                return parseBlockNumberFromBroadcast(vm, json, contractAddress);
+            } catch {
+                console.log("Warning: Could not read broadcast file, using current block number");
+                return block.number;
+            }
+        } catch {
+            console.log("Warning: Could not get project root, using current block number");
+            return block.number;
+        }
+    }
+
+    /**
+     * @notice Parses the actual deployment block from broadcast JSON
+     * @param vm The Foundry VM instance
+     * @param broadcastJson The broadcast JSON content
+     * @param contractAddress The contract address to find
+     * @return The block number where the contract was deployed
+     */
+    function parseBlockNumberFromBroadcast(Vm vm, string memory broadcastJson, address contractAddress)
+        internal
+        view
+        returns (uint256)
+    {
+        // Try to find the deployment transaction for this contract address
+        string memory addressLower = toLowerCase(vm.toString(contractAddress));
+
+        // Parse receipts array length
+        try vm.parseJsonUint(broadcastJson, ".receipts") returns (uint256) {
+            // If .receipts is a uint, it means the structure is different, fall back
+            return block.number;
+        } catch {
+            // .receipts should be an array, try to get its length
+            try vm.parseJson(broadcastJson, ".receipts") returns (bytes memory /* receiptsData */ ) {
+                // Look for transactions that created contracts
+                // We'll check the first few receipts for contract creation (to field is null or empty)
+                for (uint256 i = 0; i < 20; i++) {
+                    // Check up to 20 transactions
+                    try vm.parseJsonString(
+                        broadcastJson, string(abi.encodePacked(".receipts[", vm.toString(i), "].to"))
+                    ) returns (string memory toAddr) {
+                        // If 'to' is null/empty, this is a contract creation transaction
+                        if (bytes(toAddr).length == 0 || keccak256(bytes(toAddr)) == keccak256(bytes("null"))) {
+                            try vm.parseJsonString(
+                                broadcastJson,
+                                string(abi.encodePacked(".receipts[", vm.toString(i), "].contractAddress"))
+                            ) returns (string memory contractAddr) {
+                                if (keccak256(bytes(toLowerCase(contractAddr))) == keccak256(bytes(addressLower))) {
+                                    // Found our contract! Get its block number
+                                    try vm.parseJsonString(
+                                        broadcastJson,
+                                        string(abi.encodePacked(".receipts[", vm.toString(i), "].blockNumber"))
+                                    ) returns (string memory blockHex) {
+                                        return hexStringToUint(blockHex);
+                                    } catch {
+                                        return block.number;
+                                    }
+                                }
+                            } catch {
+                                continue;
+                            }
+                        }
+                    } catch {
+                        // If receipt[i] doesn't exist, we've reached the end
+                        break;
+                    }
+                }
+                return block.number;
+            } catch {
+                return block.number;
+            }
+        }
+    }
+
+    /**
+     * @notice Converts a hex string to uint256
+     * @param hexStr The hex string (with or without 0x prefix)
+     * @return The uint256 value
+     */
+    function hexStringToUint(string memory hexStr) public pure returns (uint256) {
+        bytes memory hexBytes = bytes(hexStr);
+        uint256 startIndex = 0;
+
+        // Skip "0x" prefix if present
+        if (hexBytes.length >= 2 && hexBytes[0] == "0" && (hexBytes[1] == "x" || hexBytes[1] == "X")) {
+            startIndex = 2;
+        }
+
+        uint256 result = 0;
+        for (uint256 i = startIndex; i < hexBytes.length; i++) {
+            result = result * 16;
+            uint8 digit = uint8(hexBytes[i]);
+
+            if (digit >= 48 && digit <= 57) {
+                // 0-9
+                result += digit - 48;
+            } else if (digit >= 65 && digit <= 70) {
+                // A-F
+                result += digit - 55;
+            } else if (digit >= 97 && digit <= 102) {
+                // a-f
+                result += digit - 87;
+            }
+            // Invalid hex characters are ignored
+        }
+
+        return result;
+    }
+
+    /**
+     * @notice Converts a string to lowercase
+     * @param str The input string
+     * @return The lowercase string
+     */
+    function toLowerCase(string memory str) public pure returns (string memory) {
+        bytes memory strBytes = bytes(str);
+        bytes memory result = new bytes(strBytes.length);
+
+        for (uint256 i = 0; i < strBytes.length; i++) {
+            if (strBytes[i] >= 0x41 && strBytes[i] <= 0x5A) {
+                // Convert A-Z to a-z
+                result[i] = bytes1(uint8(strBytes[i]) + 32);
+            } else {
+                result[i] = strBytes[i];
+            }
+        }
+
+        return string(result);
     }
 }

--- a/tee-worker/omni-executor/aa-contracts/script/DeploymentHelper.sol
+++ b/tee-worker/omni-executor/aa-contracts/script/DeploymentHelper.sol
@@ -63,20 +63,29 @@ library DeploymentHelper {
         ContractDeployment[] memory deployments
     ) internal {
         // Ensure the deployments directory exists
-        try vm.createDir(deploymentDir, false) {} catch {}
+        try vm.createDir(deploymentDir, true) {} catch {}
 
         // Create environment subdirectory if specified
         string memory targetDir = deploymentDir;
         if (bytes(environment).length > 0) {
             targetDir = string(abi.encodePacked(deploymentDir, "/", environment));
-            try vm.createDir(targetDir, false) {} catch {}
+            try vm.createDir(targetDir, true) {} catch {}
         }
 
         // Create filename based on network
         string memory filename = string(abi.encodePacked(targetDir, "/", getNetworkFilename(chainId), ".json"));
 
-        // Build JSON structure
-        string memory json = buildDeploymentJson(vm, networkName, chainId, deployments);
+        // Check if file already exists and merge if needed
+        string memory json;
+        try vm.readFile(filename) returns (string memory existingContent) {
+            // File exists, merge the new contracts with existing ones
+            json = mergeDeploymentJson(vm, existingContent, networkName, chainId, deployments);
+            console.log("Merging new contracts with existing deployment file:", filename);
+        } catch {
+            // File doesn't exist, create new JSON
+            json = buildDeploymentJson(vm, networkName, chainId, deployments);
+            console.log("Creating new deployment file:", filename);
+        }
 
         // Write to deployment file
         try vm.writeFile(filename, json) {
@@ -161,6 +170,160 @@ library DeploymentHelper {
                 "}"
             )
         );
+    }
+
+    /**
+     * @notice Merges new deployment contracts with existing deployment JSON
+     * Uses Foundry's JSON capabilities for parsing and a cleaner approach
+     * @param vm The Foundry VM instance
+     * @param existingJson The existing JSON content from the file
+     * @param networkName The name of the network
+     * @param chainId The chain ID of the network
+     * @param newDeployments Array of new contract deployments to add
+     * @return The merged JSON string
+     */
+    function mergeDeploymentJson(
+        Vm vm,
+        string memory existingJson,
+        string memory networkName,
+        uint256 chainId,
+        ContractDeployment[] memory newDeployments
+    ) internal returns (string memory) {
+        try vm.parseJson(existingJson, ".contracts") returns (bytes memory) {
+            // Successfully parsed existing contracts section - now rebuild with proper JSON
+
+            // Create a new merged contracts object
+            string memory mergedContractsObjKey = "mergedContracts";
+            string memory mergedContractsJson = "";
+
+            // Parse existing contract names that might exist and add them to merged object
+            string[] memory commonContractNames = getCommonContractNames();
+
+            // Try to extract each existing contract and add to merged object if it exists
+            for (uint256 i = 0; i < commonContractNames.length; i++) {
+                string memory contractName = commonContractNames[i];
+                string memory contractPath = string(abi.encodePacked(".contracts.", contractName));
+
+                try vm.parseJsonAddress(existingJson, string(abi.encodePacked(contractPath, ".address"))) returns (
+                    address contractAddr
+                ) {
+                    // This contract exists! Extract all its properties
+                    string memory existingContractObjKey = string(abi.encodePacked("existing_", contractName));
+
+                    // Get the contract properties
+                    vm.serializeAddress(existingContractObjKey, "address", contractAddr);
+
+                    // Get ABI - handle both array format and string format
+                    try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".abi"))) returns (
+                        string memory abiStr
+                    ) {
+                        vm.serializeString(existingContractObjKey, "abi", abiStr);
+                    } catch {
+                        vm.serializeString(existingContractObjKey, "abi", "[]");
+                    }
+
+                    // Get bytecode
+                    try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".bytecode"))) returns (
+                        string memory bytecode
+                    ) {
+                        vm.serializeString(existingContractObjKey, "bytecode", bytecode);
+                    } catch {
+                        vm.serializeString(existingContractObjKey, "bytecode", "0x");
+                    }
+
+                    // Complete the contract JSON (metadata is optional and often not present)
+                    string memory existingContractJson;
+
+                    // Try to get bytecode first for the final serialization
+                    string memory finalBytecode;
+                    try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".bytecode"))) returns (
+                        string memory bc
+                    ) {
+                        finalBytecode = bc;
+                    } catch {
+                        finalBytecode = "0x";
+                    }
+
+                    // Try to add metadata if it exists, otherwise just finalize with bytecode
+                    try vm.parseJsonString(existingJson, string(abi.encodePacked(contractPath, ".metadata"))) returns (
+                        string memory metadata
+                    ) {
+                        existingContractJson = vm.serializeString(existingContractObjKey, "metadata", metadata);
+                    } catch {
+                        // No metadata field exists, just finalize with bytecode
+                        existingContractJson = vm.serializeString(existingContractObjKey, "bytecode", finalBytecode);
+                    }
+
+                    // Add this existing contract to the merged contracts object
+                    mergedContractsJson = vm.serializeString(mergedContractsObjKey, contractName, existingContractJson);
+                } catch {
+                    // Contract doesn't exist, skip it
+                    continue;
+                }
+            }
+
+            // Add new contracts to the merged object
+            for (uint256 i = 0; i < newDeployments.length; i++) {
+                string memory contractObjKey = string(abi.encodePacked("newContract_", vm.toString(i)));
+
+                // Build the new contract JSON using Foundry's serialization
+                vm.serializeAddress(contractObjKey, "address", newDeployments[i].addr);
+                vm.serializeString(contractObjKey, "abi", newDeployments[i].abi);
+
+                string memory newContractJson;
+                if (bytes(newDeployments[i].metadata).length > 0) {
+                    vm.serializeString(contractObjKey, "bytecode", newDeployments[i].bytecode);
+                    newContractJson = vm.serializeString(contractObjKey, "metadata", newDeployments[i].metadata);
+                } else {
+                    newContractJson = vm.serializeString(contractObjKey, "bytecode", newDeployments[i].bytecode);
+                }
+
+                // Add this new contract to the merged contracts object
+                mergedContractsJson = vm.serializeString(mergedContractsObjKey, newDeployments[i].name, newContractJson);
+            }
+
+            // Build the complete deployment JSON with updated metadata
+            string memory deploymentObjKey = "finalDeployment";
+            vm.serializeString(deploymentObjKey, "network", networkName);
+            vm.serializeUint(deploymentObjKey, "chainId", chainId);
+            vm.serializeUint(deploymentObjKey, "timestamp", block.timestamp);
+            vm.serializeUint(deploymentObjKey, "blockNumber", block.number);
+            vm.serializeAddress(deploymentObjKey, "deployer", msg.sender);
+
+            return vm.serializeString(deploymentObjKey, "contracts", mergedContractsJson);
+        } catch {
+            console.log("JSON parsing failed, creating new deployment file");
+            return buildDeploymentJson(vm, networkName, chainId, newDeployments);
+        }
+    }
+
+    /**
+     * @notice Returns common contract names to check for when merging
+     * @return Array of common contract names
+     */
+    function getCommonContractNames() internal pure returns (string[] memory) {
+        string[] memory names = new string[](20);
+        names[0] = "EntryPoint";
+        names[1] = "SimpleAccount";
+        names[2] = "SimpleAccountFactory";
+        names[3] = "SimplePaymaster";
+        names[4] = "ERC20Paymaster";
+        names[5] = "ERC20PaymasterV1";
+        names[6] = "TokenPaymaster";
+        names[7] = "VerifyingPaymaster";
+        names[8] = "StakeManager";
+        names[9] = "OmniAccount";
+        names[10] = "OmniAccountFactory";
+        names[11] = "Multicall";
+        names[12] = "Create2Factory";
+        names[13] = "ProxyFactory";
+        names[14] = "UpgradeableBeacon";
+        names[15] = "Implementation";
+        names[16] = "Proxy";
+        names[17] = "Registry";
+        names[18] = "Forwarder";
+        names[19] = "Aggregator";
+        return names;
     }
 
     /**

--- a/tee-worker/omni-executor/aa-contracts/test/DeploymentHelper.t.sol
+++ b/tee-worker/omni-executor/aa-contracts/test/DeploymentHelper.t.sol
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {DeploymentHelper} from "../script/DeploymentHelper.sol";
+
+/**
+ * @title DeploymentHelperTest
+ * @notice Comprehensive test suite for DeploymentHelper library, focusing on append functionality
+ */
+contract DeploymentHelperTest is Test {
+    using DeploymentHelper for *;
+
+    string constant BASE_TEST_DIR = "./test_deployments";
+    string constant NETWORK_NAME = "test-network";
+    uint256 constant CHAIN_ID = 31337;
+
+    address mockContract1 = address(0x1111111111111111111111111111111111111111);
+    address mockContract2 = address(0x2222222222222222222222222222222222222222);
+    address mockContract3 = address(0x3333333333333333333333333333333333333333);
+
+    function setUp() public {
+        // Clean up any existing test deployment directory
+        try vm.removeDir(BASE_TEST_DIR, true) {} catch {}
+    }
+
+    function tearDown() public {
+        // Clean up test files after each test
+        try vm.removeDir(BASE_TEST_DIR, true) {} catch {}
+    }
+    
+    // Helper to get unique directory for each test
+    function getTestDir(string memory testName) internal pure returns (string memory) {
+        return string(abi.encodePacked(BASE_TEST_DIR, "/", testName));
+    }
+
+    function test_CreateNewDeploymentFile() public {
+        // Test creating a new deployment file from scratch
+        string memory testDir = getTestDir("create");
+        DeploymentHelper.ContractDeployment[] memory deployments = new DeploymentHelper.ContractDeployment[](1);
+        deployments[0] = createMockDeployment("EntryPoint", mockContract1);
+
+        DeploymentHelper.saveDeploymentArtifacts(
+            vm,
+            testDir,
+            NETWORK_NAME,
+            CHAIN_ID,
+            deployments
+        );
+
+        // Verify file was created
+        string memory filename = string(abi.encodePacked(testDir, "/local.json"));
+        assertTrue(vm.exists(filename), "Deployment file should exist");
+
+        // Verify basic content without strict JSON parsing (to avoid format issues)
+        string memory content = vm.readFile(filename);
+        assertTrue(bytes(content).length > 0, "File should not be empty");
+        assertTrue(contains(content, "EntryPoint"), "Should contain contract name");
+        assertTrue(contains(content, vm.toString(mockContract1)), "Should contain contract address");
+        assertTrue(contains(content, NETWORK_NAME), "Should contain network name");
+        assertTrue(contains(content, vm.toString(CHAIN_ID)), "Should contain chain ID");
+    }
+
+    function test_AppendToExistingFile() public {
+        // Step 1: Create initial deployment with EntryPoint
+        string memory testDir = getTestDir("append");
+        DeploymentHelper.ContractDeployment[] memory initialDeployments = new DeploymentHelper.ContractDeployment[](1);
+        initialDeployments[0] = createMockDeployment("EntryPoint", mockContract1);
+
+        DeploymentHelper.saveDeploymentArtifacts(
+            vm,
+            testDir,
+            NETWORK_NAME,
+            CHAIN_ID,
+            initialDeployments
+        );
+
+        string memory filename = string(abi.encodePacked(testDir, "/local.json"));
+        string memory initialContent = vm.readFile(filename);
+        
+        // Verify initial deployment
+        assertTrue(contains(initialContent, "EntryPoint"), "Initial file should contain EntryPoint");
+        assertTrue(contains(initialContent, vm.toString(mockContract1)), "Initial file should contain EntryPoint address");
+
+        // Step 2: Append SimpleAccountFactory
+        DeploymentHelper.ContractDeployment[] memory newDeployments = new DeploymentHelper.ContractDeployment[](1);
+        newDeployments[0] = createMockDeployment("SimpleAccountFactory", mockContract2);
+
+        vm.warp(block.timestamp + 100);
+        vm.roll(block.number + 10);
+
+        DeploymentHelper.saveDeploymentArtifacts(
+            vm,
+            testDir,
+            NETWORK_NAME,
+            CHAIN_ID,
+            newDeployments
+        );
+
+        // Step 3: Verify both contracts are present
+        string memory finalContent = vm.readFile(filename);
+        
+        // Basic content verification
+        assertTrue(contains(finalContent, "EntryPoint"), "Final file should contain EntryPoint");
+        assertTrue(contains(finalContent, vm.toString(mockContract1)), "Final file should contain EntryPoint address");
+        assertTrue(contains(finalContent, "SimpleAccountFactory"), "Final file should contain SimpleAccountFactory");
+        assertTrue(contains(finalContent, vm.toString(mockContract2)), "Final file should contain SimpleAccountFactory address");
+        
+        // Verify the final content is longer than initial (indicating append, not replace)
+        assertGt(bytes(finalContent).length, bytes(initialContent).length, "Final file should be larger than initial");
+    }
+
+    function test_MultipleSequentialAppends() public {
+        string memory testDir = getTestDir("multiple");
+        string memory filename = string(abi.encodePacked(testDir, "/local.json"));
+
+        // First deployment - EntryPoint
+        DeploymentHelper.ContractDeployment[] memory deployment1 = new DeploymentHelper.ContractDeployment[](1);
+        deployment1[0] = createMockDeployment("EntryPoint", mockContract1);
+        
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment1);
+        string memory content1 = vm.readFile(filename);
+        uint256 content1Length = bytes(content1).length;
+        
+        // Verify first deployment
+        assertTrue(contains(content1, "EntryPoint"), "Should contain EntryPoint after first deployment");
+        assertTrue(contains(content1, vm.toString(mockContract1)), "Should contain EntryPoint address");
+
+        // Second deployment (append) - SimpleAccountFactory
+        DeploymentHelper.ContractDeployment[] memory deployment2 = new DeploymentHelper.ContractDeployment[](1);
+        deployment2[0] = createMockDeployment("SimpleAccountFactory", mockContract2);
+        
+        vm.warp(block.timestamp + 50);
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment2);
+        
+        string memory content2 = vm.readFile(filename);
+        uint256 content2Length = bytes(content2).length;
+        
+        // Verify both contracts exist and content grew
+        assertTrue(contains(content2, "EntryPoint"), "Should contain EntryPoint after second deployment");
+        assertTrue(contains(content2, "SimpleAccountFactory"), "Should contain SimpleAccountFactory after second deployment");
+        assertGt(content2Length, content1Length, "File should grow after second deployment");
+
+        // Third deployment (append) - ERC20Paymaster  
+        DeploymentHelper.ContractDeployment[] memory deployment3 = new DeploymentHelper.ContractDeployment[](1);
+        deployment3[0] = createMockDeployment("ERC20Paymaster", mockContract3);
+        
+        vm.warp(block.timestamp + 50);
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment3);
+        
+        string memory finalContent = vm.readFile(filename);
+        uint256 finalContentLength = bytes(finalContent).length;
+        
+        // Verify all three contracts exist and content grew again
+        assertTrue(contains(finalContent, "EntryPoint"), "Should contain EntryPoint in final");
+        assertTrue(contains(finalContent, "SimpleAccountFactory"), "Should contain SimpleAccountFactory in final");
+        assertTrue(contains(finalContent, "ERC20Paymaster"), "Should contain ERC20Paymaster in final");
+        assertTrue(contains(finalContent, vm.toString(mockContract1)), "Should contain EntryPoint address in final");
+        assertTrue(contains(finalContent, vm.toString(mockContract2)), "Should contain SimpleAccountFactory address in final");
+        assertTrue(contains(finalContent, vm.toString(mockContract3)), "Should contain ERC20Paymaster address in final");
+        assertGt(finalContentLength, content2Length, "File should grow after third deployment");
+    }
+
+    function test_AppendWithEnvironment() public {
+        string memory testDir = getTestDir("environment");
+        string memory environment = "staging";
+        
+        DeploymentHelper.ContractDeployment[] memory deployments = new DeploymentHelper.ContractDeployment[](1);
+        deployments[0] = createMockDeployment("EntryPoint", mockContract1);
+
+        DeploymentHelper.saveDeploymentArtifacts(
+            vm,
+            testDir,
+            environment,
+            NETWORK_NAME,
+            CHAIN_ID,
+            deployments
+        );
+
+        // Verify file was created in environment subdirectory
+        string memory filename = string(abi.encodePacked(testDir, "/", environment, "/local.json"));
+        assertTrue(vm.exists(filename), "Deployment file should exist in environment subdirectory");
+
+        string memory content = vm.readFile(filename);
+        assertTrue(contains(content, "EntryPoint"), "Should contain contract name");
+        assertTrue(contains(content, vm.toString(mockContract1)), "Should contain contract address");
+        assertTrue(contains(content, NETWORK_NAME), "Should contain network name");
+    }
+
+    function test_AppendWithMetadata() public {
+        string memory testDir = getTestDir("metadata");
+        // Test with contract metadata
+        DeploymentHelper.ContractDeployment[] memory deployments = new DeploymentHelper.ContractDeployment[](1);
+        deployments[0] = DeploymentHelper.ContractDeployment({
+            name: "EntryPoint",
+            addr: mockContract1,
+            abi: "[]",
+            bytecode: DeploymentHelper.getDeployedBytecode(mockContract1),
+            metadata: '{"compiler": "solc", "version": "0.8.28"}'
+        });
+
+        DeploymentHelper.saveDeploymentArtifacts(
+            vm,
+            testDir,
+            NETWORK_NAME,
+            CHAIN_ID,
+            deployments
+        );
+
+        string memory filename = string(abi.encodePacked(testDir, "/local.json"));
+        string memory content = vm.readFile(filename);
+        
+        // Basic verification - check that metadata-related content is present
+        assertTrue(contains(content, "EntryPoint"), "Should contain contract name");
+        assertTrue(contains(content, vm.toString(mockContract1)), "Should contain contract address");
+        assertTrue(contains(content, "metadata"), "Should contain metadata field");
+        assertTrue(contains(content, "compiler"), "Should contain compiler in metadata");
+        assertTrue(contains(content, "solc"), "Should contain solc in metadata");
+    }
+
+    function test_FallbackOnInvalidJson() public {
+        string memory testDir = getTestDir("fallback");
+        // Create an invalid JSON file first
+        string memory filename = string(abi.encodePacked(testDir, "/local.json"));
+        try vm.createDir(testDir, true) {} catch {} // Allow creation to fail if directory exists
+        vm.writeFile(filename, "{ invalid json structure without proper closing");
+        
+        DeploymentHelper.ContractDeployment[] memory newDeployments = new DeploymentHelper.ContractDeployment[](1);
+        newDeployments[0] = createMockDeployment("TestContract", mockContract1);
+
+        // This should not revert but fall back to creating new JSON
+        DeploymentHelper.saveDeploymentArtifacts(
+            vm,
+            testDir,
+            NETWORK_NAME,
+            CHAIN_ID,
+            newDeployments
+        );
+
+        string memory content = vm.readFile(filename);
+        assertTrue(contains(content, "TestContract"), "Should contain new contract after fallback");
+        assertTrue(contains(content, vm.toString(mockContract1)), "Should contain new contract address after fallback");
+    }
+
+    function test_NetworkFilenameMapping() public pure {
+        // Test known chain IDs
+        assertEq(DeploymentHelper.getNetworkFilename(1), "ethereum", "Mainnet should return ethereum");
+        assertEq(DeploymentHelper.getNetworkFilename(56), "bsc", "BSC should return bsc");
+        assertEq(DeploymentHelper.getNetworkFilename(137), "polygon", "Polygon should return polygon");
+        assertEq(DeploymentHelper.getNetworkFilename(42161), "arbitrum", "Arbitrum should return arbitrum");
+        assertEq(DeploymentHelper.getNetworkFilename(31337), "local", "Local should return local");
+        
+        // Test unknown chain ID
+        uint256 unknownChainId = 999999;
+        string memory expected = "chain-999999";
+        string memory result = DeploymentHelper.getNetworkFilename(unknownChainId);
+        assertEq(result, expected, "Unknown chain should return chain-{id}");
+    }
+
+
+    function test_AppendBehaviorBasic() public {
+        string memory testDir = getTestDir("basic");
+        // Simple test to verify append behavior works at all
+        
+        // First deployment
+        DeploymentHelper.ContractDeployment[] memory deployment1 = new DeploymentHelper.ContractDeployment[](1);
+        deployment1[0] = createMockDeployment("EntryPoint", mockContract1);
+        
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment1);
+
+        // Verify first file exists
+        string memory filename = string(abi.encodePacked(testDir, "/local.json"));
+        assertTrue(vm.exists(filename), "First deployment file should exist");
+        
+        // Second deployment (should attempt to append)
+        DeploymentHelper.ContractDeployment[] memory deployment2 = new DeploymentHelper.ContractDeployment[](1);
+        deployment2[0] = createMockDeployment("SimpleAccountFactory", mockContract2);
+        
+        vm.warp(block.timestamp + 100);
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment2);
+
+        // Verify file still exists and was updated
+        assertTrue(vm.exists(filename), "Deployment file should still exist after append");
+        
+        string memory finalContent = vm.readFile(filename);
+        assertTrue(bytes(finalContent).length > 0, "Final file should not be empty");
+        
+        // At minimum, the file should contain the second contract
+        assertTrue(contains(finalContent, "SimpleAccountFactory"), "Should contain second contract name");
+        assertTrue(contains(finalContent, vm.toString(mockContract2)), "Should contain second contract address");
+    }
+
+    // Helper function to create mock deployments
+    function createMockDeployment(string memory name, address addr) 
+        internal 
+        view 
+        returns (DeploymentHelper.ContractDeployment memory) 
+    {
+        return DeploymentHelper.ContractDeployment({
+            name: name,
+            addr: addr,
+            abi: "[]",
+            bytecode: DeploymentHelper.getDeployedBytecode(addr),
+            metadata: ""
+        });
+    }
+
+    // Helper function to check if a string contains a substring
+    function contains(string memory str, string memory substr) internal pure returns (bool) {
+        bytes memory strBytes = bytes(str);
+        bytes memory substrBytes = bytes(substr);
+        
+        if (substrBytes.length > strBytes.length) {
+            return false;
+        }
+        
+        for (uint256 i = 0; i <= strBytes.length - substrBytes.length; i++) {
+            bool found = true;
+            for (uint256 j = 0; j < substrBytes.length; j++) {
+                if (strBytes[i + j] != substrBytes[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tee-worker/omni-executor/aa-contracts/test/DeploymentHelper.t.sol
+++ b/tee-worker/omni-executor/aa-contracts/test/DeploymentHelper.t.sol
@@ -29,7 +29,7 @@ contract DeploymentHelperTest is Test {
         // Clean up test files after each test
         try vm.removeDir(BASE_TEST_DIR, true) {} catch {}
     }
-    
+
     // Helper to get unique directory for each test
     function getTestDir(string memory testName) internal pure returns (string memory) {
         return string(abi.encodePacked(BASE_TEST_DIR, "/", testName));
@@ -41,13 +41,7 @@ contract DeploymentHelperTest is Test {
         DeploymentHelper.ContractDeployment[] memory deployments = new DeploymentHelper.ContractDeployment[](1);
         deployments[0] = createMockDeployment("EntryPoint", mockContract1);
 
-        DeploymentHelper.saveDeploymentArtifacts(
-            vm,
-            testDir,
-            NETWORK_NAME,
-            CHAIN_ID,
-            deployments
-        );
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployments);
 
         // Verify file was created
         string memory filename = string(abi.encodePacked(testDir, "/local.json"));
@@ -60,6 +54,7 @@ contract DeploymentHelperTest is Test {
         assertTrue(contains(content, vm.toString(mockContract1)), "Should contain contract address");
         assertTrue(contains(content, NETWORK_NAME), "Should contain network name");
         assertTrue(contains(content, vm.toString(CHAIN_ID)), "Should contain chain ID");
+        assertTrue(contains(content, "blockNumber"), "Should contain blockNumber per contract");
     }
 
     function test_AppendToExistingFile() public {
@@ -68,20 +63,16 @@ contract DeploymentHelperTest is Test {
         DeploymentHelper.ContractDeployment[] memory initialDeployments = new DeploymentHelper.ContractDeployment[](1);
         initialDeployments[0] = createMockDeployment("EntryPoint", mockContract1);
 
-        DeploymentHelper.saveDeploymentArtifacts(
-            vm,
-            testDir,
-            NETWORK_NAME,
-            CHAIN_ID,
-            initialDeployments
-        );
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, initialDeployments);
 
         string memory filename = string(abi.encodePacked(testDir, "/local.json"));
         string memory initialContent = vm.readFile(filename);
-        
+
         // Verify initial deployment
         assertTrue(contains(initialContent, "EntryPoint"), "Initial file should contain EntryPoint");
-        assertTrue(contains(initialContent, vm.toString(mockContract1)), "Initial file should contain EntryPoint address");
+        assertTrue(
+            contains(initialContent, vm.toString(mockContract1)), "Initial file should contain EntryPoint address"
+        );
 
         // Step 2: Append SimpleAccountFactory
         DeploymentHelper.ContractDeployment[] memory newDeployments = new DeploymentHelper.ContractDeployment[](1);
@@ -90,23 +81,19 @@ contract DeploymentHelperTest is Test {
         vm.warp(block.timestamp + 100);
         vm.roll(block.number + 10);
 
-        DeploymentHelper.saveDeploymentArtifacts(
-            vm,
-            testDir,
-            NETWORK_NAME,
-            CHAIN_ID,
-            newDeployments
-        );
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, newDeployments);
 
         // Step 3: Verify both contracts are present
         string memory finalContent = vm.readFile(filename);
-        
+
         // Basic content verification
         assertTrue(contains(finalContent, "EntryPoint"), "Final file should contain EntryPoint");
         assertTrue(contains(finalContent, vm.toString(mockContract1)), "Final file should contain EntryPoint address");
         assertTrue(contains(finalContent, "SimpleAccountFactory"), "Final file should contain SimpleAccountFactory");
-        assertTrue(contains(finalContent, vm.toString(mockContract2)), "Final file should contain SimpleAccountFactory address");
-        
+        assertTrue(
+            contains(finalContent, vm.toString(mockContract2)), "Final file should contain SimpleAccountFactory address"
+        );
+
         // Verify the final content is longer than initial (indicating append, not replace)
         assertGt(bytes(finalContent).length, bytes(initialContent).length, "Final file should be larger than initial");
     }
@@ -118,11 +105,11 @@ contract DeploymentHelperTest is Test {
         // First deployment - EntryPoint
         DeploymentHelper.ContractDeployment[] memory deployment1 = new DeploymentHelper.ContractDeployment[](1);
         deployment1[0] = createMockDeployment("EntryPoint", mockContract1);
-        
+
         DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment1);
         string memory content1 = vm.readFile(filename);
         uint256 content1Length = bytes(content1).length;
-        
+
         // Verify first deployment
         assertTrue(contains(content1, "EntryPoint"), "Should contain EntryPoint after first deployment");
         assertTrue(contains(content1, vm.toString(mockContract1)), "Should contain EntryPoint address");
@@ -130,34 +117,38 @@ contract DeploymentHelperTest is Test {
         // Second deployment (append) - SimpleAccountFactory
         DeploymentHelper.ContractDeployment[] memory deployment2 = new DeploymentHelper.ContractDeployment[](1);
         deployment2[0] = createMockDeployment("SimpleAccountFactory", mockContract2);
-        
+
         vm.warp(block.timestamp + 50);
         DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment2);
-        
+
         string memory content2 = vm.readFile(filename);
         uint256 content2Length = bytes(content2).length;
-        
+
         // Verify both contracts exist and content grew
         assertTrue(contains(content2, "EntryPoint"), "Should contain EntryPoint after second deployment");
-        assertTrue(contains(content2, "SimpleAccountFactory"), "Should contain SimpleAccountFactory after second deployment");
+        assertTrue(
+            contains(content2, "SimpleAccountFactory"), "Should contain SimpleAccountFactory after second deployment"
+        );
         assertGt(content2Length, content1Length, "File should grow after second deployment");
 
-        // Third deployment (append) - ERC20Paymaster  
+        // Third deployment (append) - ERC20Paymaster
         DeploymentHelper.ContractDeployment[] memory deployment3 = new DeploymentHelper.ContractDeployment[](1);
         deployment3[0] = createMockDeployment("ERC20Paymaster", mockContract3);
-        
+
         vm.warp(block.timestamp + 50);
         DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment3);
-        
+
         string memory finalContent = vm.readFile(filename);
         uint256 finalContentLength = bytes(finalContent).length;
-        
+
         // Verify all three contracts exist and content grew again
         assertTrue(contains(finalContent, "EntryPoint"), "Should contain EntryPoint in final");
         assertTrue(contains(finalContent, "SimpleAccountFactory"), "Should contain SimpleAccountFactory in final");
         assertTrue(contains(finalContent, "ERC20Paymaster"), "Should contain ERC20Paymaster in final");
         assertTrue(contains(finalContent, vm.toString(mockContract1)), "Should contain EntryPoint address in final");
-        assertTrue(contains(finalContent, vm.toString(mockContract2)), "Should contain SimpleAccountFactory address in final");
+        assertTrue(
+            contains(finalContent, vm.toString(mockContract2)), "Should contain SimpleAccountFactory address in final"
+        );
         assertTrue(contains(finalContent, vm.toString(mockContract3)), "Should contain ERC20Paymaster address in final");
         assertGt(finalContentLength, content2Length, "File should grow after third deployment");
     }
@@ -165,18 +156,11 @@ contract DeploymentHelperTest is Test {
     function test_AppendWithEnvironment() public {
         string memory testDir = getTestDir("environment");
         string memory environment = "staging";
-        
+
         DeploymentHelper.ContractDeployment[] memory deployments = new DeploymentHelper.ContractDeployment[](1);
         deployments[0] = createMockDeployment("EntryPoint", mockContract1);
 
-        DeploymentHelper.saveDeploymentArtifacts(
-            vm,
-            testDir,
-            environment,
-            NETWORK_NAME,
-            CHAIN_ID,
-            deployments
-        );
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, environment, NETWORK_NAME, CHAIN_ID, deployments);
 
         // Verify file was created in environment subdirectory
         string memory filename = string(abi.encodePacked(testDir, "/", environment, "/local.json"));
@@ -197,20 +181,15 @@ contract DeploymentHelperTest is Test {
             addr: mockContract1,
             abi: "[]",
             bytecode: DeploymentHelper.getDeployedBytecode(mockContract1),
-            metadata: '{"compiler": "solc", "version": "0.8.28"}'
+            metadata: '{"compiler": "solc", "version": "0.8.28"}',
+            blockNumber: block.number
         });
 
-        DeploymentHelper.saveDeploymentArtifacts(
-            vm,
-            testDir,
-            NETWORK_NAME,
-            CHAIN_ID,
-            deployments
-        );
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployments);
 
         string memory filename = string(abi.encodePacked(testDir, "/local.json"));
         string memory content = vm.readFile(filename);
-        
+
         // Basic verification - check that metadata-related content is present
         assertTrue(contains(content, "EntryPoint"), "Should contain contract name");
         assertTrue(contains(content, vm.toString(mockContract1)), "Should contain contract address");
@@ -225,18 +204,12 @@ contract DeploymentHelperTest is Test {
         string memory filename = string(abi.encodePacked(testDir, "/local.json"));
         try vm.createDir(testDir, true) {} catch {} // Allow creation to fail if directory exists
         vm.writeFile(filename, "{ invalid json structure without proper closing");
-        
+
         DeploymentHelper.ContractDeployment[] memory newDeployments = new DeploymentHelper.ContractDeployment[](1);
         newDeployments[0] = createMockDeployment("TestContract", mockContract1);
 
         // This should not revert but fall back to creating new JSON
-        DeploymentHelper.saveDeploymentArtifacts(
-            vm,
-            testDir,
-            NETWORK_NAME,
-            CHAIN_ID,
-            newDeployments
-        );
+        DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, newDeployments);
 
         string memory content = vm.readFile(filename);
         assertTrue(contains(content, "TestContract"), "Should contain new contract after fallback");
@@ -250,7 +223,7 @@ contract DeploymentHelperTest is Test {
         assertEq(DeploymentHelper.getNetworkFilename(137), "polygon", "Polygon should return polygon");
         assertEq(DeploymentHelper.getNetworkFilename(42161), "arbitrum", "Arbitrum should return arbitrum");
         assertEq(DeploymentHelper.getNetworkFilename(31337), "local", "Local should return local");
-        
+
         // Test unknown chain ID
         uint256 unknownChainId = 999999;
         string memory expected = "chain-999999";
@@ -258,51 +231,51 @@ contract DeploymentHelperTest is Test {
         assertEq(result, expected, "Unknown chain should return chain-{id}");
     }
 
-
     function test_AppendBehaviorBasic() public {
         string memory testDir = getTestDir("basic");
         // Simple test to verify append behavior works at all
-        
+
         // First deployment
         DeploymentHelper.ContractDeployment[] memory deployment1 = new DeploymentHelper.ContractDeployment[](1);
         deployment1[0] = createMockDeployment("EntryPoint", mockContract1);
-        
+
         DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment1);
 
         // Verify first file exists
         string memory filename = string(abi.encodePacked(testDir, "/local.json"));
         assertTrue(vm.exists(filename), "First deployment file should exist");
-        
+
         // Second deployment (should attempt to append)
         DeploymentHelper.ContractDeployment[] memory deployment2 = new DeploymentHelper.ContractDeployment[](1);
         deployment2[0] = createMockDeployment("SimpleAccountFactory", mockContract2);
-        
+
         vm.warp(block.timestamp + 100);
         DeploymentHelper.saveDeploymentArtifacts(vm, testDir, NETWORK_NAME, CHAIN_ID, deployment2);
 
         // Verify file still exists and was updated
         assertTrue(vm.exists(filename), "Deployment file should still exist after append");
-        
+
         string memory finalContent = vm.readFile(filename);
         assertTrue(bytes(finalContent).length > 0, "Final file should not be empty");
-        
+
         // At minimum, the file should contain the second contract
         assertTrue(contains(finalContent, "SimpleAccountFactory"), "Should contain second contract name");
         assertTrue(contains(finalContent, vm.toString(mockContract2)), "Should contain second contract address");
     }
 
     // Helper function to create mock deployments
-    function createMockDeployment(string memory name, address addr) 
-        internal 
-        view 
-        returns (DeploymentHelper.ContractDeployment memory) 
+    function createMockDeployment(string memory name, address addr)
+        internal
+        view
+        returns (DeploymentHelper.ContractDeployment memory)
     {
         return DeploymentHelper.ContractDeployment({
             name: name,
             addr: addr,
             abi: "[]",
             bytecode: DeploymentHelper.getDeployedBytecode(addr),
-            metadata: ""
+            metadata: "",
+            blockNumber: block.number
         });
     }
 
@@ -310,11 +283,11 @@ contract DeploymentHelperTest is Test {
     function contains(string memory str, string memory substr) internal pure returns (bool) {
         bytes memory strBytes = bytes(str);
         bytes memory substrBytes = bytes(substr);
-        
+
         if (substrBytes.length > strBytes.length) {
             return false;
         }
-        
+
         for (uint256 i = 0; i <= strBytes.length - substrBytes.length; i++) {
             bool found = true;
             for (uint256 j = 0; j < substrBytes.length; j++) {


### PR DESCRIPTION
### Context

As topic, this PR:

- tries to append newly deployed contract artefacts to the existing JSON files (instead of overwriting them)
- tries to use the actual deployed block number by reading broadcast file (please note the block numbers in existing JSON files aren't guaranteed to be correct)
- uploads the deployment artefacts of erc20 paymaster on arb-sepolia
- makes block number per contract