### PR TITLE
fix(ci): pin anchor-cli to v0.32.1 in contract-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,10 @@ jobs:
 
       - name: Install anchor
         run: |
-          cargo install --git https://github.com/coral-xyz/anchor anchor-cli --locked
+          # Pin to the tag matching the project's anchor-lang 0.32; installing
+          # from the unpinned default branch pulls a newer anchor-cli whose
+          # anchor-syn fails to build against the current Rust toolchain.
+          cargo install --git https://github.com/coral-xyz/anchor --tag v0.32.1 anchor-cli --locked
           anchor -V
           solana -V
 


### PR DESCRIPTION
## Problem

The `contract-check` job installs anchor-cli from the **unpinned** default branch:

```
cargo install --git https://github.com/coral-xyz/anchor anchor-cli --locked
```

This now resolves to a newer anchor-cli whose `anchor-syn` fails to compile against the current Rust toolchain:

```
error[E0599]: no method named `local_file` found for struct `proc_macro::Span`
  --> anchor-syn-0.32.1/src/idl/defined.rs:501
error: could not compile `anchor-syn`
Error: Building IDL failed.
```

So `anchor b --ignore-keys` fails even though the contracts and their forge tests are fine (13 tests pass). On `dev` this job is path-skipped, so it only surfaces on PRs that touch contracts.

## Fix

Pin the install to `--tag v0.32.1`, matching the project's `anchor-lang = "0.32"` dependency. This is the latest release in the 0.32 line and keeps anchor-cli and anchor-syn in lockstep.

```
cargo install --git https://github.com/coral-xyz/anchor --tag v0.32.1 anchor-cli --locked
```

Pure CI maintenance — no contract or worker code changes.