### PR TITLE
Not mask docker-login username

### DIFF
--- a/.github/workflows/benchmark-runtime-weights.yml
+++ b/.github/workflows/benchmark-runtime-weights.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Dockerhub login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: litentry
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push docker image

--- a/.github/workflows/build-docker-with-args.yml
+++ b/.github/workflows/build-docker-with-args.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Dockerhub login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: litentry
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
         if: needs.set-condition.outputs.rebuild_omni_executor == 'false'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: litentry
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Pull omni-executor image optionally
@@ -605,7 +605,7 @@ jobs:
       - name: Dockerhub login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: litentry
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push parachain image

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Dockerhub login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: litentry
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push worker image
@@ -255,7 +255,7 @@ jobs:
       - name: Dockerhub login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: litentry
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push docker image
@@ -293,7 +293,7 @@ jobs:
       - name: Dockerhub login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: litentry
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Generate release notes


### PR DESCRIPTION
### Context

It's ok not to mask the docker-login username for public repos (as the image is public anyway and can be found under the docker hub).

Otherwise the console logs will show masked strings in url, e.g. https://github.com/litentry/heima/actions/runs/19758051401