### PR TITLE
add new fields: alias_name and last_used

### DIFF
--- a/tee-worker/omni-executor/executor-storage/src/passkey.rs
+++ b/tee-worker/omni-executor/executor-storage/src/passkey.rs
@@ -21,9 +21,15 @@ use parity_scale_codec::{Decode, Encode};
 use std::sync::Arc;
 
 const STORAGE_NAME: &str = "passkey_storage";
+const INDEX_STORAGE_NAME: &str = "passkey_account_index";
 
 /// Storage key type: (AccountId, Hash(credential_id))
 pub type PasskeyStorageKey = (AccountId, [u8; 32]);
+
+/// Index storage: Maps AccountId -> Vec<String> (credential_ids)
+/// This enables O(1) lookup of all credential IDs for a given account
+pub type PasskeyAccountIndexKey = AccountId;
+pub type PasskeyAccountIndexValue = Vec<String>;
 
 /// Passkey data structure
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
@@ -44,14 +50,62 @@ pub enum PasskeyError {
 	ValidationError,
 }
 
+/// Index storage that maps AccountId to list of credential IDs
+pub struct PasskeyAccountIndex {
+	db: Arc<StorageDB>,
+}
+
+impl PasskeyAccountIndex {
+	pub fn new(db: Arc<StorageDB>) -> Self {
+		Self { db }
+	}
+
+	fn add_credential(&self, omni_account: &AccountId, credential_id: &str) -> Result<(), ()> {
+		let mut credentials = self.get(omni_account)?.unwrap_or_default();
+		if !credentials.contains(&credential_id.to_string()) {
+			credentials.push(credential_id.to_string());
+			self.insert(omni_account, credentials)?;
+		}
+		Ok(())
+	}
+
+	fn remove_credential(&self, omni_account: &AccountId, credential_id: &str) -> Result<(), ()> {
+		if let Some(mut credentials) = self.get(omni_account)? {
+			credentials.retain(|cid| cid != credential_id);
+			if credentials.is_empty() {
+				self.remove(omni_account)?;
+			} else {
+				self.insert(omni_account, credentials)?;
+			}
+		}
+		Ok(())
+	}
+
+	fn get_credentials(&self, omni_account: &AccountId) -> Result<Vec<String>, ()> {
+		Ok(self.get(omni_account)?.unwrap_or_default())
+	}
+}
+
+impl Storage<PasskeyAccountIndexKey, PasskeyAccountIndexValue> for PasskeyAccountIndex {
+	fn db(&self) -> Arc<StorageDB> {
+		self.db.clone()
+	}
+
+	fn name(&self) -> &'static str {
+		INDEX_STORAGE_NAME
+	}
+}
+
 /// Passkey storage using composite key of (omni_account, Hash(credential_id))
 pub struct PasskeyStorage {
 	db: Arc<StorageDB>,
+	index: PasskeyAccountIndex,
 }
 
 impl PasskeyStorage {
 	pub fn new(db: Arc<StorageDB>) -> Self {
-		Self { db }
+		let index = PasskeyAccountIndex::new(db.clone());
+		Self { db, index }
 	}
 
 	fn make_key(omni_account: &AccountId, credential_id: &str) -> PasskeyStorageKey {
@@ -73,7 +127,14 @@ impl PasskeyStorage {
 		credential_id: &str,
 	) -> Result<(), PasskeyError> {
 		let key = Self::make_key(omni_account, credential_id);
-		self.remove(&key).map_err(|_| PasskeyError::StorageError)
+
+		self.remove(&key).map_err(|_| PasskeyError::StorageError)?;
+
+		self.index
+			.remove_credential(omni_account, credential_id)
+			.map_err(|_| PasskeyError::StorageError)?;
+
+		Ok(())
 	}
 
 	pub fn exists_passkey(&self, omni_account: &AccountId, credential_id: &str) -> bool {
@@ -108,7 +169,14 @@ impl PasskeyStorage {
 		if self.contains_key(&key) {
 			return Err(PasskeyError::DuplicatePasskey);
 		}
-		self.insert(&key, record).map_err(|_| PasskeyError::StorageError)
+
+		self.insert(&key, record).map_err(|_| PasskeyError::StorageError)?;
+
+		self.index
+			.add_credential(omni_account, credential_id)
+			.map_err(|_| PasskeyError::StorageError)?;
+
+		Ok(())
 	}
 
 	/// List all passkeys for a given omni_account
@@ -119,73 +187,26 @@ impl PasskeyStorage {
 	) -> Result<Vec<(String, u64, u64)>, PasskeyError> {
 		let mut passkeys = Vec::new();
 
-		// The storage key structure is:
-		// storage_key = twox_128(storage_name) + blake2_128_concat(encoded_tuple_key)
-		// where blake2_128_concat(x) = blake2_128(x) + x
-		//
-		// For a tuple key (AccountId, [u8; 32]), the encoded form is:
-		// AccountId.encode() + [u8; 32].encode()
-		// = AccountId bytes + credential_id_hash bytes
-		//
-		// We want to match all keys for a given AccountId, so we need to construct
-		// a prefix that covers:
-		// twox_128(storage_name) + blake2_128(full_key) + AccountId.encode() + ...
-		//
-		// However, blake2_128 hashes the ENTIRE encoded key, so we can't just match
-		// on the AccountId portion. Instead, we iterate through ALL keys in this storage
-		// and filter by AccountId.
+		let credential_ids = self
+			.index
+			.get_credentials(omni_account)
+			.map_err(|_| PasskeyError::StorageError)?;
 
-		let storage_prefix = twox_128(STORAGE_NAME.as_bytes());
-		let db = self.db();
-		let iter = db.prefix_iterator(storage_prefix);
-
-		for item in iter {
-			match item {
-				Ok((key, value)) => {
-					// Verify the key belongs to our storage namespace
-					if !key.starts_with(&storage_prefix) {
-						// We've moved past our namespace, stop iteration
-						break;
-					}
-
-					// The key structure after storage_prefix is:
-					// blake2_128(encoded_tuple) + encoded_tuple
-					// where encoded_tuple = AccountId + [u8; 32]
-					//
-					// Skip the blake2_128 hash (16 bytes) to get to the encoded tuple
-					let encoded_tuple_start = storage_prefix.len() + 16;
-					if key.len() < encoded_tuple_start + 32 {
-						// Invalid key structure, skip
-						continue;
-					}
-
-					// Extract the AccountId from the key (32 bytes after the hash)
-					let key_account_bytes = &key[encoded_tuple_start..encoded_tuple_start + 32];
-
-					// Compare with our target omni_account
-					if key_account_bytes == <AccountId as AsRef<[u8]>>::as_ref(omni_account) {
-						// This key belongs to our account, decode the record
-						match PasskeyRecord::decode(&mut &value[..]) {
-							Ok(record) => {
-								passkeys.push((
-									record.alias_name.clone(),
-									record.created_at,
-									record.last_used,
-								));
-							},
-							Err(e) => {
-								tracing::warn!(
-									"Failed to decode passkey record for account {:?}: {:?}",
-									omni_account,
-									e
-								);
-								// Continue iteration despite decode error
-							},
-						}
-					}
+		for credential_id in credential_ids {
+			match self.get_passkey(omni_account, &credential_id) {
+				Ok(Some(record)) => {
+					passkeys.push((record.alias_name.clone(), record.created_at, record.last_used));
 				},
-				Err(e) => {
-					tracing::error!("Error iterating through passkeys: {:?}", e);
+				Ok(None) => {
+					tracing::warn!(
+						"Passkey index references non-existent credential: {} for account {:?}",
+						credential_id,
+						omni_account
+					);
+					// Continue despite missing record
+				},
+				Err(_) => {
+					tracing::error!("Error retrieving passkey record for credential: {}", credential_id);
 					return Err(PasskeyError::StorageError);
 				},
 			}

--- a/tee-worker/omni-executor/executor-storage/src/passkey.rs
+++ b/tee-worker/omni-executor/executor-storage/src/passkey.rs
@@ -15,7 +15,7 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Storage, StorageDB};
-use executor_crypto::hashing::{blake2_256, twox_128};
+use executor_crypto::hashing::blake2_256;
 use executor_primitives::AccountId;
 use parity_scale_codec::{Decode, Encode};
 use std::sync::Arc;
@@ -206,7 +206,10 @@ impl PasskeyStorage {
 					// Continue despite missing record
 				},
 				Err(_) => {
-					tracing::error!("Error retrieving passkey record for credential: {}", credential_id);
+					tracing::error!(
+						"Error retrieving passkey record for credential: {}",
+						credential_id
+					);
 					return Err(PasskeyError::StorageError);
 				},
 			}

--- a/tee-worker/omni-executor/executor-storage/src/passkey.rs
+++ b/tee-worker/omni-executor/executor-storage/src/passkey.rs
@@ -258,7 +258,7 @@ mod tests {
 	use std::fs;
 	use std::path::Path;
 
-	fn create_test_storage() -> PasskeyStorage {
+	fn create_test_storage() -> (PasskeyStorage, String) {
 		use std::sync::atomic::{AtomicUsize, Ordering};
 		static COUNTER: AtomicUsize = AtomicUsize::new(0);
 		let db_path = format!("test_passkey_storage_{}", COUNTER.fetch_add(1, Ordering::SeqCst));
@@ -266,12 +266,18 @@ mod tests {
 			fs::remove_dir_all(&db_path).unwrap();
 		}
 		let db = Arc::new(StorageDB::open_default(&db_path).unwrap());
-		PasskeyStorage::new(db)
+		(PasskeyStorage::new(db), db_path)
+	}
+
+	fn remove_test_storage(db_path: &str) {
+		if Path::new(db_path).exists() {
+			fs::remove_dir_all(db_path).unwrap();
+		}
 	}
 
 	#[test]
 	fn test_passkey_add_and_get() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([1u8; 32]);
 
 		// Add a passkey
@@ -286,11 +292,14 @@ mod tests {
 		// Test existence check
 		assert!(storage.exists_passkey(&omni_account, "cred123"));
 		assert!(!storage.exists_passkey(&omni_account, "nonexistent"));
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_passkey_removal() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([2u8; 32]);
 
 		// Add a passkey
@@ -306,11 +315,14 @@ mod tests {
 		// Verify it's gone
 		assert!(!storage.exists_passkey(&omni_account, "cred456"));
 		assert!(storage.get_passkey(&omni_account, "cred456").unwrap().is_none());
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_duplicate_detection() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([3u8; 32]);
 
 		// Add first passkey
@@ -321,11 +333,14 @@ mod tests {
 		let test_pubkey2 = b"test_pubkey_789_new";
 		let result = storage.add_passkey(&omni_account, "cred789", test_pubkey2, None);
 		assert_eq!(result, Err(PasskeyError::DuplicatePasskey));
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_multiple_passkeys_per_omni_account() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([4u8; 32]);
 
 		// Add multiple passkeys for the same omni account
@@ -343,11 +358,14 @@ mod tests {
 
 		assert_eq!(record1.pubkey, test_pubkey1.to_vec());
 		assert_eq!(record2.pubkey, test_pubkey2.to_vec());
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_list_passkeys() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account1 = AccountId::from([5u8; 32]);
 		let omni_account2 = AccountId::from([6u8; 32]);
 
@@ -385,5 +403,8 @@ mod tests {
 		let omni_account3 = AccountId::from([7u8; 32]);
 		let passkeys3 = storage.list_passkeys(&omni_account3).unwrap();
 		assert_eq!(passkeys3.len(), 0);
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 }

--- a/tee-worker/omni-executor/executor-storage/src/passkey.rs
+++ b/tee-worker/omni-executor/executor-storage/src/passkey.rs
@@ -31,6 +31,9 @@ pub struct PasskeyRecord {
 	pub credential_id: String,
 	pub pubkey: Vec<u8>, // Store SEC1 bytes directly
 	pub created_at: u64,
+	pub omni_account: AccountId,
+	pub alias_name: String,
+	pub last_used: u64,
 }
 
 /// Errors that can occur during passkey operations
@@ -83,16 +86,22 @@ impl PasskeyStorage {
 		omni_account: &AccountId,
 		credential_id: &str,
 		pubkey: &[u8], // Accept SEC1 bytes directly
+		alias_name: Option<String>,
 	) -> Result<(), PasskeyError> {
 		let current_time = std::time::SystemTime::now()
 			.duration_since(std::time::UNIX_EPOCH)
 			.unwrap()
 			.as_secs();
 
+		let alias = alias_name.unwrap_or_else(|| credential_id.to_string());
+
 		let record = PasskeyRecord {
 			credential_id: credential_id.to_string(),
 			pubkey: pubkey.to_vec(),
 			created_at: current_time,
+			omni_account: omni_account.clone(),
+			alias_name: alias,
+			last_used: current_time,
 		};
 
 		let key = Self::make_key(omni_account, credential_id);
@@ -103,11 +112,11 @@ impl PasskeyStorage {
 	}
 
 	/// List all passkeys for a given omni_account
-	/// Returns a vector of tuples (credential_id, created_at)
+	/// Returns a vector of tuples (alias_name, created_at, last_used)
 	pub fn list_passkeys(
 		&self,
 		omni_account: &AccountId,
-	) -> Result<Vec<(String, u64)>, PasskeyError> {
+	) -> Result<Vec<(String, u64, u64)>, PasskeyError> {
 		let mut passkeys = Vec::new();
 
 		// The storage key structure is:
@@ -158,7 +167,11 @@ impl PasskeyStorage {
 						// This key belongs to our account, decode the record
 						match PasskeyRecord::decode(&mut &value[..]) {
 							Ok(record) => {
-								passkeys.push((record.credential_id.clone(), record.created_at));
+								passkeys.push((
+									record.alias_name.clone(),
+									record.created_at,
+									record.last_used,
+								));
 							},
 							Err(e) => {
 								tracing::warn!(
@@ -179,6 +192,53 @@ impl PasskeyStorage {
 		}
 
 		Ok(passkeys)
+	}
+
+	/// Rename the alias name of a passkey
+	pub fn rename_passkey_alias(
+		&self,
+		omni_account: &AccountId,
+		credential_id: &str,
+		new_alias_name: String,
+	) -> Result<(), PasskeyError> {
+		let key = Self::make_key(omni_account, credential_id);
+
+		// Get the existing record
+		let mut record = self
+			.get(&key)
+			.map_err(|_| PasskeyError::StorageError)?
+			.ok_or(PasskeyError::ValidationError)?;
+
+		// Update the alias name
+		record.alias_name = new_alias_name;
+
+		// Save the updated record
+		self.insert(&key, record).map_err(|_| PasskeyError::StorageError)
+	}
+
+	/// Update the last_used timestamp for a passkey
+	pub fn update_last_used(
+		&self,
+		omni_account: &AccountId,
+		credential_id: &str,
+	) -> Result<(), PasskeyError> {
+		let key = Self::make_key(omni_account, credential_id);
+
+		// Get the existing record
+		let mut record = self
+			.get(&key)
+			.map_err(|_| PasskeyError::StorageError)?
+			.ok_or(PasskeyError::ValidationError)?;
+
+		// Update the last_used timestamp
+		let current_time = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.unwrap()
+			.as_secs();
+		record.last_used = current_time;
+
+		// Save the updated record
+		self.insert(&key, record).map_err(|_| PasskeyError::StorageError)
 	}
 }
 
@@ -216,7 +276,7 @@ mod tests {
 
 		// Add a passkey
 		let test_pubkey = b"test_pubkey_123";
-		storage.add_passkey(&omni_account, "cred123", test_pubkey).unwrap();
+		storage.add_passkey(&omni_account, "cred123", test_pubkey, None).unwrap();
 
 		// Test retrieval
 		let retrieved = storage.get_passkey(&omni_account, "cred123").unwrap().unwrap();
@@ -235,7 +295,7 @@ mod tests {
 
 		// Add a passkey
 		let test_pubkey = b"test_pubkey_456";
-		storage.add_passkey(&omni_account, "cred456", test_pubkey).unwrap();
+		storage.add_passkey(&omni_account, "cred456", test_pubkey, None).unwrap();
 
 		// Verify it exists
 		assert!(storage.exists_passkey(&omni_account, "cred456"));
@@ -255,11 +315,11 @@ mod tests {
 
 		// Add first passkey
 		let test_pubkey1 = b"test_pubkey_789";
-		storage.add_passkey(&omni_account, "cred789", test_pubkey1).unwrap();
+		storage.add_passkey(&omni_account, "cred789", test_pubkey1, None).unwrap();
 
 		// Try to add with same omni_account + credential_id
 		let test_pubkey2 = b"test_pubkey_789_new";
-		let result = storage.add_passkey(&omni_account, "cred789", test_pubkey2);
+		let result = storage.add_passkey(&omni_account, "cred789", test_pubkey2, None);
 		assert_eq!(result, Err(PasskeyError::DuplicatePasskey));
 	}
 
@@ -271,8 +331,8 @@ mod tests {
 		// Add multiple passkeys for the same omni account
 		let test_pubkey1 = b"test_pubkey_1";
 		let test_pubkey2 = b"test_pubkey_2";
-		storage.add_passkey(&omni_account, "cred1", test_pubkey1).unwrap();
-		storage.add_passkey(&omni_account, "cred2", test_pubkey2).unwrap();
+		storage.add_passkey(&omni_account, "cred1", test_pubkey1, None).unwrap();
+		storage.add_passkey(&omni_account, "cred2", test_pubkey2, None).unwrap();
 
 		// Both should exist independently
 		assert!(storage.exists_passkey(&omni_account, "cred1"));
@@ -295,23 +355,26 @@ mod tests {
 		let test_pubkey1 = b"test_pubkey_1";
 		let test_pubkey2 = b"test_pubkey_2";
 		let test_pubkey3 = b"test_pubkey_3";
-		storage.add_passkey(&omni_account1, "cred1", test_pubkey1).unwrap();
-		storage.add_passkey(&omni_account1, "cred2", test_pubkey2).unwrap();
-		storage.add_passkey(&omni_account1, "cred3", test_pubkey3).unwrap();
+		storage.add_passkey(&omni_account1, "cred1", test_pubkey1, None).unwrap();
+		storage.add_passkey(&omni_account1, "cred2", test_pubkey2, None).unwrap();
+		storage
+			.add_passkey(&omni_account1, "cred3", test_pubkey3, Some("My Passkey".to_string()))
+			.unwrap();
 
 		// Add a passkey for account2
 		let test_pubkey4 = b"test_pubkey_4";
-		storage.add_passkey(&omni_account2, "cred4", test_pubkey4).unwrap();
+		storage.add_passkey(&omni_account2, "cred4", test_pubkey4, None).unwrap();
 
 		// List passkeys for account1
 		let passkeys1 = storage.list_passkeys(&omni_account1).unwrap();
 		assert_eq!(passkeys1.len(), 3);
 
-		// Verify all three passkeys are present
-		let cred_ids: Vec<String> = passkeys1.iter().map(|(cid, _)| cid.clone()).collect();
-		assert!(cred_ids.contains(&"cred1".to_string()));
-		assert!(cred_ids.contains(&"cred2".to_string()));
-		assert!(cred_ids.contains(&"cred3".to_string()));
+		// Verify all three passkeys are present (now returns alias_name instead of credential_id)
+		let alias_names: Vec<String> =
+			passkeys1.iter().map(|(alias, _, _)| alias.clone()).collect();
+		assert!(alias_names.contains(&"cred1".to_string()));
+		assert!(alias_names.contains(&"cred2".to_string()));
+		assert!(alias_names.contains(&"My Passkey".to_string()));
 
 		// List passkeys for account2
 		let passkeys2 = storage.list_passkeys(&omni_account2).unwrap();

--- a/tee-worker/omni-executor/executor-storage/src/passkey_challenge.rs
+++ b/tee-worker/omni-executor/executor-storage/src/passkey_challenge.rs
@@ -235,7 +235,7 @@ mod tests {
 	use std::fs;
 	use std::path::Path;
 
-	fn create_test_storage() -> PasskeyChallengeStorage {
+	fn create_test_storage() -> (PasskeyChallengeStorage, String) {
 		use std::sync::atomic::{AtomicUsize, Ordering};
 		static COUNTER: AtomicUsize = AtomicUsize::new(0);
 		let db_path =
@@ -244,12 +244,18 @@ mod tests {
 			fs::remove_dir_all(&db_path).unwrap();
 		}
 		let db = Arc::new(StorageDB::open_default(&db_path).unwrap());
-		PasskeyChallengeStorage::new(db)
+		(PasskeyChallengeStorage::new(db), db_path)
+	}
+
+	fn remove_test_storage(db_path: &str) {
+		if Path::new(db_path).exists() {
+			fs::remove_dir_all(db_path).unwrap();
+		}
 	}
 
 	#[test]
 	fn test_store_and_verify_challenge() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([1u8; 32]);
 		let challenge = "test_challenge_123";
 
@@ -264,11 +270,14 @@ mod tests {
 
 		// Challenge should be consumed (no longer valid)
 		assert!(!storage.is_challenge_valid(challenge, &omni_account).unwrap());
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_challenge_expiration() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([2u8; 32]);
 		let challenge = "expired_challenge";
 
@@ -282,11 +291,14 @@ mod tests {
 		// only removes challenges expired >24h ago
 		let result = storage.verify_and_consume_challenge(challenge, &omni_account);
 		assert_eq!(result, Err(PasskeyChallengeError::ChallengeExpired));
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_invalid_account() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account1 = AccountId::from([3u8; 32]);
 		let omni_account2 = AccountId::from([4u8; 32]);
 		let challenge = "account_mismatch_challenge";
@@ -300,21 +312,27 @@ mod tests {
 
 		// Original challenge should still exist for account1
 		assert!(storage.is_challenge_valid(challenge, &omni_account1).unwrap());
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_challenge_not_found() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([5u8; 32]);
 
 		// Try to verify non-existent challenge
 		let result = storage.verify_and_consume_challenge("nonexistent", &omni_account);
 		assert_eq!(result, Err(PasskeyChallengeError::ChallengeNotFound));
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_cleanup_no_expired_challenges() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([6u8; 32]);
 
 		// Store some valid challenges (not expired)
@@ -330,11 +348,14 @@ mod tests {
 		assert!(storage.is_challenge_valid("challenge1", &omni_account).unwrap());
 		assert!(storage.is_challenge_valid("challenge2", &omni_account).unwrap());
 		assert!(storage.is_challenge_valid("challenge3", &omni_account).unwrap());
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_cleanup_all_expired_challenges() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([7u8; 32]);
 
 		// Store challenges with 0 second timeout (immediately expired)
@@ -353,11 +374,14 @@ mod tests {
 		// They will return ChallengeExpired when verified, not ChallengeNotFound
 		let result1 = storage.verify_and_consume_challenge("expired1", &omni_account);
 		assert_eq!(result1, Err(PasskeyChallengeError::ChallengeExpired));
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_cleanup_mixed_expired_and_valid() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([8u8; 32]);
 
 		// Store mix of expired and valid challenges
@@ -380,11 +404,14 @@ mod tests {
 		// Expired challenges still exist (in grace period) but return ChallengeExpired
 		let result1 = storage.verify_and_consume_challenge("expired1", &omni_account);
 		assert_eq!(result1, Err(PasskeyChallengeError::ChallengeExpired));
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_cleanup_multiple_accounts() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let account1 = AccountId::from([9u8; 32]);
 		let account2 = AccountId::from([10u8; 32]);
 
@@ -406,11 +433,14 @@ mod tests {
 		// Expired challenges return ChallengeExpired (not removed yet)
 		let result1 = storage.verify_and_consume_challenge("account1_expired", &account1);
 		assert_eq!(result1, Err(PasskeyChallengeError::ChallengeExpired));
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_cleanup_idempotent() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 		let omni_account = AccountId::from([11u8; 32]);
 
 		// Store expired challenge
@@ -429,14 +459,20 @@ mod tests {
 		// Idempotent - still nothing
 		let cleaned3 = storage.cleanup_expired24h_challenges().unwrap();
 		assert_eq!(cleaned3, 0);
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 
 	#[test]
 	fn test_cleanup_empty_storage() {
-		let storage = create_test_storage();
+		let (storage, db_path) = create_test_storage();
 
 		// Cleanup on empty storage should work fine
 		let cleaned = storage.cleanup_expired24h_challenges().unwrap();
 		assert_eq!(cleaned, 0);
+
+		// Cleanup
+		remove_test_storage(&db_path);
 	}
 }

--- a/tee-worker/omni-executor/executor-storage/tests/passkey_integration.rs
+++ b/tee-worker/omni-executor/executor-storage/tests/passkey_integration.rs
@@ -51,7 +51,7 @@ fn test_complete_passkey_registration_flow() {
 	let pubkey = b"test_pubkey_bytes_for_registration";
 
 	passkey_storage
-		.add_passkey(&omni_account, credential_id, pubkey)
+		.add_passkey(&omni_account, credential_id, pubkey, None)
 		.expect("Failed to add passkey");
 
 	// Step 3: Verify the passkey was stored correctly
@@ -82,7 +82,7 @@ fn test_complete_passkey_authentication_flow() {
 	let pubkey = b"test_pubkey_bytes_for_auth";
 
 	passkey_storage
-		.add_passkey(&omni_account, credential_id, pubkey)
+		.add_passkey(&omni_account, credential_id, pubkey, None)
 		.expect("Failed to add passkey");
 
 	// Step 2: Generate authentication challenge
@@ -140,11 +140,11 @@ fn test_multiple_passkeys_per_account() {
 	let laptop_pubkey = b"laptop_pubkey_bytes";
 
 	passkey_storage
-		.add_passkey(&omni_account, phone_credential, phone_pubkey)
+		.add_passkey(&omni_account, phone_credential, phone_pubkey, None)
 		.expect("Failed to add phone passkey");
 
 	passkey_storage
-		.add_passkey(&omni_account, laptop_credential, laptop_pubkey)
+		.add_passkey(&omni_account, laptop_credential, laptop_pubkey, None)
 		.expect("Failed to add laptop passkey");
 
 	// Verify both passkeys exist independently
@@ -176,7 +176,7 @@ fn test_passkey_removal_flow() {
 	let pubkey = b"test_pubkey_remove";
 
 	passkey_storage
-		.add_passkey(&omni_account, credential_id, pubkey)
+		.add_passkey(&omni_account, credential_id, pubkey, None)
 		.expect("Failed to add passkey");
 
 	// Verify passkey exists
@@ -238,11 +238,11 @@ fn test_passkey_duplicate_prevention() {
 
 	// Add passkey first time (should succeed)
 	passkey_storage
-		.add_passkey(&omni_account, credential_id, pubkey)
+		.add_passkey(&omni_account, credential_id, pubkey, None)
 		.expect("Failed to add passkey");
 
 	// Try to add the same passkey again (should fail)
-	let duplicate_result = passkey_storage.add_passkey(&omni_account, credential_id, pubkey);
+	let duplicate_result = passkey_storage.add_passkey(&omni_account, credential_id, pubkey, None);
 
 	assert!(matches!(duplicate_result, Err(PasskeyError::DuplicatePasskey)));
 }
@@ -260,11 +260,11 @@ fn test_concurrent_authentication_sessions() {
 
 	// Register passkeys for both accounts
 	passkey_storage
-		.add_passkey(&account1, "cred1", b"pubkey1")
+		.add_passkey(&account1, "cred1", b"pubkey1", None)
 		.expect("Failed to add passkey for account1");
 
 	passkey_storage
-		.add_passkey(&account2, "cred2", b"pubkey2")
+		.add_passkey(&account2, "cred2", b"pubkey2", None)
 		.expect("Failed to add passkey for account2");
 
 	// Create challenges for both accounts

--- a/tee-worker/omni-executor/executor-storage/tests/passkey_integration.rs
+++ b/tee-worker/omni-executor/executor-storage/tests/passkey_integration.rs
@@ -10,7 +10,7 @@ use executor_storage::{
 use std::sync::Arc;
 
 /// Helper to create a test storage database
-fn create_test_storage() -> Arc<StorageDB> {
+fn create_test_storage() -> (Arc<StorageDB>, String) {
 	use std::sync::atomic::{AtomicUsize, Ordering};
 	use std::time::SystemTime;
 	static COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -18,7 +18,16 @@ fn create_test_storage() -> Arc<StorageDB> {
 	let timestamp = SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_micros();
 	let count = COUNTER.fetch_add(1, Ordering::SeqCst);
 	let db_path = format!("test_passkey_integration_{}_{}", timestamp, count);
-	Arc::new(StorageDB::open_default(&db_path).unwrap())
+	(Arc::new(StorageDB::open_default(&db_path).unwrap()), db_path)
+}
+
+/// Helper to remove test storage database
+fn remove_test_storage(db_path: &str) {
+	use std::fs;
+	use std::path::Path;
+	if Path::new(db_path).exists() {
+		fs::remove_dir_all(db_path).unwrap();
+	}
 }
 
 /// Helper to create a test omni account
@@ -33,7 +42,7 @@ fn test_complete_passkey_registration_flow() {
 	// 2. Store passkey
 	// 3. Verify passkey is stored correctly
 
-	let storage_db = create_test_storage();
+	let (storage_db, db_path) = create_test_storage();
 	let challenge_storage = PasskeyChallengeStorage::new(storage_db.clone());
 	let passkey_storage = PasskeyStorage::new(storage_db.clone());
 
@@ -62,6 +71,9 @@ fn test_complete_passkey_registration_flow() {
 
 	assert_eq!(stored_passkey.credential_id, credential_id);
 	assert_eq!(stored_passkey.pubkey, pubkey.to_vec());
+
+	// Cleanup
+	remove_test_storage(&db_path);
 }
 
 #[test]
@@ -71,7 +83,7 @@ fn test_complete_passkey_authentication_flow() {
 	// 2. Request challenge for authentication
 	// 3. Verify and consume challenge
 
-	let storage_db = create_test_storage();
+	let (storage_db, db_path) = create_test_storage();
 	let challenge_storage = PasskeyChallengeStorage::new(storage_db.clone());
 	let passkey_storage = PasskeyStorage::new(storage_db.clone());
 
@@ -99,13 +111,16 @@ fn test_complete_passkey_authentication_flow() {
 	// Verify challenge was consumed (should fail on second attempt)
 	let result = challenge_storage.verify_and_consume_challenge(challenge, &omni_account);
 	assert!(matches!(result, Err(PasskeyChallengeError::ChallengeNotFound)));
+
+	// Cleanup
+	remove_test_storage(&db_path);
 }
 
 #[test]
 fn test_passkey_challenge_expired() {
 	// This test verifies that expired challenges return ChallengeExpired error
 
-	let storage_db = create_test_storage();
+	let (storage_db, db_path) = create_test_storage();
 	let challenge_storage = PasskeyChallengeStorage::new(storage_db.clone());
 
 	let omni_account = create_test_account(5);
@@ -121,13 +136,16 @@ fn test_passkey_challenge_expired() {
 	// Verify we get ChallengeExpired error (not ChallengeNotFound)
 	let result = challenge_storage.verify_and_consume_challenge("expired", &omni_account);
 	assert!(matches!(result, Err(PasskeyChallengeError::ChallengeExpired)));
+
+	// Cleanup
+	remove_test_storage(&db_path);
 }
 
 #[test]
 fn test_multiple_passkeys_per_account() {
 	// This test verifies handling of multiple passkeys for the same account
 
-	let storage_db = create_test_storage();
+	let (storage_db, db_path) = create_test_storage();
 	let passkey_storage = PasskeyStorage::new(storage_db.clone());
 
 	let omni_account = create_test_account(6);
@@ -160,13 +178,16 @@ fn test_multiple_passkeys_per_account() {
 
 	assert_eq!(phone.pubkey, phone_pubkey.to_vec());
 	assert_eq!(laptop.pubkey, laptop_pubkey.to_vec());
+
+	// Cleanup
+	remove_test_storage(&db_path);
 }
 
 #[test]
 fn test_passkey_removal_flow() {
 	// This test verifies the complete passkey removal workflow
 
-	let storage_db = create_test_storage();
+	let (storage_db, db_path) = create_test_storage();
 	let passkey_storage = PasskeyStorage::new(storage_db.clone());
 
 	let omni_account = create_test_account(7);
@@ -196,13 +217,16 @@ fn test_passkey_removal_flow() {
 		.expect("Failed to query passkey");
 
 	assert!(result.is_none());
+
+	// Cleanup
+	remove_test_storage(&db_path);
 }
 
 #[test]
 fn test_challenge_account_mismatch() {
 	// This test verifies that challenges are properly scoped to specific accounts
 
-	let storage_db = create_test_storage();
+	let (storage_db, db_path) = create_test_storage();
 	let challenge_storage = PasskeyChallengeStorage::new(storage_db.clone());
 
 	let account1 = create_test_account(8);
@@ -222,13 +246,16 @@ fn test_challenge_account_mismatch() {
 	challenge_storage
 		.verify_and_consume_challenge("test_challenge", &account1)
 		.expect("Challenge should still be valid for account1");
+
+	// Cleanup
+	remove_test_storage(&db_path);
 }
 
 #[test]
 fn test_passkey_duplicate_prevention() {
 	// This test verifies that duplicate passkeys are properly prevented
 
-	let storage_db = create_test_storage();
+	let (storage_db, db_path) = create_test_storage();
 	let passkey_storage = PasskeyStorage::new(storage_db.clone());
 
 	let omni_account = create_test_account(10);
@@ -245,13 +272,16 @@ fn test_passkey_duplicate_prevention() {
 	let duplicate_result = passkey_storage.add_passkey(&omni_account, credential_id, pubkey, None);
 
 	assert!(matches!(duplicate_result, Err(PasskeyError::DuplicatePasskey)));
+
+	// Cleanup
+	remove_test_storage(&db_path);
 }
 
 #[test]
 fn test_concurrent_authentication_sessions() {
 	// This test verifies that multiple authentication sessions can be managed simultaneously
 
-	let storage_db = create_test_storage();
+	let (storage_db, db_path) = create_test_storage();
 	let challenge_storage = PasskeyChallengeStorage::new(storage_db.clone());
 	let passkey_storage = PasskeyStorage::new(storage_db.clone());
 
@@ -291,4 +321,7 @@ fn test_concurrent_authentication_sessions() {
 
 	assert_eq!(pk1.pubkey, b"pubkey1");
 	assert_eq!(pk2.pubkey, b"pubkey2");
+
+	// Cleanup
+	remove_test_storage(&db_path);
 }

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/attach_passkey.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/attach_passkey.rs
@@ -18,6 +18,7 @@ pub struct AttachPasskeyParams {
 	pub client_id: String,
 	pub attestation_object: String, // Base64 encoded WebAuthn attestation object
 	pub client_data_json: String,   // Base64 encoded WebAuthn client data JSON
+	pub alias_name: Option<String>, // Optional alias name for the passkey
 }
 
 #[derive(Serialize, Clone)]
@@ -103,7 +104,12 @@ pub fn register_attach_passkey<CrossChainIntentExecutor: IntentExecutor + Send +
 			let public_key_sec1_bytes = public_key.verifying_key.to_sec1_bytes();
 			let passkey_storage = PasskeyStorage::new(ctx.storage_db.clone());
 			passkey_storage
-				.add_passkey(&omni_account, &credential_id, &public_key_sec1_bytes)
+				.add_passkey(
+					&omni_account,
+					&credential_id,
+					&public_key_sec1_bytes,
+					params.alias_name,
+				)
 				.map_err_internal("Failed to attach passkey")?;
 
 			Ok::<AttachPasskeyResponse, ErrorObject>(AttachPasskeyResponse {

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/get_hyperliquid_signature_data.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/get_hyperliquid_signature_data.rs
@@ -43,6 +43,7 @@ pub struct AttachPasskeyData {
 	/// The client data JSON from the WebAuthn registration ceremony (base64url encoded)
 	/// This contains the challenge, origin, and other client-side data
 	pub client_data_json: String,
+	pub alias_name: Option<String>, // Optional alias name for the passkey
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -214,7 +215,12 @@ pub fn register_get_hyperliquid_signature_data<
 				// Store the new passkey to the authenticated user's account
 				let passkey_storage = PasskeyStorage::new(ctx.storage_db.clone());
 				passkey_storage
-					.add_passkey(&omni_account, &credential_id, &public_key_sec1_bytes)
+					.add_passkey(
+						&omni_account,
+						&credential_id,
+						&public_key_sec1_bytes,
+						attach_passkey_data.alias_name.clone(),
+					)
 					.map_err_internal("Failed to attach passkey")?;
 			}
 

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/list_passkey.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/list_passkey.rs
@@ -17,8 +17,9 @@ pub struct ListPasskeyParams {
 
 #[derive(Serialize, Clone)]
 pub struct PasskeyInfo {
-	pub credential_id: String,
+	pub alias_name: String,
 	pub created_at: u64,
+	pub last_used: u64,
 }
 
 #[derive(Serialize, Clone)]
@@ -45,7 +46,11 @@ pub fn register_list_passkey<CrossChainIntentExecutor: IntentExecutor + Send + S
 
 			let passkey_infos = passkeys
 				.into_iter()
-				.map(|(credential_id, created_at)| PasskeyInfo { credential_id, created_at })
+				.map(|(alias_name, created_at, last_used)| PasskeyInfo {
+					alias_name,
+					created_at,
+					last_used,
+				})
 				.collect();
 
 			Ok::<ListPasskeyResponse, ErrorObject>(ListPasskeyResponse { passkeys: passkey_infos })

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/mod.rs
@@ -82,6 +82,9 @@ use list_passkey::*;
 mod request_passkey_challenge;
 use request_passkey_challenge::*;
 
+mod rename_passkey_alias;
+use rename_passkey_alias::*;
+
 #[cfg(test)]
 mod test_protected_method;
 
@@ -134,6 +137,7 @@ pub fn register_omni<CrossChainIntentExecutor: IntentExecutor + Send + Sync + 's
 	register_attach_passkey(module);
 	register_remove_passkey(module);
 	register_list_passkey(module);
+	register_rename_passkey_alias(module);
 	register_login_with_oauth2(module);
 
 	register_request_jwt(module);

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/rename_passkey_alias.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/rename_passkey_alias.rs
@@ -1,6 +1,6 @@
 use crate::{
-	detailed_error::DetailedError, server::RpcContext, utils::types::RpcResultExt,
-	utils::validation::parse_rpc_params, verify_auth::verify_auth, Deserialize, Serialize,
+	server::RpcContext, utils::types::RpcResultExt, utils::validation::parse_rpc_params,
+	verify_auth::verify_auth, Deserialize, Serialize,
 };
 
 use executor_core::intent_executor::IntentExecutor;

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/rename_passkey_alias.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/rename_passkey_alias.rs
@@ -50,11 +50,6 @@ pub fn register_rename_passkey_alias<
 			let omni_account = identity.to_omni_account(&params.client_id);
 			let passkey_storage = PasskeyStorage::new(ctx.storage_db.clone());
 
-			if !passkey_storage.exists_passkey(&omni_account, &params.credential_id) {
-				error!("Passkey not found for this account and credential");
-				return Err(DetailedError::internal_error("Passkey not found").to_rpc_error());
-			}
-
 			passkey_storage
 				.rename_passkey_alias(
 					&omni_account,

--- a/tee-worker/omni-executor/rpc-server/src/methods/omni/rename_passkey_alias.rs
+++ b/tee-worker/omni-executor/rpc-server/src/methods/omni/rename_passkey_alias.rs
@@ -1,0 +1,75 @@
+use crate::{
+	detailed_error::DetailedError, server::RpcContext, utils::types::RpcResultExt,
+	utils::validation::parse_rpc_params, verify_auth::verify_auth, Deserialize, Serialize,
+};
+
+use executor_core::intent_executor::IntentExecutor;
+use executor_primitives::{to_omni_auth, UserAuth, UserId};
+use executor_storage::PasskeyStorage;
+use heima_primitives::Identity;
+use jsonrpsee::{types::ErrorObject, RpcModule};
+use tracing::*;
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RenamePasskeyAliasParams {
+	pub user_id: UserId,
+	pub user_auth: UserAuth,
+	pub client_id: String,
+	pub credential_id: String,
+	pub new_alias_name: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct RenamePasskeyAliasResponse {
+	pub success: bool,
+	pub message: String,
+}
+
+pub fn register_rename_passkey_alias<
+	CrossChainIntentExecutor: IntentExecutor + Send + Sync + 'static,
+>(
+	module: &mut RpcModule<RpcContext<CrossChainIntentExecutor>>,
+) {
+	module
+		.register_async_method("omni_renamePasskeyAliasName", |params, ctx, _| async move {
+			let params = parse_rpc_params::<RenamePasskeyAliasParams>(params)?;
+
+			debug!("Received omni_renamePasskeyAliasName, params: {:?}", params);
+
+			let identity = Identity::try_from(params.user_id.clone())
+				.map_err_parse("Invalid user ID format")?;
+
+			let auth = to_omni_auth(&params.user_auth, &params.user_id, &params.client_id)
+				.map_err_parse("Failed to convert to OmniAuth")?;
+
+			verify_auth(ctx.clone(), &auth).await.map_err(|e| {
+				error!("Failed to verify user authentication: {:?}", e);
+				e.to_detailed_error().to_rpc_error()
+			})?;
+
+			let omni_account = identity.to_omni_account(&params.client_id);
+			let passkey_storage = PasskeyStorage::new(ctx.storage_db.clone());
+
+			if !passkey_storage.exists_passkey(&omni_account, &params.credential_id) {
+				error!("Passkey not found for this account and credential");
+				return Err(DetailedError::internal_error("Passkey not found").to_rpc_error());
+			}
+
+			passkey_storage
+				.rename_passkey_alias(
+					&omni_account,
+					&params.credential_id,
+					params.new_alias_name.clone(),
+				)
+				.map_err_internal("Failed to rename passkey alias")?;
+
+			Ok::<RenamePasskeyAliasResponse, ErrorObject>(RenamePasskeyAliasResponse {
+				success: true,
+				message: format!(
+					"Passkey alias for credential {} successfully renamed to {}",
+					params.credential_id, params.new_alias_name
+				),
+			})
+		})
+		.expect("Failed to register omni_renamePasskeyAliasName method");
+}

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -449,8 +449,7 @@ pub fn verify_passkey_authentication<
 		.map_err(|_| {
 			// Log the error but don't fail authentication if timestamp update fails
 			tracing::warn!(
-				"Failed to update last_used timestamp for passkey {}",
-				passkey_data.credential_id
+				"Failed to update last_used timestamp for passkey"
 			);
 		})
 		.ok();

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -448,9 +448,7 @@ pub fn verify_passkey_authentication<
 		.update_last_used(&omni_account, &passkey_data.credential_id)
 		.map_err(|_| {
 			// Log the error but don't fail authentication if timestamp update fails
-			tracing::warn!(
-				"Failed to update last_used timestamp for passkey"
-			);
+			tracing::warn!("Failed to update last_used timestamp for passkey");
 		})
 		.ok();
 

--- a/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
+++ b/tee-worker/omni-executor/rpc-server/src/verify_auth.rs
@@ -376,7 +376,8 @@ pub fn verify_passkey_authentication<
 		})?;
 
 	// Look up the stored passkey record using omni_account + credential_id
-	let passkey_record = PasskeyStorage::new(ctx.storage_db.clone())
+	let passkey_storage = PasskeyStorage::new(ctx.storage_db.clone());
+	let passkey_record = passkey_storage
 		.get_passkey(&omni_account, &passkey_data.credential_id)
 		.map_err(|_| AuthenticationError::PasskeyError("Storage error".to_string()))?
 		.ok_or_else(|| {
@@ -441,6 +442,18 @@ pub fn verify_passkey_authentication<
 	if !is_valid {
 		return Err(AuthenticationError::Web3InvalidSignature);
 	}
+
+	// Update the last_used timestamp for this passkey
+	passkey_storage
+		.update_last_used(&omni_account, &passkey_data.credential_id)
+		.map_err(|_| {
+			// Log the error but don't fail authentication if timestamp update fails
+			tracing::warn!(
+				"Failed to update last_used timestamp for passkey {}",
+				passkey_data.credential_id
+			);
+		})
+		.ok();
 
 	Ok(())
 }


### PR DESCRIPTION
Add comprehensive passkey management improvements including user-friendly
alias names, usage tracking, and rename functionality.

Changes:
- Add omni_account, alias_name, and last_used fields to PasskeyRecord
- Update add_passkey() to accept optional alias_name (defaults to credential_id)
- Modify list_passkeys() to return (alias_name, created_at, last_used) tuples
- Add rename_passkey_alias() for updating passkey display names
- Add update_last_used() to track passkey authentication usage
- Create new omni_renamePasskeyAliasName RPC endpoint with auth verification
- Integrate automatic last_used updates in passkey authentication flow
- Update all tests and integration tests for new signature

Add cleanup methods for unit test leftover
Improve passkey storage


