### PR TITLE
heima client id -> console mailer

### DIFF
--- a/tee-worker/omni-executor/LOCAL_DEV.md
+++ b/tee-worker/omni-executor/LOCAL_DEV.md
@@ -164,7 +164,8 @@ Key environment variables (set in `.env` file):
 ```bash
 # Mock server configuration
 OE_PUMPX_API_BASE_URL=http://omni-executor:3456/pumpx
-OE_MAILER_TYPE_CONSOLE=console
+# If you want to use console mailer type for HEIMA client id
+OE_MAILER_TYPE_HEIMA=console
 
 # Network endpoints
 OE_PARENTCHAIN_URL=ws://heima-node:9944
@@ -237,7 +238,7 @@ For even faster development, you can run the omni-executor directly without Dock
    export OE_PARENTCHAIN_URL=ws://localhost:9944
    export OE_ETHEREUM_URL=http://localhost:8545
    export OE_PUMPX_API_BASE_URL=http://localhost:3456/pumpx
-   export OE_MAILER_TYPE_CONSOLE=console
+   export OE_MAILER_TYPE_HEIMA=console
    export RUST_LOG=debug
    ```
 

--- a/tee-worker/omni-executor/docker/docker-compose.yml
+++ b/tee-worker/omni-executor/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - OE_PUMPX_WORKER_URL=ws://omni-executor:2100
       - OE_PUMPX_API_BASE_URL=http://omni-executor:3456/pumpx/
       - OE_PUMPX_SIGNER_URL=http://omni-executor:3456/jsonrpc
-      - OE_MAILER_TYPE_CONSOLE=console
+      - OE_MAILER_TYPE_HEIMA=console
       # These should be set in the .env file or overridden as needed:
       # - OE_BSC_URL=
       # - OE_BSC_TESTNET_URL=


### PR DESCRIPTION
If configured with `OE_MAILER_TYPE_CONSOLE` then `client_id` must be `console`.
`console` client id will be rejected during JWT validation.