### PR TITLE
feat(omni-executor): add SpotSend and UsdClassTransfer to TS types and tests

### DIFF
--- a/tee-worker/omni-executor/ts-tests/jsonrpc-mock-tests/hyperliquid_signature_data.test.ts
+++ b/tee-worker/omni-executor/ts-tests/jsonrpc-mock-tests/hyperliquid_signature_data.test.ts
@@ -760,5 +760,213 @@ describe('Hyperliquid Signature Data Tests', function () {
                 expect(error).to.have.property('message', 'Invalid params');
             }
         });
+
+        it('should successfully generate signature data for spot_send action on testnet', async function () {
+            const params = {
+                user_id: {
+                    type: 'email' as const,
+                    value: 'test@example.com',
+                },
+                user_auth: {
+                    type: 'auth_token' as const,
+                    value: id_token,
+                },
+                client_id: ClientId.Wildmeta,
+                client_auth: {
+                    type: 'wildmeta_hl' as const,
+                    value: {
+                        agent_address: '0x1234567890123456789012345678901234567890',
+                        business_json: JSON.stringify({ test: 'data' }),
+                        main_address: evmWallet.address,
+                        signature: 'test_signature',
+                        login_type: 1,
+                    },
+                },
+                action_type: {
+                    type: 'spot_send' as const,
+                    destination: '0x1234567890123456789012345678901234567890',
+                    token: 'USDC:0x6d1e7cde53ba9467b783cb7c530ce054',
+                    amount: '100.0',
+                },
+                chain_id: 421614,
+            };
+
+            const result: GetHyperliquidSignatureDataResponse = await omniApi.getHyperliquidSignatureData(params);
+
+            validateBasicResponse(result);
+            expect(result.hyperliquid_signature_data.action).to.have.property('type', 'spot_send');
+
+            const action = result.hyperliquid_signature_data.action;
+            validateActionBase(action, params.chain_id);
+            expect(action).to.have.property('destination', params.action_type.destination);
+            expect(action).to.have.property('token', params.action_type.token);
+            expect(action).to.have.property('amount', params.action_type.amount);
+            expect(action).to.have.property('time');
+            expect(action.time).to.be.a('number');
+            expect(action.time).to.be.greaterThan(0);
+        });
+
+        it('should successfully generate signature data for spot_send action on mainnet', async function () {
+            const params = {
+                user_id: {
+                    type: 'email' as const,
+                    value: 'test@example.com',
+                },
+                user_auth: {
+                    type: 'auth_token' as const,
+                    value: id_token,
+                },
+                client_id: ClientId.Wildmeta,
+                client_auth: {
+                    type: 'wildmeta_hl' as const,
+                    value: {
+                        agent_address: '0x1234567890123456789012345678901234567890',
+                        business_json: JSON.stringify({ test: 'data' }),
+                        main_address: evmWallet.address,
+                        signature: 'test_signature',
+                        login_type: 1,
+                    },
+                },
+                action_type: {
+                    type: 'spot_send' as const,
+                    destination: '0x1234567890123456789012345678901234567890',
+                    token: 'USDC:0x6d1e7cde53ba9467b783cb7c530ce054',
+                    amount: '50.0',
+                },
+                chain_id: 42161,
+            };
+
+            const result: GetHyperliquidSignatureDataResponse = await omniApi.getHyperliquidSignatureData(params);
+
+            validateBasicResponse(result);
+            expect(result.hyperliquid_signature_data.action).to.have.property('type', 'spot_send');
+
+            const action = result.hyperliquid_signature_data.action;
+            validateActionBase(action, params.chain_id);
+            expect(action).to.have.property('destination', params.action_type.destination);
+            expect(action).to.have.property('token', params.action_type.token);
+            expect(action).to.have.property('amount', params.action_type.amount);
+        });
+
+        it('should fail with invalid destination address in spot_send (with valid auth)', async function () {
+            try {
+                const params = {
+                    user_id: {
+                        type: 'email' as const,
+                        value: 'test@example.com',
+                    },
+                    user_auth: {
+                        type: 'auth_token' as const,
+                        value: id_token,
+                    },
+                    client_id: ClientId.Wildmeta,
+                    client_auth: {
+                        type: 'wildmeta_hl' as const,
+                        value: {
+                            agent_address: '0x1234567890123456789012345678901234567890',
+                            business_json: JSON.stringify({ test: 'data' }),
+                            main_address: evmWallet.address,
+                            signature: 'test_signature',
+                            login_type: 1,
+                        },
+                    },
+                    action_type: {
+                        type: 'spot_send' as const,
+                        destination: 'not_an_address',
+                        token: 'USDC:0x6d1e7cde53ba9467b783cb7c530ce054',
+                        amount: '100.0',
+                    },
+                    chain_id: 42161,
+                };
+
+                await omniApi.getHyperliquidSignatureData(params);
+                expect.fail('Expected method to throw an error for invalid destination');
+            } catch (error: any) {
+                expect(error).to.have.property('message', 'Invalid params');
+            }
+        });
+
+        it('should successfully generate signature data for usd_class_transfer (spot to perp) on testnet', async function () {
+            const params = {
+                user_id: {
+                    type: 'email' as const,
+                    value: 'test@example.com',
+                },
+                user_auth: {
+                    type: 'auth_token' as const,
+                    value: id_token,
+                },
+                client_id: ClientId.Wildmeta,
+                client_auth: {
+                    type: 'wildmeta_hl' as const,
+                    value: {
+                        agent_address: '0x1234567890123456789012345678901234567890',
+                        business_json: JSON.stringify({ test: 'data' }),
+                        main_address: evmWallet.address,
+                        signature: 'test_signature',
+                        login_type: 1,
+                    },
+                },
+                action_type: {
+                    type: 'usd_class_transfer' as const,
+                    amount: '50.0',
+                    to_perp: true,
+                },
+                chain_id: 421614,
+            };
+
+            const result: GetHyperliquidSignatureDataResponse = await omniApi.getHyperliquidSignatureData(params);
+
+            validateBasicResponse(result);
+            expect(result.hyperliquid_signature_data.action).to.have.property('type', 'usd_class_transfer');
+
+            const action = result.hyperliquid_signature_data.action;
+            validateActionBase(action, params.chain_id);
+            expect(action).to.have.property('amount', params.action_type.amount);
+            expect(action).to.have.property('toPerp', true);
+            expect(action).to.have.property('nonce');
+            expect(action.nonce).to.be.a('number');
+            expect(action.nonce).to.be.greaterThan(0);
+        });
+
+        it('should successfully generate signature data for usd_class_transfer (perp to spot) on mainnet', async function () {
+            const params = {
+                user_id: {
+                    type: 'email' as const,
+                    value: 'test@example.com',
+                },
+                user_auth: {
+                    type: 'auth_token' as const,
+                    value: id_token,
+                },
+                client_id: ClientId.Wildmeta,
+                client_auth: {
+                    type: 'wildmeta_hl' as const,
+                    value: {
+                        agent_address: '0x1234567890123456789012345678901234567890',
+                        business_json: JSON.stringify({ test: 'data' }),
+                        main_address: evmWallet.address,
+                        signature: 'test_signature',
+                        login_type: 1,
+                    },
+                },
+                action_type: {
+                    type: 'usd_class_transfer' as const,
+                    amount: '200.0',
+                    to_perp: false,
+                },
+                chain_id: 42161,
+            };
+
+            const result: GetHyperliquidSignatureDataResponse = await omniApi.getHyperliquidSignatureData(params);
+
+            validateBasicResponse(result);
+            expect(result.hyperliquid_signature_data.action).to.have.property('type', 'usd_class_transfer');
+
+            const action = result.hyperliquid_signature_data.action;
+            validateActionBase(action, params.chain_id);
+            expect(action).to.have.property('amount', params.action_type.amount);
+            expect(action).to.have.property('toPerp', false);
+        });
     });
 });

--- a/tee-worker/omni-executor/ts-tests/jsonrpc-mock-tests/utils/request-types.ts
+++ b/tee-worker/omni-executor/ts-tests/jsonrpc-mock-tests/utils/request-types.ts
@@ -140,13 +140,20 @@ export interface GetHyperliquidSignatureDataParams {
         };
     };
     action_type: {
-        type: 'approve_agent' | 'withdraw3' | 'approve_builder_fee';
+        type: 'approve_agent' | 'withdraw3' | 'approve_builder_fee' | 'send_asset' | 'user_dex_abstraction' | 'spot_send' | 'usd_class_transfer';
         agent_address?: string;
         agent_name?: string;
         amount?: string;
         destination?: string;
         max_fee_rate?: string;
         builder?: string;
+        source_dex?: string;
+        destination_dex?: string;
+        token?: string;
+        from_sub_account?: string;
+        user?: string;
+        enabled?: boolean;
+        to_perp?: boolean;
     };
     chain_id: number;
 }

--- a/tee-worker/omni-executor/ts-tests/jsonrpc-mock-tests/utils/response-types.ts
+++ b/tee-worker/omni-executor/ts-tests/jsonrpc-mock-tests/utils/response-types.ts
@@ -97,7 +97,7 @@ export interface GetHyperliquidSignatureDataResponse {
     main_address: string;
     hyperliquid_signature_data: {
         action: {
-            type: 'approve_agent' | 'withdraw3' | 'approve_builder_fee';
+            type: 'approve_agent' | 'withdraw3' | 'approve_builder_fee' | 'send_asset' | 'user_dex_abstraction' | 'spot_send' | 'usd_class_transfer';
             signatureChainId?: string;
             hyperliquidChain?: string;
             agentAddress?: string;
@@ -108,10 +108,15 @@ export interface GetHyperliquidSignatureDataResponse {
             destination?: string;
             maxFeeRate?: string;
             builder?: string;
+            sourceDex?: string;
+            destinationDex?: string;
+            token?: string;
+            fromSubAccount?: string;
+            user?: string;
+            enabled?: boolean;
+            toPerp?: boolean;
         };
         nonce: number;
         signature: string;
     };
 }
-
-// todo: add other types


### PR DESCRIPTION
## Summary

Follow-up to #3964 which added `SpotSend` and `UsdClassTransfer` to the Rust RPC handler. The TypeScript test utilities were stale and not updated in that PR.

- `request-types.ts`: extend `action_type.type` union to include `spot_send`, `usd_class_transfer`, `send_asset`, `user_dex_abstraction`; add corresponding optional fields (`token`, `to_perp`, `source_dex`, `destination_dex`, `from_sub_account`, `user`, `enabled`)
- `response-types.ts`: extend `action.type` union to match; add camelCase response fields (`token`, `toPerp`, `sourceDex`, `destinationDex`, `fromSubAccount`, `user`, `enabled`)
- `hyperliquid_signature_data.test.ts`: add 5 new integration test cases:
  - `spot_send` on testnet (validates `destination`, `token`, `amount`, `time`)
  - `spot_send` on mainnet
  - `spot_send` with invalid destination → expects `Invalid params`
  - `usd_class_transfer` spot→perp on testnet (validates `amount`, `toPerp: true`, `nonce`)
  - `usd_class_transfer` perp→spot on mainnet (validates `toPerp: false`)