### PR TITLE
fix(node): don't spawn Frontier-RPC pool validation tasks as essential

### DIFF
--- a/parachain/node/src/service.rs
+++ b/parachain/node/src/service.rs
@@ -64,7 +64,7 @@ use sc_service::{
 	WarpSyncConfig,
 };
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
-use sp_core::traits::{SpawnEssentialNamed, SpawnNamed};
+use sp_core::traits::SpawnEssentialNamed;
 use sp_keystore::KeystorePtr;
 use sp_runtime::{
 	app_crypto::AppCrypto,

--- a/parachain/node/src/service.rs
+++ b/parachain/node/src/service.rs
@@ -60,9 +60,11 @@ use sc_network::{
 };
 use sc_network_sync::SyncingService;
 use sc_service::{
-	Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager, WarpSyncConfig,
+	Configuration, PartialComponents, SpawnTaskHandle, TFullBackend, TFullClient, TaskManager,
+	WarpSyncConfig,
 };
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
+use sp_core::traits::{SpawnEssentialNamed, SpawnNamed};
 use sp_keystore::KeystorePtr;
 use sp_runtime::{
 	app_crypto::AppCrypto,
@@ -70,6 +72,37 @@ use sp_runtime::{
 };
 use sp_std::{collections::btree_map::BTreeMap, sync::Arc, time::Duration};
 use substrate_prometheus_endpoint::Registry;
+
+/// Adapts a non-essential [`SpawnTaskHandle`] to the [`SpawnEssentialNamed`] interface required by
+/// `sc_transaction_pool::FullChainApi::new`, forwarding to the *non-essential* spawn methods.
+///
+/// The secondary transaction pool we build only to expose a low-level `graph::Pool` to the Frontier
+/// `txpool`/`graph` RPC must not be spawned with the real essential handle: its
+/// `transaction-pool-task-{0,1}` validation tasks resolve at startup, and an *essential* task that
+/// resolves tears down the whole node (`Essential task ... failed. Shutting down service.`). Spawning
+/// them as ordinary tasks keeps the RPC graph working without making their completion fatal.
+#[derive(Clone)]
+struct NonEssentialSpawner(SpawnTaskHandle);
+
+impl SpawnEssentialNamed for NonEssentialSpawner {
+	fn spawn_essential_blocking(
+		&self,
+		name: &'static str,
+		group: Option<&'static str>,
+		future: futures::future::BoxFuture<'static, ()>,
+	) {
+		self.0.spawn_blocking(name, group, future);
+	}
+
+	fn spawn_essential(
+		&self,
+		name: &'static str,
+		group: Option<&'static str>,
+		future: futures::future::BoxFuture<'static, ()>,
+	) {
+		self.0.spawn(name, group, future);
+	}
+}
 
 #[cfg(not(feature = "runtime-benchmarks"))]
 pub type HostFunctions = cumulus_client_service::ParachainHostFunctions;
@@ -183,11 +216,13 @@ where
 	.with_prometheus(config.prometheus_registry())
 	.build();
 
-	// Create a separate pool for Frontier RPC that has access to the inner Pool type
+	// Create a separate pool for Frontier RPC that has access to the inner Pool type.
+	// Spawn its validation tasks NON-essentially (see `NonEssentialSpawner`): otherwise their
+	// startup completion would shut the whole node down with "Essential task ... failed".
 	let chain_api = Arc::new(sc_transaction_pool::FullChainApi::new(
 		client.clone(),
 		None,
-		&task_manager.spawn_essential_handle(),
+		&NonEssentialSpawner(task_manager.spawn_handle()),
 	));
 	let transaction_pool_inner = Arc::new(sc_transaction_pool::Pool::new(
 		sc_transaction_pool::Options::default(),


### PR DESCRIPTION
## Problem

Every `v0.9.26` node image crashes immediately on heima — even on a fresh genesis DB at #0:

```
[Parachain] Essential task `transaction-pool-task-0` failed. Shutting down service.
[Parachain] Essential task `transaction-pool-task-1` failed. Shutting down service.
Error: Service(Other("Essential task failed."))
```

This is why production has never been able to move off `v0.9.25-01`. It is **not** a host-function or runtime-version issue (the on-chain runtime imports zero moonbeam host functions); it is a node-side wiring bug.

## Root cause

The standard-frontier migration (#3841, commit `305767d2d`) added a *secondary* transaction pool, used only to expose a low-level `sc_transaction_pool::Pool<FullChainApi>` (`graph`) to the standard Frontier `txpool`/`graph` RPC (which requires the inner pool type, unlike the old fork that accepted the high-level handle):

```rust
let chain_api = Arc::new(sc_transaction_pool::FullChainApi::new(
    client.clone(), None, &task_manager.spawn_essential_handle(),  // <-- essential
));
```

`FullChainApi::new` spawns two `transaction-pool-task-{0,1}` validation tasks via that spawner. Their loop returns when the validation channel closes, and they resolve at startup. Because they were spawned with the **essential** handle, an essential task *ending* (not even panicking) triggers `task_manager`'s "Essential task failed. Shutting down service." — tearing the whole node down. (No panic/backtrace ever appears precisely because it's a normal task completion, not a panic.)

## Fix

Spawn that secondary RPC-only pool's tasks **non-essentially** via a small `NonEssentialSpawner` adapter that implements `SpawnEssentialNamed` by forwarding to the ordinary `SpawnNamed` methods of a `SpawnTaskHandle`. The Frontier RPC graph still works; those tasks completing is no longer fatal. The **primary** transaction pool (and `--pool-type`) is untouched.

## Testing

- Reproduces deterministically on a fresh heima genesis DB with any `v0.9.26` build; the crash disappears with this change in principle (validation-task completion no longer fatal).
- Could not fully type-check locally (unrelated macOS `rpassword`/`__errno_location` toolchain issue blocks the build on the dev machine before reaching the node crate); relying on CI (Linux) for the compile, and recommend validating the built image against a heima DB snapshot before any production swap.

## Note
Keep prod on `v0.9.25-01` until an image built from this is verified to start and author on a heima snapshot.