### PR TITLE
rebuild omni-executor docker dev image command

### DIFF
--- a/tee-worker/omni-executor/Makefile
+++ b/tee-worker/omni-executor/Makefile
@@ -96,6 +96,11 @@ stop-local:
 build-docker-test:
 	docker build --build-arg CARGO_FEATURES="mock-server,test-endpoints" --target executor-worker -t litentry/$(BIN_NAME):latest -f $(OMNI_DIR)/Dockerfile $(ROOTDIR)
 
+.PHONY: rebuild-docker-dev
+rebuild-docker-dev:
+	cargo build --release --features mock-server
+	cd docker/ && docker compose build --no-cache omni-executor
+
 .PHONY: start-test
 start-test:
 	docker compose -f $(OMNI_DIR)/docker/docker-compose.yml -f $(OMNI_DIR)/docker/docker-compose.test.yml up


### PR DESCRIPTION
It's used very often for rebuilding locally used image.

