### PR TITLE
fix(ci): wait for collator RPC before ts client connects

### DIFF
--- a/parachain/scripts/launch-network.sh
+++ b/parachain/scripts/launch-network.sh
@@ -96,6 +96,27 @@ else
 fi
 corepack pnpm install
 
+# Wait for the collator RPC to be up before the ts client connects. zombienet spawn +
+# (in the release path) docker image load can take a while, and the polkadot-js client
+# does not reliably recover if it opens before the RPC port is listening — it then hangs
+# in `ApiPromise.create()` forever (past its own timeout). Poll `system_health` on the
+# collator's RPC port until it answers, up to ~3 min.
+echo "waiting for collator RPC on 127.0.0.1:$COLLATOR_WS_PORT to be ready..."
+rpc_ready=false
+for i in $(seq 1 90); do
+  if curl -s -m 2 -H 'Content-Type: application/json' \
+      -d '{"id":1,"jsonrpc":"2.0","method":"system_health","params":[]}' \
+      "http://127.0.0.1:$COLLATOR_WS_PORT" 2>/dev/null | grep -q '"result"'; then
+    echo "collator RPC is ready (after ~$((i*2))s)"
+    rpc_ready=true
+    break
+  fi
+  sleep 2
+done
+if [ "$rpc_ready" != true ]; then
+  echo "collator RPC did not come up within ~3min; continuing anyway (wait-finalized-block will report)"
+fi
+
 echo "wait for parachain to produce block #1..."
 pnpm run wait-finalized-block 2>&1
 


### PR DESCRIPTION
## Problem

The release `create-release-draft` heima ts-test hung for the full **30-min** GH-action timeout at `wait for parachain to produce block #1` — never printing anything after `Connecting to parachain ws://127.0.0.1:9944`.

Using the node logs captured by #4062, the node was proven **healthy** (finalized to #252, zero panics, RPC bound on `0.0.0.0:9944`). The stall was entirely client-side: `ApiPromise.create()` in `wait-finalized-block.ts` **never connected**.

## Root cause

A startup race. In the release path, `build-parachain-client` finishes and the docker image loads slowly, so the collator's RPC comes up ~30s **after** the ts client opens the WS:

- client connects to `ws://127.0.0.1:9944` at 22:33:35
- collator process starts 22:33:56, RPC listens 22:34:05

When the WS opens before the RPC port is listening, `ApiPromise.create()` hangs indefinitely — past the script's own 5-min timeout (that timer's cleanup path assumes a live `api`, so it never actually exits). Confirmed the client itself is fine: polkadot-js `16.5.6` connects to a live stable2512 node in ~0.2s.

## Fix

`launch-network.sh` polls the collator's `system_health` RPC until it answers (up to ~3 min) before running `wait-finalized-block`. Test-infra only — no runtime/node change.

## Verification

Local stable2512 node via the edited script:
- `collator RPC is ready (after ~24s)` — poll detects readiness
- client then connects and `subscribeFinalizedHeads` **fires** (`Parachain finalized block #0 ...`), where before it hung in `ApiPromise.create()`

(Local parachain stays at #0 due to an unrelated zombienet core-assignment quirk; the point proven here is that the **connect race is gone**. In CI the node does finalize, so this unblocks the ts-test.)