### PR TITLE
feat: add ERC20PaymasterV1 staging address to whitelist

### DIFF
--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -74,6 +74,8 @@ const WHITELISTED_PAYMASTER_ADDRESSES: &[&str] = &[
 	// SimplePaymaster
 	"0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912", // staging-v1
 	"0xD4dCB31763CBA7295bA4023E9411CB6db607DE07", // prod-v1
+	// ERC20PaymasterV1
+	"0xA8535e013236E04FAD5dc03eCc4c05A464c01f38", // staging
 ];
 
 // Decode ERC20 paymaster data from paymasterAndData


### PR DESCRIPTION
## Summary
- Added ERC20PaymasterV1 staging address (0xA8535e013236E04FAD5dc03eCc4c05A464c01f38) to the paymaster whitelist in native-task-handler