### PR TITLE
fix(ci): pin pnpm + apply safe dependabot bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,8 @@ jobs:
           echo "Before: corepack version => $(corepack --version || echo 'not installed')"
           npm install -g corepack@latest
           echo "After : corepack version => $(corepack --version)"
-          corepack enable && corepack enable pnpm
+          corepack enable
+          corepack prepare pnpm@9.15.2 --activate
           pnpm --version
 
       - name: Fail early
@@ -426,7 +427,8 @@ jobs:
           echo "Before: corepack version => $(corepack --version || echo 'not installed')"
           npm install -g corepack@latest
           echo "After : corepack version => $(corepack --version)"
-          corepack enable && corepack enable pnpm
+          corepack enable
+          corepack prepare pnpm@9.15.2 --activate
           pnpm --version
 
       - name: Run ts tests for ${{ matrix.chain }}

--- a/tee-worker/client-api/pnpm-lock.yaml
+++ b/tee-worker/client-api/pnpm-lock.yaml
@@ -643,8 +643,8 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   bundle-require@5.1.0:
@@ -1739,7 +1739,7 @@ snapshots:
 
   bn.js@5.2.3: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1912,7 +1912,7 @@ snapshots:
 
   minimatch@9.0.8:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 

--- a/tee-worker/identity/scripts/changelog/Gemfile.lock
+++ b/tee-worker/identity/scripts/changelog/Gemfile.lock
@@ -4,14 +4,14 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.2)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     git_diff_parser (3.2.0)
-    json (2.19.2)
+    json (2.19.5)
     logger (1.4.4)
     net-http (0.9.1)
       uri (>= 0.11.1)

--- a/tee-worker/identity/ts-tests/pnpm-lock.yaml
+++ b/tee-worker/identity/ts-tests/pnpm-lock.yaml
@@ -1366,11 +1366,11 @@ packages:
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1723,8 +1723,8 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -2713,6 +2713,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -4224,7 +4225,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4315,12 +4316,12 @@ snapshots:
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
@@ -4824,7 +4825,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -5259,11 +5260,11 @@ snapshots:
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 

--- a/tee-worker/omni-executor/client-sdk/pnpm-lock.yaml
+++ b/tee-worker/omni-executor/client-sdk/pnpm-lock.yaml
@@ -2236,6 +2236,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}

--- a/tee-worker/omni-executor/ts-tests/pnpm-lock.yaml
+++ b/tee-worker/omni-executor/ts-tests/pnpm-lock.yaml
@@ -279,8 +279,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       systeminformation:
-        specifier: ^5.31.5
-        version: 5.31.5
+        specifier: ^5.31.6
+        version: 5.31.6
       table:
         specifier: ^6.8.1
         version: 6.9.0
@@ -1488,12 +1488,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
-
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1922,8 +1918,8 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2876,8 +2872,8 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
-  systeminformation@5.31.5:
-    resolution: {integrity: sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==}
+  systeminformation@5.31.6:
+    resolution: {integrity: sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -4643,7 +4639,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4803,11 +4799,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.4:
-    dependencies:
-      balanced-match: 4.0.4
-
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5304,7 +5296,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -5739,7 +5731,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -5751,7 +5743,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -6281,7 +6273,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  systeminformation@5.31.5: {}
+  systeminformation@5.31.6: {}
 
   table@6.9.0:
     dependencies:

--- a/tee-worker/omni-executor/ts-tests/stress-tests/package.json
+++ b/tee-worker/omni-executor/ts-tests/stress-tests/package.json
@@ -30,7 +30,7 @@
         "js-sha256": "^0.11.1",
         "ora": "^9.4.0",
         "pidusage": "^4.0.1",
-        "systeminformation": "^5.31.5",
+        "systeminformation": "^5.31.6",
         "table": "^6.8.1",
         "viem": "^2.48.8",
         "ws": "^8.20.0"

--- a/tee-worker/omni-executor/ts-tests/stress-tests/src/dashboard/package.json
+++ b/tee-worker/omni-executor/ts-tests/stress-tests/src/dashboard/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "16.2.3",
+    "next": "16.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "chart.js": "^4.4.1",


### PR DESCRIPTION
## Summary

- **CI fix**: pin pnpm to `9.15.2` in both `corepack enable` steps in `.github/workflows/ci.yml`. Without this pin, corepack downloads the latest pnpm (11.2.2), which requires Node ≥ 22.13 and imports `node:sqlite`. The runner is on Node 20 → `ERR_UNKNOWN_BUILTIN_MODULE` → `fmt` fails → `andymckay/cancel-action` cancels the whole workflow. This is why every recent run on `dev` and every open dependabot PR is red.
- **Dependency bumps**: absorb the safe-to-merge dependabot PRs that touch only JS/TS/Ruby tooling. No polkadot-sdk deps, no enclave/Rust under `tee-worker/**/Cargo.*`.

## Bumps included

| Target | Bump | From dependabot PR |
|---|---|---|
| `tee-worker/identity/scripts/changelog/Gemfile.lock` | faraday 2.14.1 → 2.14.2, json 2.19.2 → 2.19.5 | #3985 |
| `tee-worker/omni-executor/ts-tests/**` | systeminformation 5.31.5 → 5.31.6 | #3984 |
| `tee-worker/omni-executor/ts-tests/pnpm-lock.yaml` | fast-uri 3.1.0 → 3.1.2 | #3987 |
| `tee-worker/omni-executor/ts-tests/pnpm-lock.yaml` | brace-expansion 5.0.4/5.0.5 → 5.0.6 | #3986 |
| `tee-worker/omni-executor/client-sdk/pnpm-lock.yaml` | metadata refresh (deprecated marker) | #3988, #3989 |
| `tee-worker/client-api/pnpm-lock.yaml` | brace-expansion 5.0.5 → 5.0.6 | subset of #3991 |
| `tee-worker/identity/ts-tests/pnpm-lock.yaml` | brace-expansion 1.1.12 → 1.1.14, 2.0.2 → 2.1.0; fast-uri 3.1.0 → 3.1.2 | subset of #3991 |
| `tee-worker/omni-executor/ts-tests/stress-tests/src/dashboard/package.json` | next 16.2.3 → 16.2.6 | subset of #3991 |

## Excluded on purpose

- **`tee-worker/identity/client-sdk/pnpm-lock.yaml`** from #3991: the dependabot patch also migrates the lockfile format from v6 → v9 (~12k-line diff), well beyond the three packages it claims to bump. Leaving for a dedicated PR.
- **`tee-worker/omni-executor/contracts/aa/aa-demo-app/**`** from #3991 (next 16.2.3 → 16.2.6): touching that path triggers `contract-check`, which fails on a pre-existing `anchor-syn 0.32.1` incompatibility with the runner's rustc (`Span::local_file` not found). That's unrelated to this PR and would be fixed by #3992's `anchor-client 0.32 → 1.0` bump. Left for the cargo bundle to land.
- **#3990**: superseded by #3991.
- **#3992** (cargo bundle): spans `parachain/` and `tee-worker/omni-executor/` (Rust), which is off-limits under the "no enclave/Rust under tee-worker" rule. It also contains aggressive majors (`alloy 1.7→2.0`, `anchor-client 0.32→1.0`, `der 0.7→0.8`, `hmac 0.12→0.13`, `similar-asserts 1→2`). Should be split by dependabot.

## Supersedes (will auto-close on merge if files match)

#3984, #3985, #3986, #3987, #3988, #3989, #3990, partial #3991

## Test plan

- [ ] `fmt` job passes (verifies the pnpm pin fix)
- [ ] `parachain-build`, `omni-executor-build` complete
- [ ] `matrix.test_name` (omni-executor ts-tests) passes — exercises systeminformation, fast-uri, brace-expansion bumps
- [ ] `matrix.chain` (parachain ts-tests) passes
- [ ] `contract-check` is correctly skipped (no contract paths touched in this PR)
- [ ] All lockfiles validated locally with `pnpm install --frozen-lockfile`