### PR TITLE
fix `get_sender_address`

### DIFF
--- a/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
@@ -680,16 +680,11 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 		let tx = build_call_transaction(self.entry_point_address, call_data);
 		match self.rpc_client.call(tx).await {
 			Err(err) => {
-				if let ethereum_rpc::RpcProviderError::ExecutionReverted { reason, .. } = &err {
-					if reason.contains("0x") {
-						if let Some(start) = reason.find("0x") {
-							let hex_data = &reason[start..];
-							if let Ok(revert_data) = hex::decode(&hex_data[2..]) {
-								let result = SenderAddressResult::abi_decode(&revert_data)
-									.map_err(|_| error!("Could not decode SenderAddressResult"))?;
-								return Ok(result.sender);
-							}
-						}
+				if let ethereum_rpc::RpcProviderError::ExecutionReverted { reason, data } = &err {
+					if let Some(data) = data {
+						let result = SenderAddressResult::abi_decode(data)
+							.map_err(|_| error!("Could not decode SenderAddressResult"))?;
+						return Ok(result.sender);
 					}
 				}
 				error!("Failed to get sender address: {:?}", err);
@@ -1154,12 +1149,8 @@ pub mod test {
 			.with(mockall::predicate::always())
 			.times(1)
 			.returning(|_| {
-				let revert_data = hex::decode(
-					"0x6ca7b8060000000000000000000000005dfec187c82986cf670f4e2ed6de1cd001cee5be",
-				)
-				.unwrap();
-				let reason = format!("execution reverted: 0x{}", hex::encode(&revert_data));
-				Err(ethereum_rpc::RpcProviderError::ExecutionReverted { reason, data: None })
+				let reason = "execution reverted: custom error 0x6ca7b806: 0000000000000000000000005dfec187c82986cf670f4e2ed6de1cd001cee5be".to_string();
+				Err(ethereum_rpc::RpcProviderError::ExecutionReverted { reason, data: Some(hex::decode("0x6ca7b8060000000000000000000000005dfec187c82986cf670f4e2ed6de1cd001cee5be").unwrap()) })
 			});
 
 		let entrypoint_client = EntryPointClient::new(entrypoint_address, Arc::new(rpc_client));

--- a/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
@@ -680,12 +680,14 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 		let tx = build_call_transaction(self.entry_point_address, call_data);
 		match self.rpc_client.call(tx).await {
 			Err(err) => {
-				if let ethereum_rpc::RpcProviderError::ExecutionReverted { reason, data } = &err {
-					if let Some(data) = data {
-						let result = SenderAddressResult::abi_decode(data)
-							.map_err(|_| error!("Could not decode SenderAddressResult"))?;
-						return Ok(result.sender);
-					}
+				if let ethereum_rpc::RpcProviderError::ExecutionReverted {
+					reason: _,
+					data: Some(data),
+				} = &err
+				{
+					let result = SenderAddressResult::abi_decode(data)
+						.map_err(|_| error!("Could not decode SenderAddressResult"))?;
+					return Ok(result.sender);
 				}
 				error!("Failed to get sender address: {:?}", err);
 				Err(())


### PR DESCRIPTION
It fails with following reason

```
ethereum-node        | RPC request failed:
ethereum-node        |     Request: EthCall(WithOtherFields { inner: TransactionRequest { from: None, to: Some(Call(0xe7f1725e7734ce288f8367e1bb143e90bb3f0512)), gas_price: None, max_fee_per_gas: None, max_priority_fee_per_gas: None, max_fee_per_blob_gas: None, gas: None, value: None, input: TransactionInput { input: None, data: Some(0x9b249f69000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000d89fe46736679d2d9a65f0992f2272de9f3c7fa6e0158b8ca590622cdbc4aa82304e92d828ccc887e3ebfc03414d1a35026819c1b1ed726afd00000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000080000000000000000000000000a0ee7a142d267c1f36714e4a8f75612f20a7972000000000000000000000000000000000000000000000000000000000000000056865696d610000000000000000000000000000000000000000000000000000000000000000000000) }, nonce: None, chain_id: None, access_list: None, transaction_type: None, blob_versioned_hashes: None, sidecar: None, authorization_list: None }, other: OtherFields {} }, Some(pending), None)
ethereum-node        |     Error: Execution error: execution reverted: custom error 0x6ca7b806: 000000000000000000000000d7c8011abd68056f4b18aff7b5976e4ac0554e39
```

Aditionally address should be extracted from `data` not `reason` field.

