### PR TITLE
Include maxFeePerGas and maxPriorityFeePerGas in omni_estimateUserOpGas response

### DIFF
--- a/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/entry_point_client.rs
@@ -880,7 +880,7 @@ impl<P: RpcProvider<Transaction = TransactionRequest, Addr = Address>> EntryPoin
 	}
 
 	/// Calculate gas fees with additional buffer percentage
-	async fn calculate_gas_fees_with_buffer(
+	pub async fn calculate_gas_fees_with_buffer(
 		&self,
 		additional_buffer_percent: u64,
 	) -> Result<(U256, U256), AaContractError> {

--- a/tee-worker/omni-executor/aa-contracts/aa-demo-app/src/lib/tee-worker-client.ts
+++ b/tee-worker/omni-executor/aa-contracts/aa-demo-app/src/lib/tee-worker-client.ts
@@ -247,6 +247,8 @@ interface EstimateUserOpGasResponse {
     preVerificationGas: string;
     paymasterVerificationGasLimit: string;
     paymasterPostOpGasLimit: string;
+    maxFeePerGas: string;
+    maxPriorityFeePerGas: string;
 }
 
 // Get OmniAccount hash from email

--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -1518,6 +1518,12 @@ async fn estimate_user_op_gas(
 	let (paymaster_verification_gas_limit, paymaster_post_op_gas_limit) =
 		extract_paymaster_gas_limits(&user_op.paymasterAndData);
 
+	// Step 6: Calculate gas fees with buffer
+	let (max_fee_per_gas, max_priority_fee_per_gas) = entry_point_client
+		.calculate_gas_fees_with_buffer(10) // Use 10% additional buffer for estimation
+		.await
+		.map_err(|e| format!("Failed to calculate gas fees: {:?}", e))?;
+
 	// Convert to u128 for response, ensuring values are within bounds
 	let call_gas_limit = call_gas_limit.try_into().map_err(|_| {
 		format!("Call gas limit {} exceeds maximum supported value", call_gas_limit)
@@ -1531,12 +1537,22 @@ async fn estimate_user_op_gas(
 		format!("Pre-verification gas {} exceeds maximum supported value", pre_verification_gas)
 	})?;
 
+	let max_fee_per_gas = max_fee_per_gas.try_into().map_err(|_| {
+		format!("Max fee per gas {} exceeds maximum supported value", max_fee_per_gas)
+	})?;
+
+	let max_priority_fee_per_gas = max_priority_fee_per_gas.try_into().map_err(|_| {
+		format!("Max priority fee per gas {} exceeds maximum supported value", max_priority_fee_per_gas)
+	})?;
+
 	let response = NativeTaskOk::EstimateUserOpGas {
 		call_gas_limit,
 		verification_gas_limit,
 		pre_verification_gas,
 		paymaster_verification_gas_limit,
 		paymaster_post_op_gas_limit,
+		max_fee_per_gas,
+		max_priority_fee_per_gas,
 	};
 
 	info!("Gas estimation complete: {:?}", response);

--- a/tee-worker/omni-executor/native-task-handler/src/lib.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/lib.rs
@@ -1542,7 +1542,10 @@ async fn estimate_user_op_gas(
 	})?;
 
 	let max_priority_fee_per_gas = max_priority_fee_per_gas.try_into().map_err(|_| {
-		format!("Max priority fee per gas {} exceeds maximum supported value", max_priority_fee_per_gas)
+		format!(
+			"Max priority fee per gas {} exceeds maximum supported value",
+			max_priority_fee_per_gas
+		)
 	})?;
 
 	let response = NativeTaskOk::EstimateUserOpGas {

--- a/tee-worker/omni-executor/native-task-handler/src/types.rs
+++ b/tee-worker/omni-executor/native-task-handler/src/types.rs
@@ -37,6 +37,8 @@ pub enum NativeTaskOk {
 		pre_verification_gas: u128,
 		paymaster_verification_gas_limit: u128,
 		paymaster_post_op_gas_limit: u128,
+		max_fee_per_gas: u128,
+		max_priority_fee_per_gas: u128,
 	},
 }
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/estimate_user_op_gas.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/estimate_user_op_gas.rs
@@ -48,6 +48,8 @@ pub struct EstimateUserOpGasResponse {
 	pub pre_verification_gas: String,
 	pub paymaster_verification_gas_limit: String,
 	pub paymaster_post_op_gas_limit: String,
+	pub max_fee_per_gas: String,
+	pub max_priority_fee_per_gas: String,
 }
 
 pub fn register_estimate_user_op_gas<
@@ -117,12 +119,16 @@ pub fn register_estimate_user_op_gas<
 					pre_verification_gas,
 					paymaster_verification_gas_limit,
 					paymaster_post_op_gas_limit,
+					max_fee_per_gas,
+					max_priority_fee_per_gas,
 				} => Ok(EstimateUserOpGasResponse {
 					call_gas_limit: call_gas_limit.to_string(),
 					verification_gas_limit: verification_gas_limit.to_string(),
 					pre_verification_gas: pre_verification_gas.to_string(),
 					paymaster_verification_gas_limit: paymaster_verification_gas_limit.to_string(),
 					paymaster_post_op_gas_limit: paymaster_post_op_gas_limit.to_string(),
+					max_fee_per_gas: max_fee_per_gas.to_string(),
+					max_priority_fee_per_gas: max_priority_fee_per_gas.to_string(),
 				}),
 				_ => {
 					error!("Unexpected response type");


### PR DESCRIPTION
Add fee estimation to the `omni_estimateUserOpGas` RPC method to provide complete gas cost information to clients. The method now returns both gas limits and recommended fee values based on current network conditions.