### PR TITLE
Add cargo groups in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
       - "/parachain"
       - "/tee-worker/omni-executor"
     labels: ["automated-pr"]
+    groups:
+      cargo:
+        patterns:
+          - "*"
     # Handle updates for crates from github.com/paritytech/substrate manually.
     ignore:
       - dependency-name: "substrate-*"


### PR DESCRIPTION
### Context

As topic - try to generate fewer, grouped PRs.
For now we just assume all crates (except for those `ignored`) are good to be grouped together