### PR TITLE
fix(runtime): enable async-backing aura config to stop block-production stall

### DIFF
--- a/parachain/runtime/heima/src/lib.rs
+++ b/parachain/runtime/heima/src/lib.rs
@@ -32,7 +32,7 @@ use alloc::string::String;
 #[cfg(feature = "std")]
 use std::string::String;
 
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::AggregateMessageOrigin;
 use ethereum::AuthorizationList;
 use frame_support::{
@@ -839,7 +839,11 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+	// Async backing pipelines multiple parachain blocks against the same relay parent, so
+	// consecutive parachain blocks can share a relay number. `RelayNumberStrictlyIncreases`
+	// panics in that case; the SDK prescribes `RelayNumberMonotonicallyIncreases` whenever
+	// async backing is enabled.
+	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
 	type ConsensusHook = ConsensusHook;
 	type RelayParentOffset = ConstU32<0>;
 	type WeightInfo = ();
@@ -874,7 +878,12 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<250>;
-	type AllowMultipleBlocksPerSlot = ConstBool<false>;
+	// Must be `true` under async backing: the lookahead collator pipelines multiple parachain
+	// blocks against the same relay parent within an unincluded segment, so `pallet_aura`'s
+	// `on_initialize` would otherwise panic with "Slot must increase" on the second block built
+	// in the same relay slot. The real block rate stays bounded by `FixedVelocityConsensusHook`
+	// (BLOCK_PROCESSING_VELOCITY / UNINCLUDED_SEGMENT_CAPACITY), not by this flag.
+	type AllowMultipleBlocksPerSlot = ConstBool<true>;
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -32,7 +32,7 @@ use alloc::string::String;
 #[cfg(feature = "std")]
 use std::string::String;
 
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::AggregateMessageOrigin;
 use ethereum::AuthorizationList;
 use frame_support::{
@@ -893,7 +893,11 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+	// Async backing pipelines multiple parachain blocks against the same relay parent, so
+	// consecutive parachain blocks can share a relay number. `RelayNumberStrictlyIncreases`
+	// panics in that case; the SDK prescribes `RelayNumberMonotonicallyIncreases` whenever
+	// async backing is enabled.
+	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
 	// Use the fixed-velocity hook (same as the heima runtime). The legacy `ExpectParentIncluded`
 	// hook requires each block's parent to already be included by the relay chain and does not
 	// support an unincluded segment, so it cannot pipeline blocks for async backing — at 6s block
@@ -935,7 +939,12 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<250>;
-	type AllowMultipleBlocksPerSlot = ConstBool<false>;
+	// Must be `true` under async backing: the lookahead collator pipelines multiple parachain
+	// blocks against the same relay parent within an unincluded segment, so `pallet_aura`'s
+	// `on_initialize` would otherwise panic with "Slot must increase" on the second block built
+	// in the same relay slot. The real block rate stays bounded by `FixedVelocityConsensusHook`
+	// (BLOCK_PROCESSING_VELOCITY / UNINCLUDED_SEGMENT_CAPACITY), not by this flag.
+	type AllowMultipleBlocksPerSlot = ConstBool<true>;
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 


### PR DESCRIPTION
## Problem

After the `stable2512` SDK upgrade (#4057), the `v0.9.27` release stalled: the `create-release-draft` heima zombienet ts-test timed out for 30 min with the parachain stuck at block #0. The chain **stops producing blocks** under the stable2512 lookahead collator.

Reproduced locally (release-profile node + zombienet, with full collator logs — CI runs the node with `-l silent` and discards them, which is why CI never showed the cause). Two runtime panics, in sequence:

1. `pallet_aura::on_initialize` → **`"Slot must increase"`** (substrate `frame/aura/src/lib.rs`)
2. once that's fixed → `parachain_system` → **`"Relay chain block number needs to strictly increase between Parachain blocks!"`**

## Root cause

The `stable2512` lookahead collator pipelines **multiple parachain blocks against the same relay parent** (filling the unincluded segment for async backing). Two runtime configs were set for the pre-async-backing 1:1 model and panic under that pipelining:

| Config | Was | Now | Why |
|---|---|---|---|
| `pallet_aura::AllowMultipleBlocksPerSlot` | `ConstBool<false>` | `ConstBool<true>` | A second block in the same slot has `current_slot == new_slot`; aura's `on_initialize` asserts a strict `<` increase when this is `false` and panics. The real rate stays bounded by `FixedVelocityConsensusHook` (velocity 1), not this flag. |
| `parachain_system::CheckAssociatedRelayNumber` | `RelayNumberStrictlyIncreases` | `RelayNumberMonotonicallyIncreases` | Consecutive parachain blocks can share a relay number under async backing; the strict variant panics on `current == previous`. The SDK source comment states monotonic "should be used when asynchronous backing is enabled". |

Both values match the stable2512 **parachain-template** (`AllowMultipleBlocksPerSlot = true`, `RelayNumberMonotonicallyIncreases`).

### Why this didn't surface earlier
On `stable2412` (current mainnet v0.9.26-05, also 6s) the collator did not pipeline this way — 1 parachain block per relay parent — so neither assertion fired. This is a **latent misconfiguration** exposed by the stable2512 collator's more aggressive pipelining. (The regular dev CI ts-test happened to pass because the single-collator dev chain's timing produced one block per relay parent; the release path hit the pipelined path and panicked. Same code, timing-dependent — the fix removes the panic regardless of timing.)

### Node side / other config — audited, no change needed
Checked the node `AuraParams` against the SDK parachain-template: `authoring_duration` (1500ms), `reinitialize: false`, `max_pov_percentage: None`, `collator_peer_id`, `relay_chain_slot_duration` (6s) all match. `UNINCLUDED_SEGMENT_CAPACITY = 2` (template uses 3) is a valid conservative value for velocity 1 and is left unchanged.

## Changes
- heima + paseo runtimes: `AllowMultipleBlocksPerSlot = true`, `CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases`.
- `spec_version` stays **9270** — it has never been published on-chain (chain is at 9262), so this fix folds into the same not-yet-released 9270 wasm (9262→9270 on-chain carries SDK + migration cleanup + this fix). The earlier buggy 9270 build must never be applied on-chain; only the fixed 9270 ships.

## Verification
Local zombienet (heima-dev, release-profile node built from this branch): parachain produces and finalizes blocks continuously past #1 (#1 → #10+), **no `Slot must increase` and no relay-number panic**. (vs. the old binary which panics and stays at #0.)
