### PR TITLE
Add more loan record status

### DIFF
--- a/tee-worker/omni-executor/executor-storage/src/lib.rs
+++ b/tee-worker/omni-executor/executor-storage/src/lib.rs
@@ -17,7 +17,7 @@ pub use pumpx_account_profile::PumpxProfileStorage;
 mod wildmeta_timestamp;
 pub use wildmeta_timestamp::WildmetaTimestampStorage;
 pub mod loan_record;
-pub use loan_record::{LoanRecord, LoanRecordStorage};
+pub use loan_record::{LoanRecord, LoanRecordStorage, LoanState};
 
 pub use asset_lock::AssetLockStorage;
 pub use asset_lock::Key as AssetLockStorageKey;

--- a/tee-worker/omni-executor/executor-storage/src/loan_record.rs
+++ b/tee-worker/omni-executor/executor-storage/src/loan_record.rs
@@ -17,8 +17,8 @@ pub struct Key {
 pub enum LoanState {
 	SpotSold,
 	ToPerpMoved,
-	PositionOpened,
-	PositionClosed,
+	HedgeOpened,
+	HedgeClosed,
 	ToSpotMoved,
 	SpotBought,
 }

--- a/tee-worker/omni-executor/executor-storage/src/loan_record.rs
+++ b/tee-worker/omni-executor/executor-storage/src/loan_record.rs
@@ -30,8 +30,17 @@ pub struct LoanRecord {
 	pub usdc_sold: String,
 	pub usdc_loaned: String,
 	pub usdc_for_perp: String,
-	pub spot_sell_cloid: String,
-	pub hedge_open_cloid: String,
+	// contains all tx hashes that the worker submits to interact with corewriter
+	// each tuple is a name -> hash mapping, e.g.:
+	// ("spot_sell", "0x1234...")
+	// we expect 6 hashes for a full loan request and payback cycle in normal cases,
+	// and up to 7 hashes if the hedge were partially filled and need to canceled and closed
+	pub txs: Vec<(String, String)>,
+	// contains all cloids that the worker generate to track the hypercore orders
+	// each tuple is a name -> cloid mapping, e.g.:
+	// ("spot_sell", "173494584")
+	// we expect 4 cloids for a full loan request and payback cycle
+	pub cloids: Vec<(String, String)>,
 	/// Actual position size that was opened for this loan (filled or partially filled)
 	/// This should be set after the hedge order completes in request_loan
 	pub position_size: String,
@@ -45,8 +54,6 @@ pub struct NewLoanRecord {
 	pub usdc_sold: String,
 	pub usdc_loaned: String,
 	pub usdc_for_perp: String,
-	pub spot_sell_cloid: String,
-	pub hedge_open_cloid: String,
 }
 
 pub struct LoanRecordStorage {
@@ -133,8 +140,8 @@ impl LoanRecordStorage {
 			usdc_sold: params.usdc_sold,
 			usdc_loaned: params.usdc_loaned,
 			usdc_for_perp: params.usdc_for_perp,
-			spot_sell_cloid: params.spot_sell_cloid,
-			hedge_open_cloid: params.hedge_open_cloid,
+			txs: Vec::new(),
+			cloids: Vec::new(),
 			position_size: "0".to_string(),
 			state: LoanState::SpotSold,
 		};

--- a/tee-worker/omni-executor/executor-storage/src/loan_record.rs
+++ b/tee-worker/omni-executor/executor-storage/src/loan_record.rs
@@ -13,17 +13,40 @@ pub struct Key {
 	pub nonce: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode, Serialize, Deserialize)]
+pub enum LoanState {
+	SpotSold,
+	ToPerpMoved,
+	PositionOpened,
+	PositionClosed,
+	ToSpotMoved,
+	SpotBought,
+}
+
 #[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize)]
 pub struct LoanRecord {
 	pub collateral_ticker: String,
 	pub collateral_size: String,
 	pub usdc_sold: String,
 	pub usdc_loaned: String,
+	pub usdc_for_perp: String,
 	pub spot_sell_cloid: String,
 	pub hedge_open_cloid: String,
 	/// Actual position size that was opened for this loan (filled or partially filled)
 	/// This should be set after the hedge order completes in request_loan
 	pub position_size: String,
+	pub state: LoanState,
+}
+
+/// Parameters for creating a new loan record
+pub struct NewLoanRecord {
+	pub collateral_ticker: String,
+	pub collateral_size: String,
+	pub usdc_sold: String,
+	pub usdc_loaned: String,
+	pub usdc_for_perp: String,
+	pub spot_sell_cloid: String,
+	pub hedge_open_cloid: String,
 }
 
 pub struct LoanRecordStorage {
@@ -92,6 +115,46 @@ impl LoanRecordStorage {
 		}
 
 		results
+	}
+}
+
+impl LoanRecordStorage {
+	pub fn create(&self, key: &Key, params: NewLoanRecord) -> Result<(), String> {
+		if self.contains_key(key) {
+			return Err(format!(
+				"Key already exists, account_id: {:?}, nonce: {}",
+				key.account_id, key.nonce
+			));
+		}
+
+		let record = LoanRecord {
+			collateral_ticker: params.collateral_ticker,
+			collateral_size: params.collateral_size,
+			usdc_sold: params.usdc_sold,
+			usdc_loaned: params.usdc_loaned,
+			usdc_for_perp: params.usdc_for_perp,
+			spot_sell_cloid: params.spot_sell_cloid,
+			hedge_open_cloid: params.hedge_open_cloid,
+			position_size: "0".to_string(),
+			state: LoanState::SpotSold,
+		};
+
+		self.insert(key, record)
+			.map_err(|e| format!("Failed to insert record: {:?}", e))
+	}
+
+	/// Update loan record using a closure
+	pub fn update<F>(&self, key: &Key, updater: F) -> Result<(), String>
+	where
+		F: FnOnce(&mut LoanRecord),
+	{
+		let mut record = self
+			.get(key)
+			.map_err(|e| format!("Failed to get record: {:?}", e))?
+			.ok_or_else(|| "Record not found".to_string())?;
+		updater(&mut record);
+		self.insert(key, record)
+			.map_err(|e| format!("Failed to insert record: {:?}", e))
 	}
 }
 

--- a/tee-worker/omni-executor/hyperliquid/src/lib.rs
+++ b/tee-worker/omni-executor/hyperliquid/src/lib.rs
@@ -24,6 +24,9 @@ pub const PERP_CLOSE_PRICE_RATIO: f64 = 0.98;
 /// Ratio for spot buy orders (2% above market to ensure fill)
 pub const SPOT_BUY_PRICE_RATIO: f64 = 1.02;
 
+/// Minimum notional value for perp and spot orders ($10 minimum)
+pub const MIN_NOTIONAL_VALUE: f64 = 10.0;
+
 // Unit conversion multipliers
 /// Multiplier for converting decimal prices to HyperLiquid price units (8 decimals)
 pub const PRICE_UNIT_MULTIPLIER: f64 = 100_000_000.0;
@@ -69,6 +72,28 @@ pub fn get_bid_ask_prices(mark_price: f64, mid_price: f64) -> (f64, f64) {
 		// markPx is bid (highest buy)
 		let ask = mid_price * 2.0 - mark_price;
 		(mark_price, ask)
+	}
+}
+
+/// Validate that the notional value (price * size) meets the minimum requirement
+///
+/// # Arguments
+/// * `price` - The price of the asset
+/// * `size` - The size/quantity (should be the clamped size)
+/// * `operation` - Description of the operation for error messages (e.g., "spot sell", "perp open")
+///
+/// # Returns
+/// * `Ok(notional)` - The calculated notional value if it meets the minimum
+/// * `Err(String)` - Error message if notional is below minimum
+pub fn validate_notional_value(price: f64, size: f64, operation: &str) -> Result<f64, String> {
+	let notional = price * size;
+	if notional < MIN_NOTIONAL_VALUE {
+		Err(format!(
+			"{} notional value ({:.2}) is below minimum required ({:.2})",
+			operation, notional, MIN_NOTIONAL_VALUE
+		))
+	} else {
+		Ok(notional)
 	}
 }
 

--- a/tee-worker/omni-executor/hyperliquid/src/utils.rs
+++ b/tee-worker/omni-executor/hyperliquid/src/utils.rs
@@ -121,7 +121,7 @@ pub fn get_perp_asset_id(ticker: &str, meta: &MetaResponse) -> Result<u32, Strin
 /// Calculate the USDC received from a spot sell fill
 /// For a sell order: USDC received = price * size - fee (if fee is in USDC)
 /// Returns the net USDC amount received
-pub fn calculate_usdc_received_from_spot_sell(fill: &Fill) -> Result<f64, String> {
+pub fn usdc_from_spot_fill(fill: &Fill) -> Result<f64, String> {
 	// Parse price and size
 	let price = fill
 		.px

--- a/tee-worker/omni-executor/hyperliquid/src/utils.rs
+++ b/tee-worker/omni-executor/hyperliquid/src/utils.rs
@@ -155,7 +155,7 @@ pub fn usdc_from_spot_fill(fill: &Fill) -> Result<f64, String> {
 	};
 
 	debug!(
-		"Spot sell fill: price={}, size={}, fee={} {}, gross_usdc={:.2}, net_usdc={:.2}",
+		"Spot sell fill: price={}, size={}, fee={} {}, gross_usdc={}, net_usdc={}",
 		price, size, fee, fill.fee_token, gross_usdc, net_usdc
 	);
 
@@ -272,7 +272,7 @@ pub fn clamp_price(price: f64, sz_decimals: u8, is_spot: bool) -> String {
 ///
 /// Size rules:
 /// - Sizes are truncated (rounded down) to the sz_decimals of the asset
-/// - Example: if sz_decimals = 3, then 1.001 is valid but 1.0001 truncates to 1.001
+/// - Example: if sz_decimals = 3, then 1.001 is valid but 1.0001 truncates to 1.000
 ///
 /// # Arguments
 /// * `size` - The size to clamp

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/close_position_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/close_position_test.rs
@@ -19,7 +19,6 @@ pub struct ClosePositionTestParams {
 	pub chain_id: ChainId,
 	pub wallet_index: u32,
 	pub omni_account: String,
-	pub client_id: String,
 	pub ticker: Option<String>, // If None, close all positions
 }
 
@@ -198,7 +197,6 @@ pub fn register_close_position_test<
 					params.chain_id,
 					params.wallet_index,
 					close_calldata,
-					&params.client_id,
 				)
 				.await?;
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/close_position_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/close_position_test.rs
@@ -24,11 +24,11 @@ pub struct ClosePositionTestParams {
 
 #[derive(Serialize, Clone)]
 pub struct ClosePositionTestResponse {
-	pub positions_closed: Vec<PositionClosed>,
+	pub positions_closed: Vec<HedgeClosed>,
 }
 
 #[derive(Serialize, Clone)]
-pub struct PositionClosed {
+pub struct HedgeClosed {
 	pub ticker: String,
 	pub cloid: String,
 	pub size: String,
@@ -233,7 +233,7 @@ pub fn register_close_position_test<
 
 				info!("Position closed successfully for {}", ticker);
 
-				positions_closed.push(PositionClosed {
+				positions_closed.push(HedgeClosed {
 					ticker: ticker.to_string(),
 					cloid: close_cloid.to_string(),
 					size: clamped_close_size.to_string(),

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/close_position_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/close_position_test.rs
@@ -1,0 +1,268 @@
+use crate::detailed_error::DetailedError;
+use crate::error_code::{INTERNAL_ERROR_CODE, INVALID_CHAIN_ID_CODE, PARSE_ERROR_CODE};
+use crate::methods::omni::PumpxRpcError;
+use crate::server::RpcContext;
+use crate::utils::omni::to_omni_account;
+use crate::utils::user_op::submit_corewriter_userop;
+use executor_core::intent_executor::IntentExecutor;
+use executor_core::types::SerializablePackedUserOperation;
+use executor_primitives::ChainId;
+use hyperliquid::*;
+use jsonrpsee::RpcModule;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info};
+
+#[derive(Debug, Deserialize)]
+pub struct ClosePositionTestParams {
+	pub sender: String,
+	pub nonce: u128,
+	pub chain_id: ChainId,
+	pub wallet_index: u32,
+	pub omni_account: String,
+	pub client_id: String,
+	pub ticker: Option<String>, // If None, close all positions
+}
+
+#[derive(Serialize, Clone)]
+pub struct ClosePositionTestResponse {
+	pub positions_closed: Vec<PositionClosed>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct PositionClosed {
+	pub ticker: String,
+	pub cloid: String,
+	pub size: String,
+	pub tx_hash: Option<String>,
+}
+
+pub fn register_close_position_test<
+	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
+>(
+	module: &mut RpcModule<RpcContext<CrossChainIntentExecutor>>,
+) {
+	module
+		.register_async_method("omni_closePositionTest", |params, ctx, _ext| async move {
+			let params = params.parse::<ClosePositionTestParams>().map_err(|e| {
+				error!("Failed to parse params: {:?}", e);
+				PumpxRpcError::from(
+					DetailedError::new(PARSE_ERROR_CODE, "Parse error")
+						.with_reason("Invalid JSON format or missing required fields"),
+				)
+			})?;
+
+			debug!("Received omni_closePositionTest, params: {:?}", params);
+
+			let omni_account = to_omni_account(&params.omni_account).map_err(|_| {
+				error!("Failed to parse omni account");
+				PumpxRpcError::from(DetailedError::new(
+					PARSE_ERROR_CODE,
+					"Failed to parse omni account",
+				))
+			})?;
+
+			let smart_wallet = &params.sender;
+
+			let hypercore_client = HyperCoreClient::new(params.chain_id).map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INVALID_CHAIN_ID_CODE, "Chain not supported").with_reason(e),
+				)
+			})?;
+
+			hypercore_client.print_account_state(smart_wallet, "Before Close Position").await;
+
+			// Get current positions
+			let perp_state =
+				hypercore_client.get_perp_clearinghouse_state(smart_wallet).await.map_err(|e| {
+					error!("Failed to get perp state: {}", e);
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Failed to query perp state: {}", e)),
+					)
+				})?;
+
+			// Filter positions based on ticker parameter
+			let positions_to_close: Vec<_> = perp_state
+				.asset_positions
+				.iter()
+				.filter(|pos| {
+					let position_size = pos.position.szi.parse::<f64>().unwrap_or(0.0);
+					if position_size == 0.0 {
+						return false;
+					}
+					match &params.ticker {
+						Some(ticker) => pos.position.coin.eq_ignore_ascii_case(ticker),
+						None => true, // Close all positions
+					}
+				})
+				.collect();
+
+			if positions_to_close.is_empty() {
+				info!("No positions to close");
+				return Ok(ClosePositionTestResponse { positions_closed: vec![] });
+			}
+
+			info!("Found {} position(s) to close", positions_to_close.len());
+
+			let mut positions_closed = Vec::new();
+			let mut current_nonce = params.nonce;
+
+			for pos in positions_to_close {
+				let ticker = &pos.position.coin;
+				let position_size = pos.position.szi.parse::<f64>().map_err(|e| {
+					error!("Failed to parse position size for {}: {}", ticker, e);
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Failed to parse position size: {}", e)),
+					)
+				})?;
+
+				info!("Closing position for {}: size={}", ticker, position_size);
+
+				// Get perp market data
+				let (perp_meta, perp_mark_price, perp_mid_price) =
+					hypercore_client.get_perp_market_prices(ticker).await.map_err(|e| {
+						error!("Failed to get perp market prices for {}: {}", ticker, e);
+						PumpxRpcError::from(
+							DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+								.with_reason(format!("Failed to get perp market prices: {}", e)),
+						)
+					})?;
+
+				let perp_asset_id = get_perp_asset_id(ticker, &perp_meta).map_err(|e| {
+					error!("Failed to get perp asset ID: {}", e);
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
+					)
+				})?;
+
+				let perp_asset = perp_meta.universe.get(perp_asset_id as usize).ok_or_else(|| {
+					error!("Perp asset {} not found in meta", perp_asset_id);
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Perp asset {} not found", perp_asset_id)),
+					)
+				})?;
+
+				let perp_sz_decimals = perp_asset.sz_decimals;
+
+				// For closing long position (selling), we want to sell at the highest buy price (bid)
+				let close_size_abs = position_size.abs();
+				let clamped_close_size = clamp_size(close_size_abs, perp_sz_decimals);
+				let (perp_bid_price, _perp_ask_price) =
+					get_bid_ask_prices(perp_mark_price, perp_mid_price);
+				let target_close_price = perp_bid_price * PERP_CLOSE_PRICE_RATIO;
+				let clamped_close_price = clamp_price(target_close_price, perp_sz_decimals, false);
+
+				info!(
+					"Perp close pricing for {} - markPx: {}, midPx: {}, bid (highest buy): {}, target (with {}x buffer): {}, clamped: {}",
+					ticker, perp_mark_price, perp_mid_price, perp_bid_price, PERP_CLOSE_PRICE_RATIO, target_close_price, clamped_close_price
+				);
+
+				let clamped_close_size_f64 = clamped_close_size.parse::<f64>().map_err(|e| {
+					error!("Failed to parse clamped close size: {}", e);
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Failed to parse clamped close size: {}", e)),
+					)
+				})?;
+				let clamped_close_price_f64 = clamped_close_price.parse::<f64>().map_err(|e| {
+					error!("Failed to parse clamped close price: {}", e);
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Failed to parse clamped close price: {}", e)),
+					)
+				})?;
+
+				let close_size_units = to_price_units(clamped_close_size_f64);
+				let close_price_units = to_price_units(clamped_close_price_f64);
+
+				let close_cloid = generate_cloid();
+
+				let close_action = build_perp_close_order(
+					perp_asset_id,
+					close_size_units,
+					close_price_units,
+					close_cloid,
+				);
+
+				let close_calldata = encode_omni_account_execute(
+					get_core_writer_address(),
+					encode_send_raw_action(close_action),
+				);
+
+				let close_tx_hash = submit_corewriter_userop(
+					ctx.clone(),
+					&omni_account,
+					&generate_userop(smart_wallet, current_nonce),
+					params.chain_id,
+					params.wallet_index,
+					close_calldata,
+					&params.client_id,
+				)
+				.await?;
+
+				info!(
+					"Close order submitted for {}: price={}, size={}, tx={:?}",
+					ticker, clamped_close_price_f64, clamped_close_size_f64, close_tx_hash
+				);
+
+				current_nonce += 1;
+
+				let order_filled = hypercore_client
+					.wait_for_order(
+						smart_wallet,
+						&close_cloid.to_string(),
+						30,
+						OrderWaitCondition::Filled,
+					)
+					.await
+					.map_err(|e| {
+						error!("Close order did not complete for {}: {}", ticker, e);
+						PumpxRpcError::from(
+							DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+								.with_reason(format!("Close order failed: {}", e)),
+						)
+					})?;
+
+				if !order_filled {
+					error!("Close order was rejected or canceled for {}", ticker);
+					return Err(PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Close order was rejected or canceled for {}", ticker)),
+					));
+				}
+
+				info!("Position closed successfully for {}", ticker);
+
+				positions_closed.push(PositionClosed {
+					ticker: ticker.to_string(),
+					cloid: close_cloid.to_string(),
+					size: clamped_close_size.to_string(),
+					tx_hash: close_tx_hash,
+				});
+			}
+
+			hypercore_client.print_account_state(smart_wallet, "After Close Position").await;
+
+			Ok(ClosePositionTestResponse { positions_closed })
+		})
+		.expect("Failed to register omni_closePositionTest method");
+}
+
+fn generate_userop(sender: &str, nonce: u128) -> SerializablePackedUserOperation {
+	SerializablePackedUserOperation {
+		sender: sender.to_string(),
+		nonce,
+		init_code: "0x".to_string(),
+		call_data: "0x".to_string(),
+		account_gas_limits: "0x000000000000000000000000000f4240000000000000000000000000000186a0"
+			.to_string(),
+		pre_verification_gas: 100000,
+		gas_fees: "0x0000000000000000000000000000000000000000000000000000000007270e00".to_string(),
+		paymaster_and_data:
+			"0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912000000000000000000000000000f4240000000000000000000000000000186a0"
+				.to_string(),
+		signature: None,
+	}
+}

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
@@ -104,6 +104,11 @@ mod open_position_test;
 #[cfg(feature = "test-endpoints")]
 use open_position_test::*;
 
+#[cfg(feature = "test-endpoints")]
+mod close_position_test;
+#[cfg(feature = "test-endpoints")]
+use close_position_test::*;
+
 pub fn register_omni<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
 	module: &mut RpcModule<RpcContext<CrossChainIntentExecutor>>,
 ) {
@@ -151,4 +156,7 @@ pub fn register_omni<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 's
 
 	#[cfg(feature = "test-endpoints")]
 	register_open_position_test(module);
+
+	#[cfg(feature = "test-endpoints")]
+	register_close_position_test(module);
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
@@ -99,6 +99,11 @@ mod payback_loan_test;
 #[cfg(feature = "test-endpoints")]
 use payback_loan_test::*;
 
+#[cfg(feature = "test-endpoints")]
+mod open_position_test;
+#[cfg(feature = "test-endpoints")]
+use open_position_test::*;
+
 pub fn register_omni<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
 	module: &mut RpcModule<RpcContext<CrossChainIntentExecutor>>,
 ) {
@@ -143,4 +148,7 @@ pub fn register_omni<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 's
 
 	#[cfg(feature = "test-endpoints")]
 	register_payback_loan_test(module);
+
+	#[cfg(feature = "test-endpoints")]
+	register_open_position_test(module);
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/open_position_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/open_position_test.rs
@@ -1,0 +1,209 @@
+use crate::detailed_error::DetailedError;
+use crate::error_code::{INTERNAL_ERROR_CODE, INVALID_CHAIN_ID_CODE, PARSE_ERROR_CODE};
+use crate::methods::omni::PumpxRpcError;
+use crate::server::RpcContext;
+use crate::utils::omni::to_omni_account;
+use crate::utils::user_op::submit_corewriter_userop;
+use executor_core::intent_executor::IntentExecutor;
+use executor_core::types::SerializablePackedUserOperation;
+use executor_primitives::ChainId;
+use hyperliquid::*;
+use jsonrpsee::RpcModule;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info};
+
+#[derive(Debug, Deserialize)]
+pub struct OpenPositionTestParams {
+	pub sender: String,
+	pub nonce: u128,
+	pub chain_id: ChainId,
+	pub wallet_index: u32,
+	pub omni_account: String,
+	pub client_id: String,
+	pub collateral_ticker: String,
+	pub position_size: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct OpenPositionTestResponse {
+	pub cloid: String,
+	pub tx_hash: Option<String>,
+}
+
+pub fn register_open_position_test<
+	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
+>(
+	module: &mut RpcModule<RpcContext<CrossChainIntentExecutor>>,
+) {
+	module
+		.register_async_method("omni_openPositionTest", |params, ctx, _ext| async move {
+			let params = params.parse::<OpenPositionTestParams>().map_err(|e| {
+				error!("Failed to parse params: {:?}", e);
+				PumpxRpcError::from(
+					DetailedError::new(PARSE_ERROR_CODE, "Parse error")
+						.with_reason("Invalid JSON format or missing required fields"),
+				)
+			})?;
+
+			debug!("Received omni_openPositionTest, params: {:?}", params);
+
+			let omni_account = to_omni_account(&params.omni_account).map_err(|_| {
+				error!("Failed to parse omni account");
+				PumpxRpcError::from(DetailedError::new(
+					PARSE_ERROR_CODE,
+					"Failed to parse omni account",
+				))
+			})?;
+
+			let smart_wallet = &params.sender;
+			let collateral_ticker = &params.collateral_ticker;
+
+			let hypercore_client = HyperCoreClient::new(params.chain_id).map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INVALID_CHAIN_ID_CODE, "Chain not supported").with_reason(e),
+				)
+			})?;
+
+			let (perp_meta, perp_mark_price, perp_mid_price) =
+				hypercore_client.get_perp_market_prices(collateral_ticker).await.map_err(|e| {
+					error!("Failed to get perp market prices for {}: {}", collateral_ticker, e);
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Failed to get perp market prices: {}", e)),
+					)
+				})?;
+
+			let perp_asset_id = get_perp_asset_id(collateral_ticker, &perp_meta).map_err(|e| {
+				error!("Failed to get perp asset ID: {}", e);
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
+				)
+			})?;
+
+			let perp_asset = perp_meta.universe.get(perp_asset_id as usize).ok_or_else(|| {
+				error!("Perp asset {} not found in meta", perp_asset_id);
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+						.with_reason(format!("Perp asset {} not found", perp_asset_id)),
+				)
+			})?;
+
+			let perp_sz_decimals = perp_asset.sz_decimals;
+
+			let (_, perp_ask_price) = get_bid_ask_prices(perp_mark_price, perp_mid_price);
+			let target_hedge_price = perp_ask_price * PERP_ENTRY_PRICE_RATIO;
+			let hedge_size = params.position_size.parse::<f64>().unwrap();
+
+			let clamped_hedge_size = clamp_size(hedge_size, perp_sz_decimals);
+			let clamped_hedge_price = clamp_price(target_hedge_price, perp_sz_decimals, false);
+
+			let clamped_hedge_size_f64 = clamped_hedge_size.parse::<f64>().map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+						.with_reason(format!("Failed to parse clamped hedge size: {}", e)),
+				)
+			})?;
+			let clamped_hedge_price_f64 = clamped_hedge_price.parse::<f64>().map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+						.with_reason(format!("Failed to parse clamped hedge price: {}", e)),
+				)
+			})?;
+
+			let cloid = generate_cloid();
+
+			let hedge_action = build_perp_long_order(
+				perp_asset_id,
+				to_price_units(clamped_hedge_size_f64),
+				to_price_units(clamped_hedge_price_f64),
+				cloid,
+			);
+
+			let hedge_open_tx_hash = submit_corewriter_userop(
+				ctx.clone(),
+				&omni_account,
+				&generate_userop(smart_wallet, params.nonce),
+				params.chain_id,
+				params.wallet_index,
+				encode_omni_account_execute(
+					get_core_writer_address(),
+					encode_send_raw_action(hedge_action),
+				),
+				&params.client_id,
+			)
+			.await?;
+
+			info!(
+				"Hedge position submitted: price={}, size={}, tx={:?}",
+				clamped_hedge_price_f64, clamped_hedge_size_f64, hedge_open_tx_hash
+			);
+
+			let order_opened = hypercore_client
+				.wait_for_order(smart_wallet, &cloid.to_string(), 20, OrderWaitCondition::Opened)
+				.await
+				.map_err(|e| {
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Hedge order failed to open: {}", e)),
+					)
+				})?;
+
+			if !order_opened {
+				return Err(PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+						.with_reason("Hedge order was rejected or canceled"),
+				));
+			}
+
+			let perp_state =
+				hypercore_client.get_perp_clearinghouse_state(smart_wallet).await.map_err(|e| {
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason(format!("Failed to query perp state: {}", e)),
+					)
+				})?;
+
+			let hedge_position = perp_state
+				.asset_positions
+				.iter()
+				.find(|pos| pos.position.coin.eq_ignore_ascii_case(collateral_ticker))
+				.ok_or_else(|| {
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Position not found").with_reason(
+							format!(
+								"Position for {} not found after hedge order opened",
+								collateral_ticker
+							),
+						),
+					)
+				})?;
+
+			let actual_position_size = hedge_position.position.szi.parse::<f64>().map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+						.with_reason(format!("Invalid position size: {}", e)),
+				)
+			})?;
+
+			info!("Hedge position opened: actual size={}", actual_position_size);
+
+			hypercore_client.print_account_state(smart_wallet, "After Open Position").await;
+
+			Ok(OpenPositionTestResponse { cloid: cloid.to_string(), tx_hash: hedge_open_tx_hash })
+		})
+		.expect("Failed to register omni_requestLoanTest method");
+}
+
+fn generate_userop(sender: &str, nonce: u128) -> SerializablePackedUserOperation {
+	SerializablePackedUserOperation {
+			sender: sender.to_string(),
+			nonce,
+	 init_code: "0x".to_string(),
+	 call_data: "0x".to_string(),
+	 account_gas_limits: "0x000000000000000000000000000f4240000000000000000000000000000186a0".to_string(),
+	 pre_verification_gas: 100000,
+	 gas_fees: "0x0000000000000000000000000000000000000000000000000000000007270e00".to_string(),
+	 paymaster_and_data: "0x6255B9F4A4E80BC20eE389fD35DE9d2c029D5912000000000000000000000000000f4240000000000000000000000000000186a0".to_string(),
+	 signature: None,
+	}
+}

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/open_position_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/open_position_test.rs
@@ -19,7 +19,6 @@ pub struct OpenPositionTestParams {
 	pub chain_id: ChainId,
 	pub wallet_index: u32,
 	pub omni_account: String,
-	pub client_id: String,
 	pub ticker: String,
 	pub position_size: String,
 }
@@ -129,7 +128,6 @@ pub fn register_open_position_test<
 					get_core_writer_address(),
 					encode_send_raw_action(hedge_action),
 				),
-				&params.client_id,
 			)
 			.await?;
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/open_position_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/open_position_test.rs
@@ -155,35 +155,6 @@ pub fn register_open_position_test<
 				));
 			}
 
-			let perp_state =
-				hypercore_client.get_perp_clearinghouse_state(smart_wallet).await.map_err(|e| {
-					PumpxRpcError::from(
-						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-							.with_reason(format!("Failed to query perp state: {}", e)),
-					)
-				})?;
-
-			let hedge_position = perp_state
-				.asset_positions
-				.iter()
-				.find(|pos| pos.position.coin.eq_ignore_ascii_case(ticker))
-				.ok_or_else(|| {
-					PumpxRpcError::from(
-						DetailedError::new(INTERNAL_ERROR_CODE, "Position not found").with_reason(
-							format!("Position for {} not found after hedge order opened", ticker),
-						),
-					)
-				})?;
-
-			let actual_position_size = hedge_position.position.szi.parse::<f64>().map_err(|e| {
-				PumpxRpcError::from(
-					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-						.with_reason(format!("Invalid position size: {}", e)),
-				)
-			})?;
-
-			info!("Hedge position opened: actual size={}", actual_position_size);
-
 			hypercore_client.print_account_state(smart_wallet, "After Open Position").await;
 
 			Ok(OpenPositionTestResponse { cloid: cloid.to_string(), tx_hash: hedge_open_tx_hash })

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/open_position_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/open_position_test.rs
@@ -20,7 +20,7 @@ pub struct OpenPositionTestParams {
 	pub wallet_index: u32,
 	pub omni_account: String,
 	pub client_id: String,
-	pub collateral_ticker: String,
+	pub ticker: String,
 	pub position_size: String,
 }
 
@@ -56,7 +56,7 @@ pub fn register_open_position_test<
 			})?;
 
 			let smart_wallet = &params.sender;
-			let collateral_ticker = &params.collateral_ticker;
+			let ticker = &params.ticker;
 
 			let hypercore_client = HyperCoreClient::new(params.chain_id).map_err(|e| {
 				PumpxRpcError::from(
@@ -65,15 +65,15 @@ pub fn register_open_position_test<
 			})?;
 
 			let (perp_meta, perp_mark_price, perp_mid_price) =
-				hypercore_client.get_perp_market_prices(collateral_ticker).await.map_err(|e| {
-					error!("Failed to get perp market prices for {}: {}", collateral_ticker, e);
+				hypercore_client.get_perp_market_prices(ticker).await.map_err(|e| {
+					error!("Failed to get perp market prices for {}: {}", ticker, e);
 					PumpxRpcError::from(
 						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 							.with_reason(format!("Failed to get perp market prices: {}", e)),
 					)
 				})?;
 
-			let perp_asset_id = get_perp_asset_id(collateral_ticker, &perp_meta).map_err(|e| {
+			let perp_asset_id = get_perp_asset_id(ticker, &perp_meta).map_err(|e| {
 				error!("Failed to get perp asset ID: {}", e);
 				PumpxRpcError::from(
 					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
@@ -166,14 +166,11 @@ pub fn register_open_position_test<
 			let hedge_position = perp_state
 				.asset_positions
 				.iter()
-				.find(|pos| pos.position.coin.eq_ignore_ascii_case(collateral_ticker))
+				.find(|pos| pos.position.coin.eq_ignore_ascii_case(ticker))
 				.ok_or_else(|| {
 					PumpxRpcError::from(
 						DetailedError::new(INTERNAL_ERROR_CODE, "Position not found").with_reason(
-							format!(
-								"Position for {} not found after hedge order opened",
-								collateral_ticker
-							),
+							format!("Position for {} not found after hedge order opened", ticker),
 						),
 					)
 				})?;

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -816,10 +816,10 @@ async fn precheck_move_to_spot(
 			));
 		}
 
-		let final_amount = calculated_amount.min(withdrawable_usdc);
+		let final_amount = calculated_amount.min(withdrawable_usdc + margin_used);
 		info!(
-			"✓ Transfer amount validation passed: {} <= {} (max transferable), using {}",
-			calculated_amount, max_transferable, final_amount
+			"final_amount={}, withdrawable_usdc={}, margin_used={}, stored_withdrawable={}",
+			final_amount, withdrawable_usdc, margin_used, stored_withdrawable
 		);
 
 		final_amount
@@ -1093,7 +1093,33 @@ async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 			)
 		})?;
 
-	let transfer_amount_units = to_usdc_units(move_ctx.transfer_amount);
+	let perp_state = exec_ctx
+		.hypercore_client
+		.get_perp_clearinghouse_state(exec_ctx.smart_wallet)
+		.await
+		.map_err(|e| {
+			error!("Failed to get perp state: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to query perp state: {}", e)),
+			)
+		})?;
+
+	let withdrawable_usdc = perp_state.withdrawable.parse::<f64>().map_err(|e| {
+		error!("Failed to parse withdrawable USDC: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Failed to parse withdrawable USDC: {}", e)),
+		)
+	})?;
+
+	let final_amount = move_ctx.transfer_amount.min(withdrawable_usdc);
+	info!(
+		"Calculated transfer_amount={}, withdrawable_usdc={}, final_amount={}",
+		move_ctx.transfer_amount, withdrawable_usdc, final_amount
+	);
+
+	let transfer_amount_units = to_usdc_units(final_amount);
 	let transfer_action = build_usd_class_transfer_to_spot(transfer_amount_units);
 	let transfer_calldata = encode_omni_account_execute(
 		get_core_writer_address(),
@@ -1111,10 +1137,7 @@ async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 	.await?;
 	*current_nonce += 1;
 
-	info!(
-		"to_spot_move submitted, size: {}, tx_hash: {:?}",
-		move_ctx.transfer_amount, to_spot_move_tx_hash
-	);
+	info!("to_spot_move submitted, size: {}, tx_hash: {:?}", final_amount, to_spot_move_tx_hash);
 
 	exec_ctx
 		.hypercore_client
@@ -1122,7 +1145,7 @@ async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 			exec_ctx.smart_wallet,
 			"USDC",
 			initial_spot_usdc,
-			move_ctx.transfer_amount,
+			final_amount,
 			30,
 		)
 		.await

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -151,24 +151,6 @@ pub fn register_payback_loan_test<
 						.with_reason(format!("Invalid usdc_loaned: {}", e)),
 				)
 			})?;
-			let hedge_open_cloid_str = loan_record
-				.cloids
-				.iter()
-				.find(|(name, _)| name == "hedge_open")
-				.map(|(_, cloid)| cloid.clone())
-				.ok_or_else(|| {
-					error!("hedge_open cloid not found in loan record");
-					PumpxRpcError::from(
-						DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
-							.with_reason("hedge_open cloid not found in loan_record"),
-					)
-				})?;
-			let hedge_open_cloid = hedge_open_cloid_str.parse::<u128>().map_err(|e| {
-				PumpxRpcError::from(
-					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
-						.with_reason(format!("Invalid hedge_open_cloid: {}", e)),
-				)
-			})?;
 
 			let exec_ctx = ExecutionContext {
 				ctx: ctx.clone(),
@@ -185,6 +167,25 @@ pub fn register_payback_loan_test<
 			match loan_record.state {
 				LoanState::HedgeOpened => {
 					info!("Starting payback from HedgeOpened state");
+
+					let hedge_open_cloid_str = loan_record
+						.cloids
+						.iter()
+						.find(|(name, _)| name == "hedge_open")
+						.map(|(_, cloid)| cloid.clone())
+						.ok_or_else(|| {
+							error!("hedge_open cloid not found in loan record");
+							PumpxRpcError::from(
+								DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+									.with_reason("hedge_open cloid not found in loan_record"),
+							)
+						})?;
+					let hedge_open_cloid = hedge_open_cloid_str.parse::<u128>().map_err(|e| {
+						PumpxRpcError::from(
+							DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+								.with_reason(format!("Invalid hedge_open_cloid: {}", e)),
+						)
+					})?;
 
 					let close_ctx = precheck_close_hedge(
 						&ctx,
@@ -229,8 +230,8 @@ pub fn register_payback_loan_test<
 						spot_buy_tx_hash,
 					})
 				},
-				LoanState::HedgeClosed => {
-					info!("Resuming from HedgeClosed state");
+				LoanState::HedgeClosed | LoanState::ToPerpMoved => {
+					info!("Resuming from HedgeClosed or ToPerpMoved state");
 
 					let move_ctx = precheck_move_to_spot(
 						&hypercore_client,
@@ -260,8 +261,8 @@ pub fn register_payback_loan_test<
 						spot_buy_tx_hash,
 					})
 				},
-				LoanState::ToSpotMoved => {
-					info!("Resuming from ToSpotMoved state");
+				LoanState::ToSpotMoved | LoanState::SpotSold => {
+					info!("Resuming from ToSpotMoved or SpotSold state");
 
 					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
 
@@ -286,11 +287,6 @@ pub fn register_payback_loan_test<
 						"Payback already completed",
 					)))
 				},
-				_ => Err(PumpxRpcError::from(
-					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid loan state").with_reason(
-						format!("Cannot payback loan from state: {:?}", loan_record.state),
-					),
-				)),
 			}
 		})
 		.expect("Failed to register omni_paybackLoanTest method");

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -207,7 +207,9 @@ pub fn register_payback_loan_test<
 					)
 					.await?;
 
-					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
+					let buy_ctx =
+						precheck_buy_spot(&hypercore_client, &collateral_ticker, collateral_size)
+							.await?;
 
 					let (hedge_cancel_tx_hash, hedge_close_cloid_opt, hedge_close_tx_hash) =
 						do_close_hedge(&exec_ctx, hedge_open_cloid, &close_ctx, &mut current_nonce)
@@ -242,7 +244,9 @@ pub fn register_payback_loan_test<
 					)
 					.await?;
 
-					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
+					let buy_ctx =
+						precheck_buy_spot(&hypercore_client, &collateral_ticker, collateral_size)
+							.await?;
 
 					let to_spot_move_tx_hash =
 						do_move_to_spot(&exec_ctx, &move_ctx, &mut current_nonce).await?;
@@ -264,7 +268,9 @@ pub fn register_payback_loan_test<
 				LoanState::ToSpotMoved | LoanState::SpotSold => {
 					info!("Resuming from ToSpotMoved or SpotSold state");
 
-					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
+					let buy_ctx =
+						precheck_buy_spot(&hypercore_client, &collateral_ticker, collateral_size)
+							.await?;
 
 					let (spot_buy_cloid, spot_buy_tx_hash) =
 						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx, current_nonce).await?;
@@ -714,6 +720,27 @@ async fn precheck_close_hedge<CrossChainIntentExecutor: IntentExecutor + Send + 
 		));
 	};
 
+	// Validate notional value if closing position
+	if should_close && position_size_to_close > 0.0 {
+		let clamped_size = clamp_size(position_size_to_close, perp_sz_decimals);
+		let clamped_size_f64 = clamped_size.parse::<f64>().map_err(|e| {
+			error!("Failed to parse clamped close size: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to parse clamped close size: {}", e)),
+			)
+		})?;
+
+		// For closing long position (selling), we want to sell at the highest buy price (bid)
+		let (perp_bid_price, _) = get_bid_ask_prices(perp_mark_price, perp_mid_price);
+		validate_notional_value(perp_bid_price, clamped_size_f64, "Perp close").map_err(|e| {
+			error!("{}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Notional value too low").with_reason(e),
+			)
+		})?;
+	}
+
 	info!("✓ Close position precheck passed");
 
 	Ok(CloseHedgeContext {
@@ -809,6 +836,7 @@ async fn precheck_move_to_spot(
 async fn precheck_buy_spot(
 	hypercore_client: &HyperCoreClient,
 	collateral_ticker: &str,
+	collateral_size: f64,
 ) -> Result<BuySpotContext, PumpxRpcError> {
 	let (spot_meta, spot_mark_price, spot_mid_price) =
 		hypercore_client.get_spot_market_prices(collateral_ticker).await.map_err(|e| {
@@ -839,6 +867,25 @@ async fn precheck_buy_spot(
 		})?;
 
 	let spot_sz_decimals = spot_token.sz_decimals;
+
+	// Validate notional value with clamped size
+	let clamped_size = clamp_size(collateral_size, spot_sz_decimals);
+	let clamped_size_f64 = clamped_size.parse::<f64>().map_err(|e| {
+		error!("Failed to parse clamped buy size: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Failed to parse clamped buy size: {}", e)),
+		)
+	})?;
+
+	// For buying, we want to buy at the lowest sell price (ask)
+	let (_, spot_ask_price) = get_bid_ask_prices(spot_mark_price, spot_mid_price);
+	validate_notional_value(spot_ask_price, clamped_size_f64, "Spot buy").map_err(|e| {
+		error!("{}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Notional value too low").with_reason(e),
+		)
+	})?;
 
 	info!("✓ Buy spot precheck passed");
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -268,17 +268,11 @@ pub fn register_payback_loan_test<
 					})
 				},
 				LoanState::SpotBought => {
-					info!("Payback already completed");
-					Ok(PaybackLoanTestResponse {
-						collateral_ticker,
-						collateral_size: collateral_size.to_string(),
-						hedge_cancel_tx_hash: None,
-						hedge_close_cloid: None,
-						hedge_close_tx_hash: None,
-						usd_transfer_tx_hash: None,
-						spot_buy_cloid: None,
-						spot_buy_tx_hash: None,
-					})
+					error!("Payback already completed");
+					Err(PumpxRpcError::from(DetailedError::new(
+						INTERNAL_ERROR_CODE,
+						"Payback already completed",
+					)))
 				},
 				_ => Err(PumpxRpcError::from(
 					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid loan state").with_reason(

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -7,25 +7,45 @@ use crate::utils::user_op::{prepare_skeleton_with_nonce, submit_corewriter_usero
 use executor_core::intent_executor::IntentExecutor;
 use executor_core::types::SerializablePackedUserOperation;
 use executor_primitives::AccountId;
-use executor_storage::Storage;
+use executor_storage::{LoanState, Storage};
 use hyperliquid::*;
 use jsonrpsee::RpcModule;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, error, info};
 
-/// Result of payback loan validation, containing loan details and action plan
-struct PaybackLoanValidationResult {
-	collateral_ticker: String,
-	collateral_size: f64,
-	usdc_sold: f64,
-	usdc_loaned: f64,
-	hedge_open_cloid: u128,
+struct ExecutionContext<'a, CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static> {
+	ctx: Arc<RpcContext<CrossChainIntentExecutor>>,
+	omni_account: &'a AccountId,
+	skeleton_user_op: &'a SerializablePackedUserOperation,
+	chain_id: u64,
+	wallet_index: u32,
+	hypercore_client: &'a HyperCoreClient,
+	smart_wallet: &'a str,
+	storage_key: &'a executor_storage::loan_record::Key,
+}
+
+struct ClosePositionContext {
 	should_cancel: bool,
 	should_close: bool,
 	position_size_to_close: f64,
 	/// Position data: (unrealized_pnl, cum_funding_all_time, margin_used, position_value, withdrawable)
 	position_data: Option<(f64, f64, f64, f64, f64)>,
+	perp_asset_id: u32,
+	perp_sz_decimals: u8,
+	perp_mark_price: f64,
+	perp_mid_price: f64,
+}
+
+struct MoveToSpotContext {
+	transfer_amount: f64,
+}
+
+struct BuySpotContext {
+	spot_asset_id: u32,
+	spot_sz_decimals: u8,
+	spot_mark_price: f64,
+	spot_mid_price: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -71,46 +91,208 @@ pub fn register_payback_loan_test<
 
 			debug!("Received omni_paybackLoanTest, params: {:?}", params);
 
-			let omni_account = to_omni_account(&params.omni_account).map_err(|_| {
-				error!("Failed to parse omni account");
-				PumpxRpcError::from(DetailedError::new(
-					PARSE_ERROR_CODE,
-					"Failed to parse omni account",
-				))
+			let (omni_account, loan_nonce, min_expected_account_value_f64) =
+				precheck_params(&params)?;
+
+			let ctx = Arc::clone(&ctx);
+			let smart_wallet = &params.user_operation.sender;
+			let storage_key = executor_storage::loan_record::Key {
+				account_id: omni_account.clone(),
+				nonce: loan_nonce,
+			};
+
+			let hypercore_client = HyperCoreClient::new(params.chain_id).map_err(|e| {
+				error!("Failed to create HyperCore client: {}", e);
+				PumpxRpcError::from(
+					DetailedError::new(INVALID_CHAIN_ID_CODE, "Chain not supported")
+						.with_reason(format!("Chain ID {} is not supported", params.chain_id)),
+				)
 			})?;
 
-			// Call the handler implementation
-			handle_payback_loan_impl(
-				Arc::clone(&ctx),
-				omni_account,
-				params.user_operation,
-				params.chain_id,
-				params.wallet_index,
-				params.loan_nonce,
-				params.min_expected_account_value,
-			)
-			.await
+			hypercore_client.print_account_state(smart_wallet, "Before Payback").await;
+
+			// Retrieve and parse loan record
+			let loan_record = ctx
+				.loan_record_storage
+				.get(&storage_key)
+				.map_err(|_| {
+					error!("Failed to retrieve loan record from storage");
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+							.with_reason("Failed to retrieve loan record from storage"),
+					)
+				})?
+				.ok_or_else(|| {
+					error!("Loan record not found for nonce {}", loan_nonce);
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Loan record not found")
+							.with_reason(format!("No loan record found for nonce {}", loan_nonce)),
+					)
+				})?;
+
+			info!("Retrieved loan record: {:?}", loan_record);
+
+			let collateral_ticker = loan_record.collateral_ticker.to_uppercase();
+			let collateral_size = loan_record.collateral_size.parse::<f64>().map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+						.with_reason(format!("Invalid collateral_size: {}", e)),
+				)
+			})?;
+			let usdc_sold = loan_record.usdc_sold.parse::<f64>().map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+						.with_reason(format!("Invalid usdc_sold: {}", e)),
+				)
+			})?;
+			let usdc_loaned = loan_record.usdc_loaned.parse::<f64>().map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+						.with_reason(format!("Invalid usdc_loaned: {}", e)),
+				)
+			})?;
+			let hedge_open_cloid = loan_record.hedge_open_cloid.parse::<u128>().map_err(|e| {
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+						.with_reason(format!("Invalid hedge_open_cloid: {}", e)),
+				)
+			})?;
+
+			let exec_ctx = ExecutionContext {
+				ctx: ctx.clone(),
+				omni_account: &omni_account,
+				skeleton_user_op: &params.user_operation,
+				chain_id: params.chain_id,
+				wallet_index: params.wallet_index,
+				hypercore_client: &hypercore_client,
+				smart_wallet,
+				storage_key: &storage_key,
+			};
+
+			match loan_record.state {
+				LoanState::PositionOpened => {
+					info!("Starting payback from PositionOpened state");
+
+					let close_ctx = precheck_close_position(
+						&ctx,
+						&hypercore_client,
+						smart_wallet,
+						&collateral_ticker,
+						hedge_open_cloid,
+						min_expected_account_value_f64,
+						&loan_record,
+					)
+					.await?;
+
+					let (hedge_cancel_tx_hash, hedge_close_cloid_opt, hedge_close_tx_hash) =
+						do_close_position(&exec_ctx, hedge_open_cloid, &close_ctx).await?;
+
+					let move_ctx = precheck_move_to_spot(
+						&hypercore_client,
+						smart_wallet,
+						usdc_sold,
+						usdc_loaned,
+						&close_ctx.position_data,
+					)
+					.await?;
+
+					let usd_transfer_tx_hash = do_move_to_spot(&exec_ctx, &move_ctx).await?;
+
+					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
+
+					let (spot_buy_cloid, spot_buy_tx_hash) =
+						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx).await?;
+
+					Ok(PaybackLoanTestResponse {
+						collateral_ticker,
+						collateral_size: collateral_size.to_string(),
+						hedge_cancel_tx_hash,
+						hedge_close_cloid: hedge_close_cloid_opt,
+						hedge_close_tx_hash,
+						usd_transfer_tx_hash,
+						spot_buy_cloid: Some(spot_buy_cloid.to_string()),
+						spot_buy_tx_hash,
+					})
+				},
+				LoanState::PositionClosed => {
+					info!("Resuming payback from PositionClosed state");
+
+					let move_ctx = precheck_move_to_spot(
+						&hypercore_client,
+						smart_wallet,
+						usdc_sold,
+						usdc_loaned,
+						&None,
+					)
+					.await?;
+
+					let usd_transfer_tx_hash = do_move_to_spot(&exec_ctx, &move_ctx).await?;
+
+					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
+
+					let (spot_buy_cloid, spot_buy_tx_hash) =
+						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx).await?;
+
+					Ok(PaybackLoanTestResponse {
+						collateral_ticker,
+						collateral_size: collateral_size.to_string(),
+						hedge_cancel_tx_hash: None,
+						hedge_close_cloid: None,
+						hedge_close_tx_hash: None,
+						usd_transfer_tx_hash,
+						spot_buy_cloid: Some(spot_buy_cloid.to_string()),
+						spot_buy_tx_hash,
+					})
+				},
+				LoanState::ToSpotMoved => {
+					info!("Resuming payback from ToSpotMoved state");
+
+					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
+
+					let (spot_buy_cloid, spot_buy_tx_hash) =
+						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx).await?;
+
+					Ok(PaybackLoanTestResponse {
+						collateral_ticker,
+						collateral_size: collateral_size.to_string(),
+						hedge_cancel_tx_hash: None,
+						hedge_close_cloid: None,
+						hedge_close_tx_hash: None,
+						usd_transfer_tx_hash: None,
+						spot_buy_cloid: Some(spot_buy_cloid.to_string()),
+						spot_buy_tx_hash,
+					})
+				},
+				LoanState::SpotBought => {
+					info!("Payback already completed");
+					Ok(PaybackLoanTestResponse {
+						collateral_ticker,
+						collateral_size: collateral_size.to_string(),
+						hedge_cancel_tx_hash: None,
+						hedge_close_cloid: None,
+						hedge_close_tx_hash: None,
+						usd_transfer_tx_hash: None,
+						spot_buy_cloid: None,
+						spot_buy_tx_hash: None,
+					})
+				},
+				_ => Err(PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid loan state").with_reason(
+						format!("Cannot payback loan from state: {:?}", loan_record.state),
+					),
+				)),
+			}
 		})
 		.expect("Failed to register omni_paybackLoanTest method");
 }
 
-// Main handler implementation
-async fn handle_payback_loan_impl<
-	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
->(
-	ctx: Arc<RpcContext<CrossChainIntentExecutor>>,
-	omni_account: AccountId,
-	skeleton_user_op: SerializablePackedUserOperation,
-	chain_id: u64,
-	wallet_index: u32,
-	loan_nonce: u64,
-	min_expected_account_value: String,
-) -> Result<PaybackLoanTestResponse, PumpxRpcError> {
-	let smart_wallet_address_str = &skeleton_user_op.sender;
+fn precheck_params(params: &PaybackLoanTestParams) -> Result<(AccountId, u64, f64), PumpxRpcError> {
+	let omni_account = to_omni_account(&params.omni_account).map_err(|_| {
+		PumpxRpcError::from(DetailedError::new(PARSE_ERROR_CODE, "Invalid omni account"))
+	})?;
 
-	// Parse min_expected_account_value
 	let min_expected_account_value_f64 =
-		min_expected_account_value.parse::<f64>().map_err(|e| {
+		params.min_expected_account_value.parse::<f64>().map_err(|e| {
 			error!("Failed to parse min_expected_account_value: {}", e);
 			PumpxRpcError::from(
 				DetailedError::new(PARSE_ERROR_CODE, "Invalid parameter")
@@ -120,552 +302,7 @@ async fn handle_payback_loan_impl<
 
 	info!("Minimum expected account value threshold: {} USDC", min_expected_account_value_f64);
 
-	// Initialize HyperCore client
-	let hypercore_client = HyperCoreClient::new(chain_id).map_err(|e| {
-		error!("Failed to create HyperCore client: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INVALID_CHAIN_ID_CODE, "Chain not supported")
-				.with_reason(format!("Chain ID {} is not supported", chain_id)),
-		)
-	})?;
-
-	// Print initial account state
-	hypercore_client
-		.print_account_state(smart_wallet_address_str, "Before Payback")
-		.await;
-
-	// Validate payback loan parameters and determine actions
-	let validation_result = precheck(
-		&ctx,
-		&hypercore_client,
-		&omni_account,
-		smart_wallet_address_str,
-		loan_nonce,
-		min_expected_account_value_f64,
-	)
-	.await?;
-
-	let collateral_ticker = &validation_result.collateral_ticker;
-	let collateral_size = validation_result.collateral_size;
-	let usdc_sold = validation_result.usdc_sold;
-	let usdc_loaned = validation_result.usdc_loaned;
-	let hedge_open_cloid = validation_result.hedge_open_cloid;
-	let should_cancel = validation_result.should_cancel;
-	let should_close = validation_result.should_close;
-	let position_size_to_close = validation_result.position_size_to_close;
-	let position_data = validation_result.position_data;
-
-	// Fetch metadata and market prices from HyperCore in one call each
-	// Get spot market prices (markPx and midPx) along with spot metadata
-	let (spot_meta, spot_mark_price, spot_mid_price) =
-		hypercore_client.get_spot_market_prices(collateral_ticker).await.map_err(|e| {
-			error!("Failed to get spot market prices for {}: {}", collateral_ticker, e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
-					"Failed to get spot market prices for {}: {}",
-					collateral_ticker, e
-				)),
-			)
-		})?;
-
-	// Get perp market prices (markPx and midPx) along with perp metadata
-	let (meta, perp_mark_price, perp_mid_price) =
-		hypercore_client.get_perp_market_prices(collateral_ticker).await.map_err(|e| {
-			error!("Failed to get perp market prices for {}: {}", collateral_ticker, e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
-					"Failed to get perp market prices for {}: {}",
-					collateral_ticker, e
-				)),
-			)
-		})?;
-
-	// Get asset IDs
-	let spot_asset_id = get_spot_asset_id(collateral_ticker, &spot_meta).map_err(|e| {
-		error!("Failed to get spot asset ID: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
-		)
-	})?;
-
-	let perp_asset_id = get_perp_asset_id(collateral_ticker, &meta).map_err(|e| {
-		error!("Failed to get perp asset ID: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
-		)
-	})?;
-
-	// Get token metadata
-	let collateral_token = spot_meta
-		.tokens
-		.iter()
-		.find(|t| t.name.eq_ignore_ascii_case(collateral_ticker))
-		.ok_or_else(|| {
-			error!("Token {} not found in spot meta", collateral_ticker);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Token {} not found in spot meta", collateral_ticker)),
-			)
-		})?;
-
-	let perp_asset = meta.universe.get(perp_asset_id as usize).ok_or_else(|| {
-		error!("Perp asset {} not found in meta", perp_asset_id);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Perp asset {} not found", perp_asset_id)),
-		)
-	})?;
-
-	info!(
-		"Market prices for {} - spot markPx: {} USDC, spot midPx: {} USDC, perp markPx: {} USDC, perp midPx: {} USDC",
-		collateral_ticker, spot_mark_price, spot_mid_price, perp_mark_price, perp_mid_price
-	);
-
-	// Track cloids and tx hashes
-	let mut current_nonce = skeleton_user_op.nonce;
-	let mut hedge_cancel_tx_hash = None;
-	let mut hedge_close_cloid_opt = None;
-	let mut hedge_close_tx_hash = None;
-
-	// Action 1a: Cancel order if needed
-	if should_cancel {
-		info!("Action 1a: Canceling unfilled order...");
-
-		let cancel_action = build_cancel_order_by_cloid(perp_asset_id, hedge_open_cloid);
-		let cancel_calldata = encode_omni_account_execute(
-			get_core_writer_address(),
-			encode_send_raw_action(cancel_action),
-		);
-
-		let cancel_tx_hash = submit_corewriter_userop(
-			ctx.clone(),
-			&omni_account,
-			&prepare_skeleton_with_nonce(&skeleton_user_op, current_nonce),
-			chain_id,
-			wallet_index,
-			cancel_calldata,
-			"",
-		)
-		.await?;
-
-		info!("Action 1a: Cancel order submitted with tx_hash: {:?}", cancel_tx_hash);
-		hedge_cancel_tx_hash = cancel_tx_hash;
-		current_nonce += 1;
-
-		// Wait for the order to be canceled
-		let order_canceled = hypercore_client
-			.wait_for_order(
-				smart_wallet_address_str,
-				&hedge_open_cloid.to_string(),
-				30,
-				OrderWaitCondition::Canceled,
-			)
-			.await
-			.map_err(|e| {
-				error!("Order cancel did not complete: {}", e);
-				PumpxRpcError::from(
-					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-						.with_reason(format!("Order cancel failed: {}", e)),
-				)
-			})?;
-
-		if !order_canceled {
-			error!("Order cancel was rejected or expired");
-			return Err(PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason("Order cancel was rejected or expired"),
-			));
-		}
-
-		info!("Action 1a: Order canceled successfully");
-
-		hypercore_client
-			.print_account_state(smart_wallet_address_str, "After Action 1a - Order Canceled")
-			.await;
-	}
-
-	// Action 1b: Close position if needed
-	if should_close {
-		info!("Action 1b: Closing hedge position...");
-
-		let hedge_close_cloid = generate_cloid();
-		hedge_close_cloid_opt = Some(hedge_close_cloid.to_string());
-		let close_size_abs = position_size_to_close.abs();
-		let clamped_close_size = clamp_size(close_size_abs, perp_asset.sz_decimals);
-		// For closing long position (selling), we want to sell at the highest buy price (bid)
-		let (perp_bid_price, _perp_ask_price) = get_bid_ask_prices(perp_mark_price, perp_mid_price);
-		let target_close_price = perp_bid_price * PERP_CLOSE_PRICE_RATIO;
-		let clamped_close_price = clamp_price(target_close_price, perp_asset.sz_decimals, false);
-
-		info!(
-			"Perp close pricing - markPx: {}, midPx: {}, bid (highest buy): {}, target (with {}x buffer): {}, clamped: {}",
-			perp_mark_price, perp_mid_price, perp_bid_price, PERP_CLOSE_PRICE_RATIO, target_close_price, clamped_close_price
-		);
-
-		let clamped_close_size_f64 = clamped_close_size.parse::<f64>().map_err(|e| {
-			error!("Failed to parse clamped close size: {}", e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Failed to parse clamped close size: {}", e)),
-			)
-		})?;
-		let clamped_close_price_f64 = clamped_close_price.parse::<f64>().map_err(|e| {
-			error!("Failed to parse clamped close price: {}", e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Failed to parse clamped close price: {}", e)),
-			)
-		})?;
-
-		let close_size_units = to_price_units(clamped_close_size_f64);
-		let close_price_units = to_price_units(clamped_close_price_f64);
-
-		let close_action = build_perp_close_order(
-			perp_asset_id,
-			close_size_units,
-			close_price_units,
-			hedge_close_cloid,
-		);
-		let close_calldata = encode_omni_account_execute(
-			get_core_writer_address(),
-			encode_send_raw_action(close_action),
-		);
-
-		hedge_close_tx_hash = submit_corewriter_userop(
-			ctx.clone(),
-			&omni_account,
-			&prepare_skeleton_with_nonce(&skeleton_user_op, current_nonce),
-			chain_id,
-			wallet_index,
-			close_calldata,
-			"",
-		)
-		.await?;
-
-		info!(
-			"Action 1b: Hedge close order submitted, price: {}, size: {}, tx_hash: {:?}",
-			clamped_close_price_f64, clamped_close_size_f64, hedge_close_tx_hash
-		);
-		current_nonce += 1;
-
-		let order_filled = hypercore_client
-			.wait_for_order(
-				smart_wallet_address_str,
-				&hedge_close_cloid.to_string(),
-				30,
-				OrderWaitCondition::Filled,
-			)
-			.await
-			.map_err(|e| {
-				error!("Hedge close order did not complete: {}", e);
-				PumpxRpcError::from(
-					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-						.with_reason(format!("Hedge close order failed: {}", e)),
-				)
-			})?;
-
-		if !order_filled {
-			error!("Hedge close order was rejected or canceled");
-			return Err(PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason("Hedge close order was rejected or canceled"),
-			));
-		}
-
-		info!("Action 1b: Hedge position closed successfully");
-
-		hypercore_client
-			.print_account_state(smart_wallet_address_str, "After Action 1b - Hedge Closed")
-			.await;
-	}
-
-	// Action 2: Transfer USDC from perp to spot
-	// Always needed - either closing proceeds or unused margin from unfilled order
-	info!("Action 2: Transferring USDC from perp to spot...");
-
-	let perp_state_after_actions = hypercore_client
-		.get_perp_clearinghouse_state(smart_wallet_address_str)
-		.await
-		.map_err(|e| {
-			error!("Failed to get perp state: {}", e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Failed to query perp state: {}", e)),
-			)
-		})?;
-
-	let withdrawable_usdc = perp_state_after_actions.withdrawable.parse::<f64>().map_err(|e| {
-		error!("Failed to parse withdrawable USDC: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Failed to parse withdrawable USDC: {}", e)),
-		)
-	})?;
-
-	info!("Current withdrawable USDC from perp: {}", withdrawable_usdc);
-
-	// Calculate precise transfer amount
-	// For position closed: initial_margin + unrealized_pnl - cum_funding - close_fee - buffer
-	// For unfilled order: just initial_margin (what was deposited to perp)
-	let initial_margin = usdc_sold - usdc_loaned;
-
-	let transfer_amount = if let Some((
-		unrealized_pnl,
-		cum_funding_all_time,
-		margin_used,
-		position_value,
-		stored_withdrawable,
-	)) = position_data
-	{
-		// Position was closed - calculate precise amount
-
-		// Calculate close position fee: 0.045% of notional value
-		let close_position_fee = position_value * 0.00045;
-
-		// Calculate precise transfer amount with small buffer (0.01 USDC) for rounding errors
-		let buffer = 0.01;
-		let calculated_amount =
-			initial_margin + unrealized_pnl - cum_funding_all_time - close_position_fee - buffer;
-
-		info!(
-			"Transfer amount calculation: initial_margin={}, unrealized_pnl={}, cum_funding_all_time={}, close_fee={}, buffer={}, calculated={}",
-			initial_margin, unrealized_pnl, cum_funding_all_time, close_position_fee, buffer, calculated_amount
-		);
-
-		// Validate: transfer amount must be <= withdrawable + margin_used
-		// Note: margin_used from before closing, but after closing it becomes part of withdrawable
-		let max_transferable = stored_withdrawable + margin_used;
-		if calculated_amount > max_transferable {
-			error!(
-				"Calculated transfer amount ({}) exceeds max transferable ({} = {} withdrawable + {} margin_used)",
-				calculated_amount, max_transferable, stored_withdrawable, margin_used
-			);
-			return Err(PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Invalid transfer amount").with_reason(
-					format!(
-						"Calculated transfer amount ({}) exceeds available funds ({})",
-						calculated_amount, max_transferable
-					),
-				),
-			));
-		}
-
-		// Also ensure we don't try to transfer more than what's actually withdrawable now
-		let final_amount = calculated_amount.min(withdrawable_usdc);
-		info!(
-			"✓ Transfer amount validation passed: {} <= {} (max transferable), using {}",
-			calculated_amount, max_transferable, final_amount
-		);
-
-		final_amount
-	} else {
-		// No position was closed (order was unfilled) - transfer just initial margin
-		info!("No position closed, transferring initial margin: {}", initial_margin);
-		initial_margin.min(withdrawable_usdc)
-	};
-
-	// Get initial spot balance BEFORE submitting the transfer
-	let initial_spot_usdc = hypercore_client
-		.get_spot_balance(smart_wallet_address_str, "USDC")
-		.await
-		.map_err(|e| {
-			error!("Failed to get initial spot USDC balance: {}", e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Failed to query spot USDC balance: {}", e)),
-			)
-		})?;
-
-	let transfer_amount_units = to_usdc_units(transfer_amount);
-	let transfer_action = build_usd_class_transfer_to_spot(transfer_amount_units);
-	let transfer_calldata = encode_omni_account_execute(
-		get_core_writer_address(),
-		encode_send_raw_action(transfer_action),
-	);
-
-	let usd_transfer_tx_hash = submit_corewriter_userop(
-		ctx.clone(),
-		&omni_account,
-		&prepare_skeleton_with_nonce(&skeleton_user_op, current_nonce),
-		chain_id,
-		wallet_index,
-		transfer_calldata,
-		"",
-	)
-	.await?;
-
-	info!(
-		"Action 2: USD transfer submitted, size: {}, tx_hash: {:?}",
-		transfer_amount, usd_transfer_tx_hash
-	);
-	current_nonce += 1;
-
-	hypercore_client
-		.wait_for_spot_balance_increase(
-			smart_wallet_address_str,
-			"USDC",
-			initial_spot_usdc,
-			transfer_amount,
-			30,
-		)
-		.await
-		.map_err(|e| {
-			error!("USD transfer to spot failed: {}", e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Transfer timeout").with_reason(e),
-			)
-		})?;
-
-	info!("Action 2: USDC transfer completed");
-
-	hypercore_client
-		.print_account_state(smart_wallet_address_str, "After Action 2 - USD Transfer to Spot")
-		.await;
-
-	// Action 3: Spot buy collateral
-	info!("Action 3: Buying back collateral in spot market...");
-
-	// Get current USDC balance to determine how much collateral we can afford
-	let current_spot_usdc = hypercore_client
-		.get_spot_balance(smart_wallet_address_str, "USDC")
-		.await
-		.map_err(|e| {
-			error!("Failed to get current spot USDC balance: {}", e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Failed to query spot USDC balance: {}", e)),
-			)
-		})?;
-
-	info!("Current spot USDC balance: {} USDC", current_spot_usdc);
-
-	// Refresh spot prices before buying, as time could have elapsed since validation
-	info!("Refreshing spot market prices before Action 3...");
-	let (_spot_meta_refreshed, spot_mark_price_refreshed, spot_mid_price_refreshed) =
-		hypercore_client.get_spot_market_prices(collateral_ticker).await.map_err(|e| {
-			error!("Failed to refresh spot market prices for {}: {}", collateral_ticker, e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
-					"Failed to refresh spot market prices for {}: {}",
-					collateral_ticker, e
-				)),
-			)
-		})?;
-
-	let spot_buy_cloid = generate_cloid();
-	let spot_buy_cloid_str = spot_buy_cloid.to_string();
-	// For buying, we want to buy at the lowest sell price (ask)
-	let (_spot_bid_price, spot_ask_price) =
-		get_bid_ask_prices(spot_mark_price_refreshed, spot_mid_price_refreshed);
-	let target_buy_price = spot_ask_price * SPOT_BUY_PRICE_RATIO;
-	let clamped_buy_price = clamp_price(target_buy_price, collateral_token.sz_decimals, true);
-
-	// Calculate affordable collateral: how much can we buy with available USDC?
-	let clamped_buy_price_f64 = clamped_buy_price.parse::<f64>().map_err(|e| {
-		error!("Failed to parse clamped buy price: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Failed to parse clamped buy price: {}", e)),
-		)
-	})?;
-
-	let affordable_collateral = current_spot_usdc / clamped_buy_price_f64;
-
-	// Use the minimum of what we want vs what we can afford
-	let actual_buy_size = collateral_size.min(affordable_collateral);
-	let clamped_buy_size = clamp_size(actual_buy_size, collateral_token.sz_decimals);
-
-	info!(
-		"Spot buy calculation - desired: {}, affordable: {}, using: {} (clamped: {})",
-		collateral_size, affordable_collateral, actual_buy_size, clamped_buy_size
-	);
-
-	info!(
-		"Spot buy pricing - markPx: {}, midPx: {}, ask (lowest sell): {}, target (with {}x buffer): {}, clamped: {}",
-		spot_mark_price_refreshed, spot_mid_price_refreshed, spot_ask_price, SPOT_BUY_PRICE_RATIO, target_buy_price, clamped_buy_price
-	);
-
-	let clamped_buy_size_f64 = clamped_buy_size.parse::<f64>().map_err(|e| {
-		error!("Failed to parse clamped buy size: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Failed to parse clamped buy size: {}", e)),
-		)
-	})?;
-	let clamped_buy_price_f64 = clamped_buy_price.parse::<f64>().map_err(|e| {
-		error!("Failed to parse clamped buy price: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Failed to parse clamped buy price: {}", e)),
-		)
-	})?;
-
-	let buy_size_units = to_price_units(clamped_buy_size_f64);
-	let buy_price_units = to_price_units(clamped_buy_price_f64);
-
-	let spot_buy_action =
-		build_spot_buy_order(spot_asset_id, buy_size_units, buy_price_units, spot_buy_cloid);
-	let spot_buy_calldata = encode_omni_account_execute(
-		get_core_writer_address(),
-		encode_send_raw_action(spot_buy_action),
-	);
-
-	let spot_buy_tx_hash = submit_corewriter_userop(
-		ctx.clone(),
-		&omni_account,
-		&prepare_skeleton_with_nonce(&skeleton_user_op, current_nonce),
-		chain_id,
-		wallet_index,
-		spot_buy_calldata,
-		"",
-	)
-	.await?;
-
-	info!(
-		"Action 3: Spot buy order submitted, price: {}, size: {}, tx_hash: {:?}",
-		clamped_buy_price_f64, clamped_buy_size_f64, spot_buy_tx_hash
-	);
-
-	let buy_order_filled = hypercore_client
-		.wait_for_order(
-			smart_wallet_address_str,
-			&spot_buy_cloid.to_string(),
-			30,
-			OrderWaitCondition::Filled,
-		)
-		.await
-		.map_err(|e| {
-			error!("Spot buy order did not complete: {}", e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Spot buy order failed: {}", e)),
-			)
-		})?;
-
-	if !buy_order_filled {
-		error!("Spot buy order was rejected or canceled");
-		return Err(PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason("Spot buy order was rejected or canceled"),
-		));
-	}
-
-	info!("Action 3: Spot buy order filled successfully");
-
-	hypercore_client
-		.print_account_state(smart_wallet_address_str, "After Action 3 - Spot Buy Complete")
-		.await;
-
-	Ok(PaybackLoanTestResponse {
-		collateral_ticker: collateral_ticker.to_string(),
-		collateral_size: collateral_size.to_string(),
-		hedge_cancel_tx_hash,
-		hedge_close_cloid: hedge_close_cloid_opt,
-		hedge_close_tx_hash,
-		usd_transfer_tx_hash,
-		spot_buy_cloid: Some(spot_buy_cloid_str),
-		spot_buy_tx_hash,
-	})
+	Ok((omni_account, params.loan_nonce, min_expected_account_value_f64))
 }
 
 /// Helper to verify hedge position exists and is not liquidated
@@ -785,91 +422,51 @@ async fn verify_hedge_position(
 	))
 }
 
-/// Performs all validation checks for payback loan, including retrieving loan record and determining actions
-async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
-	ctx: &RpcContext<CrossChainIntentExecutor>,
+async fn precheck_close_position<
+	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
+>(
+	_ctx: &RpcContext<CrossChainIntentExecutor>,
 	hypercore_client: &HyperCoreClient,
-	omni_account: &AccountId,
-	smart_wallet_address: &str,
-	loan_nonce: u64,
+	smart_wallet: &str,
+	collateral_ticker: &str,
+	hedge_open_cloid: u128,
 	min_expected_account_value_f64: f64,
-) -> Result<PaybackLoanValidationResult, PumpxRpcError> {
-	// Step 1: Retrieve loan record from storage
-	info!("Retrieving loan record for omni_account {:?}, nonce {}", omni_account, loan_nonce);
-
-	let storage_key =
-		executor_storage::loan_record::Key { account_id: omni_account.clone(), nonce: loan_nonce };
-
-	let loan_record = ctx
-		.loan_record_storage
-		.get(&storage_key)
-		.map_err(|_| {
-			error!("Failed to retrieve loan record from storage");
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason("Failed to retrieve loan record from storage"),
-			)
-		})?
-		.ok_or_else(|| {
-			error!("Loan record not found for nonce {}", loan_nonce);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Loan record not found")
-					.with_reason(format!("No loan record found for nonce {}", loan_nonce)),
-			)
-		})?;
-
-	info!("Retrieved loan record: {:?}", loan_record);
-
-	let collateral_ticker = loan_record.collateral_ticker.to_uppercase();
-	let collateral_size = loan_record.collateral_size.parse::<f64>().map_err(|e| {
-		error!("Failed to parse collateral_size: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Invalid collateral_size in loan record: {}", e)),
-		)
-	})?;
-
-	let usdc_sold = loan_record.usdc_sold.parse::<f64>().map_err(|e| {
-		error!("Failed to parse usdc_sold: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Invalid usdc_sold in loan record: {}", e)),
-		)
-	})?;
+	loan_record: &executor_storage::loan_record::LoanRecord,
+) -> Result<ClosePositionContext, PumpxRpcError> {
+	// Validate loan state is PositionOpened
+	if loan_record.state != LoanState::PositionOpened {
+		error!(
+			"Invalid loan state for payback: expected PositionOpened, got {:?}",
+			loan_record.state
+		);
+		return Err(PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Invalid loan state").with_reason(format!(
+				"Loan must be in PositionOpened state for payback, current state: {:?}",
+				loan_record.state
+			)),
+		));
+	}
 
 	let usdc_loaned = loan_record.usdc_loaned.parse::<f64>().map_err(|e| {
-		error!("Failed to parse usdc_loaned: {}", e);
 		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Invalid usdc_loaned in loan record: {}", e)),
+			DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+				.with_reason(format!("Invalid usdc_loaned: {}", e)),
 		)
 	})?;
 
-	let hedge_open_cloid = loan_record.hedge_open_cloid.parse::<u128>().map_err(|e| {
-		error!("Failed to parse hedge_open_cloid: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Invalid hedge_open_cloid in loan record: {}", e)),
-		)
-	})?;
-
-	// Parse position_size from loan record (the actual position opened for this loan)
 	let loan_position_size = loan_record.position_size.parse::<f64>().map_err(|e| {
-		error!("Failed to parse position_size: {}", e);
 		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Invalid position_size in loan record: {}", e)),
+			DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+				.with_reason(format!("Invalid position_size: {}", e)),
 		)
 	})?;
 
 	info!("Loan record position size (to be closed): {}", loan_position_size);
 
-	// Step 2: Check USDC balance in spot account
+	// Check USDC balance in spot account
 	info!("Checking USDC balance in spot account...");
-	let usdc_balance = hypercore_client
-		.get_spot_balance(smart_wallet_address, "USDC")
-		.await
-		.map_err(|e| {
+	let usdc_balance =
+		hypercore_client.get_spot_balance(smart_wallet, "USDC").await.map_err(|e| {
 			error!("Failed to get USDC balance: {}", e);
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
@@ -896,14 +493,38 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 
 	info!("✓ USDC balance check passed: user has sufficient USDC");
 
-	// Step 3: Check hedge order status
-	info!(
-		"Checking hedge order status for loan nonce {} with hedge_open_cloid {}",
-		loan_nonce, hedge_open_cloid
-	);
+	// Get perp market data
+	let (perp_meta, perp_mark_price, perp_mid_price) =
+		hypercore_client.get_perp_market_prices(collateral_ticker).await.map_err(|e| {
+			error!("Failed to get perp market prices for {}: {}", collateral_ticker, e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to get perp market prices: {}", e)),
+			)
+		})?;
+
+	let perp_asset_id = get_perp_asset_id(collateral_ticker, &perp_meta).map_err(|e| {
+		error!("Failed to get perp asset ID: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
+		)
+	})?;
+
+	let perp_asset = perp_meta.universe.get(perp_asset_id as usize).ok_or_else(|| {
+		error!("Perp asset {} not found in meta", perp_asset_id);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Perp asset {} not found", perp_asset_id)),
+		)
+	})?;
+
+	let perp_sz_decimals = perp_asset.sz_decimals;
+
+	// Check hedge order status
+	info!("Checking hedge order status with hedge_open_cloid {}", hedge_open_cloid);
 
 	let order_status = hypercore_client
-		.get_order_status(smart_wallet_address, &hedge_open_cloid.to_string())
+		.get_order_status(smart_wallet, &hedge_open_cloid.to_string())
 		.await
 		.map_err(|e| {
 			error!("Failed to get order status for cloid {}: {}", hedge_open_cloid, e);
@@ -914,26 +535,20 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 			)
 		})?;
 
-	// Store position data for transfer amount calculation
-	let mut position_data: Option<(f64, f64, f64, f64, f64)> = None; // (unrealized_pnl, cum_funding_all_time, margin_used, position_value, withdrawable)
+	let mut position_data: Option<(f64, f64, f64, f64, f64)> = None;
 
-	// If the order is not found (unknownOid), we'll skip action 1 and proceed directly to action 2
+	// If the order is not found (unknownOid), skip closing
 	if order_status.status == "unknownOid" {
-		info!(
-			"Order with cloid {} not found (unknownOid), skipping action 1 and proceeding to action 2",
-			hedge_open_cloid
-		);
-		// No cancellation or closing needed, proceed directly to action 2
-		return Ok(PaybackLoanValidationResult {
-			collateral_ticker,
-			collateral_size,
-			usdc_sold,
-			usdc_loaned,
-			hedge_open_cloid,
+		info!("Order with cloid {} not found (unknownOid), skipping close", hedge_open_cloid);
+		return Ok(ClosePositionContext {
 			should_cancel: false,
 			should_close: false,
 			position_size_to_close: 0.0,
 			position_data: None,
+			perp_asset_id,
+			perp_sz_decimals,
+			perp_mark_price,
+			perp_mid_price,
 		});
 	}
 
@@ -945,7 +560,6 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 
 		match status {
 			"filled" => {
-				// Case 1: Fully filled - close position
 				info!("Case 1: Order fully filled, will close position");
 				let (
 					actual_position_size,
@@ -955,10 +569,8 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 					margin_used,
 					position_value,
 					withdrawable,
-				) = verify_hedge_position(hypercore_client, smart_wallet_address, &collateral_ticker)
-					.await?;
+				) = verify_hedge_position(hypercore_client, smart_wallet, collateral_ticker).await?;
 
-				// Validate that actual position size >= loan position size
 				if actual_position_size < loan_position_size {
 					error!(
 						"Actual position size ({}) is less than loan position size ({})",
@@ -977,27 +589,25 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 					actual_position_size, loan_position_size
 				);
 
-				// Validate account value against minimum threshold
 				if account_value < min_expected_account_value_f64 {
 					error!(
 						"Account value ({} USDC) is below minimum expected account value ({} USDC)",
 						account_value, min_expected_account_value_f64
 					);
 					return Err(PumpxRpcError::from(
-							DetailedError::new(INTERNAL_ERROR_CODE, "Account value too low").with_reason(
-								format!(
-									"Account value ({} USDC) is below minimum expected ({} USDC). Refusing to close position with unexpected loss.",
-									account_value, min_expected_account_value_f64
-								),
+						DetailedError::new(INTERNAL_ERROR_CODE, "Account value too low").with_reason(
+							format!(
+								"Account value ({} USDC) is below minimum expected ({} USDC). Refusing to close position with unexpected loss.",
+								account_value, min_expected_account_value_f64
 							),
-						));
+						),
+					));
 				}
 				info!(
 					"✓ Account value check passed: {} USDC >= {} USDC",
 					account_value, min_expected_account_value_f64
 				);
 
-				// Store position data for later transfer calculation
 				position_data = Some((
 					unrealized_pnl,
 					cum_funding_all_time,
@@ -1006,16 +616,13 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 					withdrawable,
 				));
 
-				// Use loan position size (not total position size)
 				(false, true, loan_position_size)
 			},
 			"open" => {
-				// Case 2: Not filled at all - cancel order
 				info!("Case 2: Order not filled, will cancel");
 				(true, false, 0.0)
 			},
 			"partial_fill" => {
-				// Case 3: Partially filled - cancel + close filled part
 				info!(
 					"Case 3: Order partially filled, will cancel order and close filled position"
 				);
@@ -1027,12 +634,8 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 					margin_used,
 					position_value,
 					withdrawable,
-				) = verify_hedge_position(hypercore_client, smart_wallet_address, &collateral_ticker)
-					.await?;
+				) = verify_hedge_position(hypercore_client, smart_wallet, collateral_ticker).await?;
 
-				// Validate that actual position size >= loan position size
-				// For partial fill, the actual position might be less than expected,
-				// but we should close whatever was actually filled
 				if actual_position_size < loan_position_size {
 					info!(
 						"Partial fill: actual position size ({}) is less than expected ({}), will close actual size",
@@ -1045,27 +648,25 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 					);
 				}
 
-				// Validate account value against minimum threshold
 				if account_value < min_expected_account_value_f64 {
 					error!(
 						"Account value ({} USDC) is below minimum expected account value ({} USDC)",
 						account_value, min_expected_account_value_f64
 					);
 					return Err(PumpxRpcError::from(
-							DetailedError::new(INTERNAL_ERROR_CODE, "Account value too low").with_reason(
-								format!(
-									"Account value ({} USDC) is below minimum expected ({} USDC). Refusing to close position with unexpected loss.",
-									account_value, min_expected_account_value_f64
-								),
+						DetailedError::new(INTERNAL_ERROR_CODE, "Account value too low").with_reason(
+							format!(
+								"Account value ({} USDC) is below minimum expected ({} USDC). Refusing to close position with unexpected loss.",
+								account_value, min_expected_account_value_f64
 							),
-						));
+						),
+					));
 				}
 				info!(
 					"✓ Account value check passed: {} USDC >= {} USDC",
 					account_value, min_expected_account_value_f64
 				);
 
-				// Store position data for later transfer calculation
 				position_data = Some((
 					unrealized_pnl,
 					cum_funding_all_time,
@@ -1074,8 +675,6 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 					withdrawable,
 				));
 
-				// For partial fill, close the minimum of loan position size and actual position size
-				// This handles the case where the position was partially filled
 				let position_to_close = loan_position_size.min(actual_position_size);
 				(true, true, position_to_close)
 			},
@@ -1102,15 +701,550 @@ async fn precheck<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'stat
 		));
 	};
 
-	Ok(PaybackLoanValidationResult {
-		collateral_ticker,
-		collateral_size,
-		usdc_sold,
-		usdc_loaned,
-		hedge_open_cloid,
+	info!("✓ Close position precheck passed");
+
+	Ok(ClosePositionContext {
 		should_cancel,
 		should_close,
 		position_size_to_close,
 		position_data,
+		perp_asset_id,
+		perp_sz_decimals,
+		perp_mark_price,
+		perp_mid_price,
 	})
+}
+async fn precheck_move_to_spot(
+	hypercore_client: &HyperCoreClient,
+	smart_wallet: &str,
+	usdc_sold: f64,
+	usdc_loaned: f64,
+	position_data: &Option<(f64, f64, f64, f64, f64)>,
+) -> Result<MoveToSpotContext, PumpxRpcError> {
+	let initial_margin = usdc_sold - usdc_loaned;
+
+	let perp_state =
+		hypercore_client.get_perp_clearinghouse_state(smart_wallet).await.map_err(|e| {
+			error!("Failed to get perp state: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to query perp state: {}", e)),
+			)
+		})?;
+
+	let withdrawable_usdc = perp_state.withdrawable.parse::<f64>().map_err(|e| {
+		error!("Failed to parse withdrawable USDC: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Failed to parse withdrawable USDC: {}", e)),
+		)
+	})?;
+
+	info!("Current withdrawable USDC from perp: {}", withdrawable_usdc);
+
+	let transfer_amount = if let Some((
+		unrealized_pnl,
+		cum_funding_all_time,
+		margin_used,
+		position_value,
+		stored_withdrawable,
+	)) = position_data
+	{
+		let close_position_fee = position_value * 0.00045;
+		let buffer = 0.01;
+		let calculated_amount =
+			initial_margin + unrealized_pnl - cum_funding_all_time - close_position_fee - buffer;
+
+		info!(
+			"Transfer amount calculation: initial_margin={}, unrealized_pnl={}, cum_funding_all_time={}, close_fee={}, buffer={}, calculated={}",
+			initial_margin, unrealized_pnl, cum_funding_all_time, close_position_fee, buffer, calculated_amount
+		);
+
+		let max_transferable = stored_withdrawable + margin_used;
+		if calculated_amount > max_transferable {
+			error!(
+				"Calculated transfer amount ({}) exceeds max transferable ({} = {} withdrawable + {} margin_used)",
+				calculated_amount, max_transferable, stored_withdrawable, margin_used
+			);
+			return Err(PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Invalid transfer amount").with_reason(
+					format!(
+						"Calculated transfer amount ({}) exceeds available funds ({})",
+						calculated_amount, max_transferable
+					),
+				),
+			));
+		}
+
+		let final_amount = calculated_amount.min(withdrawable_usdc);
+		info!(
+			"✓ Transfer amount validation passed: {} <= {} (max transferable), using {}",
+			calculated_amount, max_transferable, final_amount
+		);
+
+		final_amount
+	} else {
+		info!("No position closed, transferring initial margin: {}", initial_margin);
+		initial_margin.min(withdrawable_usdc)
+	};
+
+	info!("✓ Move to spot precheck passed");
+
+	Ok(MoveToSpotContext { transfer_amount })
+}
+
+async fn precheck_buy_spot(
+	hypercore_client: &HyperCoreClient,
+	collateral_ticker: &str,
+) -> Result<BuySpotContext, PumpxRpcError> {
+	let (spot_meta, spot_mark_price, spot_mid_price) =
+		hypercore_client.get_spot_market_prices(collateral_ticker).await.map_err(|e| {
+			error!("Failed to get spot market prices for {}: {}", collateral_ticker, e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to get spot market prices: {}", e)),
+			)
+		})?;
+
+	let spot_asset_id = get_spot_asset_id(collateral_ticker, &spot_meta).map_err(|e| {
+		error!("Failed to get spot asset ID: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
+		)
+	})?;
+
+	let spot_token = spot_meta
+		.tokens
+		.iter()
+		.find(|t| t.name.eq_ignore_ascii_case(collateral_ticker))
+		.ok_or_else(|| {
+			error!("Token {} not found in spot meta", collateral_ticker);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Token {} not found in spot meta", collateral_ticker)),
+			)
+		})?;
+
+	let spot_sz_decimals = spot_token.sz_decimals;
+
+	info!("✓ Buy spot precheck passed");
+
+	Ok(BuySpotContext { spot_asset_id, spot_sz_decimals, spot_mark_price, spot_mid_price })
+}
+
+async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
+	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
+	hedge_open_cloid: u128,
+	close_ctx: &ClosePositionContext,
+) -> Result<(Option<String>, Option<String>, Option<String>), PumpxRpcError> {
+	let mut current_nonce = exec_ctx.skeleton_user_op.nonce;
+	let mut hedge_cancel_tx_hash = None;
+	let mut hedge_close_cloid_opt = None;
+	let mut hedge_close_tx_hash = None;
+
+	// Action 1a: Cancel order if needed
+	if close_ctx.should_cancel {
+		info!("Action: Canceling unfilled order...");
+
+		let cancel_action = build_cancel_order_by_cloid(close_ctx.perp_asset_id, hedge_open_cloid);
+		let cancel_calldata = encode_omni_account_execute(
+			get_core_writer_address(),
+			encode_send_raw_action(cancel_action),
+		);
+
+		let cancel_tx_hash = submit_corewriter_userop(
+			exec_ctx.ctx.clone(),
+			exec_ctx.omni_account,
+			&prepare_skeleton_with_nonce(exec_ctx.skeleton_user_op, current_nonce),
+			exec_ctx.chain_id,
+			exec_ctx.wallet_index,
+			cancel_calldata,
+			"",
+		)
+		.await?;
+
+		info!("Cancel order submitted with tx_hash: {:?}", cancel_tx_hash);
+		hedge_cancel_tx_hash = cancel_tx_hash.clone();
+		current_nonce += 1;
+
+		let order_canceled = exec_ctx
+			.hypercore_client
+			.wait_for_order(
+				exec_ctx.smart_wallet,
+				&hedge_open_cloid.to_string(),
+				30,
+				OrderWaitCondition::Canceled,
+			)
+			.await
+			.map_err(|e| {
+				error!("Order cancel did not complete: {}", e);
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+						.with_reason(format!("Order cancel failed: {}", e)),
+				)
+			})?;
+
+		if !order_canceled {
+			error!("Order cancel was rejected or expired");
+			return Err(PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason("Order cancel was rejected or expired"),
+			));
+		}
+
+		info!("Order canceled successfully");
+		exec_ctx
+			.hypercore_client
+			.print_account_state(exec_ctx.smart_wallet, "After Order Canceled")
+			.await;
+	}
+
+	// Action 1b: Close position if needed
+	if close_ctx.should_close {
+		info!("Action: Closing hedge position...");
+
+		let hedge_close_cloid = generate_cloid();
+		hedge_close_cloid_opt = Some(hedge_close_cloid.to_string());
+		let close_size_abs = close_ctx.position_size_to_close.abs();
+		let clamped_close_size = clamp_size(close_size_abs, close_ctx.perp_sz_decimals);
+		// For closing long position (selling), we want to sell at the highest buy price (bid)
+		let (perp_bid_price, _perp_ask_price) =
+			get_bid_ask_prices(close_ctx.perp_mark_price, close_ctx.perp_mid_price);
+		let target_close_price = perp_bid_price * PERP_CLOSE_PRICE_RATIO;
+		let clamped_close_price =
+			clamp_price(target_close_price, close_ctx.perp_sz_decimals, false);
+
+		info!(
+			"Perp close pricing - markPx: {}, midPx: {}, bid (highest buy): {}, target (with {}x buffer): {}, clamped: {}",
+			close_ctx.perp_mark_price, close_ctx.perp_mid_price, perp_bid_price, PERP_CLOSE_PRICE_RATIO, target_close_price, clamped_close_price
+		);
+
+		let clamped_close_size_f64 = clamped_close_size.parse::<f64>().map_err(|e| {
+			error!("Failed to parse clamped close size: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to parse clamped close size: {}", e)),
+			)
+		})?;
+		let clamped_close_price_f64 = clamped_close_price.parse::<f64>().map_err(|e| {
+			error!("Failed to parse clamped close price: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to parse clamped close price: {}", e)),
+			)
+		})?;
+
+		let close_size_units = to_price_units(clamped_close_size_f64);
+		let close_price_units = to_price_units(clamped_close_price_f64);
+
+		let close_action = build_perp_close_order(
+			close_ctx.perp_asset_id,
+			close_size_units,
+			close_price_units,
+			hedge_close_cloid,
+		);
+		let close_calldata = encode_omni_account_execute(
+			get_core_writer_address(),
+			encode_send_raw_action(close_action),
+		);
+
+		hedge_close_tx_hash = submit_corewriter_userop(
+			exec_ctx.ctx.clone(),
+			exec_ctx.omni_account,
+			&prepare_skeleton_with_nonce(exec_ctx.skeleton_user_op, current_nonce),
+			exec_ctx.chain_id,
+			exec_ctx.wallet_index,
+			close_calldata,
+			"",
+		)
+		.await?;
+
+		info!(
+			"Hedge close order submitted, price: {}, size: {}, tx_hash: {:?}",
+			clamped_close_price_f64, clamped_close_size_f64, hedge_close_tx_hash
+		);
+
+		let order_filled = exec_ctx
+			.hypercore_client
+			.wait_for_order(
+				exec_ctx.smart_wallet,
+				&hedge_close_cloid.to_string(),
+				30,
+				OrderWaitCondition::Filled,
+			)
+			.await
+			.map_err(|e| {
+				error!("Hedge close order did not complete: {}", e);
+				PumpxRpcError::from(
+					DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+						.with_reason(format!("Hedge close order failed: {}", e)),
+				)
+			})?;
+
+		if !order_filled {
+			error!("Hedge close order was rejected or canceled");
+			return Err(PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason("Hedge close order was rejected or canceled"),
+			));
+		}
+
+		info!("Hedge position closed successfully");
+		exec_ctx
+			.hypercore_client
+			.print_account_state(exec_ctx.smart_wallet, "After Hedge Closed")
+			.await;
+	}
+
+	// Update state: PositionClosed (if cancel or close happened)
+	if close_ctx.should_cancel || close_ctx.should_close {
+		let _ = exec_ctx
+			.ctx
+			.loan_record_storage
+			.update(exec_ctx.storage_key, |r| r.state = LoanState::PositionClosed);
+	}
+
+	Ok((hedge_cancel_tx_hash, hedge_close_cloid_opt, hedge_close_tx_hash))
+}
+
+async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
+	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
+	move_ctx: &MoveToSpotContext,
+) -> Result<Option<String>, PumpxRpcError> {
+	info!("Action: Transferring USDC from perp to spot...");
+
+	// Get initial spot balance BEFORE submitting the transfer
+	let initial_spot_usdc = exec_ctx
+		.hypercore_client
+		.get_spot_balance(exec_ctx.smart_wallet, "USDC")
+		.await
+		.map_err(|e| {
+			error!("Failed to get initial spot USDC balance: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to query spot USDC balance: {}", e)),
+			)
+		})?;
+
+	let transfer_amount_units = to_usdc_units(move_ctx.transfer_amount);
+	let transfer_action = build_usd_class_transfer_to_spot(transfer_amount_units);
+	let transfer_calldata = encode_omni_account_execute(
+		get_core_writer_address(),
+		encode_send_raw_action(transfer_action),
+	);
+
+	// Calculate nonce offset based on state
+	let current_loan_state = exec_ctx
+		.ctx
+		.loan_record_storage
+		.get(exec_ctx.storage_key)
+		.ok()
+		.flatten()
+		.map(|r| r.state);
+
+	let nonce_offset = match current_loan_state {
+		Some(LoanState::PositionOpened) => 2, // After cancel (0 or 1) + close (1 or 2)
+		Some(LoanState::PositionClosed) => 0, // Start fresh
+		_ => 0,
+	};
+
+	let usd_transfer_tx_hash = submit_corewriter_userop(
+		exec_ctx.ctx.clone(),
+		exec_ctx.omni_account,
+		&prepare_skeleton_with_nonce(
+			exec_ctx.skeleton_user_op,
+			exec_ctx.skeleton_user_op.nonce + nonce_offset,
+		),
+		exec_ctx.chain_id,
+		exec_ctx.wallet_index,
+		transfer_calldata,
+		"",
+	)
+	.await?;
+
+	info!(
+		"USD transfer submitted, size: {}, tx_hash: {:?}",
+		move_ctx.transfer_amount, usd_transfer_tx_hash
+	);
+
+	exec_ctx
+		.hypercore_client
+		.wait_for_spot_balance_increase(
+			exec_ctx.smart_wallet,
+			"USDC",
+			initial_spot_usdc,
+			move_ctx.transfer_amount,
+			30,
+		)
+		.await
+		.map_err(|e| {
+			error!("USD transfer to spot failed: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Transfer timeout").with_reason(e),
+			)
+		})?;
+
+	info!("USDC transfer completed");
+
+	// Update state: ToSpotMoved
+	let _ = exec_ctx
+		.ctx
+		.loan_record_storage
+		.update(exec_ctx.storage_key, |r| r.state = LoanState::ToSpotMoved);
+
+	exec_ctx
+		.hypercore_client
+		.print_account_state(exec_ctx.smart_wallet, "After USD Transfer to Spot")
+		.await;
+
+	Ok(usd_transfer_tx_hash)
+}
+
+async fn do_buy_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
+	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
+	collateral_size: f64,
+	buy_ctx: &BuySpotContext,
+) -> Result<(u128, Option<String>), PumpxRpcError> {
+	info!("Action: Buying back collateral in spot market...");
+
+	// Get current USDC balance to determine how much collateral we can afford
+	let current_spot_usdc = exec_ctx
+		.hypercore_client
+		.get_spot_balance(exec_ctx.smart_wallet, "USDC")
+		.await
+		.map_err(|e| {
+			error!("Failed to get current spot USDC balance: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to query spot USDC balance: {}", e)),
+			)
+		})?;
+
+	info!("Current spot USDC balance: {} USDC", current_spot_usdc);
+
+	let spot_buy_cloid = generate_cloid();
+	// For buying, we want to buy at the lowest sell price (ask)
+	let (_spot_bid_price, spot_ask_price) =
+		get_bid_ask_prices(buy_ctx.spot_mark_price, buy_ctx.spot_mid_price);
+	let target_buy_price = spot_ask_price * SPOT_BUY_PRICE_RATIO;
+	let clamped_buy_price = clamp_price(target_buy_price, buy_ctx.spot_sz_decimals, true);
+
+	let clamped_buy_price_f64 = clamped_buy_price.parse::<f64>().map_err(|e| {
+		error!("Failed to parse clamped buy price: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Failed to parse clamped buy price: {}", e)),
+		)
+	})?;
+
+	let affordable_collateral = current_spot_usdc / clamped_buy_price_f64;
+	let actual_buy_size = collateral_size.min(affordable_collateral);
+	let clamped_buy_size = clamp_size(actual_buy_size, buy_ctx.spot_sz_decimals);
+
+	info!(
+		"Spot buy calculation - desired: {}, affordable: {}, using: {} (clamped: {})",
+		collateral_size, affordable_collateral, actual_buy_size, clamped_buy_size
+	);
+
+	info!(
+		"Spot buy pricing - markPx: {}, midPx: {}, ask (lowest sell): {}, target (with {}x buffer): {}, clamped: {}",
+		buy_ctx.spot_mark_price, buy_ctx.spot_mid_price, spot_ask_price, SPOT_BUY_PRICE_RATIO, target_buy_price, clamped_buy_price
+	);
+
+	let clamped_buy_size_f64 = clamped_buy_size.parse::<f64>().map_err(|e| {
+		error!("Failed to parse clamped buy size: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Failed to parse clamped buy size: {}", e)),
+		)
+	})?;
+
+	let buy_size_units = to_price_units(clamped_buy_size_f64);
+	let buy_price_units = to_price_units(clamped_buy_price_f64);
+
+	let spot_buy_action = build_spot_buy_order(
+		buy_ctx.spot_asset_id,
+		buy_size_units,
+		buy_price_units,
+		spot_buy_cloid,
+	);
+	let spot_buy_calldata = encode_omni_account_execute(
+		get_core_writer_address(),
+		encode_send_raw_action(spot_buy_action),
+	);
+
+	// Calculate nonce offset based on state
+	let current_loan_state = exec_ctx
+		.ctx
+		.loan_record_storage
+		.get(exec_ctx.storage_key)
+		.ok()
+		.flatten()
+		.map(|r| r.state);
+
+	let nonce_offset = match current_loan_state {
+		Some(LoanState::PositionOpened) => 3, // After cancel + close + transfer
+		Some(LoanState::PositionClosed) => 1, // After transfer
+		Some(LoanState::ToSpotMoved) => 0,    // Start fresh
+		_ => 0,
+	};
+
+	let spot_buy_tx_hash = submit_corewriter_userop(
+		exec_ctx.ctx.clone(),
+		exec_ctx.omni_account,
+		&prepare_skeleton_with_nonce(
+			exec_ctx.skeleton_user_op,
+			exec_ctx.skeleton_user_op.nonce + nonce_offset,
+		),
+		exec_ctx.chain_id,
+		exec_ctx.wallet_index,
+		spot_buy_calldata,
+		"",
+	)
+	.await?;
+
+	info!(
+		"Spot buy order submitted, price: {}, size: {}, tx_hash: {:?}",
+		clamped_buy_price_f64, clamped_buy_size_f64, spot_buy_tx_hash
+	);
+
+	let buy_order_filled = exec_ctx
+		.hypercore_client
+		.wait_for_order(
+			exec_ctx.smart_wallet,
+			&spot_buy_cloid.to_string(),
+			30,
+			OrderWaitCondition::Filled,
+		)
+		.await
+		.map_err(|e| {
+			error!("Spot buy order did not complete: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Spot buy order failed: {}", e)),
+			)
+		})?;
+
+	if !buy_order_filled {
+		error!("Spot buy order was rejected or canceled");
+		return Err(PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason("Spot buy order was rejected or canceled"),
+		));
+	}
+
+	info!("Spot buy order filled successfully");
+
+	// Update state: SpotBought (final state)
+	let _ = exec_ctx
+		.ctx
+		.loan_record_storage
+		.update(exec_ctx.storage_key, |r| r.state = LoanState::SpotBought);
+
+	exec_ctx
+		.hypercore_client
+		.print_account_state(exec_ctx.smart_wallet, "After Spot Buy Complete")
+		.await;
+
+	Ok((spot_buy_cloid, spot_buy_tx_hash))
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -14,6 +14,32 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, error, info};
 
+#[derive(Debug, Deserialize)]
+pub struct PaybackLoanTestParams {
+	pub user_operation: SerializablePackedUserOperation,
+	pub chain_id: u64,
+	pub wallet_index: u32,
+	pub omni_account: String,
+	pub loan_nonce: u64,
+	// Expected minimal account value (USDC) on user's perp account (crossMarginSummary.accountValue)
+	// If the actual account value is smaller, it will error out and not close the position.
+	//
+	// This is just a safety guard to avoid unwanted position close (when e.g user is at big loss)
+	pub min_expected_account_value: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct PaybackLoanTestResponse {
+	pub collateral_ticker: String,
+	pub collateral_size: String,
+	pub hedge_cancel_tx_hash: Option<String>,
+	pub hedge_close_cloid: Option<String>,
+	pub hedge_close_tx_hash: Option<String>,
+	pub usd_transfer_tx_hash: Option<String>,
+	pub spot_buy_cloid: Option<String>,
+	pub spot_buy_tx_hash: Option<String>,
+}
+
 struct ExecutionContext<'a, CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static> {
 	ctx: Arc<RpcContext<CrossChainIntentExecutor>>,
 	omni_account: &'a AccountId,
@@ -46,32 +72,6 @@ struct BuySpotContext {
 	spot_sz_decimals: u8,
 	spot_mark_price: f64,
 	spot_mid_price: f64,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct PaybackLoanTestParams {
-	pub user_operation: SerializablePackedUserOperation,
-	pub chain_id: u64,
-	pub wallet_index: u32,
-	pub omni_account: String,
-	pub loan_nonce: u64,
-	// Expected minimal account value (USDC) on user's perp account (crossMarginSummary.accountValue)
-	// If the actual account value is smaller, it will error out and not close the position.
-	//
-	// This is just a safety guard to avoid unwanted position close (when e.g user is at big loss)
-	pub min_expected_account_value: String,
-}
-
-#[derive(Serialize, Clone)]
-pub struct PaybackLoanTestResponse {
-	pub collateral_ticker: String,
-	pub collateral_size: String,
-	pub hedge_cancel_tx_hash: Option<String>,
-	pub hedge_close_cloid: Option<String>,
-	pub hedge_close_tx_hash: Option<String>,
-	pub usd_transfer_tx_hash: Option<String>,
-	pub spot_buy_cloid: Option<String>,
-	pub spot_buy_tx_hash: Option<String>,
 }
 
 pub fn register_payback_loan_test<
@@ -859,7 +859,6 @@ async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Syn
 			exec_ctx.chain_id,
 			exec_ctx.wallet_index,
 			cancel_calldata,
-			"",
 		)
 		.await?;
 
@@ -955,7 +954,6 @@ async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Syn
 			exec_ctx.chain_id,
 			exec_ctx.wallet_index,
 			close_calldata,
-			"",
 		)
 		.await?;
 
@@ -1058,7 +1056,6 @@ async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 		exec_ctx.chain_id,
 		exec_ctx.wallet_index,
 		transfer_calldata,
-		"",
 	)
 	.await?;
 
@@ -1199,7 +1196,6 @@ async fn do_buy_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 's
 		exec_ctx.chain_id,
 		exec_ctx.wallet_index,
 		spot_buy_calldata,
-		"",
 	)
 	.await?;
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -795,11 +795,6 @@ async fn precheck_move_to_spot(
 		let calculated_amount =
 			initial_margin + unrealized_pnl - cum_funding_all_time - close_position_fee - buffer;
 
-		info!(
-			"Transfer amount calculation: initial_margin={}, unrealized_pnl={}, cum_funding_all_time={}, close_fee={}, buffer={}, calculated={}",
-			initial_margin, unrealized_pnl, cum_funding_all_time, close_position_fee, buffer, calculated_amount
-		);
-
 		let max_transferable = stored_withdrawable + margin_used;
 		if calculated_amount > max_transferable {
 			error!(
@@ -816,16 +811,15 @@ async fn precheck_move_to_spot(
 			));
 		}
 
-		let final_amount = calculated_amount.min(withdrawable_usdc + margin_used);
 		info!(
-			"final_amount={}, withdrawable_usdc={}, margin_used={}, stored_withdrawable={}",
-			final_amount, withdrawable_usdc, margin_used, stored_withdrawable
+			"Transfer amount calculation: initial_margin={}, unrealized_pnl={}, cum_funding_all_time={}, close_fee={}, buffer={}, withdrawable={}, margin_used={}, calculated={}",
+			initial_margin, unrealized_pnl, cum_funding_all_time, close_position_fee, buffer, stored_withdrawable, margin_used, calculated_amount
 		);
 
-		final_amount
+		calculated_amount
 	} else {
 		info!("No position closed, transferring initial margin: {}", initial_margin);
-		initial_margin.min(withdrawable_usdc)
+		initial_margin
 	};
 
 	info!("✓ Move to spot precheck passed");

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -35,7 +35,7 @@ pub struct PaybackLoanTestResponse {
 	pub hedge_cancel_tx_hash: Option<String>,
 	pub hedge_close_cloid: Option<String>,
 	pub hedge_close_tx_hash: Option<String>,
-	pub usd_transfer_tx_hash: Option<String>,
+	pub to_spot_move_tx_hash: Option<String>,
 	pub spot_buy_cloid: Option<String>,
 	pub spot_buy_tx_hash: Option<String>,
 }
@@ -151,7 +151,19 @@ pub fn register_payback_loan_test<
 						.with_reason(format!("Invalid usdc_loaned: {}", e)),
 				)
 			})?;
-			let hedge_open_cloid = loan_record.hedge_open_cloid.parse::<u128>().map_err(|e| {
+			let hedge_open_cloid_str = loan_record
+				.cloids
+				.iter()
+				.find(|(name, _)| name == "hedge_open")
+				.map(|(_, cloid)| cloid.clone())
+				.ok_or_else(|| {
+					error!("hedge_open cloid not found in loan record");
+					PumpxRpcError::from(
+						DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
+							.with_reason("hedge_open cloid not found in loan_record"),
+					)
+				})?;
+			let hedge_open_cloid = hedge_open_cloid_str.parse::<u128>().map_err(|e| {
 				PumpxRpcError::from(
 					DetailedError::new(INTERNAL_ERROR_CODE, "Invalid stored data")
 						.with_reason(format!("Invalid hedge_open_cloid: {}", e)),
@@ -200,7 +212,7 @@ pub fn register_payback_loan_test<
 						do_close_hedge(&exec_ctx, hedge_open_cloid, &close_ctx, &mut current_nonce)
 							.await?;
 
-					let usd_transfer_tx_hash =
+					let to_spot_move_tx_hash =
 						do_move_to_spot(&exec_ctx, &move_ctx, &mut current_nonce).await?;
 
 					let (spot_buy_cloid, spot_buy_tx_hash) =
@@ -212,7 +224,7 @@ pub fn register_payback_loan_test<
 						hedge_cancel_tx_hash,
 						hedge_close_cloid: hedge_close_cloid_opt,
 						hedge_close_tx_hash,
-						usd_transfer_tx_hash,
+						to_spot_move_tx_hash,
 						spot_buy_cloid: Some(spot_buy_cloid.to_string()),
 						spot_buy_tx_hash,
 					})
@@ -231,7 +243,7 @@ pub fn register_payback_loan_test<
 
 					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
 
-					let usd_transfer_tx_hash =
+					let to_spot_move_tx_hash =
 						do_move_to_spot(&exec_ctx, &move_ctx, &mut current_nonce).await?;
 
 					let (spot_buy_cloid, spot_buy_tx_hash) =
@@ -243,7 +255,7 @@ pub fn register_payback_loan_test<
 						hedge_cancel_tx_hash: None,
 						hedge_close_cloid: None,
 						hedge_close_tx_hash: None,
-						usd_transfer_tx_hash,
+						to_spot_move_tx_hash,
 						spot_buy_cloid: Some(spot_buy_cloid.to_string()),
 						spot_buy_tx_hash,
 					})
@@ -262,7 +274,7 @@ pub fn register_payback_loan_test<
 						hedge_cancel_tx_hash: None,
 						hedge_close_cloid: None,
 						hedge_close_tx_hash: None,
-						usd_transfer_tx_hash: None,
+						to_spot_move_tx_hash: None,
 						spot_buy_cloid: Some(spot_buy_cloid.to_string()),
 						spot_buy_tx_hash,
 					})
@@ -843,9 +855,9 @@ async fn do_close_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync +
 	close_ctx: &CloseHedgeContext,
 	current_nonce: &mut u128,
 ) -> Result<(Option<String>, Option<String>, Option<String>), PumpxRpcError> {
-	let mut hedge_cancel_tx_hash = None;
-	let mut hedge_close_cloid_opt = None;
-	let mut hedge_close_tx_hash = None;
+	let mut hedge_cancel_tx_hash: Option<String> = None;
+	let mut hedge_close_cloid_opt: Option<String> = None;
+	let mut hedge_close_tx_hash: Option<String> = None;
 
 	// Action 1a: Cancel order if needed
 	if close_ctx.should_cancel {
@@ -857,7 +869,7 @@ async fn do_close_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync +
 			encode_send_raw_action(cancel_action),
 		);
 
-		let cancel_tx_hash = submit_corewriter_userop(
+		hedge_cancel_tx_hash = submit_corewriter_userop(
 			exec_ctx.ctx.clone(),
 			exec_ctx.omni_account,
 			&prepare_userop_no_init(exec_ctx.skeleton_user_op, *current_nonce),
@@ -867,8 +879,7 @@ async fn do_close_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync +
 		)
 		.await?;
 
-		info!("Cancel order submitted with tx_hash: {:?}", cancel_tx_hash);
-		hedge_cancel_tx_hash = cancel_tx_hash.clone();
+		info!("hedge_cancel submitted with tx_hash: {:?}", hedge_cancel_tx_hash);
 		*current_nonce += 1;
 
 		let order_canceled = exec_ctx
@@ -964,7 +975,7 @@ async fn do_close_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync +
 		*current_nonce += 1;
 
 		info!(
-			"Hedge close order submitted, price: {}, size: {}, tx_hash: {:?}",
+			"hedge_close submitted, price: {}, size: {}, tx_hash: {:?}",
 			clamped_close_price_f64, clamped_close_size_f64, hedge_close_tx_hash
 		);
 
@@ -1000,12 +1011,20 @@ async fn do_close_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync +
 			.await;
 	}
 
-	// Update state: HedgeClosed (if cancel or close happened)
+	// Update state: HedgeClosed (if cancel or close happened) and populate txs/cloids
 	if close_ctx.should_cancel || close_ctx.should_close {
-		let _ = exec_ctx
-			.ctx
-			.loan_record_storage
-			.update(exec_ctx.storage_key, |r| r.state = LoanState::HedgeClosed);
+		let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
+			r.state = LoanState::HedgeClosed;
+			if let Some(ref tx_hash) = hedge_cancel_tx_hash {
+				r.txs.push(("hedge_cancel".to_string(), tx_hash.clone()));
+			}
+			if let Some(ref cloid) = hedge_close_cloid_opt {
+				r.cloids.push(("hedge_close".to_string(), cloid.clone()));
+			}
+			if let Some(ref tx_hash) = hedge_close_tx_hash {
+				r.txs.push(("hedge_close".to_string(), tx_hash.clone()));
+			}
+		});
 	}
 
 	Ok((hedge_cancel_tx_hash, hedge_close_cloid_opt, hedge_close_tx_hash))
@@ -1038,7 +1057,7 @@ async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 		encode_send_raw_action(transfer_action),
 	);
 
-	let usd_transfer_tx_hash = submit_corewriter_userop(
+	let to_spot_move_tx_hash = submit_corewriter_userop(
 		exec_ctx.ctx.clone(),
 		exec_ctx.omni_account,
 		&prepare_userop_no_init(exec_ctx.skeleton_user_op, *current_nonce),
@@ -1050,8 +1069,8 @@ async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 	*current_nonce += 1;
 
 	info!(
-		"USD transfer submitted, size: {}, tx_hash: {:?}",
-		move_ctx.transfer_amount, usd_transfer_tx_hash
+		"to_spot_move submitted, size: {}, tx_hash: {:?}",
+		move_ctx.transfer_amount, to_spot_move_tx_hash
 	);
 
 	exec_ctx
@@ -1071,20 +1090,22 @@ async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 			)
 		})?;
 
-	info!("USDC transfer completed");
+	info!("to_spot_move completed");
 
-	// Update state: ToSpotMoved
-	let _ = exec_ctx
-		.ctx
-		.loan_record_storage
-		.update(exec_ctx.storage_key, |r| r.state = LoanState::ToSpotMoved);
+	// Update state: ToSpotMoved and populate to_spot_move tx
+	let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
+		r.state = LoanState::ToSpotMoved;
+		if let Some(ref tx_hash) = to_spot_move_tx_hash {
+			r.txs.push(("to_spot_move".to_string(), tx_hash.clone()));
+		}
+	});
 
 	exec_ctx
 		.hypercore_client
 		.print_account_state(exec_ctx.smart_wallet, "After USD Transfer to Spot")
 		.await;
 
-	Ok(usd_transfer_tx_hash)
+	Ok(to_spot_move_tx_hash)
 }
 
 async fn do_buy_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
@@ -1172,7 +1193,7 @@ async fn do_buy_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 's
 	.await?;
 
 	info!(
-		"Spot buy order submitted, price: {}, size: {}, tx_hash: {:?}",
+		"spot_buy submitted, price: {}, size: {}, tx_hash: {:?}",
 		clamped_buy_price_f64, clamped_buy_size_f64, spot_buy_tx_hash
 	);
 
@@ -1203,11 +1224,14 @@ async fn do_buy_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 's
 
 	info!("Spot buy order filled successfully");
 
-	// Update state: SpotBought (final state)
-	let _ = exec_ctx
-		.ctx
-		.loan_record_storage
-		.update(exec_ctx.storage_key, |r| r.state = LoanState::SpotBought);
+	// Update state: SpotBought (final state) and populate spot_buy tx and cloid
+	let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
+		r.state = LoanState::SpotBought;
+		r.cloids.push(("spot_buy".to_string(), spot_buy_cloid.to_string()));
+		if let Some(ref tx_hash) = spot_buy_tx_hash {
+			r.txs.push(("spot_buy".to_string(), tx_hash.clone()));
+		}
+	});
 
 	exec_ctx
 		.hypercore_client

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -3,7 +3,7 @@ use crate::error_code::{INTERNAL_ERROR_CODE, INVALID_CHAIN_ID_CODE, PARSE_ERROR_
 use crate::methods::omni::PumpxRpcError;
 use crate::server::RpcContext;
 use crate::utils::omni::to_omni_account;
-use crate::utils::user_op::{prepare_skeleton_with_nonce, submit_corewriter_userop};
+use crate::utils::user_op::submit_corewriter_userop;
 use executor_core::intent_executor::IntentExecutor;
 use executor_core::types::SerializablePackedUserOperation;
 use executor_primitives::AccountId;
@@ -168,6 +168,7 @@ pub fn register_payback_loan_test<
 				smart_wallet,
 				storage_key: &storage_key,
 			};
+			let mut current_nonce = exec_ctx.skeleton_user_op.nonce;
 
 			match loan_record.state {
 				LoanState::PositionOpened => {
@@ -184,9 +185,6 @@ pub fn register_payback_loan_test<
 					)
 					.await?;
 
-					let (hedge_cancel_tx_hash, hedge_close_cloid_opt, hedge_close_tx_hash) =
-						do_close_position(&exec_ctx, hedge_open_cloid, &close_ctx).await?;
-
 					let move_ctx = precheck_move_to_spot(
 						&hypercore_client,
 						smart_wallet,
@@ -196,12 +194,22 @@ pub fn register_payback_loan_test<
 					)
 					.await?;
 
-					let usd_transfer_tx_hash = do_move_to_spot(&exec_ctx, &move_ctx).await?;
-
 					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
 
+					let (hedge_cancel_tx_hash, hedge_close_cloid_opt, hedge_close_tx_hash) =
+						do_close_position(
+							&exec_ctx,
+							hedge_open_cloid,
+							&close_ctx,
+							&mut current_nonce,
+						)
+						.await?;
+
+					let usd_transfer_tx_hash =
+						do_move_to_spot(&exec_ctx, &move_ctx, &mut current_nonce).await?;
+
 					let (spot_buy_cloid, spot_buy_tx_hash) =
-						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx).await?;
+						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx, current_nonce).await?;
 
 					Ok(PaybackLoanTestResponse {
 						collateral_ticker,
@@ -226,12 +234,13 @@ pub fn register_payback_loan_test<
 					)
 					.await?;
 
-					let usd_transfer_tx_hash = do_move_to_spot(&exec_ctx, &move_ctx).await?;
-
 					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
 
+					let usd_transfer_tx_hash =
+						do_move_to_spot(&exec_ctx, &move_ctx, &mut current_nonce).await?;
+
 					let (spot_buy_cloid, spot_buy_tx_hash) =
-						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx).await?;
+						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx, current_nonce).await?;
 
 					Ok(PaybackLoanTestResponse {
 						collateral_ticker,
@@ -250,7 +259,7 @@ pub fn register_payback_loan_test<
 					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
 
 					let (spot_buy_cloid, spot_buy_tx_hash) =
-						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx).await?;
+						do_buy_spot(&exec_ctx, collateral_size, &buy_ctx, current_nonce).await?;
 
 					Ok(PaybackLoanTestResponse {
 						collateral_ticker,
@@ -303,6 +312,18 @@ fn precheck_params(params: &PaybackLoanTestParams) -> Result<(AccountId, u64, f6
 	info!("Minimum expected account value threshold: {} USDC", min_expected_account_value_f64);
 
 	Ok((omni_account, params.loan_nonce, min_expected_account_value_f64))
+}
+
+/// Helper to prepare UserOp with custom nonce, always clearing init_code
+/// (payback_loan never needs init_code as account is already created)
+fn prepare_userop_no_init(
+	base: &SerializablePackedUserOperation,
+	nonce: u128,
+) -> SerializablePackedUserOperation {
+	let mut op = base.clone();
+	op.nonce = nonce;
+	op.init_code = "0x".to_string(); // Always clear init_code for payback
+	op
 }
 
 /// Helper to verify hedge position exists and is not liquidated
@@ -836,8 +857,8 @@ async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Syn
 	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
 	hedge_open_cloid: u128,
 	close_ctx: &ClosePositionContext,
+	current_nonce: &mut u128,
 ) -> Result<(Option<String>, Option<String>, Option<String>), PumpxRpcError> {
-	let mut current_nonce = exec_ctx.skeleton_user_op.nonce;
 	let mut hedge_cancel_tx_hash = None;
 	let mut hedge_close_cloid_opt = None;
 	let mut hedge_close_tx_hash = None;
@@ -855,7 +876,7 @@ async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Syn
 		let cancel_tx_hash = submit_corewriter_userop(
 			exec_ctx.ctx.clone(),
 			exec_ctx.omni_account,
-			&prepare_skeleton_with_nonce(exec_ctx.skeleton_user_op, current_nonce),
+			&prepare_userop_no_init(exec_ctx.skeleton_user_op, *current_nonce),
 			exec_ctx.chain_id,
 			exec_ctx.wallet_index,
 			cancel_calldata,
@@ -864,7 +885,7 @@ async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Syn
 
 		info!("Cancel order submitted with tx_hash: {:?}", cancel_tx_hash);
 		hedge_cancel_tx_hash = cancel_tx_hash.clone();
-		current_nonce += 1;
+		*current_nonce += 1;
 
 		let order_canceled = exec_ctx
 			.hypercore_client
@@ -950,12 +971,13 @@ async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Syn
 		hedge_close_tx_hash = submit_corewriter_userop(
 			exec_ctx.ctx.clone(),
 			exec_ctx.omni_account,
-			&prepare_skeleton_with_nonce(exec_ctx.skeleton_user_op, current_nonce),
+			&prepare_userop_no_init(exec_ctx.skeleton_user_op, *current_nonce),
 			exec_ctx.chain_id,
 			exec_ctx.wallet_index,
 			close_calldata,
 		)
 		.await?;
+		*current_nonce += 1;
 
 		info!(
 			"Hedge close order submitted, price: {}, size: {}, tx_hash: {:?}",
@@ -1008,6 +1030,7 @@ async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Syn
 async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
 	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
 	move_ctx: &MoveToSpotContext,
+	current_nonce: &mut u128,
 ) -> Result<Option<String>, PumpxRpcError> {
 	info!("Action: Transferring USDC from perp to spot...");
 
@@ -1031,33 +1054,16 @@ async fn do_move_to_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 		encode_send_raw_action(transfer_action),
 	);
 
-	// Calculate nonce offset based on state
-	let current_loan_state = exec_ctx
-		.ctx
-		.loan_record_storage
-		.get(exec_ctx.storage_key)
-		.ok()
-		.flatten()
-		.map(|r| r.state);
-
-	let nonce_offset = match current_loan_state {
-		Some(LoanState::PositionOpened) => 2, // After cancel (0 or 1) + close (1 or 2)
-		Some(LoanState::PositionClosed) => 0, // Start fresh
-		_ => 0,
-	};
-
 	let usd_transfer_tx_hash = submit_corewriter_userop(
 		exec_ctx.ctx.clone(),
 		exec_ctx.omni_account,
-		&prepare_skeleton_with_nonce(
-			exec_ctx.skeleton_user_op,
-			exec_ctx.skeleton_user_op.nonce + nonce_offset,
-		),
+		&prepare_userop_no_init(exec_ctx.skeleton_user_op, *current_nonce),
 		exec_ctx.chain_id,
 		exec_ctx.wallet_index,
 		transfer_calldata,
 	)
 	.await?;
+	*current_nonce += 1;
 
 	info!(
 		"USD transfer submitted, size: {}, tx_hash: {:?}",
@@ -1101,6 +1107,7 @@ async fn do_buy_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 's
 	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
 	collateral_size: f64,
 	buy_ctx: &BuySpotContext,
+	current_nonce: u128,
 ) -> Result<(u128, Option<String>), PumpxRpcError> {
 	info!("Action: Buying back collateral in spot market...");
 
@@ -1170,29 +1177,10 @@ async fn do_buy_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 's
 		encode_send_raw_action(spot_buy_action),
 	);
 
-	// Calculate nonce offset based on state
-	let current_loan_state = exec_ctx
-		.ctx
-		.loan_record_storage
-		.get(exec_ctx.storage_key)
-		.ok()
-		.flatten()
-		.map(|r| r.state);
-
-	let nonce_offset = match current_loan_state {
-		Some(LoanState::PositionOpened) => 3, // After cancel + close + transfer
-		Some(LoanState::PositionClosed) => 1, // After transfer
-		Some(LoanState::ToSpotMoved) => 0,    // Start fresh
-		_ => 0,
-	};
-
 	let spot_buy_tx_hash = submit_corewriter_userop(
 		exec_ctx.ctx.clone(),
 		exec_ctx.omni_account,
-		&prepare_skeleton_with_nonce(
-			exec_ctx.skeleton_user_op,
-			exec_ctx.skeleton_user_op.nonce + nonce_offset,
-		),
+		&prepare_userop_no_init(exec_ctx.skeleton_user_op, current_nonce),
 		exec_ctx.chain_id,
 		exec_ctx.wallet_index,
 		spot_buy_calldata,

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/payback_loan_test.rs
@@ -51,7 +51,7 @@ struct ExecutionContext<'a, CrossChainIntentExecutor: IntentExecutor + Send + Sy
 	storage_key: &'a executor_storage::loan_record::Key,
 }
 
-struct ClosePositionContext {
+struct CloseHedgeContext {
 	should_cancel: bool,
 	should_close: bool,
 	position_size_to_close: f64,
@@ -171,10 +171,10 @@ pub fn register_payback_loan_test<
 			let mut current_nonce = exec_ctx.skeleton_user_op.nonce;
 
 			match loan_record.state {
-				LoanState::PositionOpened => {
-					info!("Starting payback from PositionOpened state");
+				LoanState::HedgeOpened => {
+					info!("Starting payback from HedgeOpened state");
 
-					let close_ctx = precheck_close_position(
+					let close_ctx = precheck_close_hedge(
 						&ctx,
 						&hypercore_client,
 						smart_wallet,
@@ -197,13 +197,8 @@ pub fn register_payback_loan_test<
 					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
 
 					let (hedge_cancel_tx_hash, hedge_close_cloid_opt, hedge_close_tx_hash) =
-						do_close_position(
-							&exec_ctx,
-							hedge_open_cloid,
-							&close_ctx,
-							&mut current_nonce,
-						)
-						.await?;
+						do_close_hedge(&exec_ctx, hedge_open_cloid, &close_ctx, &mut current_nonce)
+							.await?;
 
 					let usd_transfer_tx_hash =
 						do_move_to_spot(&exec_ctx, &move_ctx, &mut current_nonce).await?;
@@ -222,8 +217,8 @@ pub fn register_payback_loan_test<
 						spot_buy_tx_hash,
 					})
 				},
-				LoanState::PositionClosed => {
-					info!("Resuming payback from PositionClosed state");
+				LoanState::HedgeClosed => {
+					info!("Resuming from HedgeClosed state");
 
 					let move_ctx = precheck_move_to_spot(
 						&hypercore_client,
@@ -254,7 +249,7 @@ pub fn register_payback_loan_test<
 					})
 				},
 				LoanState::ToSpotMoved => {
-					info!("Resuming payback from ToSpotMoved state");
+					info!("Resuming from ToSpotMoved state");
 
 					let buy_ctx = precheck_buy_spot(&hypercore_client, &collateral_ticker).await?;
 
@@ -443,9 +438,7 @@ async fn verify_hedge_position(
 	))
 }
 
-async fn precheck_close_position<
-	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
->(
+async fn precheck_close_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
 	_ctx: &RpcContext<CrossChainIntentExecutor>,
 	hypercore_client: &HyperCoreClient,
 	smart_wallet: &str,
@@ -453,16 +446,13 @@ async fn precheck_close_position<
 	hedge_open_cloid: u128,
 	min_expected_account_value_f64: f64,
 	loan_record: &executor_storage::loan_record::LoanRecord,
-) -> Result<ClosePositionContext, PumpxRpcError> {
-	// Validate loan state is PositionOpened
-	if loan_record.state != LoanState::PositionOpened {
-		error!(
-			"Invalid loan state for payback: expected PositionOpened, got {:?}",
-			loan_record.state
-		);
+) -> Result<CloseHedgeContext, PumpxRpcError> {
+	// Validate loan state is HedgeOpened
+	if loan_record.state != LoanState::HedgeOpened {
+		error!("Invalid loan state for payback: expected HedgeOpened, got {:?}", loan_record.state);
 		return Err(PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Invalid loan state").with_reason(format!(
-				"Loan must be in PositionOpened state for payback, current state: {:?}",
+				"Loan must be in HedgeOpened state for payback, current state: {:?}",
 				loan_record.state
 			)),
 		));
@@ -561,7 +551,7 @@ async fn precheck_close_position<
 	// If the order is not found (unknownOid), skip closing
 	if order_status.status == "unknownOid" {
 		info!("Order with cloid {} not found (unknownOid), skipping close", hedge_open_cloid);
-		return Ok(ClosePositionContext {
+		return Ok(CloseHedgeContext {
 			should_cancel: false,
 			should_close: false,
 			position_size_to_close: 0.0,
@@ -724,7 +714,7 @@ async fn precheck_close_position<
 
 	info!("✓ Close position precheck passed");
 
-	Ok(ClosePositionContext {
+	Ok(CloseHedgeContext {
 		should_cancel,
 		should_close,
 		position_size_to_close,
@@ -853,10 +843,10 @@ async fn precheck_buy_spot(
 	Ok(BuySpotContext { spot_asset_id, spot_sz_decimals, spot_mark_price, spot_mid_price })
 }
 
-async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
+async fn do_close_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
 	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
 	hedge_open_cloid: u128,
-	close_ctx: &ClosePositionContext,
+	close_ctx: &CloseHedgeContext,
 	current_nonce: &mut u128,
 ) -> Result<(Option<String>, Option<String>, Option<String>), PumpxRpcError> {
 	let mut hedge_cancel_tx_hash = None;
@@ -1016,12 +1006,12 @@ async fn do_close_position<CrossChainIntentExecutor: IntentExecutor + Send + Syn
 			.await;
 	}
 
-	// Update state: PositionClosed (if cancel or close happened)
+	// Update state: HedgeClosed (if cancel or close happened)
 	if close_ctx.should_cancel || close_ctx.should_close {
 		let _ = exec_ctx
 			.ctx
 			.loan_record_storage
-			.update(exec_ctx.storage_key, |r| r.state = LoanState::PositionClosed);
+			.update(exec_ctx.storage_key, |r| r.state = LoanState::HedgeClosed);
 	}
 
 	Ok((hedge_cancel_tx_hash, hedge_close_cloid_opt, hedge_close_tx_hash))

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
@@ -15,6 +15,18 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, error, info};
 
+/// Truncates a float to at most 3 decimal places without rounding.
+/// Removes trailing zeros for cleaner storage.
+///
+/// Examples: 9.1866 -> "9.186" (truncated, not rounded to 9.187)
+fn truncate_usdc(value: f64) -> String {
+	let truncated = (value * 1000.0).floor() / 1000.0;
+	format!("{:.3}", truncated)
+		.trim_end_matches('0')
+		.trim_end_matches('.')
+		.to_string()
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RequestLoanTestParams {
 	pub user_operation: SerializablePackedUserOperation,
@@ -162,7 +174,7 @@ pub fn register_request_loan_test<
 					Ok(RequestLoanTestResponse {
 						spot_sell_cloid: spot_sell_cloid.to_string(),
 						hedge_open_cloid: hedge_open_cloid.to_string(),
-						usdc_received: format!("{:.2}", usdc_loaned),
+						usdc_received: truncate_usdc(usdc_loaned),
 						spot_sell_tx_hash,
 						to_perp_move_tx_hash,
 						hedge_open_tx_hash,
@@ -627,7 +639,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 			)
 		})?;
 
-	let usdc_sold = usdc_from_spot_fill(&spot_sell_fill).map_err(|e| {
+	let usdc_sold_f64 = usdc_from_spot_fill(&spot_sell_fill).map_err(|e| {
 		error!("Failed to calculate USDC received: {}", e);
 		PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
@@ -635,10 +647,17 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 		)
 	})?;
 
-	info!("Spot sell completed: received {:.2} USDC", usdc_sold);
+	let usdc_loaned_f64 = usdc_sold_f64 * lending_ratio_f64;
+	let usdc_for_perp_f64 = usdc_sold_f64 * (1.0 - lending_ratio_f64);
 
-	let usdc_loaned = usdc_sold * lending_ratio_f64;
-	let usdc_for_perp = usdc_sold * (1.0 - lending_ratio_f64);
+	let usdc_sold = truncate_usdc(usdc_sold_f64);
+	let usdc_loaned = truncate_usdc(usdc_loaned_f64);
+	let usdc_for_perp = truncate_usdc(usdc_for_perp_f64);
+
+	info!(
+		"Spot sell completed: usdc_sold={}, usdc_loaned={}, usdc_for_perp={}",
+		usdc_sold, usdc_loaned, usdc_for_perp
+	);
 
 	// Store loan record with SpotSold state
 	exec_ctx
@@ -649,9 +668,9 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 			executor_storage::loan_record::NewLoanRecord {
 				collateral_ticker: collateral_ticker.to_string(),
 				collateral_size: collateral_size.to_string(),
-				usdc_sold: format!("{:.2}", usdc_sold),
-				usdc_loaned: format!("{:.2}", usdc_loaned),
-				usdc_for_perp: format!("{:.2}", usdc_for_perp),
+				usdc_sold,
+				usdc_loaned,
+				usdc_for_perp,
 			},
 		)
 		.map_err(|e| {
@@ -675,7 +694,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 		.print_account_state(exec_ctx.smart_wallet, "After Spot Sell")
 		.await;
 
-	Ok((usdc_sold, spot_sell_cloid, spot_sell_tx_hash))
+	Ok((usdc_sold_f64, spot_sell_cloid, spot_sell_tx_hash))
 }
 
 async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
@@ -8,22 +8,15 @@ use alloy::primitives::Address;
 use executor_core::intent_executor::IntentExecutor;
 use executor_core::types::SerializablePackedUserOperation;
 use executor_primitives::{AccountId, ChainId};
-use executor_storage::{LoanRecord, Storage};
+use executor_storage::{LoanState, Storage};
 use hyperliquid::*;
 use jsonrpsee::RpcModule;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, error, info};
 
-/// Result of loan request validation, containing metadata needed for order construction
-struct LoanRequestValidationResult {
-	spot_asset_id: u32,
-	perp_asset_id: u32,
-	spot_sz_decimals: u8,
-	perp_sz_decimals: u8,
-	max_leverage: u32,
-	lending_ratio_f64: f64,
-}
+// minimum perp order notional value ($10 minimum)
+const MIN_PERP_NOTIONAL: f64 = 10.0;
 
 #[derive(Debug, Deserialize)]
 pub struct RequestLoanTestParams {
@@ -46,6 +39,31 @@ pub struct RequestLoanTestResponse {
 	pub hedge_open_tx_hash: Option<String>,
 }
 
+struct ExecutionContext<'a, CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static> {
+	ctx: Arc<RpcContext<CrossChainIntentExecutor>>,
+	omni_account: &'a AccountId,
+	skeleton_user_op: &'a SerializablePackedUserOperation,
+	chain_id: u64,
+	wallet_index: u32,
+	client_id: &'a str,
+	hypercore_client: &'a HyperCoreClient,
+	smart_wallet: &'a str,
+	storage_key: &'a executor_storage::loan_record::Key,
+}
+
+struct SellSpotContext {
+	spot_asset_id: u32,
+	spot_sz_decimals: u8,
+	spot_mark_price: f64,
+	spot_mid_price: f64,
+}
+
+struct OpenPositionContext {
+	perp_asset_id: u32,
+	perp_sz_decimals: u8,
+	perp_max_leverage: u32,
+}
+
 pub fn register_request_loan_test<
 	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
 >(
@@ -63,205 +81,490 @@ pub fn register_request_loan_test<
 
 			debug!("Received omni_requestLoanTest, params: {:?}", params);
 
-			let omni_account = to_omni_account(&params.omni_account).map_err(|_| {
-				error!("Failed to parse omni account");
+			let (omni_account, collateral_ticker, collateral_size, lending_ratio_f64) =
+				precheck_params(&params)?;
+
+			let ctx = Arc::clone(&ctx);
+			let smart_wallet = &params.user_operation.sender;
+			let storage_key = executor_storage::loan_record::Key {
+				account_id: omni_account.clone(),
+				nonce: params.user_operation.nonce as u64,
+			};
+
+			let hypercore_client = HyperCoreClient::new(params.chain_id).map_err(|e| {
 				PumpxRpcError::from(
-					DetailedError::new(PARSE_ERROR_CODE, "Parse error")
-						.with_reason("Failed to parse omni account"),
+					DetailedError::new(INVALID_CHAIN_ID_CODE, "Chain not supported").with_reason(e),
 				)
 			})?;
 
-			// Validate sender address
-			params.user_operation.sender.parse::<Address>().map_err(|e| {
-				error!("Invalid sender address '{}': {}", params.user_operation.sender, e);
-				PumpxRpcError::from(
-					DetailedError::new(PARSE_ERROR_CODE, "Parse error")
-						.with_field("sender")
-						.with_reason(format!(
-							"Invalid sender address '{}': {}",
-							params.user_operation.sender, e
+			let exec_ctx = ExecutionContext {
+				ctx: ctx.clone(),
+				omni_account: &omni_account,
+				skeleton_user_op: &params.user_operation,
+				chain_id: params.chain_id,
+				wallet_index: params.wallet_index,
+				client_id: &params.client_id,
+				hypercore_client: &hypercore_client,
+				smart_wallet,
+				storage_key: &storage_key,
+			};
+
+			match ctx.loan_record_storage.get(&storage_key).ok().flatten() {
+				None => {
+					info!("Starting new loan request");
+					hypercore_client.print_account_state(smart_wallet, "Before Request").await;
+
+					let sell_ctx = precheck_sell_spot(
+						&hypercore_client,
+						smart_wallet,
+						&collateral_ticker,
+						collateral_size,
+					)
+					.await?;
+
+					// use spot_mid_price as estimation
+					let usdc_for_perp =
+						sell_ctx.spot_mid_price * collateral_size * (1.0 - lending_ratio_f64);
+
+					let open_ctx = precheck_open_position(
+						&hypercore_client,
+						&collateral_ticker,
+						usdc_for_perp,
+						lending_ratio_f64,
+					)
+					.await?;
+
+					let (usdc_sold, spot_cloid, hedge_cloid) = do_sell_spot(
+						&exec_ctx,
+						&collateral_ticker,
+						collateral_size,
+						lending_ratio_f64,
+						&sell_ctx,
+					)
+					.await?;
+
+					let usdc_loaned = usdc_sold * lending_ratio_f64;
+					let usdc_for_perp = usdc_sold * (1.0 - lending_ratio_f64);
+
+					do_move_to_perp(&exec_ctx, usdc_for_perp).await?;
+
+					do_open_position(
+						&exec_ctx,
+						&collateral_ticker,
+						usdc_for_perp,
+						lending_ratio_f64,
+						hedge_cloid,
+						&open_ctx,
+					)
+					.await?;
+
+					Ok(RequestLoanTestResponse {
+						spot_sell_cloid: spot_cloid.to_string(),
+						hedge_open_cloid: hedge_cloid.to_string(),
+						usdc_received: format!("{:.2}", usdc_loaned),
+						spot_sell_tx_hash: None,
+						hedge_open_tx_hash: None,
+					})
+				},
+				Some(existing) => {
+					if existing.collateral_ticker != collateral_ticker
+						|| existing.collateral_size != format!("{}", collateral_size)
+					{
+						return Err(PumpxRpcError::from(
+							DetailedError::new(INTERNAL_ERROR_CODE, "Loan parameters mismatch")
+								.with_reason(format!(
+									"Existing: {}@{}; Requested: {}@{}",
+									existing.collateral_ticker,
+									existing.collateral_size,
+									collateral_ticker,
+									collateral_size
+								)),
+						));
+					}
+
+					match existing.state {
+						LoanState::PositionOpened => {
+							info!("Loan already completed");
+							Ok(RequestLoanTestResponse {
+								spot_sell_cloid: existing.spot_sell_cloid,
+								hedge_open_cloid: existing.hedge_open_cloid,
+								usdc_received: existing.usdc_loaned,
+								spot_sell_tx_hash: None,
+								hedge_open_tx_hash: None,
+							})
+						},
+						LoanState::SpotSold => {
+							info!("Resuming from SpotSold");
+
+							let usdc_for_perp =
+								existing.usdc_for_perp.parse::<f64>().map_err(|e| {
+									PumpxRpcError::from(
+										DetailedError::new(
+											INTERNAL_ERROR_CODE,
+											"Invalid stored data",
+										)
+										.with_reason(format!("Invalid usdc_for_perp: {}", e)),
+									)
+								})?;
+
+							let open_ctx = precheck_open_position(
+								&hypercore_client,
+								&collateral_ticker,
+								usdc_for_perp,
+								lending_ratio_f64,
+							)
+							.await?;
+
+							let hedge_cloid =
+								existing.hedge_open_cloid.parse::<u128>().map_err(|e| {
+									PumpxRpcError::from(
+										DetailedError::new(
+											INTERNAL_ERROR_CODE,
+											"Invalid stored data",
+										)
+										.with_reason(format!("Invalid hedge_open_cloid: {}", e)),
+									)
+								})?;
+
+							do_move_to_perp(&exec_ctx, usdc_for_perp).await?;
+
+							do_open_position(
+								&exec_ctx,
+								&collateral_ticker,
+								usdc_for_perp,
+								lending_ratio_f64,
+								hedge_cloid,
+								&open_ctx,
+							)
+							.await?;
+
+							Ok(RequestLoanTestResponse {
+								spot_sell_cloid: existing.spot_sell_cloid,
+								hedge_open_cloid: existing.hedge_open_cloid,
+								usdc_received: existing.usdc_loaned,
+								spot_sell_tx_hash: None,
+								hedge_open_tx_hash: None,
+							})
+						},
+						LoanState::ToPerpMoved => {
+							info!("Resuming from ToPerpMoved");
+
+							let usdc_for_perp =
+								existing.usdc_for_perp.parse::<f64>().map_err(|e| {
+									PumpxRpcError::from(
+										DetailedError::new(
+											INTERNAL_ERROR_CODE,
+											"Invalid stored data",
+										)
+										.with_reason(format!("Invalid usdc_for_perp: {}", e)),
+									)
+								})?;
+
+							let open_ctx = precheck_open_position(
+								&hypercore_client,
+								&collateral_ticker,
+								usdc_for_perp,
+								lending_ratio_f64,
+							)
+							.await?;
+
+							let hedge_cloid =
+								existing.hedge_open_cloid.parse::<u128>().map_err(|e| {
+									PumpxRpcError::from(
+										DetailedError::new(
+											INTERNAL_ERROR_CODE,
+											"Invalid stored data",
+										)
+										.with_reason(format!("Invalid hedge_open_cloid: {}", e)),
+									)
+								})?;
+
+							do_open_position(
+								&exec_ctx,
+								&collateral_ticker,
+								usdc_for_perp,
+								lending_ratio_f64,
+								hedge_cloid,
+								&open_ctx,
+							)
+							.await?;
+
+							Ok(RequestLoanTestResponse {
+								spot_sell_cloid: existing.spot_sell_cloid,
+								hedge_open_cloid: existing.hedge_open_cloid,
+								usdc_received: existing.usdc_loaned,
+								spot_sell_tx_hash: None,
+								hedge_open_tx_hash: None,
+							})
+						},
+						_ => Err(PumpxRpcError::from(
+							DetailedError::new(INTERNAL_ERROR_CODE, "Invalid loan state")
+								.with_reason(format!(
+									"Cannot resume from state: {:?}",
+									existing.state
+								)),
 						)),
-				)
-			})?;
-
-			// Validate collateral ticker is not empty and normalize to uppercase
-			if params.collateral_ticker.is_empty() {
-				return Err(PumpxRpcError::from(
-					DetailedError::new(PARSE_ERROR_CODE, "Collateral ticker cannot be empty")
-						.with_field("collateral_ticker")
-						.with_suggestion("Provide a valid ticker like ETH, PURR, etc."),
-				));
+					}
+				},
 			}
-			let collateral_ticker = params.collateral_ticker.to_uppercase();
-
-			// Validate collateral_size is not empty
-			if params.collateral_size.is_empty() {
-				return Err(PumpxRpcError::from(
-					DetailedError::new(PARSE_ERROR_CODE, "Collateral size cannot be empty")
-						.with_field("collateral_size")
-						.with_suggestion(
-							"Provide a valid collateral size in human-readable format",
-						),
-				));
-			}
-
-			// Validate lending_ratio is between 0 and 100 (0-100%)
-			if params.lending_ratio > 100 {
-				return Err(PumpxRpcError::from(
-					DetailedError::new(PARSE_ERROR_CODE, "Lending ratio must be between 0 and 100")
-						.with_field("lending_ratio")
-						.with_received(params.lending_ratio.to_string())
-						.with_expected("0-100 (percentage)"),
-				));
-			}
-
-			// Call the inlined handler logic
-			handle_request_loan_impl(
-				Arc::clone(&ctx),
-				omni_account,
-				params.user_operation.clone(),
-				params.chain_id,
-				params.wallet_index,
-				&collateral_ticker,
-				&params.collateral_size,
-				params.lending_ratio,
-				&params.client_id,
-			)
-			.await
 		})
 		.expect("Failed to register omni_requestLoanTest method");
 }
 
-// Main handler implementation
-#[allow(clippy::too_many_arguments)]
-async fn handle_request_loan_impl<
-	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
->(
-	ctx: Arc<RpcContext<CrossChainIntentExecutor>>,
-	omni_account: AccountId,
-	skeleton_user_op: SerializablePackedUserOperation,
-	chain_id: u64,
-	wallet_index: u32,
+fn precheck_params(
+	params: &RequestLoanTestParams,
+) -> Result<(AccountId, String, f64, f64), PumpxRpcError> {
+	let omni_account = to_omni_account(&params.omni_account).map_err(|_| {
+		PumpxRpcError::from(DetailedError::new(PARSE_ERROR_CODE, "Invalid omni account"))
+	})?;
+
+	params.user_operation.sender.parse::<Address>().map_err(|e| {
+		PumpxRpcError::from(
+			DetailedError::new(PARSE_ERROR_CODE, "Invalid sender address")
+				.with_field("sender")
+				.with_reason(format!("{}", e)),
+		)
+	})?;
+
+	if params.collateral_ticker.is_empty() {
+		return Err(PumpxRpcError::from(
+			DetailedError::new(PARSE_ERROR_CODE, "Empty collateral ticker")
+				.with_field("collateral_ticker"),
+		));
+	}
+
+	if params.collateral_size.is_empty() {
+		return Err(PumpxRpcError::from(
+			DetailedError::new(PARSE_ERROR_CODE, "Empty collateral size")
+				.with_field("collateral_size"),
+		));
+	}
+
+	if params.lending_ratio > 100 {
+		return Err(PumpxRpcError::from(
+			DetailedError::new(PARSE_ERROR_CODE, "Invalid lending ratio")
+				.with_field("lending_ratio")
+				.with_received(params.lending_ratio.to_string())
+				.with_expected("0-100"),
+		));
+	}
+
+	let collateral_ticker = params.collateral_ticker.to_uppercase();
+	let collateral_size = params.collateral_size.parse::<f64>().map_err(|e| {
+		PumpxRpcError::from(
+			DetailedError::new(PARSE_ERROR_CODE, "Invalid collateral size")
+				.with_field("collateral_size")
+				.with_reason(format!("{}", e)),
+		)
+	})?;
+	let lending_ratio_f64 = params.lending_ratio as f64 / 100.0;
+
+	Ok((omni_account, collateral_ticker, collateral_size, lending_ratio_f64))
+}
+
+async fn precheck_sell_spot(
+	hypercore_client: &HyperCoreClient,
+	smart_wallet: &str,
 	collateral_ticker: &str,
-	collateral_size_str: &str,
-	lending_ratio: u32,
-	client_id: &str,
-) -> Result<RequestLoanTestResponse, PumpxRpcError> {
-	let smart_wallet_address_str = &skeleton_user_op.sender;
-
-	let hypercore_client = HyperCoreClient::new(chain_id).map_err(|e| {
-		error!("Failed to create HyperCore client: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INVALID_CHAIN_ID_CODE, "Chain not supported")
-				.with_reason(format!("Chain ID {} is not supported", chain_id)),
-		)
-	})?;
-
-	let collateral_size = collateral_size_str.parse::<f64>().map_err(|e| {
-		error!("Failed to parse collateral_size: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Invalid collateral_size: {}", e)),
-		)
-	})?;
-
-	// Validate loan request parameters (including balance, size, etc.)
-	let validation_result = precheck(
-		&hypercore_client,
-		smart_wallet_address_str,
-		collateral_ticker,
-		collateral_size,
-		lending_ratio,
-	)
-	.await?;
-
-	let lending_ratio_f64 = validation_result.lending_ratio_f64;
-
-	// Print initial account state
-	hypercore_client
-		.print_account_state(smart_wallet_address_str, "Before Actions")
-		.await;
-
-	// Action 1: Sell collateral_size as spot to get X USDC
-	// Use prices from validation - precheck is fast enough that we don't need to refresh
-	let (_spot_meta, spot_mark_price, spot_mid_price) =
+	collateral_size: f64,
+) -> Result<SellSpotContext, PumpxRpcError> {
+	let (spot_meta, spot_mark_price, spot_mid_price) =
 		hypercore_client.get_spot_market_prices(collateral_ticker).await.map_err(|e| {
-			error!("Failed to get spot market prices: {}", e);
+			error!("Failed to get spot market prices for {}: {}", collateral_ticker, e);
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Failed to get spot prices: {}", e)),
+					.with_reason(format!("Failed to get spot market prices: {}", e)),
 			)
 		})?;
 
-	let clamped_size = clamp_size(collateral_size, validation_result.spot_sz_decimals);
-	// For selling, we want to sell at the highest buy price (bid)
-	let (spot_bid_price, _spot_ask_price) = get_bid_ask_prices(spot_mark_price, spot_mid_price);
-	let target_price = spot_bid_price * SPOT_SELL_PRICE_RATIO;
-	let clamped_price = clamp_price(target_price, validation_result.spot_sz_decimals, true);
+	let spot_asset_id = get_spot_asset_id(collateral_ticker, &spot_meta).map_err(|e| {
+		error!("Failed to get spot asset ID: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
+		)
+	})?;
 
-	info!(
-		"Spot sell pricing - markPx: {}, midPx: {}, bid (highest buy): {}, target (with {}x buffer): {}",
-		spot_mark_price, spot_mid_price, spot_bid_price, SPOT_SELL_PRICE_RATIO, target_price
-	);
+	let spot_token = spot_meta
+		.tokens
+		.iter()
+		.find(|t| t.name.eq_ignore_ascii_case(collateral_ticker))
+		.ok_or_else(|| {
+			error!("Token {} not found in spot meta", collateral_ticker);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Token {} not found in spot meta", collateral_ticker)),
+			)
+		})?;
+
+	let spot_sz_decimals = spot_token.sz_decimals;
+
+	// Validate trade size
+	validate_trade_size(collateral_size, spot_sz_decimals, None).map_err(|e| {
+		error!("Invalid collateral size for spot trading: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Invalid collateral size: {}", e)),
+		)
+	})?;
+
+	// Validate balance
+	let user_balance = hypercore_client
+		.get_spot_balance(smart_wallet, collateral_ticker)
+		.await
+		.map_err(|e| {
+			error!("Failed to get user balance: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to query balance: {}", e)),
+			)
+		})?;
+
+	if user_balance < collateral_size {
+		error!("Insufficient balance: has {} but needs {}", user_balance, collateral_size);
+		return Err(PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Insufficient balance").with_reason(format!(
+				"User has {} but needs {} {}",
+				user_balance, collateral_size, collateral_ticker
+			)),
+		));
+	}
+
+	info!("✓ Spot sell precheck passed");
+
+	Ok(SellSpotContext { spot_asset_id, spot_sz_decimals, spot_mark_price, spot_mid_price })
+}
+
+async fn precheck_open_position(
+	hypercore_client: &HyperCoreClient,
+	collateral_ticker: &str,
+	usdc_for_perp: f64,
+	lending_ratio_f64: f64,
+) -> Result<OpenPositionContext, PumpxRpcError> {
+	let (perp_meta, perp_mark_price, perp_mid_price) =
+		hypercore_client.get_perp_market_prices(collateral_ticker).await.map_err(|e| {
+			error!("Failed to get perp market prices for {}: {}", collateral_ticker, e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to get perp market prices: {}", e)),
+			)
+		})?;
+
+	let perp_asset_id = get_perp_asset_id(collateral_ticker, &perp_meta).map_err(|e| {
+		error!("Failed to get perp asset ID: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
+		)
+	})?;
+
+	let perp_asset = perp_meta.universe.get(perp_asset_id as usize).ok_or_else(|| {
+		error!("Perp asset {} not found in meta", perp_asset_id);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Perp asset {} not found", perp_asset_id)),
+		)
+	})?;
+
+	let perp_sz_decimals = perp_asset.sz_decimals;
+	let perp_max_leverage = perp_asset.max_leverage;
+
+	let desired_leverage = 1.0 / (1.0 - lending_ratio_f64);
+	let effective_leverage = desired_leverage.min(perp_max_leverage as f64);
+
+	let estimated_notional = usdc_for_perp * effective_leverage;
+
+	if estimated_notional < MIN_PERP_NOTIONAL {
+		error!(
+			"Perp notional too small, estimated: {}, required: {}",
+			estimated_notional, MIN_PERP_NOTIONAL
+		);
+		return Err(PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
+				"Perp notional too small, estimated: {}, required: {}",
+				estimated_notional, MIN_PERP_NOTIONAL
+			)),
+		));
+	}
+
+	// Worst case for opening long position: lowest sell price (ask) with buffer
+	let (_perp_bid_price, perp_ask_price) = get_bid_ask_prices(perp_mark_price, perp_mid_price);
+	let worst_case_perp_open_price = perp_ask_price * PERP_ENTRY_PRICE_RATIO;
+	let estimated_hedge_size = estimated_notional / worst_case_perp_open_price;
+
+	validate_trade_size(estimated_hedge_size, perp_sz_decimals, None).map_err(|e| {
+		error!("Invalid estimated hedge size for perp trading: {}", e);
+		PumpxRpcError::from(DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(
+			format!(
+				"Invalid estimated hedge size (margin={:.2}, leverage={:.2}x, perp_price={:.2}, size={}): {}",
+				usdc_for_perp, effective_leverage, worst_case_perp_open_price, estimated_hedge_size, e
+			),
+		))
+	})?;
+
+	info!("✓ Open position precheck passed");
+
+	Ok(OpenPositionContext { perp_asset_id, perp_sz_decimals, perp_max_leverage })
+}
+
+async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
+	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
+	collateral_ticker: &str,
+	collateral_size: f64,
+	lending_ratio_f64: f64,
+	sell_ctx: &SellSpotContext,
+) -> Result<(f64, u128, u128), PumpxRpcError> {
+	info!("Action: Selling {} {} in spot market", collateral_size, collateral_ticker);
+
+	let clamped_size = clamp_size(collateral_size, sell_ctx.spot_sz_decimals);
+	let (spot_bid_price, _) = get_bid_ask_prices(sell_ctx.spot_mark_price, sell_ctx.spot_mid_price);
+	let target_price = spot_bid_price * SPOT_SELL_PRICE_RATIO;
+	let clamped_price = clamp_price(target_price, sell_ctx.spot_sz_decimals, true);
 
 	let clamped_size_f64 = clamped_size.parse::<f64>().map_err(|e| {
-		error!("Failed to parse clamped size: {}", e);
 		PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 				.with_reason(format!("Failed to parse clamped size: {}", e)),
 		)
 	})?;
 	let clamped_price_f64 = clamped_price.parse::<f64>().map_err(|e| {
-		error!("Failed to parse clamped price: {}", e);
 		PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 				.with_reason(format!("Failed to parse clamped price: {}", e)),
 		)
 	})?;
 
-	let spot_sell_size_units = to_price_units(clamped_size_f64);
-	let spot_sell_price_units = to_price_units(clamped_price_f64);
-
 	let spot_sell_cloid = generate_cloid();
-	let hedge_open_cloid = generate_cloid() + 1;
+	let hedge_open_cloid = spot_sell_cloid + 1;
 
-	info!(
-		"Generated cloids - spot_sell: {} (hex: 0x{:032x}), hedge_open: {} (hex: 0x{:032x})",
-		spot_sell_cloid, spot_sell_cloid, hedge_open_cloid, hedge_open_cloid
-	);
-
-	// Build and submit spot sell action
 	let spot_sell_action = build_spot_sell_order(
-		validation_result.spot_asset_id,
-		spot_sell_size_units,
-		spot_sell_price_units,
+		sell_ctx.spot_asset_id,
+		to_price_units(clamped_size_f64),
+		to_price_units(clamped_price_f64),
 		spot_sell_cloid,
 	);
-	let spot_sell_corewriter_calldata = encode_send_raw_action(spot_sell_action);
-	let spot_sell_calldata =
-		encode_omni_account_execute(get_core_writer_address(), spot_sell_corewriter_calldata);
 
 	let spot_sell_tx_hash = submit_corewriter_userop(
-		ctx.clone(),
-		&omni_account,
-		&skeleton_user_op,
-		chain_id,
-		wallet_index,
-		spot_sell_calldata,
-		client_id,
+		exec_ctx.ctx.clone(),
+		exec_ctx.omni_account,
+		exec_ctx.skeleton_user_op,
+		exec_ctx.chain_id,
+		exec_ctx.wallet_index,
+		encode_omni_account_execute(
+			get_core_writer_address(),
+			encode_send_raw_action(spot_sell_action),
+		),
+		exec_ctx.client_id,
 	)
 	.await?;
 
 	info!(
-		"Action 1: Spot sell submitted, price: {}, size: {}, tx_hash: {:?}",
+		"Spot sell submitted: price={}, size={}, tx={:?}",
 		clamped_price_f64, clamped_size_f64, spot_sell_tx_hash
 	);
 
-	// Wait for order to be filled
-	info!("Polling HyperCore API for spot sell order completion (cloid: {})...", spot_sell_cloid);
-	let order_filled = hypercore_client
+	let order_filled = exec_ctx
+		.hypercore_client
 		.wait_for_order(
-			smart_wallet_address_str,
+			exec_ctx.smart_wallet,
 			&spot_sell_cloid.to_string(),
 			20,
 			OrderWaitCondition::Filled,
@@ -283,11 +586,9 @@ async fn handle_request_loan_impl<
 		));
 	}
 
-	info!("Action 1: Spot sell order filled successfully");
-
-	// Get the actual fill
-	let spot_sell_fill = hypercore_client
-		.get_fill_by_cloid(smart_wallet_address_str, spot_sell_cloid)
+	let spot_sell_fill = exec_ctx
+		.hypercore_client
+		.get_fill_by_cloid(exec_ctx.smart_wallet, spot_sell_cloid)
 		.await
 		.map_err(|e| {
 			error!("Failed to get fill for spot sell order: {}", e);
@@ -297,7 +598,7 @@ async fn handle_request_loan_impl<
 			)
 		})?;
 
-	let usdc_received = calculate_usdc_received_from_spot_sell(&spot_sell_fill).map_err(|e| {
+	let usdc_sold = usdc_from_spot_fill(&spot_sell_fill).map_err(|e| {
 		error!("Failed to calculate USDC received: {}", e);
 		PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
@@ -305,59 +606,54 @@ async fn handle_request_loan_impl<
 		)
 	})?;
 
-	info!("Action 1: Spot sell completed - received {:.2} USDC", usdc_received);
+	info!("Spot sell completed: received {:.2} USDC", usdc_sold);
 
-	hypercore_client
-		.print_account_state(smart_wallet_address_str, "After Action 1 - Spot Sell")
+	let usdc_loaned = usdc_sold * lending_ratio_f64;
+	let usdc_for_perp = usdc_sold * (1.0 - lending_ratio_f64);
+
+	// Store loan record with SpotSold state
+	exec_ctx
+		.ctx
+		.loan_record_storage
+		.create(
+			exec_ctx.storage_key,
+			executor_storage::loan_record::NewLoanRecord {
+				collateral_ticker: collateral_ticker.to_string(),
+				collateral_size: collateral_size.to_string(),
+				usdc_sold: format!("{:.2}", usdc_sold),
+				usdc_loaned: format!("{:.2}", usdc_loaned),
+				usdc_for_perp: format!("{:.2}", usdc_for_perp),
+				spot_sell_cloid: spot_sell_cloid.to_string(),
+				hedge_open_cloid: hedge_open_cloid.to_string(),
+			},
+		)
+		.map_err(|e| {
+			error!("Failed to create loan record: {}", e);
+			PumpxRpcError::from(
+				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+					.with_reason(format!("Failed to create loan record: {}", e)),
+			)
+		})?;
+
+	exec_ctx
+		.hypercore_client
+		.print_account_state(exec_ctx.smart_wallet, "After Spot Sell")
 		.await;
 
-	// Calculate USDC allocation
-	let usdc_for_perp = usdc_received * (1.0 - lending_ratio_f64);
-	let usdc_to_lend = usdc_received * lending_ratio_f64;
+	Ok((usdc_sold, spot_sell_cloid, hedge_open_cloid))
+}
 
-	info!(
-		"USDC allocation: total_received={:.2}, for_perp={:.2}, to_lend={:.2}",
-		usdc_received, usdc_for_perp, usdc_to_lend
-	);
+async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
+	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
+	usdc_for_perp: f64,
+) -> Result<(), PumpxRpcError> {
+	info!("Action: Moving {:.2} USDC to perp", usdc_for_perp);
 
-	// Store loan record in storage (position_size will be updated after Action 3)
-	let loan_record = LoanRecord {
-		collateral_ticker: collateral_ticker.to_string(),
-		collateral_size: collateral_size_str.to_string(),
-		usdc_sold: format!("{:.2}", usdc_received),
-		usdc_loaned: format!("{:.2}", usdc_to_lend),
-		spot_sell_cloid: spot_sell_cloid.to_string(),
-		hedge_open_cloid: hedge_open_cloid.to_string(),
-		position_size: "0".to_string(), // Will be updated after hedge order completes
-	};
-
-	let storage_key = executor_storage::loan_record::Key {
-		account_id: omni_account.clone(),
-		nonce: skeleton_user_op.nonce as u64,
-	};
-
-	if ctx.loan_record_storage.insert(&storage_key, loan_record.clone()).is_err() {
-		error!(
-			"Failed to store loan record for omni_account {:?}, nonce {}",
-			omni_account, skeleton_user_op.nonce
-		);
-		// Don't fail the entire operation, just log the error
-	} else {
-		info!(
-			"Stored loan record for omni_account {:?}, nonce {}",
-			omni_account, skeleton_user_op.nonce
-		);
-	}
-
-	// Action 2: Move USDC into perps
-	let mut current_nonce = skeleton_user_op.nonce + 1;
-
-	// Get initial perp balance BEFORE submitting the transfer
-	let initial_perp_balance = hypercore_client
-		.get_perp_clearinghouse_state(smart_wallet_address_str)
+	let initial_perp_balance = exec_ctx
+		.hypercore_client
+		.get_perp_clearinghouse_state(exec_ctx.smart_wallet)
 		.await
 		.map_err(|e| {
-			error!("Failed to get initial perp balance: {}", e);
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 					.with_reason(format!("Failed to query perp balance: {}", e)),
@@ -367,146 +663,147 @@ async fn handle_request_loan_impl<
 		.account_value
 		.parse::<f64>()
 		.map_err(|e| {
-			error!("Failed to parse initial perp balance: {}", e);
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 					.with_reason(format!("Failed to parse perp balance: {}", e)),
 			)
 		})?;
 
-	let usdc_for_perp_units = to_usdc_units(usdc_for_perp);
-	let usd_transfer_action = build_usd_class_transfer_to_perp(usdc_for_perp_units);
-	let usd_transfer_calldata = encode_omni_account_execute(
-		get_core_writer_address(),
-		encode_send_raw_action(usd_transfer_action),
-	);
-
 	let usd_transfer_tx_hash = submit_corewriter_userop(
-		ctx.clone(),
-		&omni_account,
-		&prepare_skeleton_with_nonce(&skeleton_user_op, current_nonce),
-		chain_id,
-		wallet_index,
-		usd_transfer_calldata,
-		client_id,
+		exec_ctx.ctx.clone(),
+		exec_ctx.omni_account,
+		&prepare_skeleton_with_nonce(
+			exec_ctx.skeleton_user_op,
+			exec_ctx.skeleton_user_op.nonce + 1,
+		),
+		exec_ctx.chain_id,
+		exec_ctx.wallet_index,
+		encode_omni_account_execute(
+			get_core_writer_address(),
+			encode_send_raw_action(build_usd_class_transfer_to_perp(to_usdc_units(usdc_for_perp))),
+		),
+		exec_ctx.client_id,
 	)
 	.await?;
 
-	info!(
-		"Action 2: USD class transfer submitted, size: {}, tx_hash: {:?}",
-		usdc_for_perp, usd_transfer_tx_hash
-	);
+	info!("USD transfer submitted: size={:.2}, tx={:?}", usdc_for_perp, usd_transfer_tx_hash);
 
-	// Wait for USD transfer to complete
-	let _actual_perp_balance = hypercore_client
+	exec_ctx
+		.hypercore_client
 		.wait_for_perp_balance_increase(
-			smart_wallet_address_str,
+			exec_ctx.smart_wallet,
 			initial_perp_balance,
 			usdc_for_perp,
 			20,
 		)
 		.await
 		.map_err(|e| {
-			error!("USD transfer to perp did not complete: {}", e);
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 					.with_reason(format!("USD transfer failed: {}", e)),
 			)
 		})?;
 
-	info!("Action 2: USD class transfer completed successfully");
+	info!("USD transfer completed");
 
-	hypercore_client
-		.print_account_state(smart_wallet_address_str, "After Action 2 - USD Transfer to Perp")
+	// Update state: ToPerpMoved
+	let _ = exec_ctx
+		.ctx
+		.loan_record_storage
+		.update(exec_ctx.storage_key, |r| r.state = LoanState::ToPerpMoved);
+
+	exec_ctx
+		.hypercore_client
+		.print_account_state(exec_ctx.smart_wallet, "After Move To Perp")
 		.await;
 
-	// Action 3: Open hedge position
-	current_nonce += 1;
+	Ok(())
+}
 
-	// Refresh perp market prices to get latest prices for order construction
-	info!("Refreshing perp market prices before Action 3...");
-	let (_perp_meta, perp_mark_price, perp_mid_price) =
-		hypercore_client.get_perp_market_prices(collateral_ticker).await.map_err(|e| {
-			error!("Failed to refresh perp market prices: {}", e);
+async fn do_open_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
+	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
+	collateral_ticker: &str,
+	usdc_for_perp: f64,
+	lending_ratio_f64: f64,
+	hedge_open_cloid: u128,
+	open_ctx: &OpenPositionContext,
+) -> Result<(), PumpxRpcError> {
+	let desired_leverage = 1.0 / (1.0 - lending_ratio_f64);
+	let effective_leverage = desired_leverage.min(open_ctx.perp_max_leverage as f64);
+
+	info!("Action: Opening hedge position for {}", collateral_ticker);
+
+	// Refresh prices
+	let (_, perp_mark_price, perp_mid_price) = exec_ctx
+		.hypercore_client
+		.get_perp_market_prices(collateral_ticker)
+		.await
+		.map_err(|e| {
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 					.with_reason(format!("Failed to refresh perp prices: {}", e)),
 			)
 		})?;
 
-	let desired_leverage: f64 = 1.0 / (1.0 - lending_ratio_f64);
-	let effective_leverage = desired_leverage.min(validation_result.max_leverage as f64);
-	// For opening long position (buying), we want to buy at the lowest sell price (ask)
-	let (_perp_bid_price, perp_ask_price) = get_bid_ask_prices(perp_mark_price, perp_mid_price);
+	let (_, perp_ask_price) = get_bid_ask_prices(perp_mark_price, perp_mid_price);
 	let target_hedge_price = perp_ask_price * PERP_ENTRY_PRICE_RATIO;
 	let hedge_size = (usdc_for_perp * effective_leverage) / target_hedge_price;
 
-	info!(
-		"Perp hedge open pricing - markPx: {}, midPx: {}, ask (lowest sell): {}, target (with {}x buffer): {}, hedge_size: {}",
-		perp_mark_price, perp_mid_price, perp_ask_price, PERP_ENTRY_PRICE_RATIO, target_hedge_price, hedge_size
-	);
-
-	let clamped_hedge_size = clamp_size(hedge_size, validation_result.perp_sz_decimals);
-	let clamped_hedge_price =
-		clamp_price(target_hedge_price, validation_result.perp_sz_decimals, false);
+	let clamped_hedge_size = clamp_size(hedge_size, open_ctx.perp_sz_decimals);
+	let clamped_hedge_price = clamp_price(target_hedge_price, open_ctx.perp_sz_decimals, false);
 
 	let clamped_hedge_size_f64 = clamped_hedge_size.parse::<f64>().map_err(|e| {
-		error!("Failed to parse clamped hedge size: {}", e);
 		PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 				.with_reason(format!("Failed to parse clamped hedge size: {}", e)),
 		)
 	})?;
 	let clamped_hedge_price_f64 = clamped_hedge_price.parse::<f64>().map_err(|e| {
-		error!("Failed to parse clamped hedge price: {}", e);
 		PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 				.with_reason(format!("Failed to parse clamped hedge price: {}", e)),
 		)
 	})?;
 
-	let hedge_size_units = to_price_units(clamped_hedge_size_f64);
-	let hedge_price_units = to_price_units(clamped_hedge_price_f64);
-
 	let hedge_action = build_perp_long_order(
-		validation_result.perp_asset_id,
-		hedge_size_units,
-		hedge_price_units,
+		open_ctx.perp_asset_id,
+		to_price_units(clamped_hedge_size_f64),
+		to_price_units(clamped_hedge_price_f64),
 		hedge_open_cloid,
-	);
-	let hedge_calldata = encode_omni_account_execute(
-		get_core_writer_address(),
-		encode_send_raw_action(hedge_action),
 	);
 
 	let hedge_open_tx_hash = submit_corewriter_userop(
-		ctx.clone(),
-		&omni_account,
-		&prepare_skeleton_with_nonce(&skeleton_user_op, current_nonce),
-		chain_id,
-		wallet_index,
-		hedge_calldata,
-		client_id,
+		exec_ctx.ctx.clone(),
+		exec_ctx.omni_account,
+		&prepare_skeleton_with_nonce(
+			exec_ctx.skeleton_user_op,
+			exec_ctx.skeleton_user_op.nonce + 2,
+		),
+		exec_ctx.chain_id,
+		exec_ctx.wallet_index,
+		encode_omni_account_execute(
+			get_core_writer_address(),
+			encode_send_raw_action(hedge_action),
+		),
+		exec_ctx.client_id,
 	)
 	.await?;
 
 	info!(
-		"Action 3: Hedge position submitted, price: {}, size: {}, tx_hash: {:?}",
+		"Hedge position submitted: price={}, size={}, tx={:?}",
 		clamped_hedge_price_f64, clamped_hedge_size_f64, hedge_open_tx_hash
 	);
 
-	// Wait for hedge order to be opened
-	info!("Polling HyperCore API to verify hedge order is opened (cloid: {})...", hedge_open_cloid);
-	let order_opened = hypercore_client
+	let order_opened = exec_ctx
+		.hypercore_client
 		.wait_for_order(
-			smart_wallet_address_str,
+			exec_ctx.smart_wallet,
 			&hedge_open_cloid.to_string(),
 			20,
 			OrderWaitCondition::Opened,
 		)
 		.await
 		.map_err(|e| {
-			error!("Hedge order was not successfully opened: {}", e);
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 					.with_reason(format!("Hedge order failed to open: {}", e)),
@@ -514,25 +811,17 @@ async fn handle_request_loan_impl<
 		})?;
 
 	if !order_opened {
-		error!("Hedge order was rejected or canceled");
 		return Err(PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 				.with_reason("Hedge order was rejected or canceled"),
 		));
 	}
 
-	info!("Action 3: Hedge order successfully opened");
-
-	hypercore_client
-		.print_account_state(smart_wallet_address_str, "After Action 3 - Hedge Open")
-		.await;
-
-	// Get the actual position size and update the loan record
-	let perp_state = hypercore_client
-		.get_perp_clearinghouse_state(smart_wallet_address_str)
+	let perp_state = exec_ctx
+		.hypercore_client
+		.get_perp_clearinghouse_state(exec_ctx.smart_wallet)
 		.await
 		.map_err(|e| {
-			error!("Failed to get perp state after hedge open: {}", e);
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 					.with_reason(format!("Failed to query perp state: {}", e)),
@@ -544,7 +833,6 @@ async fn handle_request_loan_impl<
 		.iter()
 		.find(|pos| pos.position.coin.eq_ignore_ascii_case(collateral_ticker))
 		.ok_or_else(|| {
-			error!("Hedge position for {} not found after opening", collateral_ticker);
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Position not found").with_reason(format!(
 					"Position for {} not found after hedge order opened",
@@ -554,233 +842,24 @@ async fn handle_request_loan_impl<
 		})?;
 
 	let actual_position_size = hedge_position.position.szi.parse::<f64>().map_err(|e| {
-		error!("Failed to parse position size: {}", e);
 		PumpxRpcError::from(
 			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
 				.with_reason(format!("Invalid position size: {}", e)),
 		)
 	})?;
 
-	info!(
-		"Actual hedge position size opened: {} (expected: ~{})",
-		actual_position_size, clamped_hedge_size_f64
-	);
+	info!("Hedge position opened: actual size={}", actual_position_size);
 
-	// Update loan record with actual position size
-	let updated_loan_record =
-		LoanRecord { position_size: format!("{}", actual_position_size), ..loan_record };
+	// Update loan record with position size and state: PositionOpened
+	let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
+		r.position_size = format!("{}", actual_position_size);
+		r.state = LoanState::PositionOpened;
+	});
 
-	let storage_key = executor_storage::loan_record::Key {
-		account_id: omni_account.clone(),
-		nonce: skeleton_user_op.nonce as u64,
-	};
+	exec_ctx
+		.hypercore_client
+		.print_account_state(exec_ctx.smart_wallet, "After Open Position")
+		.await;
 
-	if ctx.loan_record_storage.insert(&storage_key, updated_loan_record).is_err() {
-		error!(
-			"Failed to update loan record with position size for omni_account {:?}, nonce {}",
-			omni_account, skeleton_user_op.nonce
-		);
-		// Don't fail the entire operation, just log the error
-	} else {
-		info!(
-			"Updated loan record with position_size {} for omni_account {:?}, nonce {}",
-			actual_position_size, omni_account, skeleton_user_op.nonce
-		);
-	}
-
-	let usdc_received_str = format!("{:.2}", usdc_to_lend);
-
-	Ok(RequestLoanTestResponse {
-		spot_sell_cloid: spot_sell_cloid.to_string(),
-		hedge_open_cloid: hedge_open_cloid.to_string(),
-		usdc_received: usdc_received_str,
-		spot_sell_tx_hash,
-		hedge_open_tx_hash,
-	})
-}
-
-/// Precheck: Performs all validation checks for loan request
-async fn precheck(
-	hypercore_client: &HyperCoreClient,
-	smart_wallet_address: &str,
-	collateral_ticker: &str,
-	collateral_size: f64,
-	lending_ratio: u32,
-) -> Result<LoanRequestValidationResult, PumpxRpcError> {
-	// Fetch metadata and market prices from HyperCore in one call each
-	// Get spot market prices (markPx and midPx) along with spot metadata
-	let (spot_meta, spot_mark_price, spot_mid_price) =
-		hypercore_client.get_spot_market_prices(collateral_ticker).await.map_err(|e| {
-			error!("Failed to get spot market prices for {}: {}", collateral_ticker, e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
-					"Failed to get spot market prices for {}: {}",
-					collateral_ticker, e
-				)),
-			)
-		})?;
-
-	// Get perp market prices (markPx and midPx) along with perp metadata
-	let (meta, perp_mark_price, perp_mid_price) =
-		hypercore_client.get_perp_market_prices(collateral_ticker).await.map_err(|e| {
-			error!("Failed to get perp market prices for {}: {}", collateral_ticker, e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
-					"Failed to get perp market prices for {}: {}",
-					collateral_ticker, e
-				)),
-			)
-		})?;
-
-	// Get asset IDs
-	let spot_asset_id = get_spot_asset_id(collateral_ticker, &spot_meta).map_err(|e| {
-		error!("Failed to get spot asset ID: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
-		)
-	})?;
-
-	let perp_asset_id = get_perp_asset_id(collateral_ticker, &meta).map_err(|e| {
-		error!("Failed to get perp asset ID: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(e),
-		)
-	})?;
-
-	info!(
-		"Resolved asset IDs - spot: {}, perp: {} for ticker: {}",
-		spot_asset_id, perp_asset_id, collateral_ticker
-	);
-
-	// Get token metadata
-	let collateral_token = spot_meta
-		.tokens
-		.iter()
-		.find(|t| t.name.eq_ignore_ascii_case(collateral_ticker))
-		.ok_or_else(|| {
-			error!("Token {} not found in spot meta", collateral_ticker);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Token {} not found in spot meta", collateral_ticker)),
-			)
-		})?;
-
-	let perp_asset = meta.universe.get(perp_asset_id as usize).ok_or_else(|| {
-		error!("Perp asset {} not found in meta", perp_asset_id);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Perp asset {} not found", perp_asset_id)),
-		)
-	})?;
-
-	info!(
-		"Market prices for {} - spot markPx: {} USDC, spot midPx: {} USDC, perp markPx: {} USDC, perp midPx: {} USDC",
-		collateral_ticker, spot_mark_price, spot_mid_price, perp_mark_price, perp_mid_price
-	);
-
-	// 1. Validate collateral size for spot trading
-	validate_trade_size(collateral_size, collateral_token.sz_decimals, None).map_err(|e| {
-		error!("Invalid collateral size for spot trading: {}", e);
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Invalid collateral size: {}", e)),
-		)
-	})?;
-
-	info!(
-		"✓ Collateral size {} validated for spot trading (sz_decimals={})",
-		collateral_size, collateral_token.sz_decimals
-	);
-
-	// 2. Calculate estimated values for perp position using worst-case prices
-	let lending_ratio_f64 = (lending_ratio as f64) / 100.0;
-
-	// Worst case for spot sell: highest buy price (bid) with buffer
-	let (spot_bid_price, _spot_ask_price) = get_bid_ask_prices(spot_mark_price, spot_mid_price);
-	let worst_case_spot_sell_price = spot_bid_price * SPOT_SELL_PRICE_RATIO;
-	let estimated_usdc_from_spot = collateral_size * worst_case_spot_sell_price;
-	let estimated_usdc_for_perp = estimated_usdc_from_spot * (1.0 - lending_ratio_f64);
-	let estimated_leverage = (1.0 / (1.0 - lending_ratio_f64)).min(perp_asset.max_leverage as f64);
-	let estimated_perp_notional = estimated_usdc_for_perp * estimated_leverage;
-
-	// 3. Validate minimum perp order notional value ($10 minimum)
-	const MIN_PERP_NOTIONAL: f64 = 10.0;
-
-	if estimated_perp_notional < MIN_PERP_NOTIONAL {
-		error!(
-			"Perp order notional value too small: estimated ${:.2} (collateral_size={}, spot_price={:.2}, lending_ratio={}%, leverage={:.2}x) - minimum required: ${}",
-			estimated_perp_notional, collateral_size, worst_case_spot_sell_price, lending_ratio, estimated_leverage, MIN_PERP_NOTIONAL
-		);
-		return Err(PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
-				"Perp order notional value too small: ${:.2} < ${} minimum. Increase collateral_size or decrease lending_ratio.",
-				estimated_perp_notional, MIN_PERP_NOTIONAL
-			)),
-		));
-	}
-
-	info!(
-		"✓ Perp notional value: ${:.2} (margin={:.2}, leverage={:.2}x) >= ${} minimum",
-		estimated_perp_notional, estimated_usdc_for_perp, estimated_leverage, MIN_PERP_NOTIONAL
-	);
-
-	// 4. Validate estimated hedge size can be properly rounded to perp sz_decimals
-	// Worst case for opening long position: lowest sell price (ask) with buffer
-	let (_perp_bid_price, perp_ask_price) = get_bid_ask_prices(perp_mark_price, perp_mid_price);
-	let worst_case_perp_open_price = perp_ask_price * PERP_ENTRY_PRICE_RATIO;
-	let estimated_hedge_size = estimated_perp_notional / worst_case_perp_open_price;
-
-	validate_trade_size(estimated_hedge_size, perp_asset.sz_decimals, None).map_err(|e| {
-		error!("Invalid estimated hedge size for perp trading: {}", e);
-		PumpxRpcError::from(DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(
-			format!(
-				"Invalid estimated hedge size (margin={:.2}, leverage={:.2}x, perp_price={:.2}, size={}): {}",
-				estimated_usdc_for_perp, estimated_leverage, worst_case_perp_open_price, estimated_hedge_size, e
-			),
-		))
-	})?;
-
-	info!(
-		"✓ Estimated hedge size {} validated for perp trading (sz_decimals={})",
-		estimated_hedge_size, perp_asset.sz_decimals
-	);
-
-	// 5. Validate user balance
-	let user_balance = hypercore_client
-		.get_spot_balance(smart_wallet_address, collateral_ticker)
-		.await
-		.map_err(|e| {
-			error!("Failed to get user balance: {}", e);
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Failed to query balance: {}", e)),
-			)
-		})?;
-
-	if user_balance < collateral_size {
-		error!(
-			"Insufficient balance: user has {} but needs {} {}",
-			user_balance, collateral_size, collateral_ticker
-		);
-		return Err(PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
-				"Insufficient balance: user has {} but needs {} {}",
-				user_balance, collateral_size, collateral_ticker
-			)),
-		));
-	}
-
-	info!(
-		"✓ Balance check passed: user has {} {} (required: {})",
-		user_balance, collateral_ticker, collateral_size
-	);
-
-	Ok(LoanRequestValidationResult {
-		spot_asset_id,
-		perp_asset_id,
-		spot_sz_decimals: collateral_token.sz_decimals,
-		perp_sz_decimals: perp_asset.sz_decimals,
-		max_leverage: perp_asset.max_leverage,
-		lending_ratio_f64,
-	})
+	Ok(())
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
@@ -57,7 +57,7 @@ struct SellSpotContext {
 	spot_mid_price: f64,
 }
 
-struct OpenPositionContext {
+struct OpenHedgeContext {
 	perp_asset_id: u32,
 	perp_sz_decimals: u8,
 	perp_max_leverage: u32,
@@ -127,7 +127,7 @@ pub fn register_request_loan_test<
 					let usdc_for_perp =
 						sell_ctx.spot_mid_price * collateral_size * (1.0 - lending_ratio_f64);
 
-					let open_ctx = precheck_open_position(
+					let open_ctx = precheck_open_hedge(
 						&hypercore_client,
 						&collateral_ticker,
 						usdc_for_perp,
@@ -135,7 +135,7 @@ pub fn register_request_loan_test<
 					)
 					.await?;
 
-					let (usdc_sold, spot_cloid, hedge_cloid) = do_sell_spot(
+					let (usdc_sold, spot_sell_cloid, spot_sell_tx_hash) = do_sell_spot(
 						&exec_ctx,
 						&collateral_ticker,
 						collateral_size,
@@ -150,23 +150,22 @@ pub fn register_request_loan_test<
 
 					do_move_to_perp(&exec_ctx, usdc_for_perp, &mut current_nonce).await?;
 
-					do_open_position(
+					let (hedge_open_cloid, hedge_open_tx_hash) = do_open_hedge(
 						&exec_ctx,
 						&collateral_ticker,
 						usdc_for_perp,
 						lending_ratio_f64,
-						hedge_cloid,
 						&open_ctx,
 						current_nonce,
 					)
 					.await?;
 
 					Ok(RequestLoanTestResponse {
-						spot_sell_cloid: spot_cloid.to_string(),
-						hedge_open_cloid: hedge_cloid.to_string(),
+						spot_sell_cloid: spot_sell_cloid.to_string(),
+						hedge_open_cloid: hedge_open_cloid.to_string(),
 						usdc_received: format!("{:.2}", usdc_loaned),
-						spot_sell_tx_hash: None,
-						hedge_open_tx_hash: None,
+						spot_sell_tx_hash,
+						hedge_open_tx_hash,
 					})
 				},
 				Some(existing) => {
@@ -186,7 +185,7 @@ pub fn register_request_loan_test<
 					}
 
 					match existing.state {
-						LoanState::PositionOpened => {
+						LoanState::HedgeOpened => {
 							info!("Loan already completed");
 							Ok(RequestLoanTestResponse {
 								spot_sell_cloid: existing.spot_sell_cloid,
@@ -210,7 +209,7 @@ pub fn register_request_loan_test<
 									)
 								})?;
 
-							let open_ctx = precheck_open_position(
+							let open_ctx = precheck_open_hedge(
 								&hypercore_client,
 								&collateral_ticker,
 								usdc_for_perp,
@@ -218,25 +217,13 @@ pub fn register_request_loan_test<
 							)
 							.await?;
 
-							let hedge_cloid =
-								existing.hedge_open_cloid.parse::<u128>().map_err(|e| {
-									PumpxRpcError::from(
-										DetailedError::new(
-											INTERNAL_ERROR_CODE,
-											"Invalid stored data",
-										)
-										.with_reason(format!("Invalid hedge_open_cloid: {}", e)),
-									)
-								})?;
-
 							do_move_to_perp(&exec_ctx, usdc_for_perp, &mut current_nonce).await?;
 
-							do_open_position(
+							let (hedge_open_cloid, hedge_open_tx_hash) = do_open_hedge(
 								&exec_ctx,
 								&collateral_ticker,
 								usdc_for_perp,
 								lending_ratio_f64,
-								hedge_cloid,
 								&open_ctx,
 								current_nonce,
 							)
@@ -244,10 +231,10 @@ pub fn register_request_loan_test<
 
 							Ok(RequestLoanTestResponse {
 								spot_sell_cloid: existing.spot_sell_cloid,
-								hedge_open_cloid: existing.hedge_open_cloid,
+								hedge_open_cloid: hedge_open_cloid.to_string(),
 								usdc_received: existing.usdc_loaned,
 								spot_sell_tx_hash: None,
-								hedge_open_tx_hash: None,
+								hedge_open_tx_hash,
 							})
 						},
 						LoanState::ToPerpMoved => {
@@ -264,7 +251,7 @@ pub fn register_request_loan_test<
 									)
 								})?;
 
-							let open_ctx = precheck_open_position(
+							let open_ctx = precheck_open_hedge(
 								&hypercore_client,
 								&collateral_ticker,
 								usdc_for_perp,
@@ -272,23 +259,11 @@ pub fn register_request_loan_test<
 							)
 							.await?;
 
-							let hedge_cloid =
-								existing.hedge_open_cloid.parse::<u128>().map_err(|e| {
-									PumpxRpcError::from(
-										DetailedError::new(
-											INTERNAL_ERROR_CODE,
-											"Invalid stored data",
-										)
-										.with_reason(format!("Invalid hedge_open_cloid: {}", e)),
-									)
-								})?;
-
-							do_open_position(
+							let (hedge_open_cloid, hedge_open_tx_hash) = do_open_hedge(
 								&exec_ctx,
 								&collateral_ticker,
 								usdc_for_perp,
 								lending_ratio_f64,
-								hedge_cloid,
 								&open_ctx,
 								current_nonce,
 							)
@@ -296,10 +271,10 @@ pub fn register_request_loan_test<
 
 							Ok(RequestLoanTestResponse {
 								spot_sell_cloid: existing.spot_sell_cloid,
-								hedge_open_cloid: existing.hedge_open_cloid,
+								hedge_open_cloid: hedge_open_cloid.to_string(),
 								usdc_received: existing.usdc_loaned,
 								spot_sell_tx_hash: None,
-								hedge_open_tx_hash: None,
+								hedge_open_tx_hash,
 							})
 						},
 						_ => Err(PumpxRpcError::from(
@@ -439,12 +414,12 @@ async fn precheck_sell_spot(
 	Ok(SellSpotContext { spot_asset_id, spot_sz_decimals, spot_mark_price, spot_mid_price })
 }
 
-async fn precheck_open_position(
+async fn precheck_open_hedge(
 	hypercore_client: &HyperCoreClient,
 	collateral_ticker: &str,
 	usdc_for_perp: f64,
 	lending_ratio_f64: f64,
-) -> Result<OpenPositionContext, PumpxRpcError> {
+) -> Result<OpenHedgeContext, PumpxRpcError> {
 	let (perp_meta, perp_mark_price, perp_mid_price) =
 		hypercore_client.get_perp_market_prices(collateral_ticker).await.map_err(|e| {
 			error!("Failed to get perp market prices for {}: {}", collateral_ticker, e);
@@ -505,9 +480,9 @@ async fn precheck_open_position(
 		))
 	})?;
 
-	info!("✓ Open position precheck passed");
+	info!("✓ Open hedge precheck passed");
 
-	Ok(OpenPositionContext { perp_asset_id, perp_sz_decimals, perp_max_leverage })
+	Ok(OpenHedgeContext { perp_asset_id, perp_sz_decimals, perp_max_leverage })
 }
 
 async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
@@ -517,7 +492,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 	lending_ratio_f64: f64,
 	sell_ctx: &SellSpotContext,
 	current_nonce: &mut u128,
-) -> Result<(f64, u128, u128), PumpxRpcError> {
+) -> Result<(f64, u128, Option<String>), PumpxRpcError> {
 	info!("Action: Selling {} {} in spot market", collateral_size, collateral_ticker);
 
 	let clamped_size = clamp_size(collateral_size, sell_ctx.spot_sz_decimals);
@@ -539,7 +514,6 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 	})?;
 
 	let spot_sell_cloid = generate_cloid();
-	let hedge_open_cloid = spot_sell_cloid + 1;
 
 	let spot_sell_action = build_spot_sell_order(
 		sell_ctx.spot_asset_id,
@@ -634,7 +608,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 				usdc_loaned: format!("{:.2}", usdc_loaned),
 				usdc_for_perp: format!("{:.2}", usdc_for_perp),
 				spot_sell_cloid: spot_sell_cloid.to_string(),
-				hedge_open_cloid: hedge_open_cloid.to_string(),
+				hedge_open_cloid: "0".to_string(),
 			},
 		)
 		.map_err(|e| {
@@ -650,7 +624,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 		.print_account_state(exec_ctx.smart_wallet, "After Spot Sell")
 		.await;
 
-	Ok((usdc_sold, spot_sell_cloid, hedge_open_cloid))
+	Ok((usdc_sold, spot_sell_cloid, spot_sell_tx_hash))
 }
 
 async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
@@ -733,19 +707,19 @@ async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 	Ok(())
 }
 
-async fn do_open_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
+async fn do_open_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
 	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
 	collateral_ticker: &str,
 	usdc_for_perp: f64,
 	lending_ratio_f64: f64,
-	hedge_open_cloid: u128,
-	open_ctx: &OpenPositionContext,
+	open_ctx: &OpenHedgeContext,
 	current_nonce: u128,
-) -> Result<(), PumpxRpcError> {
+) -> Result<(u128, Option<String>), PumpxRpcError> {
 	let desired_leverage = 1.0 / (1.0 - lending_ratio_f64);
 	let effective_leverage = desired_leverage.min(open_ctx.perp_max_leverage as f64);
 
 	info!("Action: Opening hedge position for {}", collateral_ticker);
+	let hedge_open_cloid = generate_cloid();
 
 	// Refresh prices
 	let (_, perp_mark_price, perp_mid_price) = exec_ctx
@@ -832,16 +806,17 @@ async fn do_open_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync
 		));
 	}
 
-	// Update loan record with position size and state: PositionOpened
+	// Update loan record with position size and state: HedgeOpened
 	let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
 		r.position_size = format!("{}", clamped_hedge_size_f64);
-		r.state = LoanState::PositionOpened;
+		r.state = LoanState::HedgeOpened;
+		r.hedge_open_cloid = hedge_open_cloid.to_string();
 	});
 
 	exec_ctx
 		.hypercore_client
-		.print_account_state(exec_ctx.smart_wallet, "After Open Position")
+		.print_account_state(exec_ctx.smart_wallet, "After Open Hedge")
 		.await;
 
-	Ok(())
+	Ok((hedge_open_cloid, hedge_open_tx_hash))
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
@@ -817,42 +817,9 @@ async fn do_open_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync
 		));
 	}
 
-	let perp_state = exec_ctx
-		.hypercore_client
-		.get_perp_clearinghouse_state(exec_ctx.smart_wallet)
-		.await
-		.map_err(|e| {
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("Failed to query perp state: {}", e)),
-			)
-		})?;
-
-	let hedge_position = perp_state
-		.asset_positions
-		.iter()
-		.find(|pos| pos.position.coin.eq_ignore_ascii_case(collateral_ticker))
-		.ok_or_else(|| {
-			PumpxRpcError::from(
-				DetailedError::new(INTERNAL_ERROR_CODE, "Position not found").with_reason(format!(
-					"Position for {} not found after hedge order opened",
-					collateral_ticker
-				)),
-			)
-		})?;
-
-	let actual_position_size = hedge_position.position.szi.parse::<f64>().map_err(|e| {
-		PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-				.with_reason(format!("Invalid position size: {}", e)),
-		)
-	})?;
-
-	info!("Hedge position opened: actual size={}", actual_position_size);
-
 	// Update loan record with position size and state: PositionOpened
 	let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
-		r.position_size = format!("{}", actual_position_size);
+		r.position_size = format!("{}", clamped_hedge_size_f64);
 		r.state = LoanState::PositionOpened;
 	});
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
@@ -15,9 +15,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, error, info};
 
-// minimum perp order notional value ($10 minimum)
-const MIN_PERP_NOTIONAL: f64 = 10.0;
-
 #[derive(Debug, Deserialize)]
 pub struct RequestLoanTestParams {
 	pub user_operation: SerializablePackedUserOperation,
@@ -415,6 +412,24 @@ async fn precheck_sell_spot(
 		)
 	})?;
 
+	// Validate notional value with clamped size
+	let clamped_size = clamp_size(collateral_size, spot_sz_decimals);
+	let clamped_size_f64 = clamped_size.parse::<f64>().map_err(|e| {
+		error!("Failed to parse clamped size: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Failed to parse clamped size: {}", e)),
+		)
+	})?;
+
+	let (spot_bid_price, _) = get_bid_ask_prices(spot_mark_price, spot_mid_price);
+	validate_notional_value(spot_bid_price, clamped_size_f64, "Spot sell").map_err(|e| {
+		error!("{}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Notional value too low").with_reason(e),
+		)
+	})?;
+
 	// Validate balance
 	let user_balance = hypercore_client
 		.get_spot_balance(smart_wallet, collateral_ticker)
@@ -478,34 +493,36 @@ async fn precheck_open_hedge(
 	let desired_leverage = 1.0 / (1.0 - lending_ratio_f64);
 	let effective_leverage = desired_leverage.min(perp_max_leverage as f64);
 
-	let estimated_notional = usdc_for_perp * effective_leverage;
-
-	if estimated_notional < MIN_PERP_NOTIONAL {
-		error!(
-			"Perp notional too small, estimated: {}, required: {}",
-			estimated_notional, MIN_PERP_NOTIONAL
-		);
-		return Err(PumpxRpcError::from(
-			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(format!(
-				"Perp notional too small, estimated: {}, required: {}",
-				estimated_notional, MIN_PERP_NOTIONAL
-			)),
-		));
-	}
-
-	// Worst case for opening long position: lowest sell price (ask) with buffer
+	// Calculate estimated size for opening long position using lowest sell price (ask)
 	let (_perp_bid_price, perp_ask_price) = get_bid_ask_prices(perp_mark_price, perp_mid_price);
-	let worst_case_perp_open_price = perp_ask_price * PERP_ENTRY_PRICE_RATIO;
-	let estimated_hedge_size = estimated_notional / worst_case_perp_open_price;
+	let estimated_notional = usdc_for_perp * effective_leverage;
+	let estimated_hedge_size = estimated_notional / perp_ask_price;
 
 	validate_trade_size(estimated_hedge_size, perp_sz_decimals, None).map_err(|e| {
 		error!("Invalid estimated hedge size for perp trading: {}", e);
 		PumpxRpcError::from(DetailedError::new(INTERNAL_ERROR_CODE, "Internal error").with_reason(
 			format!(
 				"Invalid estimated hedge size (margin={:.2}, leverage={:.2}x, perp_price={:.2}, size={}): {}",
-				usdc_for_perp, effective_leverage, worst_case_perp_open_price, estimated_hedge_size, e
+				usdc_for_perp, effective_leverage, perp_ask_price, estimated_hedge_size, e
 			),
 		))
+	})?;
+
+	// Validate notional value with clamped size
+	let clamped_size = clamp_size(estimated_hedge_size, perp_sz_decimals);
+	let clamped_size_f64 = clamped_size.parse::<f64>().map_err(|e| {
+		error!("Failed to parse clamped hedge size: {}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
+				.with_reason(format!("Failed to parse clamped hedge size: {}", e)),
+		)
+	})?;
+
+	validate_notional_value(perp_ask_price, clamped_size_f64, "Perp open").map_err(|e| {
+		error!("{}", e);
+		PumpxRpcError::from(
+			DetailedError::new(INTERNAL_ERROR_CODE, "Notional value too low").with_reason(e),
+		)
 	})?;
 
 	info!("✓ Open hedge precheck passed");

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
@@ -24,10 +24,10 @@ pub struct RequestLoanTestParams {
 	pub chain_id: ChainId,
 	pub wallet_index: u32,
 	pub omni_account: String,
-	pub client_id: String,
 	pub collateral_ticker: String,
 	pub collateral_size: String,
 	pub lending_ratio: u32,
+	pub loan_nonce: Option<u64>, // If Some, resume existing loan; if None, create new
 }
 
 #[derive(Serialize, Clone)]
@@ -45,7 +45,6 @@ struct ExecutionContext<'a, CrossChainIntentExecutor: IntentExecutor + Send + Sy
 	skeleton_user_op: &'a SerializablePackedUserOperation,
 	chain_id: u64,
 	wallet_index: u32,
-	client_id: &'a str,
 	hypercore_client: &'a HyperCoreClient,
 	smart_wallet: &'a str,
 	storage_key: &'a executor_storage::loan_record::Key,
@@ -86,9 +85,11 @@ pub fn register_request_loan_test<
 
 			let ctx = Arc::clone(&ctx);
 			let smart_wallet = &params.user_operation.sender;
+
+			// Calculate storage_key based on loan_nonce parameter
 			let storage_key = executor_storage::loan_record::Key {
 				account_id: omni_account.clone(),
-				nonce: params.user_operation.nonce as u64,
+				nonce: params.loan_nonce.unwrap_or(params.user_operation.nonce as u64),
 			};
 
 			let hypercore_client = HyperCoreClient::new(params.chain_id).map_err(|e| {
@@ -103,7 +104,6 @@ pub fn register_request_loan_test<
 				skeleton_user_op: &params.user_operation,
 				chain_id: params.chain_id,
 				wallet_index: params.wallet_index,
-				client_id: &params.client_id,
 				hypercore_client: &hypercore_client,
 				smart_wallet,
 				storage_key: &storage_key,
@@ -552,7 +552,6 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 			get_core_writer_address(),
 			encode_send_raw_action(spot_sell_action),
 		),
-		exec_ctx.client_id,
 	)
 	.await?;
 
@@ -682,7 +681,6 @@ async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 			get_core_writer_address(),
 			encode_send_raw_action(build_usd_class_transfer_to_perp(to_usdc_units(usdc_for_perp))),
 		),
-		exec_ctx.client_id,
 	)
 	.await?;
 
@@ -785,7 +783,6 @@ async fn do_open_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync
 			get_core_writer_address(),
 			encode_send_raw_action(hedge_action),
 		),
-		exec_ctx.client_id,
 	)
 	.await?;
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
@@ -36,6 +36,7 @@ pub struct RequestLoanTestResponse {
 	pub hedge_open_cloid: String,
 	pub usdc_received: String,
 	pub spot_sell_tx_hash: Option<String>,
+	pub to_perp_move_tx_hash: Option<String>,
 	pub hedge_open_tx_hash: Option<String>,
 }
 
@@ -148,7 +149,8 @@ pub fn register_request_loan_test<
 					let usdc_loaned = usdc_sold * lending_ratio_f64;
 					let usdc_for_perp = usdc_sold * (1.0 - lending_ratio_f64);
 
-					do_move_to_perp(&exec_ctx, usdc_for_perp, &mut current_nonce).await?;
+					let to_perp_move_tx_hash =
+						do_move_to_perp(&exec_ctx, usdc_for_perp, &mut current_nonce).await?;
 
 					let (hedge_open_cloid, hedge_open_tx_hash) = do_open_hedge(
 						&exec_ctx,
@@ -165,6 +167,7 @@ pub fn register_request_loan_test<
 						hedge_open_cloid: hedge_open_cloid.to_string(),
 						usdc_received: format!("{:.2}", usdc_loaned),
 						spot_sell_tx_hash,
+						to_perp_move_tx_hash,
 						hedge_open_tx_hash,
 					})
 				},
@@ -188,10 +191,21 @@ pub fn register_request_loan_test<
 						LoanState::HedgeOpened => {
 							info!("Loan already completed");
 							Ok(RequestLoanTestResponse {
-								spot_sell_cloid: existing.spot_sell_cloid,
-								hedge_open_cloid: existing.hedge_open_cloid,
+								spot_sell_cloid: existing
+									.cloids
+									.iter()
+									.find(|(name, _)| name == "spot_sell")
+									.map(|(_, cloid)| cloid.clone())
+									.unwrap_or_else(|| "0".to_string()),
+								hedge_open_cloid: existing
+									.cloids
+									.iter()
+									.find(|(name, _)| name == "hedge_open")
+									.map(|(_, cloid)| cloid.clone())
+									.unwrap_or_else(|| "0".to_string()),
 								usdc_received: existing.usdc_loaned,
 								spot_sell_tx_hash: None,
+								to_perp_move_tx_hash: None,
 								hedge_open_tx_hash: None,
 							})
 						},
@@ -217,7 +231,9 @@ pub fn register_request_loan_test<
 							)
 							.await?;
 
-							do_move_to_perp(&exec_ctx, usdc_for_perp, &mut current_nonce).await?;
+							let to_perp_move_tx_hash =
+								do_move_to_perp(&exec_ctx, usdc_for_perp, &mut current_nonce)
+									.await?;
 
 							let (hedge_open_cloid, hedge_open_tx_hash) = do_open_hedge(
 								&exec_ctx,
@@ -230,10 +246,16 @@ pub fn register_request_loan_test<
 							.await?;
 
 							Ok(RequestLoanTestResponse {
-								spot_sell_cloid: existing.spot_sell_cloid,
+								spot_sell_cloid: existing
+									.cloids
+									.iter()
+									.find(|(name, _)| name == "spot_sell")
+									.map(|(_, cloid)| cloid.clone())
+									.unwrap_or_else(|| "0".to_string()),
 								hedge_open_cloid: hedge_open_cloid.to_string(),
 								usdc_received: existing.usdc_loaned,
 								spot_sell_tx_hash: None,
+								to_perp_move_tx_hash,
 								hedge_open_tx_hash,
 							})
 						},
@@ -270,10 +292,16 @@ pub fn register_request_loan_test<
 							.await?;
 
 							Ok(RequestLoanTestResponse {
-								spot_sell_cloid: existing.spot_sell_cloid,
+								spot_sell_cloid: existing
+									.cloids
+									.iter()
+									.find(|(name, _)| name == "spot_sell")
+									.map(|(_, cloid)| cloid.clone())
+									.unwrap_or_else(|| "0".to_string()),
 								hedge_open_cloid: hedge_open_cloid.to_string(),
 								usdc_received: existing.usdc_loaned,
 								spot_sell_tx_hash: None,
+								to_perp_move_tx_hash: None,
 								hedge_open_tx_hash,
 							})
 						},
@@ -541,7 +569,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 	*current_nonce += 1;
 
 	info!(
-		"Spot sell submitted: price={}, size={}, tx={:?}",
+		"spot_sell submitted: price={}, size={}, tx={:?}",
 		clamped_price_f64, clamped_size_f64, spot_sell_tx_hash
 	);
 
@@ -607,8 +635,6 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 				usdc_sold: format!("{:.2}", usdc_sold),
 				usdc_loaned: format!("{:.2}", usdc_loaned),
 				usdc_for_perp: format!("{:.2}", usdc_for_perp),
-				spot_sell_cloid: spot_sell_cloid.to_string(),
-				hedge_open_cloid: "0".to_string(),
 			},
 		)
 		.map_err(|e| {
@@ -618,6 +644,14 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 					.with_reason(format!("Failed to create loan record: {}", e)),
 			)
 		})?;
+
+	// Populate spot_sell tx and cloid
+	let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
+		r.cloids.push(("spot_sell".to_string(), spot_sell_cloid.to_string()));
+		if let Some(ref tx_hash) = spot_sell_tx_hash {
+			r.txs.push(("spot_sell".to_string(), tx_hash.clone()));
+		}
+	});
 
 	exec_ctx
 		.hypercore_client
@@ -631,7 +665,7 @@ async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
 	usdc_for_perp: f64,
 	current_nonce: &mut u128,
-) -> Result<(), PumpxRpcError> {
+) -> Result<Option<String>, PumpxRpcError> {
 	info!("Action: Moving {:.2} USDC to perp", usdc_for_perp);
 
 	let initial_perp_balance = exec_ctx
@@ -659,7 +693,7 @@ async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 	user_op.nonce = *current_nonce;
 	user_op.init_code = "0x".to_string();
 
-	let usd_transfer_tx_hash = submit_corewriter_userop(
+	let to_perp_move_tx_hash = submit_corewriter_userop(
 		exec_ctx.ctx.clone(),
 		exec_ctx.omni_account,
 		&user_op,
@@ -673,7 +707,7 @@ async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 	.await?;
 	*current_nonce += 1;
 
-	info!("USD transfer submitted: size={:.2}, tx={:?}", usdc_for_perp, usd_transfer_tx_hash);
+	info!("to_perp_move submitted: size={:.2}, tx={:?}", usdc_for_perp, to_perp_move_tx_hash);
 
 	exec_ctx
 		.hypercore_client
@@ -687,24 +721,26 @@ async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 		.map_err(|e| {
 			PumpxRpcError::from(
 				DetailedError::new(INTERNAL_ERROR_CODE, "Internal error")
-					.with_reason(format!("USD transfer failed: {}", e)),
+					.with_reason(format!("to_perp_move failed: {}", e)),
 			)
 		})?;
 
-	info!("USD transfer completed");
+	info!("to_perp_move completed");
 
-	// Update state: ToPerpMoved
-	let _ = exec_ctx
-		.ctx
-		.loan_record_storage
-		.update(exec_ctx.storage_key, |r| r.state = LoanState::ToPerpMoved);
+	// Update state: ToPerpMoved and populate to_perp_move tx
+	let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
+		r.state = LoanState::ToPerpMoved;
+		if let Some(ref tx_hash) = to_perp_move_tx_hash {
+			r.txs.push(("to_perp_move".to_string(), tx_hash.clone()));
+		}
+	});
 
 	exec_ctx
 		.hypercore_client
 		.print_account_state(exec_ctx.smart_wallet, "After Move To Perp")
 		.await;
 
-	Ok(())
+	Ok(to_perp_move_tx_hash)
 }
 
 async fn do_open_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
@@ -779,7 +815,7 @@ async fn do_open_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 
 	.await?;
 
 	info!(
-		"Hedge position submitted: price={}, size={}, tx={:?}",
+		"hedge_open submitted: price={}, size={}, tx={:?}",
 		clamped_hedge_price_f64, clamped_hedge_size_f64, hedge_open_tx_hash
 	);
 
@@ -806,11 +842,14 @@ async fn do_open_hedge<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 
 		));
 	}
 
-	// Update loan record with position size and state: HedgeOpened
+	// Update loan record with position size, state: HedgeOpened, and populate hedge_open tx and cloid
 	let _ = exec_ctx.ctx.loan_record_storage.update(exec_ctx.storage_key, |r| {
 		r.position_size = format!("{}", clamped_hedge_size_f64);
 		r.state = LoanState::HedgeOpened;
-		r.hedge_open_cloid = hedge_open_cloid.to_string();
+		r.cloids.push(("hedge_open".to_string(), hedge_open_cloid.to_string()));
+		if let Some(ref tx_hash) = hedge_open_tx_hash {
+			r.txs.push(("hedge_open".to_string(), tx_hash.clone()));
+		}
 	});
 
 	exec_ctx

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/request_loan_test.rs
@@ -3,7 +3,7 @@ use crate::error_code::{INTERNAL_ERROR_CODE, INVALID_CHAIN_ID_CODE, PARSE_ERROR_
 use crate::methods::omni::PumpxRpcError;
 use crate::server::RpcContext;
 use crate::utils::omni::to_omni_account;
-use crate::utils::user_op::{prepare_skeleton_with_nonce, submit_corewriter_userop};
+use crate::utils::user_op::submit_corewriter_userop;
 use alloy::primitives::Address;
 use executor_core::intent_executor::IntentExecutor;
 use executor_core::types::SerializablePackedUserOperation;
@@ -108,6 +108,7 @@ pub fn register_request_loan_test<
 				smart_wallet,
 				storage_key: &storage_key,
 			};
+			let mut current_nonce = params.user_operation.nonce;
 
 			match ctx.loan_record_storage.get(&storage_key).ok().flatten() {
 				None => {
@@ -140,13 +141,14 @@ pub fn register_request_loan_test<
 						collateral_size,
 						lending_ratio_f64,
 						&sell_ctx,
+						&mut current_nonce,
 					)
 					.await?;
 
 					let usdc_loaned = usdc_sold * lending_ratio_f64;
 					let usdc_for_perp = usdc_sold * (1.0 - lending_ratio_f64);
 
-					do_move_to_perp(&exec_ctx, usdc_for_perp).await?;
+					do_move_to_perp(&exec_ctx, usdc_for_perp, &mut current_nonce).await?;
 
 					do_open_position(
 						&exec_ctx,
@@ -155,6 +157,7 @@ pub fn register_request_loan_test<
 						lending_ratio_f64,
 						hedge_cloid,
 						&open_ctx,
+						current_nonce,
 					)
 					.await?;
 
@@ -226,7 +229,7 @@ pub fn register_request_loan_test<
 									)
 								})?;
 
-							do_move_to_perp(&exec_ctx, usdc_for_perp).await?;
+							do_move_to_perp(&exec_ctx, usdc_for_perp, &mut current_nonce).await?;
 
 							do_open_position(
 								&exec_ctx,
@@ -235,6 +238,7 @@ pub fn register_request_loan_test<
 								lending_ratio_f64,
 								hedge_cloid,
 								&open_ctx,
+								current_nonce,
 							)
 							.await?;
 
@@ -286,6 +290,7 @@ pub fn register_request_loan_test<
 								lending_ratio_f64,
 								hedge_cloid,
 								&open_ctx,
+								current_nonce,
 							)
 							.await?;
 
@@ -511,6 +516,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 	collateral_size: f64,
 	lending_ratio_f64: f64,
 	sell_ctx: &SellSpotContext,
+	current_nonce: &mut u128,
 ) -> Result<(f64, u128, u128), PumpxRpcError> {
 	info!("Action: Selling {} {} in spot market", collateral_size, collateral_ticker);
 
@@ -542,10 +548,14 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 		spot_sell_cloid,
 	);
 
+	let mut user_op = exec_ctx.skeleton_user_op.clone();
+	user_op.nonce = *current_nonce;
+	// init_code is kept as-is from skeleton
+
 	let spot_sell_tx_hash = submit_corewriter_userop(
 		exec_ctx.ctx.clone(),
 		exec_ctx.omni_account,
-		exec_ctx.skeleton_user_op,
+		&user_op,
 		exec_ctx.chain_id,
 		exec_ctx.wallet_index,
 		encode_omni_account_execute(
@@ -554,6 +564,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 		),
 	)
 	.await?;
+	*current_nonce += 1;
 
 	info!(
 		"Spot sell submitted: price={}, size={}, tx={:?}",
@@ -645,6 +656,7 @@ async fn do_sell_spot<CrossChainIntentExecutor: IntentExecutor + Send + Sync + '
 async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static>(
 	exec_ctx: &ExecutionContext<'_, CrossChainIntentExecutor>,
 	usdc_for_perp: f64,
+	current_nonce: &mut u128,
 ) -> Result<(), PumpxRpcError> {
 	info!("Action: Moving {:.2} USDC to perp", usdc_for_perp);
 
@@ -668,13 +680,15 @@ async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 			)
 		})?;
 
+	// Clear init_code (account already created by sell_spot)
+	let mut user_op = exec_ctx.skeleton_user_op.clone();
+	user_op.nonce = *current_nonce;
+	user_op.init_code = "0x".to_string();
+
 	let usd_transfer_tx_hash = submit_corewriter_userop(
 		exec_ctx.ctx.clone(),
 		exec_ctx.omni_account,
-		&prepare_skeleton_with_nonce(
-			exec_ctx.skeleton_user_op,
-			exec_ctx.skeleton_user_op.nonce + 1,
-		),
+		&user_op,
 		exec_ctx.chain_id,
 		exec_ctx.wallet_index,
 		encode_omni_account_execute(
@@ -683,6 +697,7 @@ async fn do_move_to_perp<CrossChainIntentExecutor: IntentExecutor + Send + Sync 
 		),
 	)
 	.await?;
+	*current_nonce += 1;
 
 	info!("USD transfer submitted: size={:.2}, tx={:?}", usdc_for_perp, usd_transfer_tx_hash);
 
@@ -725,6 +740,7 @@ async fn do_open_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync
 	lending_ratio_f64: f64,
 	hedge_open_cloid: u128,
 	open_ctx: &OpenPositionContext,
+	current_nonce: u128,
 ) -> Result<(), PumpxRpcError> {
 	let desired_leverage = 1.0 / (1.0 - lending_ratio_f64);
 	let effective_leverage = desired_leverage.min(open_ctx.perp_max_leverage as f64);
@@ -770,13 +786,15 @@ async fn do_open_position<CrossChainIntentExecutor: IntentExecutor + Send + Sync
 		hedge_open_cloid,
 	);
 
+	// Clear init_code (account already created)
+	let mut user_op = exec_ctx.skeleton_user_op.clone();
+	user_op.nonce = current_nonce;
+	user_op.init_code = "0x".to_string();
+
 	let hedge_open_tx_hash = submit_corewriter_userop(
 		exec_ctx.ctx.clone(),
 		exec_ctx.omni_account,
-		&prepare_skeleton_with_nonce(
-			exec_ctx.skeleton_user_op,
-			exec_ctx.skeleton_user_op.nonce + 2,
-		),
+		&user_op,
 		exec_ctx.chain_id,
 		exec_ctx.wallet_index,
 		encode_omni_account_execute(

--- a/tee-worker/omni-executor/rpc-server/src/utils/user_op.rs
+++ b/tee-worker/omni-executor/rpc-server/src/utils/user_op.rs
@@ -169,7 +169,6 @@ pub(crate) async fn submit_corewriter_userop<
 	chain_id: u64,
 	wallet_index: u32,
 	call_data: String,
-	_client_id: &str,
 ) -> Result<Option<String>, PumpxRpcError> {
 	let smart_wallet_address = &skeleton_user_op.sender;
 

--- a/tee-worker/omni-executor/rpc-server/src/utils/user_op.rs
+++ b/tee-worker/omni-executor/rpc-server/src/utils/user_op.rs
@@ -143,20 +143,6 @@ pub fn convert_to_packed_user_op(
 	})
 }
 
-/// Prepare a skeleton user op with incremented nonce and cleared init_code if needed
-#[allow(dead_code)]
-pub(crate) fn prepare_skeleton_with_nonce(
-	base: &SerializablePackedUserOperation,
-	nonce: u128,
-) -> SerializablePackedUserOperation {
-	let mut skeleton = base.clone();
-	skeleton.nonce = nonce;
-	if nonce > base.nonce {
-		skeleton.init_code = "0x".to_string();
-	}
-	skeleton
-}
-
 /// Helper function to submit a CoreWriter userOp
 #[allow(clippy::too_many_arguments)]
 #[allow(dead_code)]


### PR DESCRIPTION
### Context

This is a big refactoring to the current impl:
- it introduces various `LoanState` which will be updated after each action
- it tries to use a waterfall pattern to be able to resume from any state where it was left off (like state machine).
- it improves the readability by separating the logic into smaller functions and outlining the flow in the main handler
- it adds two test rpcs for easier debugging of position opening and closing:
  - `openPositionTest`
  - `closePositionTest`

Please beware of the rpc parameter change and struct change, examples:
- no `client_id` in any of the RPCs
- an optional `loan_nonce` in `requestLoanTest` - if we wish to resume from some intermediate state of a specific loan, pass in that loan nonce, for fresh new loans you either leave it out or use the same nonce as in the userop
- `to_perp_move_tx_hash` is added into requestLoan response
- the `LoanRecord` struct change