### PR TITLE
Add USDC token support for Base chain

### DIFF
--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -222,6 +222,12 @@ fn get_supported_tokens() -> std::collections::HashMap<(u64, &'static str), Toke
 		TokenInfo { decimals: 18, binance_pair: "ETHUSDT" },
 	);
 
+	// Base (Chain ID 8453)
+	tokens.insert(
+		(8453, "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"), // USDC
+		TokenInfo { decimals: 6, binance_pair: "ETHUSDC" },
+	);
+
 	tokens
 }
 


### PR DESCRIPTION
## Summary
- Added USDC token configuration for Base chain (ID 8453) in the omni-executor native task handler

After doing some testing I found a couple of things relevant for wildmeta: 
- `USD0` token is not supported in Binance
- `USD1` does not have a pair with ETH on Binance

For this reason we are only adding base USDC for now as we can't get the exchange rate