### PR TITLE
fix(runtime): add missing stable2512 storage-version migrations

### DIFF
--- a/parachain/runtime/heima/src/lib.rs
+++ b/parachain/runtime/heima/src/lib.rs
@@ -154,6 +154,17 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
+	// One-time SDK storage-version migrations introduced by the polkadot-stable2512 upgrade.
+	// Without these, on-chain storage versions stay behind the in-code versions (try-runtime
+	// `--checks=all` fails with "storage version do not match") and the affected pallets read
+	// data in the wrong format. Remove after this upgrade is enacted on-chain.
+	pallet_session::migrations::v1::MigrateV0ToV1<
+		Runtime,
+		pallet_session::migrations::v1::InitOffenceSeverity<Runtime>,
+	>,
+	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 );
@@ -246,7 +257,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: alloc::borrow::Cow::Borrowed("heima"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9270,
+	spec_version: 9271,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/parachain/runtime/paseo/src/lib.rs
+++ b/parachain/runtime/paseo/src/lib.rs
@@ -155,6 +155,17 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
+	// One-time SDK storage-version migrations introduced by the polkadot-stable2512 upgrade.
+	// Without these, on-chain storage versions stay behind the in-code versions (try-runtime
+	// `--checks=all` fails with "storage version do not match") and the affected pallets read
+	// data in the wrong format. Remove after this upgrade is enacted on-chain.
+	pallet_session::migrations::v1::MigrateV0ToV1<
+		Runtime,
+		pallet_session::migrations::v1::InitOffenceSeverity<Runtime>,
+	>,
+	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 );
@@ -247,7 +258,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: alloc::borrow::Cow::Borrowed("heima"),
 	authoring_version: 1,
 	// same versioning-mechanism as polkadot: use last digit for minor updates
-	spec_version: 9270,
+	spec_version: 9271,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
## Problem

Found while verifying the `v0.9.27-01` runtime with try-runtime **before** enacting it on-chain (thanks to the request to double-check the upgrade). The polkadot-**stable2512** upgrade bumped the storage version of three SDK pallets, but their migrations were never added to the `Migrations` tuple — it only had the permanent `MigrateToLatestXcmVersion`.

`try-runtime on-runtime-upgrade --checks=all` against **live** paseo (9263) and heima (9262) failed:

```
Session:    on-chain StorageVersion(0) != in-code StorageVersion(1)
AuraExt:    on-chain StorageVersion(0) != in-code StorageVersion(1)
XcmpQueue:  on-chain StorageVersion(5) != in-code StorageVersion(7)
"On chain and in-code storage version do not match. Missing runtime upgrade?"
```

These are **real data migrations**, not just version markers:
- `cumulus_pallet_aura_ext` v0→v1 — migrates `SlotInfo` (async-backing slot tracking)
- `pallet_session` v0→v1 — migrates `DisabledValidators` to the new offence-severity format
- `cumulus_pallet_xcmp_queue` v5→v7 — queue config format (two steps: v5→v6, v6→v7)

Without them, the bare upgrade applies (doesn't brick) but those pallets keep old-format storage while the code expects the new format → potential decode errors / misbehaviour.

## Fix

Add the SDK-provided migrations to **both** heima and paseo `Migrations` tuples, and bump `spec_version` 9270 → **9271**:

```rust
pallet_session::migrations::v1::MigrateV0ToV1<Runtime, InitOffenceSeverity<Runtime>>,
cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
```

(One-time; remove after this upgrade is enacted.)

## Verification

`try-runtime on-runtime-upgrade --checks=all` against **live** state, both networks:

| | before | after this PR |
|---|---|---|
| paseo (9263→9271) | 3 storage-version mismatches, panics | ✅ 0 mismatches, all try-state checks pass |
| heima (9262→9271) | (same gap) | ✅ 0 mismatches, 13.6 MB state decodes without error |

Both: `on_runtime_upgrade` succeeds, **migrations idempotent** (storage root unchanged on re-run), full runtime state decodes cleanly.

## Rollout note

This means the current `v0.9.27-01` runtime (spec 9270) should **not** be enacted as-is; the on-chain upgrade should carry these migrations (9271). The node/image and the async-backing runtime fix (#4061) are unaffected — this only completes the migration set.