### PR TITLE
chore(runtime): set spec_version to 9262 for the 12s->6s upgrade

### DIFF
--- a/parachain/runtime/heima/src/lib.rs
+++ b/parachain/runtime/heima/src/lib.rs
@@ -154,7 +154,7 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
 	// one-shot: rescale bounded block-number/per-block state for the 12s -> 6s block-time change
-	// (spec_version 9270). Remove in the release after this one. The large `pallet_vesting` map is
+	// (spec_version 9262). Remove in the release after this one. The large `pallet_vesting` map is
 	// migrated separately as a multi-block migration, see `pallet_migrations::Config::Migrations`.
 	migration::block_time_6s::OnePassRescale<Runtime>,
 	// permanent
@@ -249,7 +249,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: alloc::borrow::Cow::Borrowed("heima"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9270,
+	spec_version: 9262,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -475,7 +475,7 @@ impl pallet_migrations::Config for Runtime {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	type Migrations = (
 		pallet_identity::migration::v2::LazyMigrationV1ToV2<Runtime>,
-		// one-shot: rescale vesting schedules for the 12s -> 6s block-time change (spec 9270).
+		// one-shot: rescale vesting schedules for the 12s -> 6s block-time change (spec 9262).
 		// Remove in the release after this one.
 		migration::block_time_6s::VestingRescaleMigration<Runtime>,
 	);

--- a/parachain/runtime/heima/src/migration/block_time_6s/mod.rs
+++ b/parachain/runtime/heima/src/migration/block_time_6s/mod.rs
@@ -23,7 +23,7 @@
 //! * [`vesting::VestingRescaleMigration`] — a `SteppedMigration` (multi-block) for the large
 //!   `pallet_vesting` map. Register it in `pallet_migrations::Config::Migrations` in `lib.rs`.
 //!
-//! Both are one-shot: remove them in the release *after* the one that ships spec_version 9270, once
+//! Both are one-shot: remove them in the release *after* the one that ships spec_version 9262, once
 //! the upgrade has been enacted and finalized on every network.
 
 pub mod onepass;

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -155,7 +155,7 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
 	// one-shot: rescale bounded block-number/per-block state for the 12s -> 6s block-time change
-	// (spec_version 9270). Remove in the release after this one. The large `pallet_vesting` map is
+	// (spec_version 9262). Remove in the release after this one. The large `pallet_vesting` map is
 	// migrated separately as a multi-block migration, see `pallet_migrations::Config::Migrations`.
 	migration::block_time_6s::OnePassRescale<Runtime>,
 	// permanent
@@ -250,7 +250,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: alloc::borrow::Cow::Borrowed("heima"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9270,
+	spec_version: 9262,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -482,7 +482,7 @@ impl pallet_migrations::Config for Runtime {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	type Migrations = (
 		pallet_identity::migration::v2::LazyMigrationV1ToV2<Runtime>,
-		// one-shot: rescale vesting schedules for the 12s -> 6s block-time change (spec 9270).
+		// one-shot: rescale vesting schedules for the 12s -> 6s block-time change (spec 9262).
 		// Remove in the release after this one.
 		migration::block_time_6s::VestingRescaleMigration<Runtime>,
 	);

--- a/parachain/runtime/paseo/src/migration/block_time_6s/mod.rs
+++ b/parachain/runtime/paseo/src/migration/block_time_6s/mod.rs
@@ -23,7 +23,7 @@
 //! * [`vesting::VestingRescaleMigration`] — a `SteppedMigration` (multi-block) for the large
 //!   `pallet_vesting` map. Register it in `pallet_migrations::Config::Migrations` in `lib.rs`.
 //!
-//! Both are one-shot: remove them in the release *after* the one that ships spec_version 9270, once
+//! Both are one-shot: remove them in the release *after* the one that ships spec_version 9262, once
 //! the upgrade has been enacted and finalized on every network.
 
 pub mod onepass;


### PR DESCRIPTION
Follow-up to #4042. That PR set `spec_version` to **9270**; this aligns it with the **0.9.26 release series** instead — on-chain is `9261`, so this uses the minimal valid increment **9262**.

No functional change: block time (6s), the one-shot migrations, and all behaviour are identical. Only the `spec_version` value (heima + paseo) and the comments that referenced 9270 are updated.

Note: the **node/client is intentionally not bumped** — this upgrade touches only the parachain runtime (no node changes, no host-function changes since v0.9.25-01), so existing collators pick up 6s automatically via the runtime-provided slot duration. The GitHub release can stay in the `v0.9.26-0x` tag series.

Verified: `cargo fmt --check` and `cargo check -p heima-runtime` pass.