### PR TITLE
Add Google OAuth2 login support with client-specific credentials

### DIFF
--- a/tee-worker/omni-executor/config-loader/src/config.rs
+++ b/tee-worker/omni-executor/config-loader/src/config.rs
@@ -40,8 +40,6 @@ const DEFAULT_MAILER_TYPE: &str = "sendgrid";
 const DEFAULT_MAILER_API_KEY: &str = "";
 const DEFAULT_MAILER_FROM_EMAIL: &str = "no-reply@example.com";
 const DEFAULT_MAILER_FROM_NAME: &str = "Heima Verify";
-const DEFAULT_GOOGLE_CLIENT_ID: &str = "";
-const DEFAULT_GOOGLE_CLIENT_SECRET: &str = "";
 const DEFAULT_ETHEREUM_URL: &str = "https://eth-mainnet.g.alchemy.com/v2/";
 const DEFAULT_SOLANA_URL: &str = "https://solana-mainnet.g.alchemy.com/v2/";
 const DEFAULT_BSC_URL: &str = "https://bnb-mainnet.g.alchemy.com/v2/";
@@ -87,10 +85,15 @@ impl Default for MailerConfig {
 }
 
 #[derive(Debug, Clone)]
+pub struct GoogleOAuth2Config {
+	pub client_id: String,
+	pub client_secret: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct ConfigLoader {
 	pub mailer_configs: HashMap<String, MailerConfig>,
-	pub google_client_id: String,
-	pub google_client_secret: String,
+	pub google_oauth2_configs: HashMap<String, GoogleOAuth2Config>,
 	pub ethereum_url: String,
 	pub solana_url: String,
 	pub bsc_url: String,
@@ -137,24 +140,6 @@ impl ConfigLoader {
 		info!("Executing: {}", std::env::args().collect::<Vec<_>>().join(" "));
 
 		let vars: HashMap<&str, EnvVar> = HashMap::from([
-			(
-				"google_client_id",
-				EnvVar {
-					env_key: "OE_GOOGLE_CLIENT_ID",
-					default: DEFAULT_GOOGLE_CLIENT_ID,
-					sensitive: false,
-					optional: false,
-				},
-			),
-			(
-				"google_client_secret",
-				EnvVar {
-					env_key: "OE_GOOGLE_CLIENT_SECRET",
-					default: DEFAULT_GOOGLE_CLIENT_SECRET,
-					sensitive: true,
-					optional: false,
-				},
-			),
 			(
 				"ethereum_url",
 				EnvVar {
@@ -350,11 +335,11 @@ impl ConfigLoader {
 		let get_opt = |key: &str| get_env_value(&vars[key]);
 
 		let mailer_configs = Self::load_mailer_configs();
+		let google_oauth2_configs = Self::load_google_oauth2_configs();
 
 		ConfigLoader {
 			mailer_configs,
-			google_client_id: get("google_client_id"),
-			google_client_secret: get("google_client_secret"),
+			google_oauth2_configs,
 			ethereum_url: append_key(&get("ethereum_url")),
 			solana_url: append_key(&get("solana_url")),
 			bsc_url: append_key(&get("bsc_url")),
@@ -465,5 +450,64 @@ impl ConfigLoader {
 		let mut clients: Vec<String> = self.mailer_configs.keys().cloned().collect();
 		clients.sort();
 		clients
+	}
+
+	/// Load Google OAuth2 configurations for multiple clients from environment variables
+	/// Format: OE_GOOGLE_CLIENT_ID_{CLIENT}, OE_GOOGLE_CLIENT_SECRET_{CLIENT}
+	/// CLIENT can be WILDMETA, HEIMA, etc.
+	fn load_google_oauth2_configs() -> HashMap<String, GoogleOAuth2Config> {
+		let mut configs = HashMap::new();
+
+		let env_vars: HashMap<String, String> = std::env::vars().collect();
+
+		let mut clients = std::collections::HashSet::new();
+		for key in env_vars.keys() {
+			if key.starts_with("OE_GOOGLE_CLIENT_ID_") {
+				if let Some(client) = key.strip_prefix("OE_GOOGLE_CLIENT_ID_") {
+					info!("Found Google OAuth2 configuration for client: {}", client);
+					clients.insert(client.to_lowercase());
+				}
+			}
+		}
+
+		info!("Total discovered Google OAuth2 clients: {:?}", clients);
+
+		if clients.is_empty() {
+			warn!("No Google OAuth2 configurations found in environment variables.");
+			return configs;
+		}
+
+		for client in clients {
+			let client_upper = client.to_uppercase();
+
+			let client_id =
+				std::env::var(format!("OE_GOOGLE_CLIENT_ID_{}", client_upper)).unwrap_or_default();
+			let client_secret = std::env::var(format!("OE_GOOGLE_CLIENT_SECRET_{}", client_upper))
+				.unwrap_or_default();
+
+			if client_id.is_empty() || client_secret.is_empty() {
+				warn!(
+					"Incomplete Google OAuth2 config for client '{}': client_id_empty={}, client_secret_empty={}",
+					client,
+					client_id.is_empty(),
+					client_secret.is_empty()
+				);
+				continue;
+			}
+
+			let config = GoogleOAuth2Config { client_id, client_secret };
+
+			info!("Loaded Google OAuth2 config for client '{}'", client);
+
+			configs.insert(client.clone(), config);
+		}
+
+		configs
+	}
+
+	/// Get Google OAuth2 configuration for a specific client
+	pub fn get_google_oauth2_config(&self, client_id: &str) -> Option<GoogleOAuth2Config> {
+		let client_key = client_id.to_lowercase();
+		self.google_oauth2_configs.get(&client_key).cloned()
 	}
 }

--- a/tee-worker/omni-executor/config-loader/src/lib.rs
+++ b/tee-worker/omni-executor/config-loader/src/lib.rs
@@ -1,3 +1,3 @@
 mod config;
 
-pub use config::{ConfigLoader, MailerConfig, MailerType};
+pub use config::{ConfigLoader, GoogleOAuth2Config, MailerConfig, MailerType};

--- a/tee-worker/omni-executor/executor-primitives/src/auth.rs
+++ b/tee-worker/omni-executor/executor-primitives/src/auth.rs
@@ -101,7 +101,7 @@ pub enum OmniAuth {
 	Web3(String, Identity, HeimaMultiSignature), // (client_id, Signer, Signature)
 	Email(String, Email, VerificationCode),      // (client_id, Email, VerificationCode)
 	AuthToken(JwtToken),
-	OAuth2(Identity, OAuth2Data), // (Sender, OAuth2Data)
+	OAuth2(String, Identity, OAuth2Data), // (client_id, Sender, OAuth2Data)
 	Passkey(PasskeyData),
 }
 
@@ -176,6 +176,7 @@ pub struct OAuth2Data {
 	pub code: String,
 	pub state: String,
 	pub redirect_uri: String,
+	pub uid: String, // A unique identifier for the user/session requesting the OAuth2
 }
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -257,7 +258,7 @@ pub fn to_omni_auth(
 		UserAuth::OAuth2(data) => {
 			let identity =
 				Identity::try_from(user_id.clone()).map_err(|_| "Invalid user ID format")?;
-			OmniAuth::OAuth2(identity, data.clone())
+			OmniAuth::OAuth2(client_id.to_string(), identity, data.clone())
 		},
 		UserAuth::Passkey(data) => OmniAuth::Passkey(data.clone()),
 	};

--- a/tee-worker/omni-executor/rpc-server/src/google_oauth2_factory.rs
+++ b/tee-worker/omni-executor/rpc-server/src/google_oauth2_factory.rs
@@ -1,0 +1,79 @@
+use config_loader::{ConfigLoader, GoogleOAuth2Config};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct GoogleOAuth2Factory {
+	config_loader: Arc<ConfigLoader>,
+	config_cache: std::sync::RwLock<HashMap<String, GoogleOAuth2Config>>,
+}
+
+impl GoogleOAuth2Factory {
+	pub fn new(config_loader: Arc<ConfigLoader>) -> Self {
+		Self { config_loader, config_cache: std::sync::RwLock::new(HashMap::new()) }
+	}
+
+	pub fn get_google_config_for_client(
+		&self,
+		client_id: &str,
+	) -> Result<GoogleOAuth2Config, Box<dyn std::error::Error>> {
+		let client_key = client_id.to_lowercase();
+
+		let cache = self.config_cache.read().map_err(|e| format!("Failed to read cache: {}", e))?;
+		if let Some(config) = cache.get(&client_key) {
+			return Ok(config.clone());
+		}
+
+		drop(cache);
+
+		let config = self.config_loader.get_google_oauth2_config(client_id).ok_or_else(|| {
+			let available_clients = self.config_loader.list_available_clients();
+			format!(
+				"No Google OAuth2 configuration found for client '{}'. Available clients: {:?}",
+				client_id, available_clients
+			)
+		})?;
+
+		tracing::info!("Loaded Google OAuth2 config for client '{}'", client_id);
+
+		let mut cache =
+			self.config_cache.write().map_err(|e| format!("Failed to write cache: {}", e))?;
+		cache.insert(client_key.clone(), config.clone());
+
+		Ok(config)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use config_loader::ConfigLoader;
+
+	#[test]
+	fn test_google_oauth2_factory_caching() {
+		std::env::set_var("OE_GOOGLE_CLIENT_ID_TESTCLIENT", "test_client_id");
+		std::env::set_var("OE_GOOGLE_CLIENT_SECRET_TESTCLIENT", "test_client_secret");
+
+		let config = ConfigLoader::from_env();
+		let factory = GoogleOAuth2Factory::new(Arc::new(config));
+
+		let config1 = factory
+			.get_google_config_for_client("testclient")
+			.expect("Should create config");
+		let config2 = factory
+			.get_google_config_for_client("testclient")
+			.expect("Should get cached config");
+
+		assert_eq!(config1.client_id, config2.client_id);
+		assert_eq!(config1.client_secret, config2.client_secret);
+	}
+
+	#[test]
+	fn test_google_oauth2_factory_missing_client() {
+		let config = ConfigLoader::from_env();
+		let factory = GoogleOAuth2Factory::new(Arc::new(config));
+
+		let result = factory.get_google_config_for_client("nonexistent");
+		assert!(result.is_err());
+		assert!(result.unwrap_err().to_string().contains("No Google OAuth2 configuration found"));
+	}
+}

--- a/tee-worker/omni-executor/rpc-server/src/lib.rs
+++ b/tee-worker/omni-executor/rpc-server/src/lib.rs
@@ -3,6 +3,7 @@ mod auth_utils;
 mod config;
 mod detailed_error;
 mod error_code;
+mod google_oauth2_factory;
 mod mailer_factory;
 mod methods;
 mod middlewares;

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_oauth2_google_authorization_url.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_oauth2_google_authorization_url.rs
@@ -1,12 +1,25 @@
-use crate::server::RpcContext;
+use crate::{
+	detailed_error::DetailedError, error_code::EXTERNAL_API_ERROR_CODE, server::RpcContext,
+};
 use executor_core::intent_executor::IntentExecutor;
-use executor_primitives::{utils::hex::ToHexPrefixed, Identity, Web2IdentityType};
+use executor_crypto::hashing::blake2_256;
+use executor_primitives::Hash;
 use executor_storage::{OAuth2StateVerifierStorage, Storage};
 use heima_identity_verification::web2::google;
 use jsonrpsee::{
 	types::{ErrorCode, ErrorObject},
 	RpcModule,
 };
+use parity_scale_codec::Encode;
+use serde::Deserialize;
+use tracing::error;
+
+#[derive(Debug, Deserialize)]
+struct GetOAuth2GoogleAuthorizationUrlParams {
+	pub uid: String, // A unique identifier for the user/session requesting the OAuth2 URL
+	pub redirect_uri: String,
+	pub client_id: String,
+}
 
 pub fn register_get_oauth2_google_authorization_url<
 	EthereumIntentExecutor: IntentExecutor + Send + Sync + 'static,
@@ -21,20 +34,39 @@ pub fn register_get_oauth2_google_authorization_url<
 		.register_async_method(
 			"omni_getOAuth2GoogleAuthorizationUrl",
 			|params, ctx, _| async move {
-				match params.parse::<(String, String)>() {
-					Ok((google_account, redirect_uri)) => {
-						let google_identity =
-							Identity::from_web2_account(&google_account, Web2IdentityType::Google);
-						let authorization_data =
-							google::get_authorize_data(&ctx.google_client_id, &redirect_uri);
-						let storage = OAuth2StateVerifierStorage::new(ctx.storage_db.clone());
-						storage
-							.insert(&google_identity.hash(), authorization_data.state.clone())
-							.map_err(|_| ErrorCode::InternalError)?;
-						Ok::<String, ErrorObject>(authorization_data.authorize_url.to_hex())
-					},
-					Err(_) => Err(ErrorCode::ParseError.into()),
-				}
+				let params = params
+					.parse::<GetOAuth2GoogleAuthorizationUrlParams>()
+					.map_err(|_| ErrorCode::ParseError)?;
+
+				let google_config = ctx
+					.google_oauth2_factory
+					.get_google_config_for_client(&params.client_id)
+					.map_err(|e| {
+						error!(
+							"Failed to get Google OAuth2 config for client '{}': {}",
+							params.client_id, e
+						);
+						DetailedError::new(
+							EXTERNAL_API_ERROR_CODE,
+							"Failed to get Google OAuth2 configuration",
+						)
+						.with_field("client_id")
+						.with_received(&params.client_id)
+						.with_reason(format!("Error: {}", e))
+						.to_error_object()
+					})?;
+
+				let authorization_data =
+					google::get_authorize_data(&google_config.client_id, &params.redirect_uri);
+				let storage = OAuth2StateVerifierStorage::new(ctx.storage_db.clone());
+				let key: Hash =
+					blake2_256((params.client_id.clone(), params.uid.clone()).encode().as_slice())
+						.into();
+
+				storage
+					.insert(&key, authorization_data.state.clone())
+					.map_err(|_| ErrorCode::InternalError)?;
+				Ok::<String, ErrorObject>(authorization_data.authorize_url)
 			},
 		)
 		.expect("Failed to register omni_getOAuth2GoogleAuthorizationUrl method");

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/login_with_oauth2.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/login_with_oauth2.rs
@@ -1,0 +1,159 @@
+use crate::{
+	detailed_error::DetailedError,
+	error_code::{AUTH_VERIFICATION_FAILED_CODE, INTERNAL_ERROR_CODE, PARSE_ERROR_CODE},
+	server::RpcContext,
+	verify_auth::verify_oauth2_authentication,
+	Deserialize, ErrorCode, Serialize,
+};
+use chrono::{Days, Utc};
+use executor_core::intent_executor::IntentExecutor;
+use executor_crypto::jwt;
+use executor_primitives::{utils::hex::ToHexPrefixed, OAuth2Data, OAuth2Provider};
+use heima_authentication::{
+	auth_token::{AuthOptions, AuthTokenClaims},
+	constants::{AUTH_TOKEN_ACCESS_TYPE, AUTH_TOKEN_EXPIRATION_DAYS},
+};
+use heima_primitives::Identity;
+use jsonrpsee::{types::ErrorObject, RpcModule};
+use tracing::error;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct LoginWithOAuth2Params {
+	pub client_id: String,
+	pub provider: String,
+	pub code: String,
+	pub state: String,
+	pub redirect_uri: String,
+	pub uid: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct LoginWithOAuth2Response {
+	pub user_id: String,
+	pub access_token: String,
+}
+
+fn parse_oauth2_provider(provider: &str) -> Result<OAuth2Provider, ErrorCode> {
+	match provider.to_lowercase().as_str() {
+		"google" => Ok(OAuth2Provider::Google),
+		_ => {
+			error!("Unsupported OAuth2 provider: {}", provider);
+			Err(ErrorCode::InvalidParams)
+		},
+	}
+}
+
+fn create_jwt_for_user(
+	identity: Identity,
+	token_type: &str,
+	client_id: &str,
+	jwt_rsa_private_key: &[u8],
+) -> Result<String, ()> {
+	let expires_at = Utc::now()
+		.checked_add_days(Days::new(AUTH_TOKEN_EXPIRATION_DAYS))
+		.expect("Failed to calculate expiration")
+		.timestamp();
+	let auth_options = AuthOptions { expires_at };
+	let omni_account = identity.to_omni_account(client_id);
+	let token_claims = AuthTokenClaims::new(
+		omni_account.to_hex(),
+		token_type.to_string(),
+		client_id.to_string(),
+		auth_options,
+	);
+	jwt::create(&token_claims, jwt_rsa_private_key).map_err(|e| {
+		error!("Failed to create JWT token: {:?}", e);
+	})
+}
+
+pub fn register_login_with_oauth2<
+	EthereumIntentExecutor: IntentExecutor + Send + Sync + 'static,
+	SolanaIntentExecutor: IntentExecutor + Send + Sync + 'static,
+	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
+>(
+	module: &mut RpcModule<
+		RpcContext<EthereumIntentExecutor, SolanaIntentExecutor, CrossChainIntentExecutor>,
+	>,
+) {
+	module
+		.register_async_method("omni_loginWithOAuth2", |params, ctx, _| async move {
+			let params = params.parse::<LoginWithOAuth2Params>().map_err(|e| {
+				error!("Failed to parse params: {:?}", e);
+				DetailedError::new(PARSE_ERROR_CODE, "Parse error")
+					.with_reason("Invalid JSON format or missing required fields")
+					.to_error_object()
+			})?;
+
+			let provider = parse_oauth2_provider(&params.provider).map_err(|_e| {
+				error!("Invalid OAuth2 provider: {}", params.provider);
+				DetailedError::new(PARSE_ERROR_CODE, "Invalid provider")
+					.with_field("provider")
+					.with_received(&params.provider)
+					.with_expected("google")
+					.to_error_object()
+			})?;
+
+			let oauth2_data = OAuth2Data {
+				provider,
+				code: params.code.clone(),
+				state: params.state.clone(),
+				redirect_uri: params.redirect_uri.clone(),
+				uid: params.uid.clone(),
+			};
+
+			let verified_identity =
+				verify_oauth2_authentication(ctx.clone(), &params.client_id, &oauth2_data)
+					.await
+					.map_err(|e| {
+						error!("Failed to verify OAuth2 authentication: {:?}", e);
+						DetailedError::new(
+							AUTH_VERIFICATION_FAILED_CODE,
+							"OAuth2 authentication failed",
+						)
+						.with_reason(format!("{}", e))
+						.with_suggestion("Please check your OAuth2 credentials and try again")
+						.to_error_object()
+					})?;
+
+			let access_token = create_jwt_for_user(
+				verified_identity.clone(),
+				AUTH_TOKEN_ACCESS_TYPE,
+				&params.client_id,
+				&ctx.jwt_rsa_private_key,
+			)
+			.map_err(|_| {
+				error!("Failed to create access token for user");
+				DetailedError::new(INTERNAL_ERROR_CODE, "Failed to create access token")
+					.with_reason("Internal error while generating JWT token")
+					.to_error_object()
+			})?;
+
+			let user_id = match &verified_identity {
+				Identity::Google(identity_string) => {
+					std::str::from_utf8(identity_string.inner_ref())
+						.map_err(|_| {
+							error!("Failed to convert identity to string");
+							DetailedError::new(INTERNAL_ERROR_CODE, "Failed to parse identity")
+								.with_reason("Invalid UTF-8 in identity string")
+								.to_error_object()
+						})?
+						.to_string()
+				},
+				_ => {
+					error!("Unexpected identity type for OAuth2: {:?}", verified_identity);
+					return Err(DetailedError::new(
+						INTERNAL_ERROR_CODE,
+						"Failed to extract user identity",
+					)
+					.with_reason("OAuth2 provider returned unsupported identity type")
+					.to_error_object());
+				},
+			};
+
+			Ok::<LoginWithOAuth2Response, ErrorObject>(LoginWithOAuth2Response {
+				user_id,
+				access_token,
+			})
+		})
+		.expect("Failed to register omni_loginWithOAuth2 method");
+}

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
@@ -68,6 +68,9 @@ use submit_user_op_with_auth::*;
 mod user_login;
 use user_login::*;
 
+mod login_with_oauth2;
+use login_with_oauth2::*;
+
 mod get_hyperliquid_signature_data;
 use get_hyperliquid_signature_data::*;
 
@@ -96,6 +99,7 @@ pub fn register_omni<
 	register_get_oauth2_google_authorization_url(module);
 	register_get_web3_sign_in_message(module);
 	register_user_login(module);
+	register_login_with_oauth2(module);
 
 	register_request_jwt(module);
 	register_export_wallet(module);

--- a/tee-worker/omni-executor/rpc-server/src/server.rs
+++ b/tee-worker/omni-executor/rpc-server/src/server.rs
@@ -1,3 +1,4 @@
+use crate::google_oauth2_factory::GoogleOAuth2Factory;
 use crate::mailer_factory::MailerFactory;
 use crate::{
 	methods::register_methods,
@@ -30,9 +31,8 @@ pub(crate) struct RpcContext<
 	pub shielding_key: ShieldingKey,
 	pub storage_db: Arc<StorageDB>,
 	pub mailer_factory: Arc<MailerFactory>,
+	pub google_oauth2_factory: Arc<GoogleOAuth2Factory>,
 	pub jwt_rsa_private_key: Vec<u8>,
-	pub google_client_id: String,
-	pub google_client_secret: String,
 	pub pumpx_api: Arc<Box<dyn PumpxApi>>,
 	// we could save copying client (and other objects) around when P-1527 is done
 	// there could some a single `handler` that wraps up all accessible member variables
@@ -61,9 +61,8 @@ impl<
 		shielding_key: ShieldingKey,
 		storage_db: Arc<StorageDB>,
 		mailer_factory: Arc<MailerFactory>,
+		google_oauth2_factory: Arc<GoogleOAuth2Factory>,
 		jwt_rsa_private_key: Vec<u8>,
-		google_client_id: String,
-		google_client_secret: String,
 		pumpx_api: Arc<Box<dyn PumpxApi>>,
 		signer_client: Arc<Box<dyn SignerClient>>,
 		binance_api_client: Arc<dyn BinancePaymasterApi>,
@@ -82,9 +81,8 @@ impl<
 			shielding_key,
 			storage_db,
 			mailer_factory,
+			google_oauth2_factory,
 			jwt_rsa_private_key,
-			google_client_id,
-			google_client_secret,
 			pumpx_api,
 			signer_client,
 			binance_api_client,
@@ -146,16 +144,16 @@ pub async fn start_server<
 	aes256_key: Aes256Key,
 	entry_point_clients: Arc<HashMap<u64, Arc<EntryPointClient<AlloyRpcProvider>>>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-	// Create mailer factory
-	let mailer_factory = Arc::new(MailerFactory::new(Arc::new(config_loader.clone())));
+	let config_loader_arc = Arc::new(config_loader.clone());
+	let mailer_factory = Arc::new(MailerFactory::new(config_loader_arc.clone()));
+	let google_oauth2_factory = Arc::new(GoogleOAuth2Factory::new(config_loader_arc));
 
 	let ctx = RpcContext::new(
 		shielding_key,
 		storage_db,
 		mailer_factory,
+		google_oauth2_factory,
 		jwt_rsa_private_key.clone(),
-		config_loader.google_client_id.clone(),
-		config_loader.google_client_secret.clone(),
 		pumpx_api,
 		signer_client,
 		binance_api_client,

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -1,8 +1,9 @@
 use crate::server::RpcContext;
 use executor_core::intent_executor::IntentExecutor;
+use executor_crypto::hashing::blake2_256;
 use executor_primitives::{
-	signature::HeimaMultiSignature, utils::hex::ToHexPrefixed, Hashable, Identity, OAuth2Data,
-	OAuth2Provider, OmniAuth, VerificationCode, Web2IdentityType,
+	signature::HeimaMultiSignature, utils::hex::ToHexPrefixed, Hash, Hashable, Identity,
+	OAuth2Data, OAuth2Provider, OmniAuth, VerificationCode, Web2IdentityType,
 };
 use executor_storage::{OAuth2StateVerifierStorage, Storage, StorageDB, VerificationCodeStorage};
 use heima_authentication::{
@@ -12,6 +13,7 @@ use heima_authentication::{
 };
 use heima_identity_verification::web2::google::decode_id_token;
 use oauth_providers::google::GoogleOAuth2Client;
+use parity_scale_codec::Encode;
 use std::{fmt::Display, sync::Arc};
 
 #[derive(Debug, PartialEq)]
@@ -60,8 +62,8 @@ pub async fn verify_auth<
 		OmniAuth::Email(ref client_id, ref email, ref verification_code) => {
 			verify_email_authentication(ctx, client_id, email, verification_code)
 		},
-		OmniAuth::OAuth2(ref sender, ref oauth2_data) => {
-			verify_oauth2_authentication(ctx, sender, oauth2_data).await
+		OmniAuth::OAuth2(ref client_id, ref sender, ref oauth2_data) => {
+			verify_oauth2_authentication(ctx, client_id, sender, oauth2_data).await
 		},
 		OmniAuth::AuthToken(ref auth_token) => verify_auth_token_authentication(
 			&ctx.jwt_rsa_private_key,
@@ -148,11 +150,12 @@ pub async fn verify_oauth2_authentication<
 	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
 >(
 	ctx: Arc<RpcContext<EthereumIntentExecutor, SolanaIntentExecutor, CrossChainIntentExecutor>>,
+	client_id: &str,
 	sender: &Identity,
 	payload: &OAuth2Data,
 ) -> Result<(), AuthenticationError> {
 	match payload.provider {
-		OAuth2Provider::Google => verify_google_oauth2(ctx, sender, payload).await,
+		OAuth2Provider::Google => verify_google_oauth2(ctx, client_id, sender, payload).await,
 	}
 }
 
@@ -162,18 +165,30 @@ async fn verify_google_oauth2<
 	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
 >(
 	ctx: Arc<RpcContext<EthereumIntentExecutor, SolanaIntentExecutor, CrossChainIntentExecutor>>,
+	client_id: &str,
 	sender: &Identity,
 	payload: &OAuth2Data,
 ) -> Result<(), AuthenticationError> {
 	let state_verifier_storage = OAuth2StateVerifierStorage::new(ctx.storage_db.clone());
-	let Ok(Some(state_verifier)) = state_verifier_storage.get(&sender.hash()) else {
+	let key: Hash = blake2_256((client_id, &payload.uid).encode().as_slice()).into();
+	let Ok(Some(stored_state)) = state_verifier_storage.get(&key) else {
 		return Err(AuthenticationError::OAuth2Error("State verifier not found".to_string()));
 	};
-	if state_verifier != payload.state {
+
+	if stored_state != payload.state {
 		return Err(AuthenticationError::OAuth2Error("State verifier mismatch".to_string()));
 	}
+
+	let google_config =
+		ctx.google_oauth2_factory.get_google_config_for_client(client_id).map_err(|e| {
+			AuthenticationError::OAuth2Error(format!(
+				"Failed to get Google OAuth2 config for client '{}': {}",
+				client_id, e
+			))
+		})?;
+
 	let google_client =
-		GoogleOAuth2Client::new(ctx.google_client_id.clone(), ctx.google_client_secret.clone());
+		GoogleOAuth2Client::new(google_config.client_id, google_config.client_secret);
 	let code = payload.code.clone();
 	let redirect_uri = payload.redirect_uri.clone();
 	let token = google_client.exchange_code_for_token(code, redirect_uri).await.map_err(|_| {

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -63,7 +63,13 @@ pub async fn verify_auth<
 			verify_email_authentication(ctx, client_id, email, verification_code)
 		},
 		OmniAuth::OAuth2(ref client_id, ref sender, ref oauth2_data) => {
-			verify_oauth2_authentication(ctx, client_id, sender, oauth2_data).await
+			let verified_identity =
+				verify_oauth2_authentication(ctx, client_id, oauth2_data).await?;
+			if sender.hash() == verified_identity.hash() {
+				Ok(())
+			} else {
+				Err(AuthenticationError::OAuth2Error("Identity mismatch".to_string()))
+			}
 		},
 		OmniAuth::AuthToken(ref auth_token) => verify_auth_token_authentication(
 			&ctx.jwt_rsa_private_key,
@@ -151,11 +157,10 @@ pub async fn verify_oauth2_authentication<
 >(
 	ctx: Arc<RpcContext<EthereumIntentExecutor, SolanaIntentExecutor, CrossChainIntentExecutor>>,
 	client_id: &str,
-	sender: &Identity,
 	payload: &OAuth2Data,
-) -> Result<(), AuthenticationError> {
+) -> Result<Identity, AuthenticationError> {
 	match payload.provider {
-		OAuth2Provider::Google => verify_google_oauth2(ctx, client_id, sender, payload).await,
+		OAuth2Provider::Google => verify_google_oauth2(ctx, client_id, payload).await,
 	}
 }
 
@@ -166,9 +171,8 @@ async fn verify_google_oauth2<
 >(
 	ctx: Arc<RpcContext<EthereumIntentExecutor, SolanaIntentExecutor, CrossChainIntentExecutor>>,
 	client_id: &str,
-	sender: &Identity,
 	payload: &OAuth2Data,
-) -> Result<(), AuthenticationError> {
+) -> Result<Identity, AuthenticationError> {
 	let state_verifier_storage = OAuth2StateVerifierStorage::new(ctx.storage_db.clone());
 	let key: Hash = blake2_256((client_id, &payload.uid).encode().as_slice()).into();
 	let Ok(Some(stored_state)) = state_verifier_storage.get(&key) else {
@@ -198,10 +202,7 @@ async fn verify_google_oauth2<
 		.map_err(|_| AuthenticationError::OAuth2Error("Could not decode id token".to_string()))?;
 	let google_identity = Identity::from_web2_account(&id_token.email, Web2IdentityType::Google);
 
-	match sender.hash() == google_identity.hash() {
-		true => Ok(()),
-		false => Err(AuthenticationError::OAuth2Error("Identity mismatch".to_string())),
-	}
+	Ok(google_identity)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR adds Google OAuth2 authentication support with per-client credential configuration:

- **Client-specific OAuth2 credentials**: Configure separate Google OAuth2 credentials per client via environment variables (`OE_GOOGLE_CLIENT_ID_{CLIENT}`, `OE_GOOGLE_CLIENT_SECRET_{CLIENT}`)
- **GoogleOAuth2Factory**: Factory pattern with caching to retrieve client-specific OAuth2 configurations
- **New RPC method**: `omni_loginWithOAuth2` accepts OAuth2 authorization code and returns user identity + JWT access token
- **Refactored verification**: OAuth2 verification now returns verified `Identity` from provider, enabling identity extraction without re-verification

This new flow will allow clients to create the omni account and add passkeys using the access token after signing in with the oauth2 provider