### PR TITLE
chore(ci): capture zombienet node logs on ts-test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,12 @@ jobs:
         if: failure()
         with:
           name: ${{ matrix.chain }}-ts-tests-artifact
-          path: /tmp/parachain_dev/
+          # Only log/spec files, NOT the downloaded relay binaries: the `polkadot` binary
+          # has no owner read bit, so archiving the whole dir fails the zip with EACCES and
+          # loses all logs. Globs below match readable text only.
+          path: |
+            /tmp/parachain_dev/**/*.log
+            /tmp/parachain_dev/**/*.json
           if-no-files-found: ignore
           retention-days: 3
 

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -249,8 +249,14 @@ jobs:
         if: ${{ failure() }}
         with:
           name: ${{ matrix.chain }}-ts-tests-artifacts
-          path: /tmp/parachain_dev/
+          # Only the log/spec files, NOT the downloaded relay binaries: the `polkadot`
+          # binary is written without an owner read bit, so archiving the whole dir fails
+          # the zip with EACCES and we lose all logs. Globs below are readable text only.
+          path: |
+            /tmp/parachain_dev/**/*.log
+            /tmp/parachain_dev/**/*.json
           retention-days: 3
+          if-no-files-found: warn
 
       - name: Dockerhub login
         uses: docker/login-action@v4

--- a/parachain/scripts/launch-network.sh
+++ b/parachain/scripts/launch-network.sh
@@ -80,12 +80,12 @@ fi
 print_divider
 
 echo "launching zombienet network (in background), dir = $ZOMBIENET_DIR ..."
-# Log at `info` (not `silent`) and keep the orchestrator output in a file under the
-# zombienet dir so it is captured by CI's "Archive logs if test fails" step. Per-node
-# logs already land in $ZOMBIENET_DIR/*.log; this adds zombienet's own startup/scheduling
-# output, which is what reveals stalls (e.g. a collator that never produces block #1).
-mkdir -p "$HEIMA_DIR/$ZOMBIENET_DIR"
-nohup $ZOMBIENET_BIN -d $ZOMBIENET_DIR -l info spawn config.toml > "$HEIMA_DIR/$ZOMBIENET_DIR/zombienet.log" 2>&1 &
+# Log at `text` (not `silent`) and keep the orchestrator output in a file so it is captured
+# by CI's "Archive logs if test fails" step. Write it as a sibling of the zombienet dir
+# (NOT inside it — zombienet requires `-d` to be a fresh/absent directory and pre-creating
+# it breaks spawn). Per-node logs still land in $ZOMBIENET_DIR/*.log.
+# (`-l` accepts only table|text|silent; `text` is the plain-text verbose mode.)
+nohup $ZOMBIENET_BIN -d $ZOMBIENET_DIR -l text spawn config.toml > "$HEIMA_DIR/zombienet-$ZOMBIENET_DIR.log" 2>&1 &
 
 cd "$ROOTDIR/parachain/ts-tests"
 

--- a/parachain/scripts/launch-network.sh
+++ b/parachain/scripts/launch-network.sh
@@ -80,7 +80,12 @@ fi
 print_divider
 
 echo "launching zombienet network (in background), dir = $ZOMBIENET_DIR ..."
-nohup $ZOMBIENET_BIN -d $ZOMBIENET_DIR -l silent spawn config.toml > /dev/null 2>&1 &
+# Log at `info` (not `silent`) and keep the orchestrator output in a file under the
+# zombienet dir so it is captured by CI's "Archive logs if test fails" step. Per-node
+# logs already land in $ZOMBIENET_DIR/*.log; this adds zombienet's own startup/scheduling
+# output, which is what reveals stalls (e.g. a collator that never produces block #1).
+mkdir -p "$HEIMA_DIR/$ZOMBIENET_DIR"
+nohup $ZOMBIENET_BIN -d $ZOMBIENET_DIR -l info spawn config.toml > "$HEIMA_DIR/$ZOMBIENET_DIR/zombienet.log" 2>&1 &
 
 cd "$ROOTDIR/parachain/ts-tests"
 


### PR DESCRIPTION
## Summary

Make the zombienet ts-test node logs survive to CI artifacts on failure. Prompted by the `v0.9.27` release stalling with the parachain stuck at block #0 and **no diagnosable logs** — the actual cause could only be found by reproducing locally. With these changes, a future stall is diagnosable directly from the CI artifacts.

Two problems previously discarded all node logs on a failing ts-test, leaving only a bare "timed out after 30 minutes":

1. **`launch-network.sh`** launched zombienet with `-l silent` and `> /dev/null`, suppressing the orchestrator (startup/scheduling) output. Now `-l info`, with output redirected to `$ZOMBIENET_DIR/zombienet.log` under the archived dir. Per-node `*.log` files are unchanged.

2. **The archive step** (`create-release-draft.yml` + `ci.yml`) uploaded the whole `/tmp/parachain_dev/`, but the downloaded `polkadot` relay binary is written **without an owner read bit** (`--wxrw--wt`), so the zip failed with `EACCES` and uploaded **nothing**. Now archives only `**/*.log` and `**/*.json` (readable text), so node/relay/zombienet logs actually upload.

## Scope
Test-infra observability only — no runtime or node binary change. This is a companion to #4061 (the async-backing `AllowMultipleBlocksPerSlot` / `RelayNumberMonotonicallyIncreases` runtime fix), which is the actual block-production fix. This PR does not change block-production behavior; it just ensures that if the ts-test network fails to produce blocks again, the logs are captured.

## Verification
`launch-network.sh` change exercised locally: zombienet still spawns correctly and its orchestrator output lands in `zombienet.log` alongside the per-node logs, all under `/tmp/parachain_dev/<dir>/` which the corrected archive globs pick up.