### PR TITLE
enhance omni-cli

### DIFF
--- a/tee-worker/omni-executor/Cargo.lock
+++ b/tee-worker/omni-executor/Cargo.lock
@@ -6738,6 +6738,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "hex",
+ "libsecp256k1 0.7.2",
  "log",
  "serde_json",
  "sp-core 35.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7163,11 +7164,14 @@ dependencies = [
 name = "omni-cli"
 version = "0.1.0"
 dependencies = [
+ "aa-contracts-client",
  "alloy",
  "anyhow",
  "clap",
+ "ethereum-rpc",
  "executor-core",
  "executor-primitives",
+ "heima-primitives",
  "hex",
  "reqwest 0.12.23",
  "serde",

--- a/tee-worker/omni-executor/aa-contracts-client/src/lib.rs
+++ b/tee-worker/omni-executor/aa-contracts-client/src/lib.rs
@@ -21,7 +21,8 @@ mod types;
 mod utils;
 
 pub use entry_point_client::{
-	prepare_factory_init_code, EntryPointClient, GasPriceConfig, RetryConfig,
+	create_paymaster_and_data, prepare_factory_init_code, EntryPointClient, GasPriceConfig,
+	RetryConfig,
 };
 pub use error::{AaContractError, ContractError, RpcError};
 pub use omni_account_client::OmniAccountClient;

--- a/tee-worker/omni-executor/mock-server/Cargo.toml
+++ b/tee-worker/omni-executor/mock-server/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [dependencies]
 alloy = { workspace = true, features = ["node-bindings", "json-rpc"] }
 hex = { workspace = true, features = ["std"] }
+libsecp256k1 = { workspace = true }
 log = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 sp-core = { workspace = true, features = ["std"] }

--- a/tee-worker/omni-executor/mock-server/src/dex.rs
+++ b/tee-worker/omni-executor/mock-server/src/dex.rs
@@ -33,13 +33,45 @@ fn ethereum_to_substrate_signature(ethereum_sig: &[u8]) -> [u8; 65] {
 	substrate_sig
 }
 
-fn get_mock_wallet_address() -> String {
-	// This will return the address corresponding to MOCK_PRIVATE_KEY
-	// Address: 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
-	let private_key_bytes = hex::decode(&MOCK_PRIVATE_KEY[2..]).expect("Invalid private key");
-	let private_key = B256::from_slice(&private_key_bytes);
-	let signer = PrivateKeySigner::from_bytes(&private_key).expect("Invalid private key");
-	signer.address().to_string()
+fn get_mock_pubkey_bytes(chain_type: &str) -> Vec<u8> {
+	match chain_type {
+		"Evm" | "Tron" => {
+			// Calculate the compressed public key from MOCK_PRIVATE_KEY for EVM/Tron chains
+			// We'll use secp256k1 to derive the public key properly
+			let private_key_bytes =
+				hex::decode(&MOCK_PRIVATE_KEY[2..]).expect("Invalid private key");
+
+			// Use secp256k1 to get the compressed public key
+			let secret_key = libsecp256k1::SecretKey::parse_slice(&private_key_bytes)
+				.expect("Invalid private key for secp256k1");
+			let public_key = libsecp256k1::PublicKey::from_secret_key(&secret_key);
+
+			// Serialize as compressed (33 bytes)
+			public_key.serialize_compressed().to_vec()
+		},
+		"Solana" => {
+			// For Solana, we use a derived 32-byte Ed25519-style key
+			// Since the actual signer service would derive this differently for Solana,
+			// we'll use a deterministic derivation from the MOCK_PRIVATE_KEY
+			let private_key_bytes =
+				hex::decode(&MOCK_PRIVATE_KEY[2..]).expect("Invalid private key");
+
+			// Use keccak256 hash of the private key as a mock Ed25519 public key (32 bytes)
+			let ed25519_pubkey = keccak_256(&private_key_bytes);
+			ed25519_pubkey.to_vec()
+		},
+		_ => {
+			// Default to EVM format for unknown chain types
+			let private_key_bytes =
+				hex::decode(&MOCK_PRIVATE_KEY[2..]).expect("Invalid private key");
+
+			let secret_key = libsecp256k1::SecretKey::parse_slice(&private_key_bytes)
+				.expect("Invalid private key for secp256k1");
+			let public_key = libsecp256k1::PublicKey::from_secret_key(&secret_key);
+
+			public_key.serialize_compressed().to_vec()
+		},
+	}
 }
 
 fn build_success_response(body: Value) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
@@ -63,14 +95,24 @@ pub async fn handle_dex_method(request: Value) -> Result<Box<dyn warp::Reply>, w
 			build_success_response(response)
 		},
 		"dex_getWallet" => {
-			// Return the wallet address derived from the private key
-			let wallet_address = get_mock_wallet_address();
+			// Extract chain type from the request params
+			let empty_params = json!({});
+			let params = request.get("params").unwrap_or(&empty_params);
+			let empty_payload = json!({});
+			let payload = params.get("payload").unwrap_or(&empty_payload);
+			let empty_wallet = json!({});
+			let wallet = payload.get("wallet").unwrap_or(&empty_wallet);
+			let chain_type = wallet.get("chain_type").and_then(|ct| ct.as_str()).unwrap_or("Evm");
 
-			tracing::info!("Returning wallet address: {}", wallet_address);
+			// Return the public key bytes as hex string (instead of address)
+			let pubkey_bytes = get_mock_pubkey_bytes(chain_type);
+			let pubkey_hex = hex::encode(&pubkey_bytes);
+
+			tracing::info!("Returning public key for chain type {}: 0x{}", chain_type, pubkey_hex);
 
 			let response = json!({
 				"jsonrpc": "2.0",
-				"result": wallet_address.to_string(),
+				"result": pubkey_hex,
 				"id": id
 			});
 			build_success_response(response)

--- a/tee-worker/omni-executor/omni-cli/Cargo.toml
+++ b/tee-worker/omni-executor/omni-cli/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+aa-contracts-client = { workspace = true }
 alloy = { workspace = true }
 anyhow = "1.0"
 clap = { workspace = true, features = ["derive"] }
+ethereum-rpc = { workspace = true }
 executor-core = { workspace = true }
 executor-primitives = { workspace = true }
+heima-primitives = { workspace = true }
 hex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }

--- a/tee-worker/omni-executor/omni-cli/src/main.rs
+++ b/tee-worker/omni-executor/omni-cli/src/main.rs
@@ -11,7 +11,6 @@ use ethereum_rpc::{AlloyRpcProvider, RpcProvider};
 use executor_core::types::SerializablePackedUserOperation;
 use executor_primitives::{ChainId, Web2IdentityType};
 use heima_primitives::Identity;
-use hex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::{debug, info};
@@ -714,7 +713,7 @@ async fn handle_generate_aa_address(
 		.map_err(|e| anyhow::anyhow!("Invalid root address '{}': {}", root_address, e))?;
 
 	info!("Debug info:");
-	info!("  OA bytes: 0x{}", hex::encode(&oa_bytes));
+	info!("  OA bytes: 0x{}", hex::encode(oa_bytes));
 	info!("  OA type: {}", oa_type_str);
 	info!("  Client ID: {}", client_id);
 	info!("  Factory address: {}", factory_address);
@@ -781,7 +780,7 @@ async fn handle_generate_aa_address(
 
 	info!(
 		"Generated AA address for oa_bytes '0x{}' with oa_type '{}', client_id '{}', factory '{}', root '{}': 0x{}",
-		hex::encode(&oa_bytes),
+		hex::encode(oa_bytes),
 		oa_type_str,
 		client_id,
 		factory_address,
@@ -825,7 +824,7 @@ fn handle_generate_init_code(
 
 	info!(
 		"Generated init code for oa_bytes '0x{}' with oa_type '{}', client_id '{}', factory '{}', root '{}': 0x{}",
-		hex::encode(&oa_bytes), oa_type_str, client_id, factory_address, root_address, init_code_hex
+		hex::encode(oa_bytes), oa_type_str, client_id, factory_address, root_address, init_code_hex
 	);
 
 	println!("Init Code: 0x{}", init_code_hex);
@@ -872,7 +871,7 @@ fn handle_get_omni_account(email: String, client_id: String) -> Result<()> {
 	let oa_bytes: [u8; 32] = omni_account.into();
 
 	// Convert to hex string
-	let omni_account_hex = hex::encode(&oa_bytes);
+	let omni_account_hex = hex::encode(oa_bytes);
 
 	info!(
 		"Generated OmniAccount for email '{}' with client_id '{}': 0x{}",

--- a/tee-worker/omni-executor/omni-cli/src/main.rs
+++ b/tee-worker/omni-executor/omni-cli/src/main.rs
@@ -1,10 +1,41 @@
+use aa_contracts_client::{
+	calculate_omni_account_address, create_paymaster_and_data, prepare_factory_init_code, OwnerType,
+};
+use alloy::primitives::{Address, FixedBytes, TxKind, U256};
+use alloy::rpc::types::{TransactionInput, TransactionRequest};
+use alloy::sol;
+use alloy::sol_types::SolCall;
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
+use ethereum_rpc::{AlloyRpcProvider, RpcProvider};
 use executor_core::types::SerializablePackedUserOperation;
-use executor_primitives::ChainId;
+use executor_primitives::{ChainId, Web2IdentityType};
+use heima_primitives::Identity;
+use hex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::{debug, info};
+
+sol! {
+	// Owner type enum from aa-contracts-client
+	enum OwnerTypeEnum {
+		Pumpx,
+		Email,
+		Twitter,
+		Discord,
+		Github,
+		Substrate,
+		Evm,
+		Bitcoin,
+		Solana,
+		Google,
+		Passkey
+	}
+
+	// OmniAccountFactory interface
+	function getAddress(bytes32 oa, OwnerTypeEnum oaType, bytes memory clientId, address root) public view returns (address);
+	function accountImplementation() public view returns (address);
+}
 
 #[derive(Debug, Clone, ValueEnum, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -242,6 +273,87 @@ enum Commands {
 		#[arg(long, default_value = "0")]
 		wallet_index: u32,
 	},
+
+	/// Generate OmniAccount (AA) address from omni-account bytes and owner type
+	GenerateAAAddress {
+		#[arg(long, help = "32-byte omni-account identifier in hex format (0x-prefixed)")]
+		oa_bytes: String,
+
+		#[arg(
+			long,
+			help = "Owner type: Email, Evm, Substrate, Bitcoin, Solana, Twitter, Discord, Github, Google, Pumpx, Passkey"
+		)]
+		oa_type: String,
+
+		#[arg(long)]
+		client_id: String,
+
+		#[arg(long)]
+		factory_address: String,
+
+		#[arg(long)]
+		root_address: String,
+
+		#[arg(long, default_value = "http://localhost:8545")]
+		rpc_url: String,
+
+		#[arg(
+			long,
+			help = "Account implementation address (if not provided, will try to get from factory)"
+		)]
+		account_implementation: Option<String>,
+	},
+
+	/// Generate user operation init code from omni-account bytes and owner type
+	GenerateInitCode {
+		#[arg(long, help = "32-byte omni-account identifier in hex format (0x-prefixed)")]
+		oa_bytes: String,
+
+		#[arg(
+			long,
+			help = "Owner type: Email, Evm, Substrate, Bitcoin, Solana, Twitter, Discord, Github, Google, Pumpx, Passkey"
+		)]
+		oa_type: String,
+
+		#[arg(long)]
+		client_id: String,
+
+		#[arg(long)]
+		factory_address: String,
+
+		#[arg(long)]
+		root_address: String,
+	},
+
+	/// Generate paymaster and data for user operations
+	GeneratePaymasterData {
+		#[arg(long)]
+		paymaster_address: String,
+
+		#[arg(long, default_value = "50000")]
+		verification_gas_limit: u64,
+
+		#[arg(long, default_value = "50000")]
+		post_op_gas_limit: u64,
+	},
+
+	/// Get OmniAccount identifier from email/identity and client_id
+	GetOmniAccount {
+		#[arg(long)]
+		email: String,
+
+		#[arg(long)]
+		client_id: String,
+	},
+
+	/// Pack two gas limits into accountGasLimits format for PackedUserOperation
+	PackGasLimits {
+		#[arg(long, help = "Gas limit for account verification (decimal)")]
+		verification_gas: u64,
+
+		#[arg(long, help = "Gas limit for call execution (decimal)")]
+		call_gas: u64,
+	},
 }
 
 struct RpcClient {
@@ -320,6 +432,23 @@ fn parse_hex_to_array<const N: usize>(hex_str: &str) -> Result<[u8; N]> {
 	let mut array = [0u8; N];
 	array.copy_from_slice(&bytes);
 	Ok(array)
+}
+
+fn parse_owner_type(oa_type_str: &str) -> Result<OwnerType> {
+	match oa_type_str.to_lowercase().as_str() {
+		"email" => Ok(OwnerType::Email),
+		"evm" => Ok(OwnerType::Evm),
+		"substrate" => Ok(OwnerType::Substrate),
+		"bitcoin" => Ok(OwnerType::Bitcoin),
+		"solana" => Ok(OwnerType::Solana),
+		"twitter" => Ok(OwnerType::Twitter),
+		"discord" => Ok(OwnerType::Discord),
+		"github" => Ok(OwnerType::Github),
+		"google" => Ok(OwnerType::Google),
+		"pumpx" => Ok(OwnerType::Pumpx),
+		"passkey" => Ok(OwnerType::Passkey),
+		_ => anyhow::bail!("Invalid owner type '{}'. Valid types are: Email, Evm, Substrate, Bitcoin, Solana, Twitter, Discord, Github, Google, Pumpx, Passkey", oa_type_str),
+	}
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -560,6 +689,230 @@ async fn handle_get_smart_wallet_root_signer(
 	Ok(())
 }
 
+async fn handle_generate_aa_address(
+	oa_bytes_hex: String,
+	oa_type_str: String,
+	client_id: String,
+	factory_address: String,
+	root_address: String,
+	rpc_url: String,
+	account_implementation: Option<String>,
+) -> Result<()> {
+	// Parse OmniAccount bytes from hex
+	let oa_bytes = parse_hex_to_array::<32>(&oa_bytes_hex)?;
+
+	// Parse owner type
+	let oa_type = parse_owner_type(&oa_type_str)?;
+
+	// Parse addresses
+	let factory_addr = factory_address
+		.parse::<Address>()
+		.map_err(|e| anyhow::anyhow!("Invalid factory address '{}': {}", factory_address, e))?;
+
+	let root_addr = root_address
+		.parse::<Address>()
+		.map_err(|e| anyhow::anyhow!("Invalid root address '{}': {}", root_address, e))?;
+
+	info!("Debug info:");
+	info!("  OA bytes: 0x{}", hex::encode(&oa_bytes));
+	info!("  OA type: {}", oa_type_str);
+	info!("  Client ID: {}", client_id);
+	info!("  Factory address: {}", factory_address);
+	info!("  Root address: {}", root_address);
+	info!("  RPC URL: {}", rpc_url);
+
+	// Create RPC provider
+	let provider = AlloyRpcProvider::new(&rpc_url);
+
+	// Check if the contract exists
+	info!("Checking if contract exists at {}", factory_address);
+	match provider.get_code_at(factory_addr).await {
+		Ok(code) => {
+			if code.is_empty() {
+				return Err(anyhow::anyhow!("No contract deployed at address {}", factory_address));
+			}
+			info!("Contract exists, code length: {} bytes", code.len());
+		},
+		Err(e) => {
+			return Err(anyhow::anyhow!("Failed to check contract code: {}", e));
+		},
+	}
+
+	// Get account implementation address - either from parameter or from factory contract
+	let account_impl_addr = if let Some(impl_addr_str) = account_implementation {
+		info!("Using provided account implementation address: {}", impl_addr_str);
+		impl_addr_str.parse::<Address>().map_err(|e| {
+			anyhow::anyhow!("Invalid account implementation address '{}': {}", impl_addr_str, e)
+		})?
+	} else {
+		info!("Getting account implementation address from factory...");
+		let impl_call = accountImplementationCall {};
+		let impl_tx = TransactionRequest {
+			to: Some(TxKind::Call(factory_addr)),
+			input: TransactionInput {
+				data: Some(impl_call.abi_encode().into()),
+				..Default::default()
+			},
+			..Default::default()
+		};
+
+		let impl_result = provider.call(impl_tx).await
+			.map_err(|e| anyhow::anyhow!("Failed to get account implementation from factory (you can provide --account-implementation manually): {}", e))?;
+
+		let addr = if impl_result.len() >= 32 {
+			Address::from_slice(&impl_result[12..32])
+		} else {
+			return Err(anyhow::anyhow!("Invalid implementation address response length: expected at least 32 bytes, got {}", impl_result.len()));
+		};
+
+		info!("Retrieved account implementation address: 0x{}", hex::encode(addr.as_slice()));
+		addr
+	};
+
+	// Now calculate the address locally using the same logic as the contract
+	let aa_address = calculate_omni_account_address(
+		factory_addr,
+		account_impl_addr,
+		FixedBytes::from_slice(&oa_bytes),
+		oa_type,
+		client_id.as_bytes(),
+		root_addr,
+	);
+
+	info!(
+		"Generated AA address for oa_bytes '0x{}' with oa_type '{}', client_id '{}', factory '{}', root '{}': 0x{}",
+		hex::encode(&oa_bytes),
+		oa_type_str,
+		client_id,
+		factory_address,
+		root_address,
+		hex::encode(aa_address.as_slice())
+	);
+
+	println!("AA Address: 0x{}", hex::encode(aa_address.as_slice()));
+
+	Ok(())
+}
+
+fn handle_generate_init_code(
+	oa_bytes_hex: String,
+	oa_type_str: String,
+	client_id: String,
+	factory_address: String,
+	root_address: String,
+) -> Result<()> {
+	// Parse OmniAccount bytes from hex
+	let oa_bytes = parse_hex_to_array::<32>(&oa_bytes_hex)?;
+
+	// Parse owner type
+	let oa_type = parse_owner_type(&oa_type_str)?;
+
+	// Parse addresses
+	let factory_addr = factory_address
+		.parse::<Address>()
+		.map_err(|e| anyhow::anyhow!("Invalid factory address '{}': {}", factory_address, e))?;
+
+	let root_addr = root_address
+		.parse::<Address>()
+		.map_err(|e| anyhow::anyhow!("Invalid root address '{}': {}", root_address, e))?;
+
+	// Generate init code using the specified owner type
+	let init_code =
+		prepare_factory_init_code(factory_addr, oa_bytes, oa_type, client_id.as_bytes(), root_addr);
+
+	// Convert to hex string
+	let init_code_hex = hex::encode(&init_code);
+
+	info!(
+		"Generated init code for oa_bytes '0x{}' with oa_type '{}', client_id '{}', factory '{}', root '{}': 0x{}",
+		hex::encode(&oa_bytes), oa_type_str, client_id, factory_address, root_address, init_code_hex
+	);
+
+	println!("Init Code: 0x{}", init_code_hex);
+
+	Ok(())
+}
+
+fn handle_generate_paymaster_data(
+	paymaster_address: String,
+	verification_gas_limit: u64,
+	post_op_gas_limit: u64,
+) -> Result<()> {
+	// Parse paymaster address
+	let paymaster_addr = paymaster_address
+		.parse::<Address>()
+		.map_err(|e| anyhow::anyhow!("Invalid paymaster address '{}': {}", paymaster_address, e))?;
+
+	// Generate paymaster and data
+	let paymaster_and_data = create_paymaster_and_data(
+		paymaster_addr,
+		U256::from(verification_gas_limit),
+		U256::from(post_op_gas_limit),
+	);
+
+	// Convert to hex string
+	let paymaster_data_hex = hex::encode(&paymaster_and_data);
+
+	info!(
+		"Generated paymaster data for address '{}', verification_gas: {}, post_op_gas: {}: 0x{}",
+		paymaster_address, verification_gas_limit, post_op_gas_limit, paymaster_data_hex
+	);
+
+	println!("Paymaster Data: 0x{}", paymaster_data_hex);
+
+	Ok(())
+}
+
+fn handle_get_omni_account(email: String, client_id: String) -> Result<()> {
+	// Create Identity from email
+	let identity = Identity::from_web2_account(&email, Web2IdentityType::Email);
+
+	// Generate OmniAccount
+	let omni_account = identity.to_omni_account(&client_id);
+	let oa_bytes: [u8; 32] = omni_account.into();
+
+	// Convert to hex string
+	let omni_account_hex = hex::encode(&oa_bytes);
+
+	info!(
+		"Generated OmniAccount for email '{}' with client_id '{}': 0x{}",
+		email, client_id, omni_account_hex
+	);
+
+	println!("OmniAccount: 0x{}", omni_account_hex);
+
+	Ok(())
+}
+
+fn handle_pack_gas_limits(verification_gas: u64, call_gas: u64) -> Result<()> {
+	// Pack the gas limits into a 32-byte (256-bit) value
+	// Higher 128 bits = verification_gas, lower 128 bits = call_gas
+
+	// Create the packed value as two 128-bit parts
+	let verification_part = verification_gas as u128;
+	let call_part = call_gas as u128;
+
+	// Since we need 256 bits total, we'll use a byte array approach
+	let mut packed_bytes = [0u8; 32];
+
+	// Put verification_gas in the higher 16 bytes (128 bits)
+	packed_bytes[16..32].copy_from_slice(&verification_part.to_be_bytes());
+	// Put call_gas in the lower 16 bytes (128 bits)
+	packed_bytes[0..16].copy_from_slice(&call_part.to_be_bytes());
+
+	// Convert to hex string
+	let packed_hex = format!("0x{}", hex::encode(packed_bytes));
+
+	info!(
+		"Packed gas limits: verification={}, call={} -> {}",
+		verification_gas, call_gas, packed_hex
+	);
+
+	println!("Packed Gas Limits: {}", packed_hex);
+
+	Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
 	tracing_subscriber::fmt::init();
@@ -655,6 +1008,52 @@ async fn main() -> Result<()> {
 		Commands::GetSmartWalletRootSigner { omni_account, chain_type, wallet_index } => {
 			handle_get_smart_wallet_root_signer(&client, omni_account, chain_type, wallet_index)
 				.await?;
+		},
+		Commands::GenerateAAAddress {
+			oa_bytes,
+			oa_type,
+			client_id,
+			factory_address,
+			root_address,
+			rpc_url,
+			account_implementation,
+		} => {
+			handle_generate_aa_address(
+				oa_bytes,
+				oa_type,
+				client_id,
+				factory_address,
+				root_address,
+				rpc_url,
+				account_implementation,
+			)
+			.await?;
+		},
+		Commands::GenerateInitCode {
+			oa_bytes,
+			oa_type,
+			client_id,
+			factory_address,
+			root_address,
+		} => {
+			handle_generate_init_code(oa_bytes, oa_type, client_id, factory_address, root_address)?;
+		},
+		Commands::GeneratePaymasterData {
+			paymaster_address,
+			verification_gas_limit,
+			post_op_gas_limit,
+		} => {
+			handle_generate_paymaster_data(
+				paymaster_address,
+				verification_gas_limit,
+				post_op_gas_limit,
+			)?;
+		},
+		Commands::GetOmniAccount { email, client_id } => {
+			handle_get_omni_account(email, client_id)?;
+		},
+		Commands::PackGasLimits { verification_gas, call_gas } => {
+			handle_pack_gas_limits(verification_gas, call_gas)?;
 		},
 	}
 


### PR DESCRIPTION
  Adds comprehensive Account Abstraction (ERC-4337) tooling to the omni-cli utility:

  New Features

  - AA Address Generation: Generate OmniAccount addresses from omni-account bytes and owner types
  - Init Code Generation: Create factory init code for user operations
  - Paymaster Data: Generate paymaster and data for sponsored transactions
  - OmniAccount Creation: Convert email identities to omni-account identifiers
  - Gas Limit Packing: Pack verification and call gas limits for PackedUserOperation format

