### PR TITLE
fix wrong hyperliquid action signature

### DIFF
--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_hyperliquid_signature_data.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_hyperliquid_signature_data.rs
@@ -167,10 +167,10 @@ impl HyperliquidEip712Signature for Withdraw3Action {
 	fn struct_hash(&self) -> B256 {
 		let items = (
 			keccak256("HyperliquidTransaction:Withdraw(string hyperliquidChain,string destination,string amount,uint64 time)"),
-			keccak256(&self.hyperliquid_chain),
-			keccak256(&self.amount),
-			&self.time,
-			&self.destination
+            keccak256(&self.hyperliquid_chain),
+            keccak256(&self.destination),
+            keccak256(&self.amount),
+            &self.time,
 		);
 		keccak256(items.abi_encode())
 	}

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_hyperliquid_signature_data.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_hyperliquid_signature_data.rs
@@ -80,9 +80,9 @@ pub struct Withdraw3Action {
 	#[serde(serialize_with = "serialize_hex")]
 	pub signature_chain_id: u64,
 	pub hyperliquid_chain: String,
+	pub destination: String,
 	pub amount: String,
 	pub time: u64,
-	pub destination: Address,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -401,7 +401,8 @@ pub fn register_get_hyperliquid_signature_data<
 						amount,
 						time: nonce,
 						destination: validate_ethereum_address(&destination, "destination")
-							.map_err(|e| e.to_error_object())?,
+							.map_err(|e| e.to_error_object())?
+							.to_string(),
 					};
 					let signature =
 						generate_eip712_signature(&ctx, &action, omni_account.as_ref()).await?;
@@ -512,7 +513,9 @@ mod tests {
 			hyperliquid_chain: "Mainnet".to_string(),
 			amount: "100.0".to_string(),
 			time: 1234567890,
-			destination: Address::from_str("0x1234567890123456789012345678901234567890").unwrap(),
+			destination: Address::from_str("0x1234567890123456789012345678901234567890")
+				.unwrap()
+				.to_string(),
 		};
 
 		// Test domain generation

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_hyperliquid_signature_data.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_hyperliquid_signature_data.rs
@@ -166,7 +166,7 @@ impl HyperliquidEip712Signature for Withdraw3Action {
 
 	fn struct_hash(&self) -> B256 {
 		let items = (
-			keccak256("HyperliquidTransaction:Withdraw3(string hyperliquidChain,string amount,uint64 time,address destination)"),
+			keccak256("HyperliquidTransaction:Withdraw(string hyperliquidChain,string destination,string amount,uint64 time)"),
 			keccak256(&self.hyperliquid_chain),
 			keccak256(&self.amount),
 			&self.time,


### PR DESCRIPTION
keep the same as official sdk. https://github.com/hyperliquid-dex/hyperliquid-rust-sdk/blob/5aca1a08237f3c1d720b42d75bec40181b250e78/src/exchange/actions.rs#L147C5-L147C5

will refactor completely to use sdk actions later.

