### PR TITLE
fix: correct omni-executor Cargo.toml path in generate-release-notes.sh

### DIFF
--- a/parachain/scripts/generate-release-notes.sh
+++ b/parachain/scripts/generate-release-notes.sh
@@ -225,8 +225,8 @@ EOF
 fi
 
 if is_omni_executor_release; then
-  WORKER_VERSION=$(grep '^version' tee-worker/omni-executor/executor-worker/Cargo.toml | head -n1 | sed -E 's/^version *= *["'\''](.*)["'\'']/\1/')
-  WORKER_BIN=$(grep '^name' tee-worker/omni-executor/executor-worker/Cargo.toml | head -n1 | sed -E 's/^name *= *["'\''](.*)["'\'']/\1/')
+  WORKER_VERSION=$(grep '^version' tee-worker/omni-executor/bin/Cargo.toml | head -n1 | sed -E 's/^version *= *["'\''](.*)["'\'']/\1/')
+  WORKER_BIN=$(grep '^name' tee-worker/omni-executor/bin/Cargo.toml | head -n1 | sed -E 's/^name *= *["'\''](.*)["'\'']/\1/')
   WORKER_RUSTC_VERSION=$(cd tee-worker/omni-executor && rustc --version)
   docker run --rm --entrypoint gramine-sgx-sigstruct-view -v /var/run/aesmd:/var/run/aesmd litentry/omni-executor:$OMNI_EXECUTOR_DOCKER_TAG omni-executor.sig > enclave-sigstruct.txt
   SIGSTRUCT=$(<enclave-sigstruct.txt)


### PR DESCRIPTION
## Summary

- `generate-release-notes.sh` was reading `tee-worker/omni-executor/executor-worker/Cargo.toml` which does not exist, causing the release workflow to fail with exit code 2
- The binary crate is located at `tee-worker/omni-executor/bin/Cargo.toml`
- Fix updates both the `version` and `name` grep lines to use the correct path

## Root Cause

CI failure in run [24602425136](https://github.com/litentry/heima/actions/runs/24602425136/job/71943984471):
```
grep: tee-worker/omni-executor/executor-worker/Cargo.toml: No such file or directory
Error on line 228
```